### PR TITLE
fix: fireworks.ai URL has changed

### DIFF
--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
@@ -98,7 +98,7 @@
       return `https://platform.openai.com/finetune/${finetune.finetune.provider_id}`
     } else if (finetune?.finetune.provider === "fireworks_ai") {
       const url_id = finetune.finetune.provider_id?.split("/").pop()
-      return `https://fireworks.ai/dashboard/fine-tuning/${url_id}`
+      return `https://fireworks.ai/dashboard/fine-tuning/v1/${url_id}`
     }
     return undefined
   }


### PR DESCRIPTION
## What does this PR do?

Fireworks.ai has moved their fine-tuning job detail page under a `v1/` prefix. The link shown in the Fine Tune detail page for a Fireworks.ai fine-tune job in the Kiln dashboard now leads to a 404.

## Related Issues

- fixes: https://github.com/Kiln-AI/Kiln/issues/127

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
