### PR TITLE
Big perf improvement (30x) 

### DIFF
--- a/libs/core/kiln_ai/datamodel/__init__.py
+++ b/libs/core/kiln_ai/datamodel/__init__.py
@@ -483,61 +483,62 @@ class TaskRun(KilnParentedModel):
 
     @model_validator(mode="after")
     def validate_input_format(self, info: ValidationInfo) -> Self:
-        try:
-            # Don't validate if loading from file (not new). Too slow.
-            # We don't allow changing task schema, so this is redundant validation.
-            # Note: we still validate if editing a loaded model
-            if self.loading_from_file(info):
-                return self
-
-            # Don't validate if input has not changed. Too slow to run this every time.
-            if hasattr(self, "_previous_input") and self.input == self._previous_input:
-                return self
-
-            task = self.parent_task()
-            if task is None:
-                # don't validate this relationship until we have a path or parent. Give them time to build it (but will catch it before saving)
-                return self
-
-            # validate output
-            if task.input_json_schema is not None:
-                try:
-                    validate_schema(json.loads(self.input), task.input_json_schema)
-                except json.JSONDecodeError:
-                    raise ValueError("Input is not a valid JSON object")
-                except jsonschema.exceptions.ValidationError as e:
-                    raise ValueError(f"Input does not match task input schema: {e}")
+        # Don't validate if loading from file (not new). Too slow.
+        # We don't allow changing task schema, so this is redundant validation.
+        # Note: we still validate if editing a loaded model
+        if self.loading_from_file(info):
+            # Consider loading an existing model as validated.
+            self._last_validated_input = self.input
             return self
-        finally:
-            # Store current output for future change detection
-            self._previous_input = self.input
+
+        # Don't validate if input has not changed. Too slow to run this every time.
+        if (
+            hasattr(self, "_last_validated_input")
+            and self.input == self._last_validated_input
+        ):
+            return self
+
+        task = self.parent_task()
+        if task is None:
+            # don't validate this relationship until we have a path or parent. Give them time to build it (but will catch it before saving)
+            return self
+
+        # validate output
+        if task.input_json_schema is not None:
+            try:
+                validate_schema(json.loads(self.input), task.input_json_schema)
+            except json.JSONDecodeError:
+                raise ValueError("Input is not a valid JSON object")
+            except jsonschema.exceptions.ValidationError as e:
+                raise ValueError(f"Input does not match task input schema: {e}")
+        self._last_validated_input = self.input
+        return self
 
     @model_validator(mode="after")
     def validate_output_format(self, info: ValidationInfo) -> Self:
-        try:
-            # Don't validate if loading from file (not new). Too slow.
-            # We don't allow changing task schema, so this is redundant validation.
-            # Note: we still validate if editing a loaded model.
-            if self.loading_from_file(info):
-                return self
-
-            # Don't validate unless output has changed. The validator is slow and costly, don't want it running when setting other fields.
-            if (
-                hasattr(self, "_previous_output_output")
-                and self.output is not None
-                and self.output.output == self._previous_output_output
-            ):
-                return self
-
-            task = self.parent_task()
-            if task is None:
-                return self
-
-            self.output.validate_output_format(task)
+        # Don't validate if loading from file (not new). Too slow.
+        # Note: we still validate if editing a loaded model's output.
+        if self.loading_from_file(info):
+            # Consider loading an existing model as validated.
+            self._last_validated_output = self.output.output if self.output else None
             return self
-        finally:
-            # Store current output for future change detection
-            self._previous_output_output = self.output.output if self.output else None
+
+        # Don't validate unless output has changed since last validation.
+        # The validator is slow and costly, don't want it running when setting other fields.
+        if (
+            hasattr(self, "_last_validated_output")
+            and self.output is not None
+            and self.output.output == self._last_validated_output
+        ):
+            return self
+
+        task = self.parent_task()
+        if task is None:
+            return self
+
+        self.output.validate_output_format(task)
+        self._last_validated_output = self.output.output if self.output else None
+        return self
 
     @model_validator(mode="after")
     def validate_repaired_output(self) -> Self:

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -169,13 +169,20 @@ class KilnBaseModel(BaseModel):
         # Two methods of indicated it's loaded from file:
         # 1) info.context.get("loading_from_file") -> During actual loading, before we can set _loaded_from_file
         # 2) self._loaded_from_file -> After loading, set by the loader
+        if self.loading_from_file(info):
+            return True
+        return self._loaded_from_file
+
+    # indicates the model is currently being loaded from file (not mutating it after)
+    def loading_from_file(self, info: ValidationInfo | None = None) -> bool:
+        # info.context.get("loading_from_file") -> During actual loading, before we can set _loaded_from_file
         if (
             info is not None
             and info.context is not None
             and info.context.get("loading_from_file", False)
         ):
             return True
