### PR TITLE
Remove exit call

### DIFF
--- a/app/desktop/desktop.py
+++ b/app/desktop/desktop.py
@@ -49,8 +49,6 @@ def quit_app():
     global root
     if root is not None:
         root.destroy()
-        # TODO: shouldn't need explicit exit, but would need to test all platforms to remove
-        sys.exit(0)
 
 
 def on_quit():


### PR DESCRIPTION
Let it exit gracefully.

Note, this did not resolve: https://github.com/pyinstaller/pyinstaller/issues/8866