### PR TITLE
fix: unicode converted into escape sequences in repair prompt

### DIFF
--- a/libs/core/kiln_ai/adapters/prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/prompt_builders.py
@@ -58,7 +58,7 @@ class BasePromptBuilder(metaclass=ABCMeta):
             str: The formatted user message.
         """
         if isinstance(input, Dict):
-            return f"The input is:\n{json.dumps(input, indent=2)}"
+            return f"The input is:\n{json.dumps(input, indent=2, ensure_ascii=False)}"
 
         return f"The input is:\n{input}"
 

--- a/libs/core/kiln_ai/adapters/test_prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_builders.py
@@ -72,6 +72,14 @@ def test_simple_prompt_builder_structured_output(tmp_path):
     assert input not in prompt
 
 
+def test_simple_prompt_builder_structured_input_non_ascii(tmp_path):
+    task = build_structured_output_test_task(tmp_path)
+    builder = SimplePromptBuilder(task=task)
+    input = {"key": "你好👋"}
+    user_msg = builder.build_user_message(input)
+    assert "你好👋" in user_msg
+
+
 @pytest.fixture
 def task_with_examples(tmp_path):
     # Create a project and task hierarchy


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug where Unicode characters in structured output are passed back as escaped ASCII literals in the repair prompt. Since the structured output being repaired is serialized into a string, the LLM does not decode it and instead consumes the escape literals rather than the actual characters.

As LLMs have some understanding of escape sequences, this bug breaks the repair output in semi-sporadic, subtle and unpredictable ways - for example, it may inject random characters (often newlines) into the repaired output, or respond with escape sequences instead of the characters.

## Related Issues

This is part of a broader issue related to unicode escaping: https://github.com/Kiln-AI/Kiln/issues/95

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
