### PR TITLE
fix: unicode in list_json_schema_for_task

### DIFF
--- a/libs/core/kiln_ai/adapters/data_gen/data_gen_task.py
+++ b/libs/core/kiln_ai/adapters/data_gen/data_gen_task.py
@@ -163,7 +163,7 @@ def list_json_schema_for_task(task: Task) -> str:
         "required": ["generated_samples"],
     }
 
-    return json.dumps(top_level_schema)
+    return json.dumps(top_level_schema, ensure_ascii=False)
 
 
 class DataGenSampleTask(Task, parent_of={}):

--- a/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
+++ b/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
@@ -202,6 +202,26 @@ def test_list_json_schema_for_task_with_output_schema(base_task):
     assert generated_samples_schema["items"]["properties"]["age"]["type"] == "integer"
 
 
+def test_list_json_schema_for_task_with_input_schema_non_ascii(base_task):
+    # Arrange
+    base_task.input_json_schema = json.dumps(
+        {
+            "type": "object",
+            "properties": {
+                "名字": {"type": "string"},
+                "年齢": {"type": "integer"},
+            },
+        }
+    )
+
+    # Act
+    schema = list_json_schema_for_task(base_task)
+
+    # Assert
+    assert "名字" in schema
+    assert "年齢" in schema
+
+
 def test_list_json_schema_for_task_without_output_schema(base_task):
     # Arrange
     base_task.output_json_schema = None

--- a/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
+++ b/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
@@ -180,7 +180,7 @@ def test_data_gen_sample_task_initialization(base_task):
     }
 
 
-def test_list_json_schema_for_task_with_output_schema(base_task):
+def test_list_json_schema_for_task_with_input_schema(base_task):
     # Arrange
     base_task.input_json_schema = json.dumps(
         {
@@ -222,9 +222,9 @@ def test_list_json_schema_for_task_with_input_schema_non_ascii(base_task):
     assert "年齢" in schema
 
 
-def test_list_json_schema_for_task_without_output_schema(base_task):
+def test_list_json_schema_for_task_without_input_schema(base_task):
     # Arrange
-    base_task.output_json_schema = None
+    base_task.input_json_schema = None
 
     # Act
     schema = list_json_schema_for_task(base_task)


### PR DESCRIPTION
## What does this PR do?

This PR fixes:
- bug: a task with structured input will have its schema ASCII-escaped in the sample input generation task (due to `list_json_schema_for_task`), which would cause issues if the schema contains Unicode characters
- test: two existing tests had seemingly contradictory naming, and one test seemed to accidentally be setting `output_json_schema = None` instead of `input_json_schema = None`

## Related Issues

Part of a group of bugs caused by escaped Unicode: https://github.com/Kiln-AI/Kiln/issues/95

This seems like this was the last unicode-related issue I found - the remaining `json.dumps` are not serializing user-supplied data that could contain non-ASCII.

This seems

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
