### PR TITLE
fix: escaped Unicode in BaseAdapter

### DIFF
--- a/libs/core/kiln_ai/adapters/base_adapter.py
+++ b/libs/core/kiln_ai/adapters/base_adapter.py
@@ -126,9 +126,11 @@ class BaseAdapter(metaclass=ABCMeta):
         self, input: Dict | str, input_source: DataSource | None, run_output: RunOutput
     ) -> TaskRun:
         # Convert input and output to JSON strings if they are dictionaries
-        input_str = json.dumps(input) if isinstance(input, dict) else input
+        input_str = (
+            json.dumps(input, ensure_ascii=False) if isinstance(input, dict) else input
+        )
         output_str = (
-            json.dumps(run_output.output)
+            json.dumps(run_output.output, ensure_ascii=False)
             if isinstance(run_output.output, dict)
             else run_output.output
         )


### PR DESCRIPTION
## What does this PR do?

Fix a bug where Unicode in structured `input` and `output` is escaped in the `BaseAdapter`, causing two main issues:
1. Structured `input` and `output` are sent back to the frontend as escaped strings ([code reference](https://github.com/leonardmq/Kiln/blob/be9d0d6b311d3072aa210d5b16357534036d7d0f/libs/server/kiln_server/run_api.py#L98)), which are displayed as-is in the `Datasets` page.
2. Structured `input` and `output` are persisted in `.kiln` files as ASCII. While valid JSON, this is not ideal for scenarios like collaboration, committing datasets to GitHub, and searching. Additionally, there is a risk of improperly decoding these strings.

After this fix, Kiln will store structured `input` and `output` without escaping Unicode, which is already the behavior for plain text `input` and `output`. This change is non-breaking, as `json.load` and `json.loads` can handle both Unicode and ASCII-escaped Unicode.

## Related Issues

Part of a group of bugs caused by escaped Unicode: https://github.com/Kiln-AI/Kiln/issues/95

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib