### PR TITLE
Add a more "UV" like build system for desktop apps

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -20,24 +20,21 @@ jobs:
         with:
           enable-cache: true
 
+      # Use 3.12 - 3.13 not working yet (Numpy verion too old)
       - uses: actions/setup-python@v5
         with:
           python-version: 3.12
           cache: "pip"
 
-      - name: Set up Python
-        run: uv python install
+      # Use GH python version (includes TK/TCL)
+      - name: Set up Python using GH python version
+        run: uv venv --python 3.12 --python-preference only-system
 
       - name: Install the project
         run: uv sync
 
-      - name: generate requirements.txt
-        run: uv pip freeze > requirements.txt
-
-      - run: pip install -r requirements.txt
-
       # Compress MacOS app param ignored on Windows
-      - run: sh ./app/desktop/build_desktop_app.sh --compress-mac-app
+      - run: uv run sh ./app/desktop/build_desktop_app.sh --compress-mac-app
       - uses: actions/upload-artifact@v4
         with:
           name: kiln-desktop-${{ runner.os }}-${{ runner.arch }}


### PR DESCRIPTION
Still use system python, but let UV do it's thing.