### PR TITLE
fix: unicode is escaped in structured output

### DIFF
--- a/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
@@ -68,7 +68,7 @@ def generate_chat_message_toolcall(
                         "function": {
                             "name": "task_response",
                             # Yes we parse then dump again. This ensures it's valid JSON, and ensures it goes to 1 line
-                            "arguments": json.dumps(arguments),
+                            "arguments": json.dumps(arguments, ensure_ascii=False),
                         },
                     }
                 ],

--- a/libs/core/kiln_ai/adapters/fine_tune/test_dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/test_dataset_formatter.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+
 from kiln_ai.adapters.fine_tune.dataset_formatter import (
     DatasetFormat,
     DatasetFormatter,

--- a/libs/core/kiln_ai/adapters/fine_tune/test_dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/test_dataset_formatter.py
@@ -50,6 +50,7 @@ def mock_task():
     task.runs.return_value = task_runs
     return task
 
+
 @pytest.fixture
 def mock_task_non_ascii():
     task = Mock(spec=Task)
@@ -86,6 +87,7 @@ def mock_dataset(mock_task):
     dataset.split_contents = {"train": ["run1", "run2"], "test": ["run3"]}
     return dataset
 
+
 @pytest.fixture
 def mock_dataset_non_ascii(mock_task_non_ascii):
     dataset = Mock(spec=DatasetSplit)
@@ -93,6 +95,7 @@ def mock_dataset_non_ascii(mock_task_non_ascii):
     dataset.parent_task.return_value = mock_task_non_ascii
     dataset.split_contents = {"train": ["run1", "run2"], "test": ["run3"]}
     return dataset
+
 
 def test_generate_chat_message_response():
     task_run = TaskRun(
@@ -311,10 +314,13 @@ def test_dataset_formatter_dump_to_temp_file_non_ascii(mock_dataset):
         content = f.read()
         assert "你好" in content
 
+
 def test_dataset_formatter_dump_to_file_tool_format_non_ascii(mock_dataset_non_ascii):
     formatter = DatasetFormatter(mock_dataset_non_ascii, "system message")
 
-    result_path = formatter.dump_to_file("train", DatasetFormat.OPENAI_CHAT_TOOLCALL_JSONL)
+    result_path = formatter.dump_to_file(
+        "train", DatasetFormat.OPENAI_CHAT_TOOLCALL_JSONL
+    )
 
     assert result_path.exists()
     assert result_path.parent == Path(tempfile.gettempdir())


### PR DESCRIPTION
## What does this PR do?

This PR disables escaping unicode characters into ASCII in the structured output formatter which seemed to be causing unicode characters to be passed on to OpenAI as escaped strings in toolcall arguments during fine-tuning. Additionally adds some tests to demonstrate the issue - the newly added tests fail when `ensure_ascii=False` is not present.

## Related Issues

Follow up on: https://github.com/Kiln-AI/Kiln/commit/daf18e62ac87821c23437a1e9c5d0eee8cb1bf29

Fixes: https://github.com/Kiln-AI/Kiln/issues/95 - as it pertains to escaping unicode in structured output arguments.

As illustrated in this [comment](https://github.com/Kiln-AI/Kiln/issues/95#issuecomment-2581395722), fine-tuning jobs for Structured Output tasks currently appear to use up many more `Trained tokens` on OpenAI when the arguments are `json.dumps` without `ensure_ascii`. This suggests that that unicode text contained in toolcall `arguments` is not being decoded by OpenAI and that the fine-tuning is being done over the unicode escape literals, rather than the unicode characters themselves.

The scope of this particular problem is limited to the structured output formatter (`OPENAI_CHAT_TOOLCALL_JSONL`). The reason being that there is double serialization happening there (`arguments` is being treated as a string). Other formatters do not exhibit this issue.

There may be a broader discussion to be had about unicode escaping in general as I have noticed other similar issues but they are hard to debug.

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