-        return self._loaded_from_file
+        return False
 
     def save_to_file(self) -> None:
         """Save the model instance to a file.

--- a/libs/core/kiln_ai/datamodel/test_example_models.py
+++ b/libs/core/kiln_ai/datamodel/test_example_models.py
@@ -325,6 +325,12 @@ def test_task_output_schema_validation(tmp_path):
         task_output.output.output = '{"name": "John Doe", "age": "thirty"}'
         task_output.save_to_file()
 
+    # changing to invalid output from loaded model
+    loaded_task_output = TaskRun.load_from_file(task_output.path)
+    with pytest.raises(ValueError, match="does not match task output schema"):
+        loaded_task_output.output.output = '{"name": "John Doe", "age": "forty"}'
+        loaded_task_output.save_to_file()
+
     # Invalid case: output does not match task output schema
     with pytest.raises(ValueError, match="does not match task output schema"):
         task_output = TaskRun(
@@ -385,6 +391,12 @@ def test_task_input_schema_validation(tmp_path):
     with pytest.raises(ValueError, match="does not match task input schema"):
         valid_task_output.input = '{"name": "John Doe", "age": "thirty"}'
         valid_task_output.save_to_file()
+
+    # loading from file, then changing to invalid input
+    loaded_task_output = TaskRun.load_from_file(valid_task_output.path)
+    with pytest.raises(ValueError, match="does not match task input schema"):
+        loaded_task_output.input = '{"name": "John Doe", "age": "thirty"}'
+        loaded_task_output.save_to_file()
 
     # Invalid case: input does not match task input schema
     with pytest.raises(ValueError, match="does not match task input schema"):

--- a/libs/core/kiln_ai/datamodel/test_model_perf.py
+++ b/libs/core/kiln_ai/datamodel/test_model_perf.py
@@ -49,7 +49,7 @@ test_json_schema = """{
 
 @pytest.fixture
 def task_run(tmp_path):
-    # Setup basic output source for validation
+    # setup a valid project/task/task_run for testing
     output_source = DataSource(
         type=DataSourceType.synthetic,
         properties={
@@ -72,7 +72,6 @@ def task_run(tmp_path):
 
     task.save_to_file()
 
-    # Test 1: Creating without source should work when strict mode is off
     task_output = TaskOutput(
         output='{"setup": "Why did the chicken cross the road?", "punchline": "To get to the other side"}',
         source=DataSource(

--- a/libs/core/kiln_ai/datamodel/test_model_perf.py
+++ b/libs/core/kiln_ai/datamodel/test_model_perf.py
@@ -1,0 +1,126 @@
+import shutil
+import uuid
+
+import pytest
+
+from kiln_ai.datamodel import (
+    DataSource,
+    DataSourceType,
+    Project,
+    Task,
+    TaskOutput,
+    TaskRun,
+)
+
+test_json_schema = """{
+  "type": "object",
+  "properties": {
+    "setup": {
+      "description": "The setup of the joke",
+      "title": "Setup",
+      "type": "string"
+    },
+    "punchline": {
+      "description": "The punchline to the joke",
+      "title": "Punchline",
+      "type": "string"
+    },
+    "rating": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "How funny the joke is, from 1 to 10",
+      "title": "Rating"
+    }
+  },
+  "required": [
+    "setup",
+    "punchline"
+  ]
+}
+"""
+
+
+@pytest.fixture
+def task_run(tmp_path):
+    # Setup basic output source for validation
+    output_source = DataSource(
+        type=DataSourceType.synthetic,
+        properties={
+            "model_name": "test-model",
+            "model_provider": "test-provider",
+            "adapter_name": "test-adapter",
+        },
+    )
+
+    project_path = tmp_path / "project.kiln"
+    project = Project(name="Test Project", path=project_path)
+    project.save_to_file()
+    task = Task(
+        name="Test Task",
+        instruction="Test Instruction",
+        parent=project,
+        output_json_schema=test_json_schema,
+        input_json_schema=test_json_schema,
+    )
+
+    task.save_to_file()
+
+    # Test 1: Creating without source should work when strict mode is off
+    task_output = TaskOutput(
+        output='{"setup": "Why did the chicken cross the road?", "punchline": "To get to the other side"}',
+        source=DataSource(
+            type=DataSourceType.synthetic,
+            properties={
+                "model_name": "test-model",
+                "model_provider": "test-provider",
+                "adapter_name": "test-adapter",
+            },
+        ),
+    )
+
+    # Save for later usage
+    task_run = TaskRun(
+        input='{"setup": "Why did the chicken cross the road?", "punchline": "To get to the other side"}',
+        input_source=output_source,
+        output=task_output,
+    )
+    task_run.parent = task
+    task_run.save_to_file()
+
+    return task_run
+
+
+@pytest.mark.benchmark
+def test_benchmark_load_from_file(benchmark, task_run):
+    task_run_path = task_run.path
+
+    iterations = 500
+    total_time = 0
+
+    for _ in range(iterations):
+        # Copy the task to a new temp path, so we don't get warm loads/cached loads
+        temp_path = task_run.path.parent / f"temp_task_run_{uuid.uuid4()}.json"
+        shutil.copy(str(task_run_path), str(temp_path))
+
+        # only time loading the model (and one accessor for delayed validation)
+        start_time = benchmark._timer()
+        loaded = TaskRun.load_from_file(temp_path)
+        assert loaded.id == task_run.id
+        end_time = benchmark._timer()
+
+        total_time += end_time - start_time
+
+    avg_time_per_iteration = total_time / iterations
+    ops_per_second = 1.0 / avg_time_per_iteration
+
+    # I get 8k ops per second on my MBP. Lower value here for CI.
+    # Prior to optimization was 290 ops per second.
+    if ops_per_second < 1000:
+        pytest.fail(f"Ops per second: {ops_per_second:.6f}, expected more than 1k ops")


### PR DESCRIPTION
Big perf improvement (30x) on loading our TaskRun datamodel from disk… All the slowness was the JSON schema validation, which we only need to run when changing, not loading.

Added benchmark (may need to adjust the CI limit, but 8k/s on Macbook).

Used profiler for first time - see notes on how to use cprofile