### PR TITLE
Refactor

### DIFF
--- a/app/desktop/studio_server/data_gen_api.py
+++ b/app/desktop/studio_server/data_gen_api.py
@@ -1,11 +1,11 @@
 from fastapi import FastAPI
+from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.data_gen.data_gen_task import (
     DataGenCategoriesTask,
     DataGenCategoriesTaskInput,
     DataGenSampleTask,
     DataGenSampleTaskInput,
 )
-from kiln_ai.adapters.langchain_adapters import LangChainPromptAdapter
 from kiln_ai.adapters.prompt_builders import prompt_builder_from_ui_name
 from kiln_ai.datamodel import DataSource, DataSourceType, TaskRun
 from kiln_server.task_api import task_from_id
@@ -80,7 +80,7 @@ def connect_data_gen_api(app: FastAPI):
             existing_topics=input.existing_topics,
         )
 
-        adapter = LangChainPromptAdapter(
+        adapter = adapter_for_task(
             categories_task,
             model_name=input.model_name,
             provider=input.provider,
@@ -103,7 +103,7 @@ def connect_data_gen_api(app: FastAPI):
             human_guidance=input.human_guidance,
         )
 
-        adapter = LangChainPromptAdapter(
+        adapter = adapter_for_task(
             sample_task,
             model_name=input.model_name,
             provider=input.provider,
@@ -122,7 +122,7 @@ def connect_data_gen_api(app: FastAPI):
 
         prompt_builder = prompt_builder_from_ui_name(sample.prompt_method)(task)
 
-        adapter = LangChainPromptAdapter(
+        adapter = adapter_for_task(
             task,
             model_name=sample.output_model_name,
             provider=sample.output_provider,

--- a/app/desktop/studio_server/repair_api.py
+++ b/app/desktop/studio_server/repair_api.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, HTTPException
-from kiln_ai.adapters.langchain_adapters import LangChainPromptAdapter
+from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.repair.repair_task import RepairTaskRun
 from kiln_ai.datamodel import TaskRun
 from kiln_server.run_api import task_and_run_from_id
@@ -54,7 +54,7 @@ def connect_repair_api(app: FastAPI):
                 detail="Model name and provider must be specified.",
             )
 
-        adapter = LangChainPromptAdapter(
+        adapter = adapter_for_task(
             repair_task, model_name=model_name, provider=provider
         )
 

--- a/app/desktop/studio_server/test_data_gen_api.py
+++ b/app/desktop/studio_server/test_data_gen_api.py
@@ -74,7 +74,7 @@ def mock_task_run(data_source, test_task):
 
 @pytest.fixture
 def mock_langchain_adapter(mock_task_run):
-    with patch("app.desktop.studio_server.data_gen_api.LangChainPromptAdapter") as mock:
+    with patch("app.desktop.studio_server.data_gen_api.adapter_for_task") as mock:
         mock_adapter = AsyncMock()
         mock_adapter.invoke = AsyncMock()
         mock.return_value = mock_adapter

--- a/app/desktop/studio_server/test_repair_api.py
+++ b/app/desktop/studio_server/test_repair_api.py
@@ -85,7 +85,7 @@ def mock_repair_task_run(improvement_task, data_source):
 
 @pytest.fixture
 def mock_langchain_adapter(mock_repair_task_run):
-    with patch("app.desktop.studio_server.repair_api.LangChainPromptAdapter") as mock:
+    with patch("app.desktop.studio_server.repair_api.adapter_for_task") as mock:
         mock_adapter = AsyncMock()
         mock_adapter.invoke = AsyncMock()
         mock.return_value = mock_adapter

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -1,0 +1,19 @@
+from kiln_ai import datamodel
+from kiln_ai.adapters.base_adapter import BaseAdapter
+from kiln_ai.adapters.langchain_adapters import LangchainAdapter
+from kiln_ai.adapters.prompt_builders import BasePromptBuilder
+
+
+def adapter_for_task(
+    kiln_task: datamodel.Task,
+    # TODO custom_model: BaseChatModel | None = None,
+    model_name: str | None = None,
+    provider: str | None = None,
+    prompt_builder: BasePromptBuilder | None = None,
+) -> BaseAdapter:
+    return LangchainAdapter(
+        kiln_task,
+        model_name=model_name,
+        provider=provider,
+        prompt_builder=prompt_builder,
+    )

--- a/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
+++ b/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.data_gen.data_gen_task import (
     DataGenCategoriesTask,
     DataGenCategoriesTaskInput,
@@ -10,7 +11,6 @@ from kiln_ai.adapters.data_gen.data_gen_task import (
     DataGenSampleTaskInput,
     list_json_schema_for_task,
 )
-from kiln_ai.adapters.langchain_adapters import LangChainPromptAdapter
 from kiln_ai.adapters.ml_model_list import get_model_and_provider
 from kiln_ai.adapters.test_prompt_adaptors import get_all_models_and_providers
 from kiln_ai.datamodel import Project, Task
@@ -108,7 +108,7 @@ async def test_data_gen_all_models_providers(
     data_gen_task = DataGenCategoriesTask()
     data_gen_input = DataGenCategoriesTaskInput.from_task(base_task, num_subtopics=6)
 
-    adapter = LangChainPromptAdapter(
+    adapter = adapter_for_task(
         data_gen_task,
         model_name=model_name,
         provider=provider_name,
@@ -232,7 +232,7 @@ async def test_data_gen_sample_all_models_providers(
         base_task, topic=["riding horses"], num_samples=4
     )
 
-    adapter = LangChainPromptAdapter(
+    adapter = adapter_for_task(
         data_gen_task,
         model_name=model_name,
         provider=provider_name,
@@ -274,7 +274,7 @@ async def test_data_gen_sample_all_models_providers_with_structured_output(
         base_task, topic=["riding horses"], num_samples=4
     )
 
-    adapter = LangChainPromptAdapter(
+    adapter = adapter_for_task(
         data_gen_task,
         model_name=model_name,
         provider=provider_name,

--- a/libs/core/kiln_ai/adapters/langchain_adapters.py
+++ b/libs/core/kiln_ai/adapters/langchain_adapters.py
@@ -15,7 +15,7 @@ from .ml_model_list import langchain_model_from
 LangChainModelType = BaseChatModel | Runnable[LanguageModelInput, Dict | BaseModel]
 
 
-class LangChainPromptAdapter(BaseAdapter):
+class LangchainAdapter(BaseAdapter):
     _model: LangChainModelType | None = None
 
     def __init__(

--- a/libs/core/kiln_ai/adapters/repair/test_repair_task.py
+++ b/libs/core/kiln_ai/adapters/repair/test_repair_task.py
@@ -5,10 +5,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pydantic import ValidationError
 
+from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.base_adapter import RunOutput
-from kiln_ai.adapters.langchain_adapters import (
-    LangChainPromptAdapter,
-)
+from kiln_ai.adapters.langchain_adapters import LangchainAdapter
 from kiln_ai.adapters.repair.repair_task import (
     RepairTaskInput,
     RepairTaskRun,
@@ -190,9 +189,7 @@ async def test_live_run(sample_task, sample_task_run, sample_repair_data):
     repair_task_input = RepairTaskRun.build_repair_task_input(**sample_repair_data)
     assert isinstance(repair_task_input, RepairTaskInput)
 
-    adapter = LangChainPromptAdapter(
-        repair_task, model_name="llama_3_1_8b", provider="groq"
-    )
+    adapter = adapter_for_task(repair_task, model_name="llama_3_1_8b", provider="groq")
 
     run = await adapter.invoke(repair_task_input.model_dump())
     assert run is not None
@@ -220,14 +217,12 @@ async def test_mocked_repair_task_run(sample_task, sample_task_run, sample_repai
         "rating": 8,
     }
 
-    with patch.object(
-        LangChainPromptAdapter, "_run", new_callable=AsyncMock
-    ) as mock_run:
+    with patch.object(LangchainAdapter, "_run", new_callable=AsyncMock) as mock_run:
         mock_run.return_value = RunOutput(
             output=mocked_output, intermediate_outputs=None
         )
 
-        adapter = LangChainPromptAdapter(
+        adapter = adapter_for_task(
             repair_task, model_name="llama_3_1_8b", provider="groq"
         )
 

--- a/libs/core/kiln_ai/adapters/test_langchain_adapter.py
+++ b/libs/core/kiln_ai/adapters/test_langchain_adapter.py
@@ -3,16 +3,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_groq import ChatGroq
 
-from kiln_ai.adapters.langchain_adapters import LangChainPromptAdapter
+from kiln_ai.adapters.langchain_adapters import LangchainAdapter
 from kiln_ai.adapters.prompt_builders import SimpleChainOfThoughtPromptBuilder
 from kiln_ai.adapters.test_prompt_adaptors import build_test_task
 
 
 def test_langchain_adapter_munge_response(tmp_path):
     task = build_test_task(tmp_path)
-    lca = LangChainPromptAdapter(
-        kiln_task=task, model_name="llama_3_1_8b", provider="ollama"
-    )
+    lca = LangchainAdapter(kiln_task=task, model_name="llama_3_1_8b", provider="ollama")
     # Mistral Large tool calling format is a bit different
     response = {
         "name": "task_response",
@@ -35,7 +33,7 @@ def test_langchain_adapter_infer_model_name(tmp_path):
     task = build_test_task(tmp_path)
     custom = ChatGroq(model="llama-3.1-8b-instant", groq_api_key="test")
 
-    lca = LangChainPromptAdapter(kiln_task=task, custom_model=custom)
+    lca = LangchainAdapter(kiln_task=task, custom_model=custom)
 
     model_info = lca.adapter_info()
     assert model_info.model_name == "custom.langchain:llama-3.1-8b-instant"
@@ -45,9 +43,7 @@ def test_langchain_adapter_infer_model_name(tmp_path):
 def test_langchain_adapter_info(tmp_path):
     task = build_test_task(tmp_path)
 
-    lca = LangChainPromptAdapter(
-        kiln_task=task, model_name="llama_3_1_8b", provider="ollama"
-    )
+    lca = LangchainAdapter(kiln_task=task, model_name="llama_3_1_8b", provider="ollama")
 
     model_info = lca.adapter_info()
     assert model_info.adapter_name == "kiln_langchain_adapter"
@@ -60,7 +56,7 @@ async def test_langchain_adapter_with_cot(tmp_path):
     task.output_json_schema = (
         '{"type": "object", "properties": {"count": {"type": "integer"}}}'
     )
-    lca = LangChainPromptAdapter(
+    lca = LangchainAdapter(
         kiln_task=task,
         model_name="llama_3_1_8b",
         provider="ollama",
@@ -85,7 +81,7 @@ async def test_langchain_adapter_with_cot(tmp_path):
         patch(
             "kiln_ai.adapters.langchain_adapters.langchain_model_from", mock_model_from
         ),
-        patch.object(LangChainPromptAdapter, "model", return_value=mock_model_instance),
+        patch.object(LangchainAdapter, "model", return_value=mock_model_instance),
     ):
         response = await lca._run("test input")
 

--- a/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
@@ -5,7 +5,8 @@ import pytest
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
 
 import kiln_ai.datamodel as datamodel
-from kiln_ai.adapters.langchain_adapters import LangChainPromptAdapter
+from kiln_ai.adapters.adapter_registry import adapter_for_task
+from kiln_ai.adapters.langchain_adapters import LangchainAdapter
 from kiln_ai.adapters.ml_model_list import built_in_models, ollama_online
 from kiln_ai.adapters.prompt_builders import (
     BasePromptBuilder,
@@ -106,7 +107,7 @@ async def test_amazon_bedrock(tmp_path):
 async def test_mock(tmp_path):
     task = build_test_task(tmp_path)
     mockChatModel = FakeListChatModel(responses=["mock response"])
-    adapter = LangChainPromptAdapter(task, custom_model=mockChatModel)
+    adapter = LangchainAdapter(task, custom_model=mockChatModel)
     run = await adapter.invoke("You are a mock, send me the response!")
     assert "mock response" in run.output.output
 
@@ -114,7 +115,7 @@ async def test_mock(tmp_path):
 async def test_mock_returning_run(tmp_path):
     task = build_test_task(tmp_path)
     mockChatModel = FakeListChatModel(responses=["mock response"])
-    adapter = LangChainPromptAdapter(task, custom_model=mockChatModel)
+    adapter = LangchainAdapter(task, custom_model=mockChatModel)
     run = await adapter.invoke("You are a mock, send me the response!")
     assert run.output.output == "mock response"
     assert run is not None
@@ -192,7 +193,7 @@ async def run_simple_task(
     provider: str,
     prompt_builder: BasePromptBuilder | None = None,
 ) -> datamodel.TaskRun:
-    adapter = LangChainPromptAdapter(
+    adapter = adapter_for_task(
         task, model_name=model_name, provider=provider, prompt_builder=prompt_builder
     )
 

--- a/libs/core/kiln_ai/adapters/test_structured_output.py
+++ b/libs/core/kiln_ai/adapters/test_structured_output.py
@@ -6,8 +6,8 @@ import jsonschema.exceptions
 import pytest
 
 import kiln_ai.datamodel as datamodel
+from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.base_adapter import AdapterInfo, BaseAdapter, RunOutput
-from kiln_ai.adapters.langchain_adapters import LangChainPromptAdapter
 from kiln_ai.adapters.ml_model_list import (
     built_in_models,
     ollama_online,
@@ -157,7 +157,7 @@ def build_structured_output_test_task(tmp_path: Path):
 
 async def run_structured_output_test(tmp_path: Path, model_name: str, provider: str):
     task = build_structured_output_test_task(tmp_path)
-    a = LangChainPromptAdapter(task, model_name=model_name, provider=provider)
+    a = adapter_for_task(task, model_name=model_name, provider=provider)
     parsed = await a.invoke_returning_raw("Cows")  # a joke about cows
     if parsed is None or not isinstance(parsed, Dict):
         raise RuntimeError(f"structured response is not a dict: {parsed}")
@@ -204,7 +204,7 @@ async def run_structured_input_task(
     provider: str,
     pb: BasePromptBuilder | None = None,
 ):
-    a = LangChainPromptAdapter(
+    a = adapter_for_task(
         task, model_name=model_name, provider=provider, prompt_builder=pb
     )
     with pytest.raises(ValueError):

--- a/libs/server/kiln_server/run_api.py
+++ b/libs/server/kiln_server/run_api.py
@@ -2,7 +2,7 @@ from asyncio import Lock
 from typing import Any, Dict
 
 from fastapi import FastAPI, HTTPException
-from kiln_ai.adapters.langchain_adapters import LangChainPromptAdapter
+from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.prompt_builders import prompt_builder_from_ui_name
 from kiln_ai.datamodel import Task, TaskRun
 from pydantic import BaseModel, ConfigDict
@@ -99,7 +99,7 @@ def connect_run_api(app: FastAPI):
                 detail=f"Unknown prompt method: {request.ui_prompt_method}",
             )
         prompt_builder = prompt_builder_class(task)
-        adapter = LangChainPromptAdapter(
+        adapter = adapter_for_task(
             task,
             model_name=request.model_name,
             provider=request.provider,

--- a/libs/server/kiln_server/test_run_api.py
+++ b/libs/server/kiln_server/test_run_api.py
@@ -3,7 +3,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-from kiln_ai.adapters.langchain_adapters import LangChainPromptAdapter
+from kiln_ai.adapters.adapter_registry import adapter_for_task
+from kiln_ai.adapters.langchain_adapters import LangchainAdapter
 from kiln_ai.datamodel import (
     DataSource,
     DataSourceType,
@@ -99,9 +100,7 @@ async def test_run_task_success(client, task_run_setup):
 
     with (
         patch("kiln_server.run_api.project_from_id") as mock_project_from_id,
-        patch.object(
-            LangChainPromptAdapter, "invoke", new_callable=AsyncMock
-        ) as mock_invoke,
+        patch.object(LangchainAdapter, "invoke", new_callable=AsyncMock) as mock_invoke,
         patch("kiln_ai.utils.config.Config.shared") as MockConfig,
     ):
         mock_project_from_id.return_value = project
@@ -130,9 +129,7 @@ async def test_run_task_structured_output(client, task_run_setup):
 
     with (
         patch("kiln_server.run_api.project_from_id") as mock_project_from_id,
-        patch.object(
-            LangChainPromptAdapter, "invoke", new_callable=AsyncMock
-        ) as mock_invoke,
+        patch.object(LangchainAdapter, "invoke", new_callable=AsyncMock) as mock_invoke,
         patch("kiln_ai.utils.config.Config.shared") as MockConfig,
     ):
         mock_project_from_id.return_value = project
@@ -212,7 +209,7 @@ async def test_run_task_structured_input(client, task_run_setup):
         with (
             patch("kiln_server.run_api.project_from_id") as mock_project_from_id,
             patch.object(
-                LangChainPromptAdapter, "invoke", new_callable=AsyncMock
+                LangchainAdapter, "invoke", new_callable=AsyncMock
             ) as mock_invoke,
             patch("kiln_ai.utils.config.Config.shared") as MockConfig,
         ):


### PR DESCRIPTION
 - Rename LangChainPromptAdapter to LangchainAdapter... because that's what it is
 - Add a adapter_registry so there aren't any explicit LC deps outside of the 2 files it's used.