### PR TITLE
Make custom models and fine-tunes work in our new adapter regsitry

### DIFF
--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -10,6 +10,7 @@ from kiln_ai.adapters.model_adapters.openai_model_adapter import (
     OpenAICompatibleConfig,
 )
 from kiln_ai.adapters.prompt_builders import BasePromptBuilder
+from kiln_ai.adapters.provider_tools import core_provider
 from kiln_ai.utils.config import Config
 
 
@@ -20,7 +21,10 @@ def adapter_for_task(
     prompt_builder: BasePromptBuilder | None = None,
     tags: list[str] | None = None,
 ) -> BaseAdapter:
-    match provider:
+    # Get the provider to run. For things like the fine-tune provider, we want to run the underlying provider
+    core_provider_name = core_provider(model_name, provider)
+
+    match core_provider_name:
         case ModelProviderName.openrouter:
             return OpenAICompatibleAdapter(
                 kiln_task=kiln_task,

--- a/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
@@ -218,13 +218,21 @@ class OpenAICompatibleAdapter(BaseAdapter):
                 return NoReturn
 
     def tool_call_params(self) -> dict[str, Any]:
+        # Add additional_properties: false to the schema (OpenAI requires this for some models)
+        output_schema = self.kiln_task.output_schema()
+        if not isinstance(output_schema, dict):
+            raise ValueError(
+                "Invalid output schema for this task. Can not use tool calls."
+            )
+        output_schema["additionalProperties"] = False
+
         return {
             "tools": [
                 {
                     "type": "function",
                     "function": {
                         "name": "task_response",
-                        "parameters": self.kiln_task.output_schema(),
+                        "parameters": output_schema,
                         "strict": True,
                     },
                 }

--- a/libs/core/kiln_ai/datamodel/model_cache.py
+++ b/libs/core/kiln_ai/datamodel/model_cache.py
@@ -65,7 +65,7 @@ class ModelCache:
     def get_model(
         self, path: Path, model_type: Type[T], readonly: bool = False
     ) -> Optional[T]:
-        # We return a copy so in-memory edits don't impact the cache until they are saved
+        # We return a copy by default, so in-memory edits don't impact the cache until they are saved
         # Benchmark shows about 2x slower, but much more foolproof
         model = self._get_model(path, model_type)
         if model:


### PR DESCRIPTION
Now they use the correct adapter (OpenAI for OpenAI fine-tunes or custom models, etc)

Improve fine-tune cache.
