### PR TITLE
Full support for "thinking" models, and an OpenAI adapter

### DIFF
--- a/app/desktop/studio_server/data_gen_api.py
+++ b/app/desktop/studio_server/data_gen_api.py
@@ -8,6 +8,7 @@ from kiln_ai.adapters.data_gen.data_gen_task import (
 )
 from kiln_ai.adapters.prompt_builders import prompt_builder_from_ui_name
 from kiln_ai.datamodel import DataSource, DataSourceType, TaskRun
+from kiln_server.run_api import model_provider_from_string
 from kiln_server.task_api import task_from_id
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -83,7 +84,7 @@ def connect_data_gen_api(app: FastAPI):
         adapter = adapter_for_task(
             categories_task,
             model_name=input.model_name,
-            provider=input.provider,
+            provider=model_provider_from_string(input.provider),
         )
 
         categories_run = await adapter.invoke(task_input.model_dump())
@@ -106,7 +107,7 @@ def connect_data_gen_api(app: FastAPI):
         adapter = adapter_for_task(
             sample_task,
             model_name=input.model_name,
-            provider=input.provider,
+            provider=model_provider_from_string(input.provider),
         )
 
         samples_run = await adapter.invoke(task_input.model_dump())
@@ -130,7 +131,7 @@ def connect_data_gen_api(app: FastAPI):
         adapter = adapter_for_task(
             task,
             model_name=sample.output_model_name,
-            provider=sample.output_provider,
+            provider=model_provider_from_string(sample.output_provider),
             prompt_builder=prompt_builder,
             tags=tags,
         )

--- a/app/desktop/studio_server/finetune_api.py
+++ b/app/desktop/studio_server/finetune_api.py
@@ -317,7 +317,9 @@ def system_message_from_request(
             )
         try:
             prompt_builder = prompt_builder_from_ui_name(system_message_generator, task)
-            system_message = prompt_builder.build_prompt()
+            system_message = prompt_builder.build_prompt(
+                include_json_instructions=False
+            )
         except Exception as e:
             raise HTTPException(
                 status_code=400,

--- a/app/desktop/studio_server/repair_api.py
+++ b/app/desktop/studio_server/repair_api.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException
 from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.repair.repair_task import RepairTaskRun
 from kiln_ai.datamodel import TaskRun
-from kiln_server.run_api import task_and_run_from_id
+from kiln_server.run_api import model_provider_from_string, task_and_run_from_id
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -60,7 +60,9 @@ def connect_repair_api(app: FastAPI):
             )
 
         adapter = adapter_for_task(
-            repair_task, model_name=model_name, provider=provider
+            repair_task,
+            model_name=model_name,
+            provider=model_provider_from_string(provider),
         )
 
         repair_run = await adapter.invoke(repair_task_input.model_dump())

--- a/app/desktop/studio_server/test_prompt_api.py
+++ b/app/desktop/studio_server/test_prompt_api.py
@@ -24,7 +24,7 @@ class MockPromptBuilder(BasePromptBuilder):
     def prompt_builder_name(cls):
         return "MockPromptBuilder"
 
-    def build_prompt(self):
+    def build_base_prompt(self):
         return "Mock prompt"
 
     def build_prompt_for_ui(self):

--- a/libs/core/kiln_ai/adapters/__init__.py
+++ b/libs/core/kiln_ai/adapters/__init__.py
@@ -3,31 +3,31 @@
 
 Adapters are used to connect Kiln to external systems, or to add new functionality to Kiln.
 
-BaseAdapter is extensible, and used for adding adapters that provide AI functionality. There's currently a LangChain adapter which provides a bridge to LangChain.
+Model adapters are used to call AI models, like Ollama, OpenAI, Anthropic, etc.
 
 The ml_model_list submodule contains a list of models that can be used for machine learning tasks. More can easily be added, but we keep a list here of models that are known to work well with Kiln's structured data and tool calling systems.
 
 The prompt_builders submodule contains classes that build prompts for use with the AI agents.
 
 The repair submodule contains an adapter for the repair task.
+
+The parser submodule contains parsers for the output of the AI models.
 """
 
 from . import (
-    base_adapter,
     data_gen,
     fine_tune,
-    langchain_adapters,
     ml_model_list,
+    model_adapters,
     prompt_builders,
     repair,
 )
 
 __all__ = [
-    "base_adapter",
-    "langchain_adapters",
+    "model_adapters",
+    "data_gen",
+    "fine_tune",
     "ml_model_list",
     "prompt_builders",
     "repair",
-    "data_gen",
-    "fine_tune",
 ]

--- a/libs/core/kiln_ai/adapters/__init__.py
+++ b/libs/core/kiln_ai/adapters/__init__.py
@@ -3,7 +3,7 @@
 
 Adapters are used to connect Kiln to external systems, or to add new functionality to Kiln.
 
-Model adapters are used to call AI models, like Ollama, OpenAI, Anthropic, etc.
+Model adapters are used to call AI models, like Ollama, OpenAI, etc.
 
 The ml_model_list submodule contains a list of models that can be used for machine learning tasks. More can easily be added, but we keep a list here of models that are known to work well with Kiln's structured data and tool calling systems.
 

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -71,10 +71,15 @@ def adapter_for_task(
             pass
         case ModelProviderName.fireworks_ai:
             pass
+        # These are virtual providers that should have mapped to an actual provider in core_provider
         case ModelProviderName.kiln_fine_tune:
-            pass
+            raise ValueError(
+                "Fine tune is not a supported core provider. It should map to an actual provider."
+            )
         case ModelProviderName.kiln_custom_registry:
-            pass
+            raise ValueError(
+                "Custom openai compatible provider is not a supported core provider. It should map to an actual provider."
+            )
         case _:
             raise ValueError(f"Unsupported provider: {provider}")
             # Triggers typechecking if I miss a case

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -10,6 +10,7 @@ from kiln_ai.adapters.model_adapters.openai_model_adapter import (
     OpenAICompatibleConfig,
 )
 from kiln_ai.adapters.prompt_builders import BasePromptBuilder
+from kiln_ai.adapters.provider_tools import core_provider
 from kiln_ai.utils.config import Config
 
 
@@ -20,7 +21,10 @@ def adapter_for_task(
     prompt_builder: BasePromptBuilder | None = None,
     tags: list[str] | None = None,
 ) -> BaseAdapter:
-    match provider:
+    # Get the provider to run. For things like the fine-tune provider, we want to run the underlying provider
+    core_provider_name = core_provider(model_name, provider)
+
+    match core_provider_name:
         case ModelProviderName.openrouter:
             return OpenAICompatibleAdapter(
                 kiln_task=kiln_task,

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -1,17 +1,44 @@
+from os import getenv
+
 from kiln_ai import datamodel
-from kiln_ai.adapters.base_adapter import BaseAdapter
-from kiln_ai.adapters.langchain_adapters import LangchainAdapter
+from kiln_ai.adapters.ml_model_list import ModelProviderName
+from kiln_ai.adapters.model_adapters.base_adapter import BaseAdapter
+from kiln_ai.adapters.model_adapters.langchain_adapters import LangchainAdapter
+from kiln_ai.adapters.model_adapters.openai_model_adapter import (
+    OpenAICompatibleAdapter,
+    OpenAICompatibleConfig,
+)
 from kiln_ai.adapters.prompt_builders import BasePromptBuilder
+from kiln_ai.utils.config import Config
 
 
 def adapter_for_task(
     kiln_task: datamodel.Task,
-    model_name: str | None = None,
+    model_name: str,
     provider: str | None = None,
     prompt_builder: BasePromptBuilder | None = None,
     tags: list[str] | None = None,
 ) -> BaseAdapter:
-    # We use langchain for everything right now, but can add any others here
+    if provider == ModelProviderName.openrouter:
+        return OpenAICompatibleAdapter(
+            kiln_task=kiln_task,
+            config=OpenAICompatibleConfig(
+                base_url=getenv("OPENROUTER_BASE_URL")
+                or "https://openrouter.ai/api/v1",
+                api_key=Config.shared().open_router_api_key,
+                model_name=model_name,
+                provider_name=provider,
+                openrouter_style_reasoning=True,
+                default_headers={
+                    "HTTP-Referer": "https://getkiln.ai/openrouter",
+                    "X-Title": "KilnAI",
+                },
+            ),
+            prompt_builder=prompt_builder,
+            tags=tags,
+        )
+
+    # We use langchain for all others right now, but moving off it as we touch anything.
     return LangchainAdapter(
         kiln_task,
         model_name=model_name,

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -10,7 +10,7 @@ from kiln_ai.adapters.model_adapters.openai_model_adapter import (
     OpenAICompatibleConfig,
 )
 from kiln_ai.adapters.prompt_builders import BasePromptBuilder
-from kiln_ai.adapters.provider_tools import core_provider
+from kiln_ai.adapters.provider_tools import core_provider, openai_compatible_config
 from kiln_ai.utils.config import Config
 
 
@@ -54,9 +54,15 @@ def adapter_for_task(
                 prompt_builder=prompt_builder,
                 tags=tags,
             )
-        # Use LangchainAdapter for the rest
         case ModelProviderName.openai_compatible:
-            pass
+            config = openai_compatible_config(model_name)
+            return OpenAICompatibleAdapter(
+                kiln_task=kiln_task,
+                config=config,
+                prompt_builder=prompt_builder,
+                tags=tags,
+            )
+        # Use LangchainAdapter for the rest
         case ModelProviderName.groq:
             pass
         case ModelProviderName.amazon_bedrock:

--- a/libs/core/kiln_ai/adapters/data_gen/data_gen_task.py
+++ b/libs/core/kiln_ai/adapters/data_gen/data_gen_task.py
@@ -55,7 +55,7 @@ class DataGenCategoriesTaskInput(BaseModel):
             num_subtopics=num_subtopics,
             human_guidance=human_guidance,
             existing_topics=existing_topics,
-            system_prompt=prompt_builder.build_prompt(),
+            system_prompt=prompt_builder.build_prompt(include_json_instructions=False),
         )
 
 
@@ -132,7 +132,7 @@ class DataGenSampleTaskInput(BaseModel):
             topic=topic,
             num_samples=num_samples,
             human_guidance=human_guidance,
-            system_prompt=prompt_builder.build_prompt(),
+            system_prompt=prompt_builder.build_prompt(include_json_instructions=False),
         )
 
 

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -103,6 +103,7 @@ class KilnModelProvider(BaseModel):
         provider_options: Additional provider-specific configuration options
         structured_output_mode: The mode we should use to call the model for structured output, if it was trained with structured output.
         parser: A parser to use for the model, if applicable
+        reasoning_capable: Whether the model is designed to output thinking in a structured format (eg <think></think>). If so we don't use COT across 2 calls, and ask for thinking and final response in the same call.
     """
 
     name: ModelProviderName
@@ -113,6 +114,7 @@ class KilnModelProvider(BaseModel):
     provider_options: Dict = {}
     structured_output_mode: StructuredOutputMode = StructuredOutputMode.default
     parser: ModelParserID | None = None
+    reasoning_capable: bool = False
 
 
 class KilnModel(BaseModel):
@@ -222,12 +224,14 @@ built_in_models: List[KilnModel] = [
                 provider_options={"model": "deepseek/deepseek-r1"},
                 # No custom parser -- openrouter implemented it themselves
                 structured_output_mode=StructuredOutputMode.json_instructions,
+                reasoning_capable=True,
             ),
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 provider_options={"model": "accounts/fireworks/models/deepseek-r1"},
                 parser=ModelParserID.r1_thinking,
                 structured_output_mode=StructuredOutputMode.json_instructions,
+                reasoning_capable=True,
             ),
             KilnModelProvider(
                 # I want your RAM
@@ -235,6 +239,7 @@ built_in_models: List[KilnModel] = [
                 provider_options={"model": "deepseek-r1:671b"},
                 parser=ModelParserID.r1_thinking,
                 structured_output_mode=StructuredOutputMode.json_instructions,
+                reasoning_capable=True,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -167,7 +167,7 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                provider_options={"model": "openai/gpt-4o-2024-08-06"},
+                provider_options={"model": "openai/gpt-4o"},
                 structured_output_mode=StructuredOutputMode.json_schema,
             ),
         ],

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -309,6 +309,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.amazon_bedrock,
                 structured_output_mode=StructuredOutputMode.json_schema,
+                supports_data_gen=False,
                 provider_options={
                     "model": "meta.llama3-1-8b-instruct-v1:0",
                     "region_name": "us-west-2",  # Llama 3.1 only in west-2
@@ -324,6 +325,7 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
+                supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.function_calling,
                 provider_options={"model": "meta-llama/llama-3.1-8b-instruct"},
             ),
@@ -351,6 +353,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.amazon_bedrock,
                 structured_output_mode=StructuredOutputMode.json_schema,
+                supports_data_gen=False,
                 provider_options={
                     "model": "meta.llama3-1-70b-instruct-v1:0",
                     "region_name": "us-west-2",  # Llama 3.1 only in west-2
@@ -358,6 +361,7 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
+                supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.function_calling,
                 provider_options={"model": "meta-llama/llama-3.1-70b-instruct"},
             ),
@@ -614,6 +618,7 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.fireworks_ai,
                 # No finetune support. https://docs.fireworks.ai/fine-tuning/fine-tuning-models
                 structured_output_mode=StructuredOutputMode.json_mode,
+                supports_data_gen=False,
                 provider_options={
                     "model": "accounts/fireworks/models/phi-3-vision-128k-instruct"
                 },
@@ -709,6 +714,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 provider_options={"model": "mistralai/mixtral-8x7b-instruct"},
+                supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
             ),
             KilnModelProvider(

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -82,6 +82,14 @@ class ModelName(str, Enum):
     deepseek_r1 = "deepseek_r1"
 
 
+class ModelParserID(str, Enum):
+    """
+    Enumeration of supported model parsers.
+    """
+
+    r1_thinking = "r1_thinking"
+
+
 class KilnModelProvider(BaseModel):
     """
     Configuration for a specific model provider.
@@ -94,6 +102,7 @@ class KilnModelProvider(BaseModel):
         provider_finetune_id: The finetune ID for the provider, if applicable
         provider_options: Additional provider-specific configuration options
         structured_output_mode: The mode we should use to call the model for structured output, if it was trained with structured output.
+        parser: A parser to use for the model, if applicable
     """
 
     name: ModelProviderName
@@ -103,6 +112,7 @@ class KilnModelProvider(BaseModel):
     provider_finetune_id: str | None = None
     provider_options: Dict = {}
     structured_output_mode: StructuredOutputMode = StructuredOutputMode.default
+    parser: ModelParserID | None = None
 
 
 class KilnModel(BaseModel):
@@ -170,6 +180,7 @@ built_in_models: List[KilnModel] = [
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
+                structured_output_mode=StructuredOutputMode.function_calling,
                 provider_options={"model": "anthropic/claude-3-5-haiku"},
             ),
         ],
@@ -182,6 +193,7 @@ built_in_models: List[KilnModel] = [
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
+                structured_output_mode=StructuredOutputMode.function_calling,
                 provider_options={"model": "anthropic/claude-3.5-sonnet"},
             ),
         ],
@@ -195,6 +207,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 provider_options={"model": "deepseek/deepseek-chat"},
+                structured_output_mode=StructuredOutputMode.function_calling,
             ),
         ],
     ),
@@ -207,21 +220,21 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 provider_options={"model": "deepseek/deepseek-r1"},
-                structured_output_mode=StructuredOutputMode.json_schema,
+                # No custom parser -- openrouter implemented it themselves
+                structured_output_mode=StructuredOutputMode.json_instructions,
             ),
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 provider_options={"model": "accounts/fireworks/models/deepseek-r1"},
-                # Truncates the thinking, but json_mode works
-                structured_output_mode=StructuredOutputMode.json_mode,
-                supports_structured_output=False,
-                supports_data_gen=False,
+                parser=ModelParserID.r1_thinking,
+                structured_output_mode=StructuredOutputMode.json_instructions,
             ),
             KilnModelProvider(
                 # I want your RAM
                 name=ModelProviderName.ollama,
                 provider_options={"model": "deepseek-r1:671b"},
-                structured_output_mode=StructuredOutputMode.json_schema,
+                parser=ModelParserID.r1_thinking,
+                structured_output_mode=StructuredOutputMode.json_instructions,
             ),
         ],
     ),
@@ -306,7 +319,7 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                structured_output_mode=StructuredOutputMode.json_schema,
+                structured_output_mode=StructuredOutputMode.function_calling,
                 provider_options={"model": "meta-llama/llama-3.1-8b-instruct"},
             ),
             KilnModelProvider(
@@ -340,7 +353,7 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                structured_output_mode=StructuredOutputMode.json_schema,
+                structured_output_mode=StructuredOutputMode.function_calling,
                 provider_options={"model": "meta-llama/llama-3.1-70b-instruct"},
             ),
             KilnModelProvider(
@@ -381,7 +394,7 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                structured_output_mode=StructuredOutputMode.json_schema,
+                structured_output_mode=StructuredOutputMode.function_calling,
                 provider_options={"model": "meta-llama/llama-3.1-405b-instruct"},
             ),
             KilnModelProvider(
@@ -403,6 +416,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 provider_options={"model": "mistralai/mistral-nemo"},
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
             ),
         ],
     ),
@@ -442,6 +456,7 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.openrouter,
                 supports_structured_output=False,
                 supports_data_gen=False,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 provider_options={"model": "meta-llama/llama-3.2-1b-instruct"},
             ),
             KilnModelProvider(
@@ -462,6 +477,7 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.openrouter,
                 supports_structured_output=False,
                 supports_data_gen=False,
+                structured_output_mode=StructuredOutputMode.json_schema,
                 provider_options={"model": "meta-llama/llama-3.2-3b-instruct"},
             ),
             KilnModelProvider(
@@ -587,6 +603,7 @@ built_in_models: List[KilnModel] = [
                 supports_structured_output=False,
                 supports_data_gen=False,
                 provider_options={"model": "microsoft/phi-3.5-mini-128k-instruct"},
+                structured_output_mode=StructuredOutputMode.json_schema,
             ),
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
@@ -612,8 +629,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 # JSON mode not consistent enough to enable in UI
-                structured_output_mode=StructuredOutputMode.json_mode,
-                supports_structured_output=False,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=False,
                 provider_options={"model": "microsoft/phi-4"},
             ),
@@ -651,7 +667,7 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                structured_output_mode=StructuredOutputMode.json_schema,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=False,
                 provider_options={"model": "google/gemma-2-9b-it"},
             ),
@@ -673,6 +689,7 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=False,
                 provider_options={"model": "google/gemma-2-27b-it"},
             ),
@@ -687,7 +704,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 provider_options={"model": "mistralai/mixtral-8x7b-instruct"},
-                structured_output_mode=StructuredOutputMode.json_schema,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
             ),
             KilnModelProvider(
                 name=ModelProviderName.ollama,
@@ -705,7 +722,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 provider_options={"model": "qwen/qwen-2.5-7b-instruct"},
-                structured_output_mode=StructuredOutputMode.json_schema,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
             ),
             KilnModelProvider(
                 name=ModelProviderName.ollama,
@@ -726,7 +743,7 @@ built_in_models: List[KilnModel] = [
                 # Not consistent with structure data. Works sometimes but not often
                 supports_structured_output=False,
                 supports_data_gen=False,
-                structured_output_mode=StructuredOutputMode.json_schema,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
             ),
             KilnModelProvider(
                 name=ModelProviderName.ollama,

--- a/libs/core/kiln_ai/adapters/model_adapters/__init__.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/__init__.py
@@ -1,0 +1,18 @@
+"""
+# Model Adapters
+
+Model adapters are used to call AI models, like Ollama, OpenAI, Anthropic, etc.
+
+"""
+
+from . import (
+    base_adapter,
+    langchain_adapters,
+    openai_model_adapter,
+)
+
+__all__ = [
+    "base_adapter",
+    "langchain_adapters",
+    "openai_model_adapter",
+]

--- a/libs/core/kiln_ai/adapters/model_adapters/__init__.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/__init__.py
@@ -1,7 +1,7 @@
 """
 # Model Adapters
 
-Model adapters are used to call AI models, like Ollama, OpenAI, Anthropic, etc.
+Model adapters are used to call AI models, like Ollama, OpenAI, etc.
 
 """
 

--- a/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
@@ -10,7 +10,6 @@ from langchain_core.runnables import Runnable
 from langchain_fireworks import ChatFireworks
 from langchain_groq import ChatGroq
 from langchain_ollama import ChatOllama
-from langchain_openai import ChatOpenAI
 from pydantic import BaseModel
 
 import kiln_ai.datamodel as datamodel
@@ -256,8 +255,8 @@ async def langchain_model_from_provider(
         # We use the OpenAICompatibleAdapter for OpenAI
         raise ValueError("OpenAI is not supported in Langchain adapter")
     elif provider.name == ModelProviderName.openai_compatible:
-        # See provider_tools.py for how base_url, key and other parameters are set
-        return ChatOpenAI(**provider.provider_options)  # type: ignore[arg-type]
+        # We use the OpenAICompatibleAdapter for OpenAI compatible
+        raise ValueError("OpenAI compatible is not supported in Langchain adapter")
     elif provider.name == ModelProviderName.groq:
         api_key = Config.shared().groq_api_key
         if api_key is None:

--- a/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
@@ -1,5 +1,4 @@
 import os
-from os import getenv
 from typing import Any, Dict, NoReturn
 
 from langchain_aws import ChatBedrockConverse
@@ -15,16 +14,23 @@ from langchain_openai import ChatOpenAI
 from pydantic import BaseModel
 
 import kiln_ai.datamodel as datamodel
+from kiln_ai.adapters.ml_model_list import (
+    KilnModelProvider,
+    ModelProviderName,
+    StructuredOutputMode,
+)
+from kiln_ai.adapters.model_adapters.base_adapter import (
+    AdapterInfo,
+    BaseAdapter,
+    BasePromptBuilder,
+    RunOutput,
+)
 from kiln_ai.adapters.ollama_tools import (
     get_ollama_connection,
     ollama_base_url,
     ollama_model_installed,
 )
 from kiln_ai.utils.config import Config
-
-from .base_adapter import AdapterInfo, BaseAdapter, BasePromptBuilder, RunOutput
-from .ml_model_list import KilnModelProvider, ModelProviderName, StructuredOutputMode
-from .provider_tools import kiln_model_provider_from
 
 LangChainModelType = BaseChatModel | Runnable[LanguageModelInput, Dict | BaseModel]
 
@@ -41,39 +47,62 @@ class LangchainAdapter(BaseAdapter):
         prompt_builder: BasePromptBuilder | None = None,
         tags: list[str] | None = None,
     ):
-        super().__init__(kiln_task, prompt_builder=prompt_builder, tags=tags)
         if custom_model is not None:
             self._model = custom_model
 
             # Attempt to infer model provider and name from custom model
-            self.model_provider = "custom.langchain:" + custom_model.__class__.__name__
-            self.model_name = "custom.langchain:unknown_model"
-            if hasattr(custom_model, "model_name") and isinstance(
-                getattr(custom_model, "model_name"), str
-            ):
-                self.model_name = "custom.langchain:" + getattr(
-                    custom_model, "model_name"
-                )
-            if hasattr(custom_model, "model") and isinstance(
-                getattr(custom_model, "model"), str
-            ):
-                self.model_name = "custom.langchain:" + getattr(custom_model, "model")
+            if provider is None:
+                provider = "custom.langchain:" + custom_model.__class__.__name__
+
+            if model_name is None:
+                model_name = "custom.langchain:unknown_model"
+                if hasattr(custom_model, "model_name") and isinstance(
+                    getattr(custom_model, "model_name"), str
+                ):
+                    model_name = "custom.langchain:" + getattr(
+                        custom_model, "model_name"
+                    )
+                if hasattr(custom_model, "model") and isinstance(
+                    getattr(custom_model, "model"), str
+                ):
+                    model_name = "custom.langchain:" + getattr(custom_model, "model")
         elif model_name is not None:
-            self.model_name = model_name
-            self.model_provider = provider or "custom.langchain.default_provider"
+            # default provider name if not provided
+            provider = provider or "custom.langchain.default_provider"
         else:
             raise ValueError(
                 "model_name and provider must be provided if custom_model is not provided"
             )
+
+        if model_name is None:
+            raise ValueError("model_name must be provided")
+
+        super().__init__(
+            kiln_task,
+            model_name=model_name,
+            model_provider_name=provider,
+            prompt_builder=prompt_builder,
+            tags=tags,
+        )
 
     async def model(self) -> LangChainModelType:
         # cached model
         if self._model:
             return self._model
 
-        self._model = await langchain_model_from(self.model_name, self.model_provider)
+        self._model = await self.langchain_model_from()
 
-        if self.has_structured_output():
+        # Decide if we want to use Langchain's structured output:
+        # 1. Only for structured tasks
+        # 2. Only if the provider's mode isn't json_instructions (only mode that doesn't use an API option for structured output capabilities)
+        provider = await self.model_provider()
+        use_lc_structured_output = (
+            self.has_structured_output()
+            and provider.structured_output_mode
+            != StructuredOutputMode.json_instructions
+        )
+
+        if use_lc_structured_output:
             if not hasattr(self._model, "with_structured_output") or not callable(
                 getattr(self._model, "with_structured_output")
             ):
@@ -88,8 +117,8 @@ class LangchainAdapter(BaseAdapter):
                 )
             output_schema["title"] = "task_response"
             output_schema["description"] = "A response from the task"
-            with_structured_output_options = await get_structured_output_options(
-                self.model_name, self.model_provider
+            with_structured_output_options = await self.get_structured_output_options(
+                self.model_name, self.model_provider_name
             )
             self._model = self._model.with_structured_output(
                 output_schema,
@@ -103,20 +132,19 @@ class LangchainAdapter(BaseAdapter):
         chain = model
         intermediate_outputs = {}
 
-        prompt = self.build_prompt()
+        prompt = await self.build_prompt()
         user_msg = self.prompt_builder.build_user_message(input)
         messages = [
             SystemMessage(content=prompt),
             HumanMessage(content=user_msg),
         ]
 
+        # TODO: make this compatible with thinking models
         # COT with structured output
         cot_prompt = self.prompt_builder.chain_of_thought_prompt()
         if cot_prompt and self.has_structured_output():
             # Base model (without structured output) used for COT message
-            base_model = await langchain_model_from(
-                self.model_name, self.model_provider
-            )
+            base_model = await self.langchain_model_from()
             messages.append(
                 SystemMessage(content=cot_prompt),
             )
@@ -133,33 +161,36 @@ class LangchainAdapter(BaseAdapter):
 
         response = await chain.ainvoke(messages)
 
-        if self.has_structured_output():
-            if (
-                not isinstance(response, dict)
-                or "parsed" not in response
-                or not isinstance(response["parsed"], dict)
-            ):
-                raise RuntimeError(f"structured response not returned: {response}")
+        # Langchain may have already parsed the response into structured output, so use that if available.
+        # However, a plain string may still be fixed at the parsing layer, so not being structured isn't a critical failure (yet)
+        if (
+            self.has_structured_output()
+            and isinstance(response, dict)
+            and "parsed" in response
+            and isinstance(response["parsed"], dict)
+        ):
             structured_response = response["parsed"]
             return RunOutput(
                 output=self._munge_response(structured_response),
                 intermediate_outputs=intermediate_outputs,
             )
-        else:
-            if not isinstance(response, BaseMessage):
-                raise RuntimeError(f"response is not a BaseMessage: {response}")
-            text_content = response.content
-            if not isinstance(text_content, str):
-                raise RuntimeError(f"response is not a string: {text_content}")
-            return RunOutput(
-                output=text_content,
-                intermediate_outputs=intermediate_outputs,
-            )
+
+        if not isinstance(response, BaseMessage):
+            raise RuntimeError(f"response is not a BaseMessage: {response}")
+
+        text_content = response.content
+        if not isinstance(text_content, str):
+            raise RuntimeError(f"response is not a string: {text_content}")
+
+        return RunOutput(
+            output=text_content,
+            intermediate_outputs=intermediate_outputs,
+        )
 
     def adapter_info(self) -> AdapterInfo:
         return AdapterInfo(
             model_name=self.model_name,
-            model_provider=self.model_provider,
+            model_provider=self.model_provider_name,
             adapter_name="kiln_langchain_adapter",
             prompt_builder_name=self.prompt_builder.__class__.prompt_builder_name(),
             prompt_id=self.prompt_builder.prompt_id(),
@@ -175,38 +206,40 @@ class LangchainAdapter(BaseAdapter):
             return response["arguments"]
         return response
 
+    async def get_structured_output_options(
+        self, model_name: str, model_provider_name: str
+    ) -> Dict[str, Any]:
+        provider = await self.model_provider()
+        if not provider:
+            return {}
 
-async def get_structured_output_options(
-    model_name: str, model_provider: str
-) -> Dict[str, Any]:
-    finetune_provider = await kiln_model_provider_from(model_name, model_provider)
-    if not finetune_provider:
-        return {}
+        options = {}
+        # We may need to add some provider specific logic here if providers use different names for the same mode, but everyone is copying openai for now
+        match provider.structured_output_mode:
+            case StructuredOutputMode.function_calling:
+                options["method"] = "function_calling"
+            case StructuredOutputMode.json_mode:
+                options["method"] = "json_mode"
+            case StructuredOutputMode.json_schema:
+                options["method"] = "json_schema"
+            case StructuredOutputMode.json_instructions:
+                # JSON done via instructions in prompt, not via API
+                pass
+            case StructuredOutputMode.default:
+                # Let langchain decide the default
+                pass
+            case _:
+                raise ValueError(
+                    f"Unhandled enum value: {provider.structured_output_mode}"
+                )
+                # triggers pyright warning if I miss a case
+                return NoReturn
 
-    options = {}
-    # We may need to add some provider specific logic here if providers use different names for the same mode, but everyone is copying openai for now
-    match finetune_provider.structured_output_mode:
-        case StructuredOutputMode.function_calling:
-            options["method"] = "function_calling"
-        case StructuredOutputMode.json_mode:
-            options["method"] = "json_mode"
-        case StructuredOutputMode.json_schema:
-            options["method"] = "json_schema"
-        case StructuredOutputMode.default:
-            # Let langchain decide the default
-            pass
-        case _:
-            # triggers pyright warning if I miss a case
-            raise_exhaustive_error(finetune_provider.structured_output_mode)
+        return options
 
-    return options
-
-
-async def langchain_model_from(
-    name: str, provider_name: str | None = None
-) -> BaseChatModel:
-    provider = await kiln_model_provider_from(name, provider_name)
-    return await langchain_model_from_provider(provider, name)
+    async def langchain_model_from(self) -> BaseChatModel:
+        provider = await self.model_provider()
+        return await langchain_model_from_provider(provider, self.model_name)
 
 
 async def langchain_model_from_provider(
@@ -257,20 +290,6 @@ async def langchain_model_from_provider(
 
         raise ValueError(f"Model {model_name} not installed on Ollama")
     elif provider.name == ModelProviderName.openrouter:
-        api_key = Config.shared().open_router_api_key
-        base_url = getenv("OPENROUTER_BASE_URL") or "https://openrouter.ai/api/v1"
-        return ChatOpenAI(
-            **provider.provider_options,
-            openai_api_key=api_key,  # type: ignore[arg-type]
-            openai_api_base=base_url,  # type: ignore[arg-type]
-            default_headers={
-                "HTTP-Referer": "https://getkiln.ai/openrouter",
-                "X-Title": "KilnAI",
-            },
-        )
+        raise ValueError("OpenRouter is not supported in Langchain adapter")
     else:
         raise ValueError(f"Invalid model or provider: {model_name} - {provider.name}")
-
-
-def raise_exhaustive_error(value: NoReturn) -> NoReturn:
-    raise ValueError(f"Unhandled enum value: {value}")

--- a/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
@@ -160,7 +160,7 @@ class LangchainAdapter(BaseAdapter):
             intermediate_outputs["chain_of_thought"] = cot_response.content
             messages.append(AIMessage(content=cot_response.content))
             messages.append(
-                SystemMessage(content="Considering the above, return a final result.")
+                HumanMessage(content="Considering the above, return a final result.")
             )
 
         response = await chain.ainvoke(messages)

--- a/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
@@ -246,8 +246,8 @@ async def langchain_model_from_provider(
     provider: KilnModelProvider, model_name: str
 ) -> BaseChatModel:
     if provider.name == ModelProviderName.openai:
-        api_key = Config.shared().open_ai_api_key
-        return ChatOpenAI(**provider.provider_options, openai_api_key=api_key)  # type: ignore[arg-type]
+        # We use the OpenAICompatibleAdapter for OpenAI
+        raise ValueError("OpenAI is not supported in Langchain adapter")
     elif provider.name == ModelProviderName.openai_compatible:
         # See provider_tools.py for how base_url, key and other parameters are set
         return ChatOpenAI(**provider.provider_options)  # type: ignore[arg-type]

--- a/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/langchain_adapters.py
@@ -128,6 +128,7 @@ class LangchainAdapter(BaseAdapter):
         return self._model
 
     async def _run(self, input: Dict | str) -> RunOutput:
+        provider = await self.model_provider()
         model = await self.model()
         chain = model
         intermediate_outputs = {}
@@ -139,10 +140,18 @@ class LangchainAdapter(BaseAdapter):
             HumanMessage(content=user_msg),
         ]
 
-        # TODO: make this compatible with thinking models
-        # COT with structured output
+        # Handle chain of thought if enabled. 3 Modes:
+        # 1. Unstructured output: just call the LLM, with prompting for thinking
+        # 2. "Thinking" LLM designed to output thinking in a structured format: we make 1 call to the LLM, which outputs thinking in a structured format.
+        # 3. Normal LLM with structured output: we make 2 calls to the LLM - one for thinking and one for the final response. This helps us use the LLM's structured output modes (json_schema, tools, etc), which can't be used in a single call.
         cot_prompt = self.prompt_builder.chain_of_thought_prompt()
-        if cot_prompt and self.has_structured_output():
+        thinking_llm = provider.reasoning_capable
+
+        if cot_prompt and (not self.has_structured_output() or thinking_llm):
+            # Case 1 or 2: Unstructured output, or "Thinking" LLM designed to output thinking in a structured format
+            messages.append({"role": "system", "content": cot_prompt})
+        elif not thinking_llm and cot_prompt and self.has_structured_output():
+            # Case 3: Normal LLM with structured output
             # Base model (without structured output) used for COT message
             base_model = await self.langchain_model_from()
             messages.append(
@@ -156,8 +165,6 @@ class LangchainAdapter(BaseAdapter):
             messages.append(
                 SystemMessage(content="Considering the above, return a final result.")
             )
-        elif cot_prompt:
-            messages.append(SystemMessage(content=cot_prompt))
 
         response = await chain.ainvoke(messages)
 

--- a/libs/core/kiln_ai/adapters/model_adapters/openai_compatible_config.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/openai_compatible_config.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class OpenAICompatibleConfig:
+    api_key: str
+    model_name: str
+    provider_name: str
+    base_url: str | None = None  # Defaults to OpenAI
+    default_headers: dict[str, str] | None = None
+    openrouter_style_reasoning: bool = False

--- a/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
@@ -25,7 +25,7 @@ class OpenAICompatibleConfig:
     api_key: str
     model_name: str
     provider_name: str
-    base_url: str | None = None
+    base_url: str | None = None  # Defaults to OpenAI
     default_headers: dict[str, str] | None = None
     openrouter_style_reasoning: bool = False
 

--- a/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
@@ -218,13 +218,21 @@ class OpenAICompatibleAdapter(BaseAdapter):
                 return NoReturn
 
     def tool_call_params(self) -> dict[str, Any]:
+        # Add additional_properties: false to the schema (OpenAI requires this for some models)
+        output_schema = self.kiln_task.output_schema()
+        if not isinstance(output_schema, dict):
+            raise ValueError(
+                "Invalid output schema for this task. Can not use tool calls."
+            )
+        output_schema["additionalProperties"] = False
+
         return {
             "tools": [
                 {
                     "type": "function",
                     "function": {
                         "name": "task_response",
-                        "parameters": self.kiln_task.output_schema(),
+                        "parameters": output_schema,
                         "strict": True,
                     },
                 }

--- a/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
@@ -1,0 +1,228 @@
+from dataclasses import dataclass
+from typing import Any, Dict, NoReturn
+
+from openai import AsyncOpenAI
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionSystemMessageParam,
+    ChatCompletionUserMessageParam,
+)
+
+import kiln_ai.datamodel as datamodel
+from kiln_ai.adapters.ml_model_list import StructuredOutputMode
+from kiln_ai.adapters.model_adapters.base_adapter import (
+    AdapterInfo,
+    BaseAdapter,
+    BasePromptBuilder,
+    RunOutput,
+)
+from kiln_ai.adapters.parsers.json_parser import parse_json_string
+
+
+@dataclass
+class OpenAICompatibleConfig:
+    api_key: str
+    model_name: str
+    provider_name: str
+    base_url: str | None = None
+    default_headers: dict[str, str] | None = None
+    openrouter_style_reasoning: bool = False
+
+
+class OpenAICompatibleAdapter(BaseAdapter):
+    def __init__(
+        self,
+        config: OpenAICompatibleConfig,
+        kiln_task: datamodel.Task,
+        prompt_builder: BasePromptBuilder | None = None,
+        tags: list[str] | None = None,
+    ):
+        self.config = config
+        self.client = AsyncOpenAI(
+            api_key=config.api_key,
+            base_url=config.base_url,
+            default_headers=config.default_headers,
+        )
+
+        super().__init__(
+            kiln_task,
+            model_name=config.model_name,
+            model_provider_name=config.provider_name,
+            prompt_builder=prompt_builder,
+            tags=tags,
+        )
+
+    async def _run(self, input: Dict | str) -> RunOutput:
+        provider = await self.model_provider()
+
+        intermediate_outputs: dict[str, str] = {}
+
+        prompt = await self.build_prompt()
+        user_msg = self.prompt_builder.build_user_message(input)
+        messages = [
+            ChatCompletionSystemMessageParam(role="system", content=prompt),
+            ChatCompletionUserMessageParam(role="user", content=user_msg),
+        ]
+
+        # Handle chain of thought if enabled
+        cot_prompt = self.prompt_builder.chain_of_thought_prompt()
+        if cot_prompt and self.has_structured_output():
+            # TODO P0: Fix COT
+            messages.append({"role": "system", "content": cot_prompt})
+
+            # First call for chain of thought
+            cot_response = await self.client.chat.completions.create(
+                model=self.model_name,
+                messages=messages,
+            )
+            cot_content = cot_response.choices[0].message.content
+            if cot_content is not None:
+                intermediate_outputs["chain_of_thought"] = cot_content
+
+            messages.extend(
+                [
+                    ChatCompletionAssistantMessageParam(
+                        role="assistant", content=cot_content
+                    ),
+                    ChatCompletionSystemMessageParam(
+                        role="system",
+                        content="Considering the above, return a final result.",
+                    ),
+                ]
+            )
+        elif cot_prompt:
+            messages.append({"role": "system", "content": cot_prompt})
+        else:
+            intermediate_outputs = {}
+
+        # Main completion call
+        response_format_options = await self.response_format_options()
+        response = await self.client.chat.completions.create(
+            model=provider.provider_options["model"],
+            messages=messages,
+            extra_body={"include_reasoning": True}
+            if self.config.openrouter_style_reasoning
+            else {},
+            **response_format_options,
+        )
+
+        if not isinstance(response, ChatCompletion):
+            raise RuntimeError(
+                f"Expected ChatCompletion response, got {type(response)}."
+            )
+
+        if hasattr(response, "error") and response.error:  # pyright: ignore
+            raise RuntimeError(
+                f"OpenAI compatible API returned status code {response.error.get('code')}: {response.error.get('message') or 'Unknown error'}."  # pyright: ignore
+            )
+        if not response.choices or len(response.choices) == 0:
+            raise RuntimeError(
+                "No message content returned in the response from OpenAI compatible API"
+            )
+
+        message = response.choices[0].message
+
+        # Save reasoning if it exists
+        if (
+            self.config.openrouter_style_reasoning
+            and hasattr(message, "reasoning")
+            and message.reasoning  # pyright: ignore
+        ):
+            intermediate_outputs["reasoning"] = message.reasoning  # pyright: ignore
+
+        # the string content of the response
+        response_content = message.content
+
+        # Fallback: Use args of first tool call to task_response if it exists
+        if not response_content and message.tool_calls:
+            tool_call = next(
+                (
+                    tool_call
+                    for tool_call in message.tool_calls
+                    if tool_call.function.name == "task_response"
+                ),
+                None,
+            )
+            if tool_call:
+                response_content = tool_call.function.arguments
+
+        if not isinstance(response_content, str):
+            raise RuntimeError(f"response is not a string: {response_content}")
+
+        if self.has_structured_output():
+            structured_response = parse_json_string(response_content)
+            return RunOutput(
+                output=structured_response,
+                intermediate_outputs=intermediate_outputs,
+            )
+
+        return RunOutput(
+            output=response_content,
+            intermediate_outputs=intermediate_outputs,
+        )
+
+    def adapter_info(self) -> AdapterInfo:
+        return AdapterInfo(
+            model_name=self.model_name,
+            model_provider=self.model_provider_name,
+            adapter_name="kiln_openai_compatible_adapter",
+            prompt_builder_name=self.prompt_builder.__class__.prompt_builder_name(),
+            prompt_id=self.prompt_builder.prompt_id(),
+        )
+
+    async def response_format_options(self) -> dict[str, Any]:
+        # Unstructured if task isn't structured
+        if not self.has_structured_output():
+            return {}
+
+        provider = await self.model_provider()
+        match provider.structured_output_mode:
+            case StructuredOutputMode.json_mode:
+                return {"response_format": {"type": "json_object"}}
+            case StructuredOutputMode.json_schema:
+                output_schema = self.kiln_task.output_schema()
+                return {
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "task_response",
+                            "schema": output_schema,
+                        },
+                    }
+                }
+            case StructuredOutputMode.function_calling:
+                return self.tool_call_params()
+            case StructuredOutputMode.json_instructions:
+                # JSON done via instructions in prompt, not the API response format. Do not ask for json_object (see option below).
+                return {}
+            case StructuredOutputMode.json_instruction_and_object:
+                # We set response_format to json_object and also set json instructions in the prompt
+                return {"response_format": {"type": "json_object"}}
+            case StructuredOutputMode.default:
+                # Default to function calling -- it's older than the other modes. Higher compatibility.
+                return self.tool_call_params()
+            case _:
+                raise ValueError(
+                    f"Unsupported structured output mode: {provider.structured_output_mode}"
+                )
+                # pyright will detect missing cases with this
+                return NoReturn
+
+    def tool_call_params(self) -> dict[str, Any]:
+        return {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "task_response",
+                        "parameters": self.kiln_task.output_schema(),
+                        "strict": True,
+                    },
+                }
+            ],
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "task_response"},
+            },
+        }

--- a/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
@@ -46,27 +46,26 @@ class OpenAICompatibleAdapter(BaseAdapter):
         )
 
     async def _run(self, input: Dict | str) -> RunOutput:
-        provider = await self.model_provider()
+        provider = self.model_provider()
         intermediate_outputs: dict[str, str] = {}
-        prompt = await self.build_prompt()
+        prompt = self.build_prompt()
         user_msg = self.prompt_builder.build_user_message(input)
         messages = [
             ChatCompletionSystemMessageParam(role="system", content=prompt),
             ChatCompletionUserMessageParam(role="user", content=user_msg),
         ]
 
-        # Handle chain of thought if enabled. 3 Modes:
-        # 1. Unstructured output: just call the LLM, with prompting for thinking
-        # 2. "Thinking" LLM designed to output thinking in a structured format: we make 1 call to the LLM, which outputs thinking in a structured format.
-        # 3. Normal LLM with structured output: we make 2 calls to the LLM - one for thinking and one for the final response. This helps us use the LLM's structured output modes (json_schema, tools, etc), which can't be used in a single call.
-        cot_prompt = self.prompt_builder.chain_of_thought_prompt()
-        thinking_llm = provider.reasoning_capable
+        run_strategy, cot_prompt = self.run_strategy()
 
-        if cot_prompt and (not self.has_structured_output() or thinking_llm):
-            # Case 1 or 2: Unstructured output or "Thinking" LLM designed to output thinking in a structured format
-            messages.append({"role": "system", "content": cot_prompt})
-        elif not thinking_llm and cot_prompt and self.has_structured_output():
-            # Case 3: Normal LLM with structured output, requires 2 calls
+        if run_strategy == "cot_as_message":
+            if not cot_prompt:
+                raise ValueError("cot_prompt is required for cot_as_message strategy")
+            messages.append(
+                ChatCompletionSystemMessageParam(role="system", content=cot_prompt)
+            )
+        elif run_strategy == "cot_two_call":
+            if not cot_prompt:
+                raise ValueError("cot_prompt is required for cot_two_call strategy")
             messages.append(
                 ChatCompletionSystemMessageParam(role="system", content=cot_prompt)
             )
@@ -93,7 +92,7 @@ class OpenAICompatibleAdapter(BaseAdapter):
             )
 
         extra_body = {}
-        if self.config.openrouter_style_reasoning and thinking_llm:
+        if self.config.openrouter_style_reasoning and provider.reasoning_capable:
             extra_body["include_reasoning"] = True
             # Filter to providers that support the reasoning parameter
             extra_body["provider"] = {"require_parameters": True}
@@ -176,7 +175,7 @@ class OpenAICompatibleAdapter(BaseAdapter):
         if not self.has_structured_output():
             return {}
 
-        provider = await self.model_provider()
+        provider = self.model_provider()
         match provider.structured_output_mode:
             case StructuredOutputMode.json_mode:
                 return {"response_format": {"type": "json_object"}}

--- a/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
@@ -84,8 +84,8 @@ class OpenAICompatibleAdapter(BaseAdapter):
                     ChatCompletionAssistantMessageParam(
                         role="assistant", content=cot_content
                     ),
-                    ChatCompletionSystemMessageParam(
-                        role="system",
+                    ChatCompletionUserMessageParam(
+                        role="user",
                         content="Considering the above, return a final result.",
                     ),
                 ]
@@ -113,7 +113,7 @@ class OpenAICompatibleAdapter(BaseAdapter):
 
         if hasattr(response, "error") and response.error:  # pyright: ignore
             raise RuntimeError(
-                f"OpenAI compatible API returned status code {response.error.get('code')}: {response.error.get('message') or 'Unknown error'}."  # pyright: ignore
+                f"OpenAI compatible API returned status code {response.error.get('code')}: {response.error.get('message') or 'Unknown error'}.\nError: {response.error}"  # pyright: ignore
             )
         if not response.choices or len(response.choices) == 0:
             raise RuntimeError(

--- a/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/openai_model_adapter.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Any, Dict, NoReturn
 
 from openai import AsyncOpenAI
@@ -17,17 +16,10 @@ from kiln_ai.adapters.model_adapters.base_adapter import (
     BasePromptBuilder,
     RunOutput,
 )
+from kiln_ai.adapters.model_adapters.openai_compatible_config import (
+    OpenAICompatibleConfig,
+)
 from kiln_ai.adapters.parsers.json_parser import parse_json_string
-
-
-@dataclass
-class OpenAICompatibleConfig:
-    api_key: str
-    model_name: str
-    provider_name: str
-    base_url: str | None = None  # Defaults to OpenAI
-    default_headers: dict[str, str] | None = None
-    openrouter_style_reasoning: bool = False
 
 
 class OpenAICompatibleAdapter(BaseAdapter):

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -1,0 +1,190 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiln_ai.adapters.ml_model_list import KilnModelProvider, StructuredOutputMode
+from kiln_ai.adapters.model_adapters.base_adapter import AdapterInfo, BaseAdapter
+from kiln_ai.datamodel import Task
+
+
+class TestAdapter(BaseAdapter):
+    """Concrete implementation of BaseAdapter for testing"""
+
+    async def _run(self, input):
+        return None
+
+    def adapter_info(self) -> AdapterInfo:
+        return AdapterInfo(
+            adapter_name="test",
+            model_name=self.model_name,
+            model_provider=self.model_provider_name,
+            prompt_builder_name="test",
+        )
+
+
+@pytest.fixture
+def mock_provider():
+    return KilnModelProvider(
+        name="openai",
+    )
+
+
+@pytest.fixture
+def base_task():
+    return Task(name="test_task", instruction="test_instruction")
+
+
+@pytest.fixture
+def adapter(base_task):
+    return TestAdapter(
+        kiln_task=base_task,
+        model_name="test_model",
+        model_provider_name="test_provider",
+    )
+
+
+async def test_model_provider_uses_cache(adapter, mock_provider):
+    """Test that cached provider is returned if it exists"""
+    # Set up cached provider
+    adapter._model_provider = mock_provider
+
+    # Mock the provider loader to ensure it's not called
+    with patch(
+        "kiln_ai.adapters.model_adapters.base_adapter.kiln_model_provider_from"
+    ) as mock_loader:
+        provider = adapter.model_provider()
+
+        assert provider == mock_provider
+        mock_loader.assert_not_called()
+
+
+async def test_model_provider_loads_and_caches(adapter, mock_provider):
+    """Test that provider is loaded and cached if not present"""
+    # Ensure no cached provider
+    adapter._model_provider = None
+
+    # Mock the provider loader
+    with patch(
+        "kiln_ai.adapters.model_adapters.base_adapter.kiln_model_provider_from"
+    ) as mock_loader:
+        mock_loader.return_value = mock_provider
+
+        # First call should load and cache
+        provider1 = adapter.model_provider()
+        assert provider1 == mock_provider
+        mock_loader.assert_called_once_with("test_model", "test_provider")
+
+        # Second call should use cache
+        mock_loader.reset_mock()
+        provider2 = adapter.model_provider()
+        assert provider2 == mock_provider
+        mock_loader.assert_not_called()
+
+
+async def test_model_provider_missing_names(base_task):
+    """Test error when model or provider name is missing"""
+    # Test with missing model name
+    adapter = TestAdapter(
+        kiln_task=base_task, model_name="", model_provider_name="test_provider"
+    )
+    with pytest.raises(
+        ValueError, match="model_name and model_provider_name must be provided"
+    ):
+        await adapter.model_provider()
+
+    # Test with missing provider name
+    adapter = TestAdapter(
+        kiln_task=base_task, model_name="test_model", model_provider_name=""
+    )
+    with pytest.raises(
+        ValueError, match="model_name and model_provider_name must be provided"
+    ):
+        await adapter.model_provider()
+
+
+async def test_model_provider_not_found(adapter):
+    """Test error when provider loader returns None"""
+    # Mock the provider loader to return None
+    with patch(
+        "kiln_ai.adapters.model_adapters.base_adapter.kiln_model_provider_from"
+    ) as mock_loader:
+        mock_loader.return_value = None
+
+        with pytest.raises(
+            ValueError,
+            match="model_provider_name test_provider not found for model test_model",
+        ):
+            await adapter.model_provider()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "output_schema,structured_output_mode,expected_json_instructions",
+    [
+        (False, StructuredOutputMode.json_instructions, False),
+        (True, StructuredOutputMode.json_instructions, True),
+        (False, StructuredOutputMode.json_instruction_and_object, False),
+        (True, StructuredOutputMode.json_instruction_and_object, True),
+        (True, StructuredOutputMode.json_mode, False),
+        (False, StructuredOutputMode.json_mode, False),
+    ],
+)
+async def test_prompt_builder_json_instructions(
+    base_task,
+    adapter,
+    output_schema,
+    structured_output_mode,
+    expected_json_instructions,
+):
+    """Test that prompt builder is called with correct include_json_instructions value"""
+    # Mock the prompt builder and has_structured_output method
+    mock_prompt_builder = MagicMock()
+    adapter.prompt_builder = mock_prompt_builder
+    adapter.model_provider_name = "openai"
+    adapter.has_structured_output = MagicMock(return_value=output_schema)
+
+    # provider mock
+    provider = MagicMock()
+    provider.structured_output_mode = structured_output_mode
+    adapter.model_provider = MagicMock(return_value=provider)
+
+    # Test
+    adapter.build_prompt()
+    mock_prompt_builder.build_prompt.assert_called_with(
+        include_json_instructions=expected_json_instructions
+    )
+
+
+@pytest.mark.parametrize(
+    "cot_prompt,has_structured_output,reasoning_capable,expected",
+    [
+        # COT and normal LLM
+        ("think carefully", False, False, ("cot_two_call", "think carefully")),
+        # Structured output with thinking-capable LLM
+        ("think carefully", True, True, ("cot_as_message", "think carefully")),
+        # Structured output with normal LLM
+        ("think carefully", True, False, ("cot_two_call", "think carefully")),
+        # Basic cases - no COT
+        (None, True, True, ("basic", None)),
+        (None, False, False, ("basic", None)),
+        (None, True, False, ("basic", None)),
+        (None, False, True, ("basic", None)),
+        # Edge case - COT prompt exists but structured output is False and reasoning_capable is True
+        ("think carefully", False, True, ("cot_as_message", "think carefully")),
+    ],
+)
+async def test_run_strategy(
+    adapter, cot_prompt, has_structured_output, reasoning_capable, expected
+):
+    """Test that run_strategy returns correct strategy based on conditions"""
+    # Mock dependencies
+    adapter.prompt_builder.chain_of_thought_prompt = MagicMock(return_value=cot_prompt)
+    adapter.has_structured_output = MagicMock(return_value=has_structured_output)
+
+    provider = MagicMock()
+    provider.reasoning_capable = reasoning_capable
+    adapter.model_provider = MagicMock(return_value=provider)
+
+    # Test
+    result = adapter.run_strategy()
+    assert result == expected

--- a/libs/core/kiln_ai/adapters/model_adapters/test_langchain_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_langchain_adapter.py
@@ -128,7 +128,7 @@ async def test_langchain_adapter_with_cot(tmp_path):
     invoke_args = mock_model_instance.ainvoke.call_args[0][0]
     assert isinstance(invoke_args[3], AIMessage)
     assert "Chain of thought reasoning..." in invoke_args[3].content
-    assert isinstance(invoke_args[4], SystemMessage)
+    assert isinstance(invoke_args[4], HumanMessage)
     assert "Considering the above, return a final result." in invoke_args[4].content
 
     assert (

--- a/libs/core/kiln_ai/adapters/model_adapters/test_langchain_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_langchain_adapter.py
@@ -163,21 +163,6 @@ async def test_get_structured_output_options(
 
 
 @pytest.mark.asyncio
-async def test_langchain_model_from_provider_openai():
-    provider = KilnModelProvider(
-        name=ModelProviderName.openai, provider_options={"model": "gpt-4"}
-    )
-
-    with patch(
-        "kiln_ai.adapters.model_adapters.langchain_adapters.Config.shared"
-    ) as mock_config:
-        mock_config.return_value.open_ai_api_key = "test_key"
-        model = await langchain_model_from_provider(provider, "gpt-4")
-        assert isinstance(model, ChatOpenAI)
-        assert model.model_name == "gpt-4"
-
-
-@pytest.mark.asyncio
 async def test_langchain_model_from_provider_groq():
     provider = KilnModelProvider(
         name=ModelProviderName.groq, provider_options={"model": "mixtral-8x7b"}

--- a/libs/core/kiln_ai/adapters/model_adapters/test_langchain_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_langchain_adapter.py
@@ -7,7 +7,6 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_fireworks import ChatFireworks
 from langchain_groq import ChatGroq
 from langchain_ollama import ChatOllama
-from langchain_openai import ChatOpenAI
 
 from kiln_ai.adapters.ml_model_list import (
     KilnModelProvider,

--- a/libs/core/kiln_ai/adapters/model_adapters/test_openai_model_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_openai_model_adapter.py
@@ -1,0 +1,225 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+from openai import AsyncOpenAI
+
+from kiln_ai.adapters.ml_model_list import StructuredOutputMode
+from kiln_ai.adapters.model_adapters.base_adapter import AdapterInfo, BasePromptBuilder
+from kiln_ai.adapters.model_adapters.openai_compatible_config import (
+    OpenAICompatibleConfig,
+)
+from kiln_ai.adapters.model_adapters.openai_model_adapter import OpenAICompatibleAdapter
+from kiln_ai.datamodel import Project, Task
+
+
+@pytest.fixture
+def mock_task(tmp_path):
+    # Create a project first since Task requires a parent
+    project_path = tmp_path / "test_project" / "project.kiln"
+    project_path.parent.mkdir()
+
+    project = Project(name="Test Project", path=str(project_path))
+    project.save_to_file()
+
+    schema = {
+        "type": "object",
+        "properties": {"test": {"type": "string"}},
+    }
+
+    task = Task(
+        name="Test Task",
+        instruction="Test instruction",
+        parent=project,
+        output_json_schema=json.dumps(schema),
+    )
+    task.save_to_file()
+    return task
+
+
+@pytest.fixture
+def mock_prompt_builder():
+    builder = Mock(spec=BasePromptBuilder)
+    type(builder).prompt_builder_name = Mock(return_value="test_prompt_builder")
+    builder.prompt_id = Mock(return_value="test_prompt_id")
+    return builder
+
+
+@pytest.fixture
+def config():
+    return OpenAICompatibleConfig(
+        api_key="test_key",
+        base_url="https://api.test.com",
+        model_name="test-model",
+        provider_name="test-provider",
+        default_headers={"X-Test": "test"},
+    )
+
+
+def test_initialization(config, mock_task, mock_prompt_builder):
+    adapter = OpenAICompatibleAdapter(
+        config=config,
+        kiln_task=mock_task,
+        prompt_builder=mock_prompt_builder,
+        tags=["test-tag"],
+    )
+
+    assert isinstance(adapter.client, AsyncOpenAI)
+    assert adapter.config == config
+    assert adapter.kiln_task == mock_task
+    assert adapter.prompt_builder == mock_prompt_builder
+    assert adapter.default_tags == ["test-tag"]
+    assert adapter.model_name == config.model_name
+    assert adapter.model_provider_name == config.provider_name
+
+
+def test_adapter_info(config, mock_task, mock_prompt_builder):
+    adapter = OpenAICompatibleAdapter(
+        config=config, kiln_task=mock_task, prompt_builder=mock_prompt_builder
+    )
+
+    info = adapter.adapter_info()
+    assert isinstance(info, AdapterInfo)
+    assert info.model_name == config.model_name
+    assert info.model_provider == config.provider_name
+    assert info.adapter_name == "kiln_openai_compatible_adapter"
+    assert info.prompt_builder_name == "base_prompt_builder"
+    assert info.prompt_id == "test_prompt_id"
+
+
+@pytest.mark.asyncio
+async def test_response_format_options_unstructured(
+    config, mock_task, mock_prompt_builder
+):
+    adapter = OpenAICompatibleAdapter(
+        config=config, kiln_task=mock_task, prompt_builder=mock_prompt_builder
+    )
+
+    # Mock has_structured_output to return False
+    with patch.object(adapter, "has_structured_output", return_value=False):
+        options = await adapter.response_format_options()
+        assert options == {}
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        StructuredOutputMode.json_mode,
+        StructuredOutputMode.json_instruction_and_object,
+    ],
+)
+@pytest.mark.asyncio
+async def test_response_format_options_json_mode(
+    config, mock_task, mock_prompt_builder, mode
+):
+    adapter = OpenAICompatibleAdapter(
+        config=config, kiln_task=mock_task, prompt_builder=mock_prompt_builder
+    )
+
+    with (
+        patch.object(adapter, "has_structured_output", return_value=True),
+        patch.object(adapter, "model_provider") as mock_provider,
+    ):
+        mock_provider.return_value.structured_output_mode = mode
+
+        options = await adapter.response_format_options()
+        assert options == {"response_format": {"type": "json_object"}}
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        StructuredOutputMode.default,
+        StructuredOutputMode.function_calling,
+    ],
+)
+@pytest.mark.asyncio
+async def test_response_format_options_function_calling(
+    config, mock_task, mock_prompt_builder, mode
+):
+    adapter = OpenAICompatibleAdapter(
+        config=config, kiln_task=mock_task, prompt_builder=mock_prompt_builder
+    )
+
+    with (
+        patch.object(adapter, "has_structured_output", return_value=True),
+        patch.object(adapter, "model_provider") as mock_provider,
+    ):
+        mock_provider.return_value.structured_output_mode = mode
+
+        options = await adapter.response_format_options()
+        assert "tools" in options
+        # full tool structure validated below
+
+
+@pytest.mark.asyncio
+async def test_response_format_options_json_instructions(
+    config, mock_task, mock_prompt_builder
+):
+    adapter = OpenAICompatibleAdapter(
+        config=config, kiln_task=mock_task, prompt_builder=mock_prompt_builder
+    )
+
+    with (
+        patch.object(adapter, "has_structured_output", return_value=True),
+        patch.object(adapter, "model_provider") as mock_provider,
+    ):
+        mock_provider.return_value.structured_output_mode = (
+            StructuredOutputMode.json_instructions
+        )
+        options = await adapter.response_format_options()
+        assert options == {}
+
+
+@pytest.mark.asyncio
+async def test_response_format_options_json_schema(
+    config, mock_task, mock_prompt_builder
+):
+    adapter = OpenAICompatibleAdapter(
+        config=config, kiln_task=mock_task, prompt_builder=mock_prompt_builder
+    )
+
+    with (
+        patch.object(adapter, "has_structured_output", return_value=True),
+        patch.object(adapter, "model_provider") as mock_provider,
+    ):
+        mock_provider.return_value.structured_output_mode = (
+            StructuredOutputMode.json_schema
+        )
+        options = await adapter.response_format_options()
+        assert options == {
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "task_response",
+                    "schema": mock_task.output_schema(),
+                },
+            }
+        }
+
+
+def test_tool_call_params(config, mock_task, mock_prompt_builder):
+    adapter = OpenAICompatibleAdapter(
+        config=config, kiln_task=mock_task, prompt_builder=mock_prompt_builder
+    )
+
+    params = adapter.tool_call_params()
+    expected_schema = mock_task.output_schema()
+    expected_schema["additionalProperties"] = False
+
+    assert params == {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "task_response",
+                    "parameters": expected_schema,
+                    "strict": True,
+                },
+            }
+        ],
+        "tool_choice": {
+            "type": "function",
+            "function": {"name": "task_response"},
+        },
+    }

--- a/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Dict
 
@@ -97,19 +98,10 @@ async def test_mock_unstructred_response(tmp_path):
         answer = await adapter.invoke("You are a mock, send me the response!")
 
 
-@pytest.mark.paid
-@pytest.mark.ollama
-@pytest.mark.parametrize("model_name,provider_name", get_all_models_and_providers())
-async def test_all_built_in_models_structured_output(
-    tmp_path, model_name, provider_name
-):
+def check_supports_structured_output(model_name: str, provider_name: str):
     for model in built_in_models:
         if model.name != model_name:
             continue
-        if not model.supports_structured_output:
-            pytest.skip(
-                f"Skipping {model.name} because it does not support structured output"
-            )
         for provider in model.providers:
             if provider.name != provider_name:
                 continue
@@ -117,9 +109,18 @@ async def test_all_built_in_models_structured_output(
                 pytest.skip(
                     f"Skipping {model.name} {provider.name} because it does not support structured output"
                 )
-            await run_structured_output_test(tmp_path, model.name, provider.name)
             return
     raise RuntimeError(f"No model {model_name} {provider_name} found")
+
+
+@pytest.mark.paid
+@pytest.mark.ollama
+@pytest.mark.parametrize("model_name,provider_name", get_all_models_and_providers())
+async def test_all_built_in_models_structured_output(
+    tmp_path, model_name, provider_name
+):
+    check_supports_structured_output(model_name, provider_name)
+    await run_structured_output_test(tmp_path, model_name, provider_name)
 
 
 def build_structured_output_test_task(tmp_path: Path):
@@ -144,7 +145,14 @@ def build_structured_output_test_task(tmp_path: Path):
 async def run_structured_output_test(tmp_path: Path, model_name: str, provider: str):
     task = build_structured_output_test_task(tmp_path)
     a = adapter_for_task(task, model_name=model_name, provider=provider)
-    parsed = await a.invoke_returning_raw("Cows")  # a joke about cows
+    try:
+        parsed = await a.invoke_returning_raw("Cows")  # a joke about cows
+    except ValueError as e:
+        if str(e) == "Failed to connect to Ollama. Ensure Ollama is running.":
+            pytest.skip(
+                f"Skipping {model_name} {provider} because Ollama is not running"
+            )
+        raise e
     if parsed is None or not isinstance(parsed, Dict):
         raise RuntimeError(f"structured response is not a dict: {parsed}")
     assert parsed["setup"] is not None
@@ -165,6 +173,7 @@ def build_structured_input_test_task(tmp_path: Path):
         parent=project,
         name="test task",
         instruction="You are an assistant which classifies a triangle given the lengths of its sides. If all sides are of equal length, the triangle is equilateral. If two sides are equal, the triangle is isosceles. Otherwise, it is scalene.\n\nAt the end of your response return the result in double square brackets. It should be plain text. It should be exactly one of the three following strings: '[[equilateral]]', or '[[isosceles]]', or '[[scalene]]'.",
+        thinking_prompt="Think step by step.",
     )
     task.input_json_schema = json_triangle_schema
     schema = task.input_schema()
@@ -181,7 +190,14 @@ def build_structured_input_test_task(tmp_path: Path):
 
 async def run_structured_input_test(tmp_path: Path, model_name: str, provider: str):
     task = build_structured_input_test_task(tmp_path)
-    await run_structured_input_task(task, model_name, provider)
+    try:
+        await run_structured_input_task(task, model_name, provider)
+    except ValueError as e:
+        if str(e) == "Failed to connect to Ollama. Ensure Ollama is running.":
+            pytest.skip(
+                f"Skipping {model_name} {provider} because Ollama is not running"
+            )
+        raise e
 
 
 async def run_structured_input_task(
@@ -200,10 +216,19 @@ async def run_structured_input_task(
         # invalid structured input
         await a.invoke({"a": 1, "b": 2, "d": 3})
 
-    response = await a.invoke_returning_raw({"a": 2, "b": 2, "c": 2})
+    try:
+        response = await a.invoke_returning_raw({"a": 2, "b": 2, "c": 2})
+    except ValueError as e:
+        if str(e) == "Failed to connect to Ollama. Ensure Ollama is running.":
+            pytest.skip(
+                f"Skipping {model_name} {provider} because Ollama is not running"
+            )
+        raise e
     assert response is not None
-    assert isinstance(response, str)
-    assert "[[equilateral]]" in response
+    if isinstance(response, str):
+        assert "[[equilateral]]" in response
+    else:
+        assert response["is_equilateral"] is True
     adapter_info = a.adapter_info()
     expected_pb_name = "simple_prompt_builder"
     if pb is not None:
@@ -211,7 +236,6 @@ async def run_structured_input_task(
     assert adapter_info.prompt_builder_name == expected_pb_name
     assert adapter_info.model_name == model_name
     assert adapter_info.model_provider == provider
-    assert adapter_info.adapter_name == "kiln_langchain_adapter"
 
 
 @pytest.mark.paid
@@ -231,7 +255,52 @@ async def test_all_built_in_models_structured_input(
 @pytest.mark.paid
 @pytest.mark.ollama
 @pytest.mark.parametrize("model_name,provider_name", get_all_models_and_providers())
-async def test_structured_cot_prompt_builder(tmp_path, model_name, provider_name):
+async def test_structured_input_cot_prompt_builder(tmp_path, model_name, provider_name):
     task = build_structured_input_test_task(tmp_path)
+    pb = SimpleChainOfThoughtPromptBuilder(task)
+    await run_structured_input_task(task, model_name, provider_name, pb)
+
+
+@pytest.mark.paid
+@pytest.mark.ollama
+@pytest.mark.parametrize("model_name,provider_name", get_all_models_and_providers())
+async def test_structured_output_cot_prompt_builder(
+    tmp_path, model_name, provider_name
+):
+    check_supports_structured_output(model_name, provider_name)
+    triangle_schema = {
+        "type": "object",
+        "properties": {
+            "is_equilateral": {
+                "type": "boolean",
+                "description": "True if all sides of the triangle are equal in length",
+            },
+            "is_scalene": {
+                "type": "boolean",
+                "description": "True if all sides of the triangle have different lengths",
+            },
+            "is_obtuse": {
+                "type": "boolean",
+                "description": "True if one of the angles is greater than 90 degrees",
+            },
+        },
+        "required": ["is_equilateral", "is_scalene", "is_obtuse"],
+        "additionalProperties": False,
+    }
+    task = build_structured_input_test_task(tmp_path)
+    task.instruction = """
+You are an assistant which classifies a triangle given the lengths of its sides. If all sides are of equal length, the triangle is equilateral. If two sides are equal, the triangle is isosceles. Otherwise, it is scalene.\n\n"
+
+When asked for a final result, this is the format (for an equilateral example):
+```json
+{
+    "is_equilateral": true,
+    "is_scalene": false,
+    "is_obtuse": false
+}
+```
+"""
+    task.output_json_schema = json.dumps(triangle_schema)
+    task.save_to_file()
     pb = SimpleChainOfThoughtPromptBuilder(task)
     await run_structured_input_task(task, model_name, provider_name, pb)

--- a/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
@@ -7,9 +7,13 @@ import pytest
 
 import kiln_ai.datamodel as datamodel
 from kiln_ai.adapters.adapter_registry import adapter_for_task
-from kiln_ai.adapters.base_adapter import AdapterInfo, BaseAdapter, RunOutput
 from kiln_ai.adapters.ml_model_list import (
     built_in_models,
+)
+from kiln_ai.adapters.model_adapters.base_adapter import (
+    AdapterInfo,
+    BaseAdapter,
+    RunOutput,
 )
 from kiln_ai.adapters.ollama_tools import ollama_online
 from kiln_ai.adapters.prompt_builders import (
@@ -44,7 +48,7 @@ async def test_structured_output_ollama_llama(tmp_path, model_name):
 
 class MockAdapter(BaseAdapter):
     def __init__(self, kiln_task: datamodel.Task, response: Dict | str | None):
-        super().__init__(kiln_task)
+        super().__init__(kiln_task, model_name="phi_3_5", model_provider_name="ollama")
         self.response = response
 
     async def _run(self, input: str) -> RunOutput:

--- a/libs/core/kiln_ai/adapters/parsers/__init__.py
+++ b/libs/core/kiln_ai/adapters/parsers/__init__.py
@@ -1,0 +1,10 @@
+"""
+# Parsers
+
+Parsing utilities for JSON and models with custom output formats (R1, etc.)
+
+"""
+
+from . import base_parser, json_parser, r1_parser
+
+__all__ = ["r1_parser", "base_parser", "json_parser"]

--- a/libs/core/kiln_ai/adapters/parsers/base_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/base_parser.py
@@ -1,0 +1,12 @@
+from kiln_ai.adapters.run_output import RunOutput
+
+
+class BaseParser:
+    def __init__(self, structured_output: bool = False):
+        self.structured_output = structured_output
+
+    def parse_output(self, original_output: RunOutput) -> RunOutput:
+        """
+        Method for parsing the output of a model. Typically overridden by subclasses.
+        """
+        return original_output

--- a/libs/core/kiln_ai/adapters/parsers/json_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/json_parser.py
@@ -1,0 +1,35 @@
+import json
+from typing import Any, Dict
+
+
+def parse_json_string(json_string: str) -> Dict[str, Any]:
+    """
+    Parse a JSON string into a dictionary. Handles multiple formats:
+    - Plain JSON
+    - JSON wrapped in ```json code blocks
+    - JSON wrapped in ``` code blocks
+
+    Args:
+        json_string: String containing JSON data, possibly wrapped in code blocks
+
+    Returns:
+        Dict containing parsed JSON data
+
+    Raises:
+        ValueError: If JSON parsing fails
+    """
+    # Remove code block markers if present
+    cleaned_string = json_string.strip()
+    if cleaned_string.startswith("```"):
+        # Split by newlines and remove first/last lines if they contain ```
+        lines = cleaned_string.split("\n")
+        if lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        cleaned_string = "\n".join(lines)
+
+    try:
+        return json.loads(cleaned_string)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Failed to parse JSON: {str(e)}") from e

--- a/libs/core/kiln_ai/adapters/parsers/json_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/json_parser.py
@@ -32,4 +32,4 @@ def parse_json_string(json_string: str) -> Dict[str, Any]:
     try:
         return json.loads(cleaned_string)
     except json.JSONDecodeError as e:
-        raise ValueError(f"Failed to parse JSON: {str(e)}") from e
+        raise ValueError(f"Failed to parse JSON: {str(e)}\n\n{cleaned_string}") from e

--- a/libs/core/kiln_ai/adapters/parsers/parser_registry.py
+++ b/libs/core/kiln_ai/adapters/parsers/parser_registry.py
@@ -1,0 +1,22 @@
+from typing import NoReturn, Type
+
+from kiln_ai.adapters.ml_model_list import ModelParserID
+from kiln_ai.adapters.parsers.base_parser import BaseParser
+from kiln_ai.adapters.parsers.r1_parser import R1ThinkingParser
+
+
+def model_parser_from_id(parser_id: ModelParserID | None) -> Type[BaseParser]:
+    """
+    Get a model parser from its ID.
+    """
+    match parser_id:
+        case None:
+            return BaseParser
+        case ModelParserID.r1_thinking:
+            return R1ThinkingParser
+        case _:
+            # triggers pyright warning if I miss a case
+            raise ValueError(
+                f"Unhandled enum value for parser ID. You may need to update Kiln to work with this project. Value: {parser_id}"
+            )
+            return NoReturn

--- a/libs/core/kiln_ai/adapters/parsers/r1_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/r1_parser.py
@@ -1,0 +1,69 @@
+from kiln_ai.adapters.parsers.base_parser import BaseParser
+from kiln_ai.adapters.parsers.json_parser import parse_json_string
+from kiln_ai.adapters.run_output import RunOutput
+
+
+class R1ThinkingParser(BaseParser):
+    START_TAG = "<think>"
+    END_TAG = "</think>"
+
+    def parse_output(self, original_output: RunOutput) -> RunOutput:
+        """
+        Parse the <think> </think> tags from the response into the intermediate and final outputs.
+
+        Args:
+            original_output: RunOutput containing the raw response string
+
+        Returns:
+            ParsedOutput containing the intermediate content (thinking content) and final result
+
+        Raises:
+            ValueError: If response format is invalid (missing tags, multiple tags, or no content after closing tag)
+        """
+        # This parser only works for strings
+        if not isinstance(original_output.output, str):
+            raise ValueError("Response must be a string for R1 parser")
+
+        # Strip whitespace and validate basic structure
+        cleaned_response = original_output.output.strip()
+        if not cleaned_response.startswith(self.START_TAG):
+            raise ValueError("Response must start with <think> tag")
+
+        # Find the thinking tags
+        think_start = cleaned_response.find(self.START_TAG)
+        think_end = cleaned_response.find(self.END_TAG)
+
+        if think_start == -1 or think_end == -1:
+            raise ValueError("Missing thinking tags")
+
+        # Check for multiple tags
+        if (
+            cleaned_response.count(self.START_TAG) > 1
+            or cleaned_response.count(self.END_TAG) > 1
+        ):
+            raise ValueError("Multiple thinking tags found")
+
+        # Extract thinking content
+        thinking_content = cleaned_response[
+            think_start + len(self.START_TAG) : think_end
+        ].strip()
+
+        # Extract result (everything after </think>)
+        result = cleaned_response[think_end + len(self.END_TAG) :].strip()
+
+        if not result or len(result) == 0:
+            raise ValueError("No content found after </think> tag")
+
+        # Parse JSON if needed
+        output = result
+        if self.structured_output:
+            output = parse_json_string(result)
+
+        # Add thinking content to intermediate outputs if it exists
+        intermediate_outputs = original_output.intermediate_outputs or {}
+        intermediate_outputs["reasoning"] = thinking_content
+
+        return RunOutput(
+            output=output,
+            intermediate_outputs=intermediate_outputs,
+        )

--- a/libs/core/kiln_ai/adapters/parsers/test_json_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/test_json_parser.py
@@ -1,0 +1,75 @@
+import pytest
+
+from kiln_ai.adapters.parsers.json_parser import parse_json_string
+
+
+def test_parse_plain_json():
+    json_str = '{"key": "value", "number": 42}'
+    result = parse_json_string(json_str)
+    assert result == {"key": "value", "number": 42}
+
+
+def test_parse_json_with_code_block():
+    json_str = """```
+    {"key": "value", "number": 42}
+    ```"""
+    result = parse_json_string(json_str)
+    assert result == {"key": "value", "number": 42}
+
+
+def test_parse_json_with_language_block():
+    json_str = """```json
+    {"key": "value", "number": 42}
+    ```"""
+    result = parse_json_string(json_str)
+    assert result == {"key": "value", "number": 42}
+
+
+def test_parse_json_with_whitespace():
+    json_str = """
+        {
+            "key": "value",
+            "number": 42
+        }
+    """
+    result = parse_json_string(json_str)
+    assert result == {"key": "value", "number": 42}
+
+
+def test_parse_invalid_json():
+    json_str = '{"key": "value", invalid}'
+    with pytest.raises(ValueError) as exc_info:
+        parse_json_string(json_str)
+    assert "Failed to parse JSON" in str(exc_info.value)
+
+
+def test_parse_empty_code_block():
+    json_str = """```json
+    ```"""
+    with pytest.raises(ValueError) as exc_info:
+        parse_json_string(json_str)
+    assert "Failed to parse JSON" in str(exc_info.value)
+
+
+def test_parse_complex_json():
+    json_str = """```json
+    {
+        "string": "hello",
+        "number": 42,
+        "bool": true,
+        "null": null,
+        "array": [1, 2, 3],
+        "nested": {
+            "inner": "value"
+        }
+    }
+    ```"""
+    result = parse_json_string(json_str)
+    assert result == {
+        "string": "hello",
+        "number": 42,
+        "bool": True,
+        "null": None,
+        "array": [1, 2, 3],
+        "nested": {"inner": "value"},
+    }

--- a/libs/core/kiln_ai/adapters/parsers/test_parser_registry.py
+++ b/libs/core/kiln_ai/adapters/parsers/test_parser_registry.py
@@ -1,0 +1,32 @@
+import pytest
+
+from kiln_ai.adapters.ml_model_list import ModelParserID
+from kiln_ai.adapters.parsers.base_parser import BaseParser
+from kiln_ai.adapters.parsers.parser_registry import model_parser_from_id
+from kiln_ai.adapters.parsers.r1_parser import R1ThinkingParser
+
+
+def test_model_parser_from_id_invalid():
+    """Test that invalid parser ID raises ValueError."""
+
+    # Create a mock enum value that isn't handled
+    class MockModelParserID:
+        mock_value = "mock_value"
+
+    with pytest.raises(ValueError) as exc_info:
+        model_parser_from_id(MockModelParserID.mock_value)  # type: ignore
+
+    assert "Unhandled enum value for parser ID" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "parser_id,expected_class",
+    [
+        (None, BaseParser),
+        (ModelParserID.r1_thinking, R1ThinkingParser),
+    ],
+)
+def test_model_parser_from_id_parametrized(parser_id, expected_class):
+    """Test all valid parser IDs using parametrize."""
+    parser_class = model_parser_from_id(parser_id)
+    assert parser_class == expected_class

--- a/libs/core/kiln_ai/adapters/parsers/test_r1_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/test_r1_parser.py
@@ -1,0 +1,144 @@
+import pytest
+
+from kiln_ai.adapters.parsers.r1_parser import R1ThinkingParser
+from kiln_ai.adapters.run_output import RunOutput
+
+
+@pytest.fixture
+def parser():
+    return R1ThinkingParser()
+
+
+def test_valid_response(parser):
+    response = RunOutput(
+        output="<think>This is thinking content</think>This is the result",
+        intermediate_outputs=None,
+    )
+    parsed = parser.parse_output(response)
+    assert parsed.intermediate_outputs["reasoning"] == "This is thinking content"
+    assert parsed.output == "This is the result"
+
+
+def test_response_with_whitespace(parser):
+    response = RunOutput(
+        output="""
+        <think>
+            This is thinking content
+        </think>
+            This is the result
+    """,
+        intermediate_outputs=None,
+    )
+    parsed = parser.parse_output(response)
+    assert (
+        parsed.intermediate_outputs["reasoning"].strip() == "This is thinking content"
+    )
+    assert parsed.output.strip() == "This is the result"
+
+
+def test_missing_start_tag(parser):
+    with pytest.raises(ValueError, match="Response must start with <think> tag"):
+        parser.parse_output(
+            RunOutput(output="Some content</think>result", intermediate_outputs=None)
+        )
+
+
+def test_missing_end_tag(parser):
+    with pytest.raises(ValueError, match="Missing thinking tags"):
+        parser.parse_output(
+            RunOutput(output="<think>Some content", intermediate_outputs=None)
+        )
+
+
+def test_multiple_start_tags(parser):
+    with pytest.raises(ValueError, match="Multiple thinking tags found"):
+        parser.parse_output(
+            RunOutput(
+                output="<think>content1<think>content2</think>result",
+                intermediate_outputs=None,
+            )
+        )
+
+
+def test_multiple_end_tags(parser):
+    with pytest.raises(ValueError, match="Multiple thinking tags found"):
+        parser.parse_output(
+            RunOutput(
+                output="<think>content</think></think>result", intermediate_outputs=None
+            )
+        )
+
+
+def test_empty_thinking_content(parser):
+    response = RunOutput(
+        output="<think></think>This is the result", intermediate_outputs=None
+    )
+    parsed = parser.parse_output(response)
+    assert parsed.intermediate_outputs == {"reasoning": ""}
+    assert parsed.output == "This is the result"
+
+
+def test_missing_result(parser):
+    with pytest.raises(ValueError, match="No content found after </think> tag"):
+        parser.parse_output(
+            RunOutput(output="<think>Some content</think>", intermediate_outputs=None)
+        )
+
+
+def test_multiline_content(parser):
+    response = RunOutput(
+        output="""<think>Line 1
+    Line 2
+    Line 3</think>Final result""",
+        intermediate_outputs=None,
+    )
+    parsed = parser.parse_output(response)
+    assert "Line 1" in parsed.intermediate_outputs["reasoning"]
+    assert "Line 2" in parsed.intermediate_outputs["reasoning"]
+    assert "Line 3" in parsed.intermediate_outputs["reasoning"]
+    assert parsed.output == "Final result"
+
+
+def test_special_characters(parser):
+    response = RunOutput(
+        output="<think>Content with: !@#$%^&*思()</think>Result with: !@#$%^&*思()",
+        intermediate_outputs=None,
+    )
+    parsed = parser.parse_output(response)
+    assert parsed.intermediate_outputs["reasoning"] == "Content with: !@#$%^&*思()"
+    assert parsed.output == "Result with: !@#$%^&*思()"
+
+
+def test_non_string_input(parser):
+    with pytest.raises(ValueError, match="Response must be a string for R1 parser"):
+        parser.parse_output(RunOutput(output={}, intermediate_outputs=None))
+
+
+def test_intermediate_outputs(parser):
+    # append to existing intermediate outputs
+    out = parser.parse_output(
+        RunOutput(
+            output="<think>Some content</think>result",
+            intermediate_outputs={"existing": "data"},
+        )
+    )
+    assert out.intermediate_outputs["reasoning"] == "Some content"
+    assert out.intermediate_outputs["existing"] == "data"
+
+    # empty dict is allowed
+    out = parser.parse_output(
+        RunOutput(
+            output="<think>Some content</think>result",
+            intermediate_outputs={},
+        )
+    )
+    assert out.intermediate_outputs["reasoning"] == "Some content"
+
+    # None is allowed
+    out = parser.parse_output(
+        RunOutput(
+            output="<think>Some content</think>result",
+            intermediate_outputs=None,
+        )
+    )
+    assert out.intermediate_outputs["reasoning"] == "Some content"

--- a/libs/core/kiln_ai/adapters/prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/prompt_builders.py
@@ -28,8 +28,24 @@ class BasePromptBuilder(metaclass=ABCMeta):
         """
         return None
 
+    def build_prompt(self, include_json_instructions: bool = False) -> str:
+        """Build and return the complete prompt string.
+
+        Returns:
+            str: The constructed prompt.
+        """
+        prompt = self.build_base_prompt()
+
+        if include_json_instructions and self.task.output_schema():
+            prompt = (
+                prompt
+                + f"\n\n# Format Instructions\n\nReturn a JSON object conforming to the following schema:\n```\n{self.task.output_schema()}\n```"
+            )
+
+        return prompt
+
     @abstractmethod
-    def build_prompt(self) -> str:
+    def build_base_prompt(self) -> str:
         """Build and return the complete prompt string.
 
         Returns:
@@ -88,7 +104,7 @@ class BasePromptBuilder(metaclass=ABCMeta):
 class SimplePromptBuilder(BasePromptBuilder):
     """A basic prompt builder that combines task instruction with requirements."""
 
-    def build_prompt(self) -> str:
+    def build_base_prompt(self) -> str:
         """Build a simple prompt with instruction and requirements.
 
         Returns:
@@ -120,7 +136,7 @@ class MultiShotPromptBuilder(BasePromptBuilder):
         """
         return 25
 
-    def build_prompt(self) -> str:
+    def build_base_prompt(self) -> str:
         """Build a prompt with instruction, requirements, and multiple examples.
 
         Returns:
@@ -272,7 +288,7 @@ class SavedPromptBuilder(BasePromptBuilder):
     def prompt_id(self) -> str | None:
         return self.prompt_model.id
 
-    def build_prompt(self) -> str:
+    def build_base_prompt(self) -> str:
         """Returns a saved prompt.
 
         Returns:

--- a/libs/core/kiln_ai/adapters/prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/prompt_builders.py
@@ -28,7 +28,7 @@ class BasePromptBuilder(metaclass=ABCMeta):
         """
         return None
 
-    def build_prompt(self, include_json_instructions: bool = False) -> str:
+    def build_prompt(self, include_json_instructions) -> str:
         """Build and return the complete prompt string.
 
         Returns:
@@ -94,7 +94,7 @@ class BasePromptBuilder(metaclass=ABCMeta):
         Returns:
             str: The constructed prompt string.
         """
-        base_prompt = self.build_prompt()
+        base_prompt = self.build_prompt(include_json_instructions=False)
         cot_prompt = self.chain_of_thought_prompt()
         if cot_prompt:
             base_prompt += "\n# Thinking Instructions\n\n" + cot_prompt

--- a/libs/core/kiln_ai/adapters/provider_tools.py
+++ b/libs/core/kiln_ai/adapters/provider_tools.py
@@ -64,7 +64,7 @@ def check_provider_warnings(provider_name: ModelProviderName):
             raise ValueError(warning_check.message)
 
 
-async def builtin_model_from(
+def builtin_model_from(
     name: str, provider_name: str | None = None
 ) -> KilnModelProvider | None:
     """
@@ -145,7 +145,7 @@ def parse_custom_model_id(
     return ModelProviderName(provider_name), model_name
 
 
-async def kiln_model_provider_from(
+def kiln_model_provider_from(
     name: str, provider_name: str | None = None
 ) -> KilnModelProvider:
     if provider_name == ModelProviderName.kiln_fine_tune:
@@ -154,7 +154,7 @@ async def kiln_model_provider_from(
     if provider_name == ModelProviderName.openai_compatible:
         return openai_compatible_provider_model(name)
 
-    built_in_model = await builtin_model_from(name, provider_name)
+    built_in_model = builtin_model_from(name, provider_name)
     if built_in_model:
         return built_in_model
 

--- a/libs/core/kiln_ai/adapters/provider_tools.py
+++ b/libs/core/kiln_ai/adapters/provider_tools.py
@@ -9,6 +9,9 @@ from kiln_ai.adapters.ml_model_list import (
     StructuredOutputMode,
     built_in_models,
 )
+from kiln_ai.adapters.model_adapters.openai_compatible_config import (
+    OpenAICompatibleConfig,
+)
 from kiln_ai.adapters.ollama_tools import (
     get_ollama_connection,
 )
@@ -175,9 +178,9 @@ async def kiln_model_provider_from(
     )
 
 
-def openai_compatible_provider_model(
+def openai_compatible_config(
     model_id: str,
-) -> KilnModelProvider:
+) -> OpenAICompatibleConfig:
     try:
         openai_provider_name, model_id = model_id.split("::")
     except Exception:
@@ -201,12 +204,21 @@ def openai_compatible_provider_model(
             f"OpenAI compatible provider {openai_provider_name} has no base URL"
         )
 
+    return OpenAICompatibleConfig(
+        api_key=api_key,
+        model_name=model_id,
+        provider_name=ModelProviderName.openai_compatible,
+        base_url=base_url,
+    )
+
+
+def openai_compatible_provider_model(
+    model_id: str,
+) -> KilnModelProvider:
     return KilnModelProvider(
         name=ModelProviderName.openai_compatible,
         provider_options={
             "model": model_id,
-            "api_key": api_key,
-            "openai_api_base": base_url,
         },
         supports_structured_output=False,
         supports_data_gen=False,

--- a/libs/core/kiln_ai/adapters/repair/repair_task.py
+++ b/libs/core/kiln_ai/adapters/repair/repair_task.py
@@ -53,7 +53,7 @@ feedback describing what should be improved. Your job is to understand the evalu
         prompt_id = run.output.source.properties.get("prompt_id", None)
         if prompt_id is not None and isinstance(prompt_id, str):
             static_prompt_builder = SavedPromptBuilder(task, prompt_id)
-            return static_prompt_builder.build_prompt()
+            return static_prompt_builder.build_prompt(include_json_instructions=False)
 
         prompt_builder_class: Type[BasePromptBuilder] | None = None
         prompt_builder_name = run.output.source.properties.get(
@@ -70,7 +70,7 @@ feedback describing what should be improved. Your job is to understand the evalu
             raise ValueError(
                 f"Prompt builder {prompt_builder_name} is not a valid prompt builder"
             )
-        return prompt_builder.build_prompt()
+        return prompt_builder.build_prompt(include_json_instructions=False)
 
     @classmethod
     def build_repair_task_input(

--- a/libs/core/kiln_ai/adapters/repair/test_repair_task.py
+++ b/libs/core/kiln_ai/adapters/repair/test_repair_task.py
@@ -6,8 +6,8 @@ import pytest
 from pydantic import ValidationError
 
 from kiln_ai.adapters.adapter_registry import adapter_for_task
-from kiln_ai.adapters.base_adapter import RunOutput
-from kiln_ai.adapters.langchain_adapters import LangchainAdapter
+from kiln_ai.adapters.model_adapters.base_adapter import RunOutput
+from kiln_ai.adapters.model_adapters.langchain_adapters import LangchainAdapter
 from kiln_ai.adapters.repair.repair_task import (
     RepairTaskInput,
     RepairTaskRun,
@@ -223,7 +223,7 @@ async def test_mocked_repair_task_run(sample_task, sample_task_run, sample_repai
         )
 
         adapter = adapter_for_task(
-            repair_task, model_name="llama_3_1_8b", provider="groq"
+            repair_task, model_name="llama_3_1_8b", provider="ollama"
         )
 
         run = await adapter.invoke(repair_task_input.model_dump())
@@ -237,7 +237,7 @@ async def test_mocked_repair_task_run(sample_task, sample_task_run, sample_repai
     assert run.output.source.properties == {
         "adapter_name": "kiln_langchain_adapter",
         "model_name": "llama_3_1_8b",
-        "model_provider": "groq",
+        "model_provider": "ollama",
         "prompt_builder_name": "simple_prompt_builder",
     }
     assert run.input_source.type == DataSourceType.human

--- a/libs/core/kiln_ai/adapters/run_output.py
+++ b/libs/core/kiln_ai/adapters/run_output.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class RunOutput:
+    output: Dict | str
+    intermediate_outputs: Dict[str, str] | None

--- a/libs/core/kiln_ai/adapters/test_adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/test_adapter_registry.py
@@ -1,0 +1,177 @@
+from unittest.mock import patch
+
+import pytest
+
+from kiln_ai import datamodel
+from kiln_ai.adapters.adapter_registry import adapter_for_task
+from kiln_ai.adapters.ml_model_list import ModelProviderName
+from kiln_ai.adapters.model_adapters.langchain_adapters import LangchainAdapter
+from kiln_ai.adapters.model_adapters.openai_model_adapter import OpenAICompatibleAdapter
+from kiln_ai.adapters.prompt_builders import BasePromptBuilder
+from kiln_ai.adapters.provider_tools import kiln_model_provider_from
+
+
+@pytest.fixture
+def mock_config():
+    with patch("kiln_ai.adapters.adapter_registry.Config") as mock:
+        mock.shared.return_value.open_ai_api_key = "test-openai-key"
+        mock.shared.return_value.open_router_api_key = "test-openrouter-key"
+        yield mock
+
+
+@pytest.fixture
+def basic_task():
+    return datamodel.Task(
+        task_id="test-task",
+        task_type="test",
+        input_text="test input",
+        name="test-task",
+        instruction="test-task",
+    )
+
+
+@pytest.fixture
+def mock_finetune_from_id():
+    with patch("kiln_ai.adapters.provider_tools.finetune_from_id") as mock:
+        mock.return_value.provider = ModelProviderName.openai
+        mock.return_value.fine_tune_model_id = "test-model"
+        yield mock
+
+
+def test_openai_adapter_creation(mock_config, basic_task):
+    adapter = adapter_for_task(
+        kiln_task=basic_task, model_name="gpt-4", provider=ModelProviderName.openai
+    )
+
+    assert isinstance(adapter, OpenAICompatibleAdapter)
+    assert adapter.config.model_name == "gpt-4"
+    assert adapter.config.api_key == "test-openai-key"
+    assert adapter.config.provider_name == ModelProviderName.openai
+    assert adapter.config.base_url is None  # OpenAI url is default
+    assert adapter.config.default_headers is None
+
+
+def test_openrouter_adapter_creation(mock_config, basic_task):
+    adapter = adapter_for_task(
+        kiln_task=basic_task,
+        model_name="anthropic/claude-3-opus",
+        provider=ModelProviderName.openrouter,
+    )
+
+    assert isinstance(adapter, OpenAICompatibleAdapter)
+    assert adapter.config.model_name == "anthropic/claude-3-opus"
+    assert adapter.config.api_key == "test-openrouter-key"
+    assert adapter.config.provider_name == ModelProviderName.openrouter
+    assert adapter.config.base_url == "https://openrouter.ai/api/v1"
+    assert adapter.config.default_headers == {
+        "HTTP-Referer": "https://getkiln.ai/openrouter",
+        "X-Title": "KilnAI",
+    }
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        ModelProviderName.groq,
+        ModelProviderName.amazon_bedrock,
+        ModelProviderName.ollama,
+        ModelProviderName.fireworks_ai,
+    ],
+)
+def test_langchain_adapter_creation(mock_config, basic_task, provider):
+    adapter = adapter_for_task(
+        kiln_task=basic_task, model_name="test-model", provider=provider
+    )
+
+    assert isinstance(adapter, LangchainAdapter)
+    assert adapter.model_name == "test-model"
+
+
+# TODO should run for all cases
+def test_custom_prompt_builder(mock_config, basic_task):
+    class TestPromptBuilder(BasePromptBuilder):
+        def build_base_prompt(self, kiln_task) -> str:
+            return "test-prompt"
+
+    prompt_builder = TestPromptBuilder(basic_task)
+    adapter = adapter_for_task(
+        kiln_task=basic_task,
+        model_name="gpt-4",
+        provider=ModelProviderName.openai,
+        prompt_builder=prompt_builder,
+    )
+
+    assert adapter.prompt_builder == prompt_builder
+
+
+# TODO should run for all cases
+def test_tags_passed_through(mock_config, basic_task):
+    tags = ["test-tag-1", "test-tag-2"]
+    adapter = adapter_for_task(
+        kiln_task=basic_task,
+        model_name="gpt-4",
+        provider=ModelProviderName.openai,
+        tags=tags,
+    )
+
+    assert adapter.default_tags == tags
+
+
+def test_invalid_provider(mock_config, basic_task):
+    with pytest.raises(ValueError, match="Unsupported provider: invalid"):
+        adapter_for_task(
+            kiln_task=basic_task, model_name="test-model", provider="invalid"
+        )
+
+
+@patch("kiln_ai.adapters.adapter_registry.openai_compatible_config")
+def test_openai_compatible_adapter(mock_compatible_config, mock_config, basic_task):
+    mock_compatible_config.return_value.model_name = "test-model"
+    mock_compatible_config.return_value.api_key = "test-key"
+    mock_compatible_config.return_value.base_url = "https://test.com/v1"
+
+    adapter = adapter_for_task(
+        kiln_task=basic_task,
+        model_name="provider::test-model",
+        provider=ModelProviderName.openai_compatible,
+    )
+
+    assert isinstance(adapter, OpenAICompatibleAdapter)
+    mock_compatible_config.assert_called_once_with("provider::test-model")
+    assert adapter.config.model_name == "test-model"
+    assert adapter.config.api_key == "test-key"
+    assert adapter.config.base_url == "https://test.com/v1"
+
+
+def test_custom_openai_compatible_provider(mock_config, basic_task):
+    adapter = adapter_for_task(
+        kiln_task=basic_task,
+        model_name="openai::test-model",
+        provider=ModelProviderName.kiln_custom_registry,
+    )
+
+    assert isinstance(adapter, OpenAICompatibleAdapter)
+    assert adapter.config.model_name == "openai::test-model"
+    assert adapter.config.api_key == "test-openai-key"
+    assert adapter.config.base_url is None  # openai is none
+    assert adapter.config.provider_name == ModelProviderName.kiln_custom_registry
+
+
+async def test_fine_tune_provider(mock_config, basic_task, mock_finetune_from_id):
+    adapter = adapter_for_task(
+        kiln_task=basic_task,
+        model_name="proj::task::tune",
+        provider=ModelProviderName.kiln_fine_tune,
+    )
+
+    mock_finetune_from_id.assert_called_once_with("proj::task::tune")
+    assert isinstance(adapter, OpenAICompatibleAdapter)
+    assert adapter.config.provider_name == ModelProviderName.kiln_fine_tune
+    # Kiln model name here, but the underlying openai model id below
+    assert adapter.config.model_name == "proj::task::tune"
+
+    provider = kiln_model_provider_from(
+        "proj::task::tune", provider_name=ModelProviderName.kiln_fine_tune
+    )
+    # The actual model name from the fine tune object
+    assert provider.provider_options["model"] == "test-model"

--- a/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
@@ -6,8 +6,8 @@ from langchain_core.language_models.fake_chat_models import FakeListChatModel
 
 import kiln_ai.datamodel as datamodel
 from kiln_ai.adapters.adapter_registry import adapter_for_task
-from kiln_ai.adapters.langchain_adapters import LangchainAdapter
 from kiln_ai.adapters.ml_model_list import built_in_models
+from kiln_ai.adapters.model_adapters.langchain_adapters import LangchainAdapter
 from kiln_ai.adapters.ollama_tools import ollama_online
 from kiln_ai.adapters.prompt_builders import (
     BasePromptBuilder,
@@ -108,7 +108,11 @@ async def test_amazon_bedrock(tmp_path):
 async def test_mock(tmp_path):
     task = build_test_task(tmp_path)
     mockChatModel = FakeListChatModel(responses=["mock response"])
-    adapter = LangchainAdapter(task, custom_model=mockChatModel)
+    adapter = LangchainAdapter(
+        task,
+        custom_model=mockChatModel,
+        provider="ollama",
+    )
     run = await adapter.invoke("You are a mock, send me the response!")
     assert "mock response" in run.output.output
 
@@ -116,7 +120,7 @@ async def test_mock(tmp_path):
 async def test_mock_returning_run(tmp_path):
     task = build_test_task(tmp_path)
     mockChatModel = FakeListChatModel(responses=["mock response"])
-    adapter = LangchainAdapter(task, custom_model=mockChatModel)
+    adapter = LangchainAdapter(task, custom_model=mockChatModel, provider="ollama")
     run = await adapter.invoke("You are a mock, send me the response!")
     assert run.output.output == "mock response"
     assert run is not None
@@ -127,7 +131,7 @@ async def test_mock_returning_run(tmp_path):
     assert run.output.source.properties == {
         "adapter_name": "kiln_langchain_adapter",
         "model_name": "custom.langchain:unknown_model",
-        "model_provider": "custom.langchain:FakeListChatModel",
+        "model_provider": "ollama",
         "prompt_builder_name": "simple_prompt_builder",
     }
 

--- a/libs/core/kiln_ai/adapters/test_prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_builders.py
@@ -2,7 +2,10 @@ import json
 
 import pytest
 
-from kiln_ai.adapters.base_adapter import AdapterInfo, BaseAdapter
+from kiln_ai.adapters.model_adapters.base_adapter import AdapterInfo, BaseAdapter
+from kiln_ai.adapters.model_adapters.test_structured_output import (
+    build_structured_output_test_task,
+)
 from kiln_ai.adapters.prompt_builders import (
     FewShotChainOfThoughtPromptBuilder,
     FewShotPromptBuilder,
@@ -16,7 +19,6 @@ from kiln_ai.adapters.prompt_builders import (
     prompt_builder_from_ui_name,
 )
 from kiln_ai.adapters.test_prompt_adaptors import build_test_task
-from kiln_ai.adapters.test_structured_output import build_structured_output_test_task
 from kiln_ai.datamodel import (
     DataSource,
     DataSourceType,

--- a/libs/core/kiln_ai/adapters/test_provider_tools.py
+++ b/libs/core/kiln_ai/adapters/test_provider_tools.py
@@ -318,7 +318,7 @@ async def test_kiln_model_provider_from_custom_model_valid(mock_config):
     # Mock config to pass provider warnings check
     mock_config.return_value = "fake-api-key"
 
-    provider = await kiln_model_provider_from("custom_model", ModelProviderName.openai)
+    provider = kiln_model_provider_from("custom_model", ModelProviderName.openai)
 
     assert provider.name == ModelProviderName.openai
     assert provider.supports_structured_output is False
@@ -385,7 +385,7 @@ async def test_kiln_model_provider_from_custom_registry(mock_config):
     mock_config.return_value = "fake-api-key"
 
     # Test with a custom registry model ID in format "provider::model_name"
-    provider = await kiln_model_provider_from(
+    provider = kiln_model_provider_from(
         "openai::gpt-4-turbo", ModelProviderName.kiln_custom_registry
     )
 
@@ -399,7 +399,7 @@ async def test_kiln_model_provider_from_custom_registry(mock_config):
 @pytest.mark.asyncio
 async def test_builtin_model_from_invalid_model():
     """Test that an invalid model name returns None"""
-    result = await builtin_model_from("non_existent_model")
+    result = builtin_model_from("non_existent_model")
     assert result is None
 
 
@@ -408,7 +408,7 @@ async def test_builtin_model_from_valid_model_default_provider(mock_config):
     """Test getting a valid model with default provider"""
     mock_config.return_value = "fake-api-key"
 
-    provider = await builtin_model_from(ModelName.phi_3_5)
+    provider = builtin_model_from(ModelName.phi_3_5)
 
     assert provider is not None
     assert provider.name == ModelProviderName.ollama
@@ -420,7 +420,7 @@ async def test_builtin_model_from_valid_model_specific_provider(mock_config):
     """Test getting a valid model with specific provider"""
     mock_config.return_value = "fake-api-key"
 
-    provider = await builtin_model_from(
+    provider = builtin_model_from(
         ModelName.llama_3_1_70b, provider_name=ModelProviderName.groq
     )
 
@@ -434,9 +434,7 @@ async def test_builtin_model_from_invalid_provider(mock_config):
     """Test that requesting an invalid provider returns None"""
     mock_config.return_value = "fake-api-key"
 
-    provider = await builtin_model_from(
-        ModelName.phi_3_5, provider_name="invalid_provider"
-    )
+    provider = builtin_model_from(ModelName.phi_3_5, provider_name="invalid_provider")
 
     assert provider is None
 

--- a/libs/core/kiln_ai/datamodel/__init__.py
+++ b/libs/core/kiln_ai/datamodel/__init__.py
@@ -278,12 +278,21 @@ class FineTuneStatusType(str, Enum):
 class StructuredOutputMode(str, Enum):
     """
     Enumeration of supported structured output modes.
+
+    - default: let the adapter decide
+    - json_schema: request json using API capabilities for json_schema
+    - function_calling: request json using API capabilities for function calling
+    - json_mode: request json using API's JSON mode, which should return valid JSON, but isn't checking/passing the schema
+    - json_instructions: append instructions to the prompt to request json matching the schema. No API capabilities are used. You should have a custom parser on these models as they will be returning strings.
+    - json_instruction_and_object: append instructions to the prompt to request json matching the schema. Also request the response as json_mode via API capabilities (returning dictionaries).
     """
 
     default = "default"
     json_schema = "json_schema"
     function_calling = "function_calling"
     json_mode = "json_mode"
+    json_instructions = "json_instructions"
+    json_instruction_and_object = "json_instruction_and_object"
 
 
 class Finetune(KilnParentedModel):

--- a/libs/core/kiln_ai/datamodel/model_cache.py
+++ b/libs/core/kiln_ai/datamodel/model_cache.py
@@ -65,7 +65,7 @@ class ModelCache:
     def get_model(
         self, path: Path, model_type: Type[T], readonly: bool = False
     ) -> Optional[T]:
-        # We return a copy so in-memory edits don't impact the cache until they are saved
+        # We return a copy by default, so in-memory edits don't impact the cache until they are saved
         # Benchmark shows about 2x slower, but much more foolproof
         model = self._get_model(path, model_type)
         if model:

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "langchain-fireworks>=0.2.5",
     "langchain-groq>=0.2.0",
     "langchain-ollama>=0.2.2",
-    "langchain-openai>=0.2.4",
     "langchain>=0.3.5",
     "openai>=1.53.0",
     "pdoc>=15.0.0",

--- a/libs/server/kiln_server/run_api.py
+++ b/libs/server/kiln_server/run_api.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from fastapi import FastAPI, HTTPException
 from kiln_ai.adapters.adapter_registry import adapter_for_task
+from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.prompt_builders import prompt_builder_from_ui_name
 from kiln_ai.datamodel import Task, TaskOutputRating, TaskOutputRatingType, TaskRun
 from kiln_ai.datamodel.basemodel import ID_TYPE
@@ -199,7 +200,7 @@ def connect_run_api(app: FastAPI):
         adapter = adapter_for_task(
             task,
             model_name=request.model_name,
-            provider=request.provider,
+            provider=model_provider_from_string(request.provider),
             prompt_builder=prompt_builder,
             tags=request.tags,
         )
@@ -281,3 +282,9 @@ async def update_run_util(
         updated_run.path = run.path
         updated_run.save_to_file()
         return updated_run
+
+
+def model_provider_from_string(provider: str) -> ModelProviderName:
+    if not provider or provider not in ModelProviderName.__members__:
+        raise ValueError(f"Unsupported provider: {provider}")
+    return ModelProviderName(provider)

--- a/libs/server/kiln_server/test_run_api.py
+++ b/libs/server/kiln_server/test_run_api.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-from kiln_ai.adapters.langchain_adapters import LangchainAdapter
+from kiln_ai.adapters.model_adapters.langchain_adapters import LangchainAdapter
 from kiln_ai.datamodel import (
     DataSource,
     DataSourceType,

--- a/libs/server/kiln_server/test_run_api.py
+++ b/libs/server/kiln_server/test_run_api.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.model_adapters.langchain_adapters import LangchainAdapter
 from kiln_ai.datamodel import (
     DataSource,
@@ -20,6 +21,7 @@ from kiln_server.run_api import (
     RunSummary,
     connect_run_api,
     deep_update,
+    model_provider_from_string,
     run_from_id,
 )
 
@@ -64,7 +66,7 @@ def task_run_setup(tmp_path):
 
     run_task_request = {
         "model_name": "gpt_4o",
-        "provider": "openai",
+        "provider": "ollama",
         "plaintext_input": "Test input",
     }
 
@@ -80,7 +82,7 @@ def task_run_setup(tmp_path):
                 type=DataSourceType.synthetic,
                 properties={
                     "model_name": "gpt_4o",
-                    "model_provider": "openai",
+                    "model_provider": "ollama",
                     "adapter_name": "kiln_langchain_adapter",
                     "prompt_builder_name": "simple_prompt_builder",
                 },
@@ -188,7 +190,7 @@ async def test_run_task_structured_input(client, task_run_setup):
     ):
         run_task_request = {
             "model_name": "gpt_4o",
-            "provider": "openai",
+            "provider": "ollama",
             "structured_input": {"key": "value"},
         }
 
@@ -1215,3 +1217,11 @@ async def test_remove_tags_multiple_runs(client, task_run_setup):
     updated_run2 = TaskRun.from_id_and_parent_path(second_run.id, task.path)
     assert set(updated_run1.tags) == {"tag2"}
     assert set(updated_run2.tags) == {"tag3"}
+
+
+def test_model_provider_from_string():
+    assert model_provider_from_string("openai") == ModelProviderName.openai
+    assert model_provider_from_string("ollama") == ModelProviderName.ollama
+
+    with pytest.raises(ValueError, match="Unsupported provider: unknown"):
+        model_provider_from_string("unknown")

--- a/uv.lock
+++ b/uv.lock
@@ -766,7 +766,6 @@ dependencies = [
     { name = "langchain-fireworks" },
     { name = "langchain-groq" },
     { name = "langchain-ollama" },
-    { name = "langchain-openai" },
     { name = "openai" },
     { name = "pdoc" },
     { name = "pydantic" },
@@ -795,7 +794,6 @@ requires-dist = [
     { name = "langchain-fireworks", specifier = ">=0.2.5" },
     { name = "langchain-groq", specifier = ">=0.2.0" },
     { name = "langchain-ollama", specifier = ">=0.2.2" },
-    { name = "langchain-openai", specifier = ">=0.2.4" },
     { name = "openai", specifier = ">=1.53.0" },
     { name = "pdoc", specifier = ">=15.0.0" },
     { name = "pydantic", specifier = ">=2.9.2" },
@@ -1009,20 +1007,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/8e/21f1df6af0983cf1bc6d15c71f21bd17d968114bf6cce0fb40442f5ba81f/langchain_ollama-0.2.2.tar.gz", hash = "sha256:2d9bcb06ffdbe43c7c6906c46e710d36d33b6b99cd4975cbf54060f13e51c875", size = 16970 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/77/219fb2290c832e33af2731246ea3328bade50756288c1e97ae73c4ccc197/langchain_ollama-0.2.2-py3-none-any.whl", hash = "sha256:8a1ee72dbb6ea3b3ace1d9dd317e472d667a8ed491328550da59f4893a6796f8", size = 18362 },
-]
-
-[[package]]
-name = "langchain-openai"
-version = "0.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "langchain-core" },
-    { name = "openai" },
-    { name = "tiktoken" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/7b/43a0c280557c6efb1d7db29e1a86f8f39df43224dae9f12bfc27f4e56d8f/langchain_openai-0.2.4.tar.gz", hash = "sha256:8fe494ea0b61241fe213bede8234e41e6927b348eaa8f6ce60f547676b0f2e14", size = 43152 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/8e/d119b19ca8bdbadc10b1a6e704af95d259c99166be3325b067021d7c3706/langchain_openai-0.2.4-py3-none-any.whl", hash = "sha256:7e78adde0f97bf28440b0e08be27bc3b45ff88e41c12a859b30959d9504506a4", size = 50358 },
 ]
 
 [[package]]
@@ -1866,75 +1850,6 @@ wheels = [
 ]
 
 [[package]]
-name = "regex"
-version = "2024.9.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/38/148df33b4dbca3bd069b963acab5e0fa1a9dbd6820f8c322d0dd6faeff96/regex-2024.9.11.tar.gz", hash = "sha256:6c188c307e8433bcb63dc1915022deb553b4203a70722fc542c363bf120a01fd", size = 399403 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/12/497bd6599ce8a239ade68678132296aec5ee25ebea45fc8ba91aa60fceec/regex-2024.9.11-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1494fa8725c285a81d01dc8c06b55287a1ee5e0e382d8413adc0a9197aac6408", size = 482488 },
-    { url = "https://files.pythonhosted.org/packages/c1/24/595ddb9bec2a9b151cdaf9565b0c9f3da9f0cb1dca6c158bc5175332ddf8/regex-2024.9.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0e12c481ad92d129c78f13a2a3662317e46ee7ef96c94fd332e1c29131875b7d", size = 287443 },
-    { url = "https://files.pythonhosted.org/packages/69/a8/b2fb45d9715b1469383a0da7968f8cacc2f83e9fbbcd6b8713752dd980a6/regex-2024.9.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:16e13a7929791ac1216afde26f712802e3df7bf0360b32e4914dca3ab8baeea5", size = 284561 },
-    { url = "https://files.pythonhosted.org/packages/88/87/1ce4a5357216b19b7055e7d3b0efc75a6e426133bf1e7d094321df514257/regex-2024.9.11-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46989629904bad940bbec2106528140a218b4a36bb3042d8406980be1941429c", size = 783177 },
-    { url = "https://files.pythonhosted.org/packages/3c/65/b9f002ab32f7b68e7d1dcabb67926f3f47325b8dbc22cc50b6a043e1d07c/regex-2024.9.11-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a906ed5e47a0ce5f04b2c981af1c9acf9e8696066900bf03b9d7879a6f679fc8", size = 823193 },
-    { url = "https://files.pythonhosted.org/packages/22/91/8339dd3abce101204d246e31bc26cdd7ec07c9f91598472459a3a902aa41/regex-2024.9.11-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e9a091b0550b3b0207784a7d6d0f1a00d1d1c8a11699c1a4d93db3fbefc3ad35", size = 809950 },
-    { url = "https://files.pythonhosted.org/packages/cb/19/556638aa11c2ec9968a1da998f07f27ec0abb9bf3c647d7c7985ca0b8eea/regex-2024.9.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ddcd9a179c0a6fa8add279a4444015acddcd7f232a49071ae57fa6e278f1f71", size = 782661 },
-    { url = "https://files.pythonhosted.org/packages/d1/e9/7a5bc4c6ef8d9cd2bdd83a667888fc35320da96a4cc4da5fa084330f53db/regex-2024.9.11-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6b41e1adc61fa347662b09398e31ad446afadff932a24807d3ceb955ed865cc8", size = 772348 },
-    { url = "https://files.pythonhosted.org/packages/f1/0b/29f2105bfac3ed08e704914c38e93b07c784a6655f8a015297ee7173e95b/regex-2024.9.11-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ced479f601cd2f8ca1fd7b23925a7e0ad512a56d6e9476f79b8f381d9d37090a", size = 697460 },
-    { url = "https://files.pythonhosted.org/packages/71/3a/52ff61054d15a4722605f5872ad03962b319a04c1ebaebe570b8b9b7dde1/regex-2024.9.11-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:635a1d96665f84b292e401c3d62775851aedc31d4f8784117b3c68c4fcd4118d", size = 769151 },
-    { url = "https://files.pythonhosted.org/packages/97/07/37e460ab5ca84be8e1e197c3b526c5c86993dcc9e13cbc805c35fc2463c1/regex-2024.9.11-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c0256beda696edcf7d97ef16b2a33a8e5a875affd6fa6567b54f7c577b30a137", size = 777478 },
-    { url = "https://files.pythonhosted.org/packages/65/7b/953075723dd5ab00780043ac2f9de667306ff9e2a85332975e9f19279174/regex-2024.9.11-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:3ce4f1185db3fbde8ed8aa223fc9620f276c58de8b0d4f8cc86fd1360829edb6", size = 845373 },
-    { url = "https://files.pythonhosted.org/packages/40/b8/3e9484c6230b8b6e8f816ab7c9a080e631124991a4ae2c27a81631777db0/regex-2024.9.11-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:09d77559e80dcc9d24570da3745ab859a9cf91953062e4ab126ba9d5993688ca", size = 845369 },
-    { url = "https://files.pythonhosted.org/packages/b7/99/38434984d912edbd2e1969d116257e869578f67461bd7462b894c45ed874/regex-2024.9.11-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7a22ccefd4db3f12b526eccb129390942fe874a3a9fdbdd24cf55773a1faab1a", size = 773935 },
-    { url = "https://files.pythonhosted.org/packages/ab/67/43174d2b46fa947b7b9dfe56b6c8a8a76d44223f35b1d64645a732fd1d6f/regex-2024.9.11-cp310-cp310-win32.whl", hash = "sha256:f745ec09bc1b0bd15cfc73df6fa4f726dcc26bb16c23a03f9e3367d357eeedd0", size = 261624 },
-    { url = "https://files.pythonhosted.org/packages/c4/2a/4f9c47d9395b6aff24874c761d8d620c0232f97c43ef3cf668c8b355e7a7/regex-2024.9.11-cp310-cp310-win_amd64.whl", hash = "sha256:01c2acb51f8a7d6494c8c5eafe3d8e06d76563d8a8a4643b37e9b2dd8a2ff623", size = 274020 },
-    { url = "https://files.pythonhosted.org/packages/86/a1/d526b7b6095a0019aa360948c143aacfeb029919c898701ce7763bbe4c15/regex-2024.9.11-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2cce2449e5927a0bf084d346da6cd5eb016b2beca10d0013ab50e3c226ffc0df", size = 482483 },
-    { url = "https://files.pythonhosted.org/packages/32/d9/bfdd153179867c275719e381e1e8e84a97bd186740456a0dcb3e7125c205/regex-2024.9.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b37fa423beefa44919e009745ccbf353d8c981516e807995b2bd11c2c77d268", size = 287442 },
-    { url = "https://files.pythonhosted.org/packages/33/c4/60f3370735135e3a8d673ddcdb2507a8560d0e759e1398d366e43d000253/regex-2024.9.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:64ce2799bd75039b480cc0360907c4fb2f50022f030bf9e7a8705b636e408fad", size = 284561 },
-    { url = "https://files.pythonhosted.org/packages/b1/51/91a5ebdff17f9ec4973cb0aa9d37635efec1c6868654bbc25d1543aca4ec/regex-2024.9.11-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a4cc92bb6db56ab0c1cbd17294e14f5e9224f0cc6521167ef388332604e92679", size = 791779 },
-    { url = "https://files.pythonhosted.org/packages/07/4a/022c5e6f0891a90cd7eb3d664d6c58ce2aba48bff107b00013f3d6167069/regex-2024.9.11-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d05ac6fa06959c4172eccd99a222e1fbf17b5670c4d596cb1e5cde99600674c4", size = 832605 },
-    { url = "https://files.pythonhosted.org/packages/ac/1c/3793990c8c83ca04e018151ddda83b83ecc41d89964f0f17749f027fc44d/regex-2024.9.11-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040562757795eeea356394a7fb13076ad4f99d3c62ab0f8bdfb21f99a1f85664", size = 818556 },
-    { url = "https://files.pythonhosted.org/packages/e9/5c/8b385afbfacb853730682c57be56225f9fe275c5bf02ac1fc88edbff316d/regex-2024.9.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6113c008a7780792efc80f9dfe10ba0cd043cbf8dc9a76ef757850f51b4edc50", size = 792808 },
-    { url = "https://files.pythonhosted.org/packages/9b/8b/a4723a838b53c771e9240951adde6af58c829fb6a6a28f554e8131f53839/regex-2024.9.11-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e5fb5f77c8745a60105403a774fe2c1759b71d3e7b4ca237a5e67ad066c7199", size = 781115 },
-    { url = "https://files.pythonhosted.org/packages/83/5f/031a04b6017033d65b261259c09043c06f4ef2d4eac841d0649d76d69541/regex-2024.9.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:54d9ff35d4515debf14bc27f1e3b38bfc453eff3220f5bce159642fa762fe5d4", size = 778155 },
-    { url = "https://files.pythonhosted.org/packages/fd/cd/4660756070b03ce4a66663a43f6c6e7ebc2266cc6b4c586c167917185eb4/regex-2024.9.11-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:df5cbb1fbc74a8305b6065d4ade43b993be03dbe0f8b30032cced0d7740994bd", size = 784614 },
-    { url = "https://files.pythonhosted.org/packages/93/8d/65b9bea7df120a7be8337c415b6d256ba786cbc9107cebba3bf8ff09da99/regex-2024.9.11-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7fb89ee5d106e4a7a51bce305ac4efb981536301895f7bdcf93ec92ae0d91c7f", size = 853744 },
-    { url = "https://files.pythonhosted.org/packages/96/a7/fba1eae75eb53a704475baf11bd44b3e6ccb95b316955027eb7748f24ef8/regex-2024.9.11-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:a738b937d512b30bf75995c0159c0ddf9eec0775c9d72ac0202076c72f24aa96", size = 855890 },
-    { url = "https://files.pythonhosted.org/packages/45/14/d864b2db80a1a3358534392373e8a281d95b28c29c87d8548aed58813910/regex-2024.9.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e28f9faeb14b6f23ac55bfbbfd3643f5c7c18ede093977f1df249f73fd22c7b1", size = 781887 },
-    { url = "https://files.pythonhosted.org/packages/4d/a9/bfb29b3de3eb11dc9b412603437023b8e6c02fb4e11311863d9bf62c403a/regex-2024.9.11-cp311-cp311-win32.whl", hash = "sha256:18e707ce6c92d7282dfce370cd205098384b8ee21544e7cb29b8aab955b66fa9", size = 261644 },
-    { url = "https://files.pythonhosted.org/packages/c7/ab/1ad2511cf6a208fde57fafe49829cab8ca018128ab0d0b48973d8218634a/regex-2024.9.11-cp311-cp311-win_amd64.whl", hash = "sha256:313ea15e5ff2a8cbbad96ccef6be638393041b0a7863183c2d31e0c6116688cf", size = 274033 },
-    { url = "https://files.pythonhosted.org/packages/6e/92/407531450762bed778eedbde04407f68cbd75d13cee96c6f8d6903d9c6c1/regex-2024.9.11-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b0d0a6c64fcc4ef9c69bd5b3b3626cc3776520a1637d8abaa62b9edc147a58f7", size = 483590 },
-    { url = "https://files.pythonhosted.org/packages/8e/a2/048acbc5ae1f615adc6cba36cc45734e679b5f1e4e58c3c77f0ed611d4e2/regex-2024.9.11-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:49b0e06786ea663f933f3710a51e9385ce0cba0ea56b67107fd841a55d56a231", size = 288175 },
-    { url = "https://files.pythonhosted.org/packages/8a/ea/909d8620329ab710dfaf7b4adee41242ab7c9b95ea8d838e9bfe76244259/regex-2024.9.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5b513b6997a0b2f10e4fd3a1313568e373926e8c252bd76c960f96fd039cd28d", size = 284749 },
-    { url = "https://files.pythonhosted.org/packages/ca/fa/521eb683b916389b4975337873e66954e0f6d8f91bd5774164a57b503185/regex-2024.9.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee439691d8c23e76f9802c42a95cfeebf9d47cf4ffd06f18489122dbb0a7ad64", size = 795181 },
-    { url = "https://files.pythonhosted.org/packages/28/db/63047feddc3280cc242f9c74f7aeddc6ee662b1835f00046f57d5630c827/regex-2024.9.11-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a8f877c89719d759e52783f7fe6e1c67121076b87b40542966c02de5503ace42", size = 835842 },
-    { url = "https://files.pythonhosted.org/packages/e3/94/86adc259ff8ec26edf35fcca7e334566c1805c7493b192cb09679f9c3dee/regex-2024.9.11-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:23b30c62d0f16827f2ae9f2bb87619bc4fba2044911e2e6c2eb1af0161cdb766", size = 823533 },
-    { url = "https://files.pythonhosted.org/packages/29/52/84662b6636061277cb857f658518aa7db6672bc6d1a3f503ccd5aefc581e/regex-2024.9.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85ab7824093d8f10d44330fe1e6493f756f252d145323dd17ab6b48733ff6c0a", size = 797037 },
-    { url = "https://files.pythonhosted.org/packages/c3/2a/cd4675dd987e4a7505f0364a958bc41f3b84942de9efaad0ef9a2646681c/regex-2024.9.11-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8dee5b4810a89447151999428fe096977346cf2f29f4d5e29609d2e19e0199c9", size = 784106 },
-    { url = "https://files.pythonhosted.org/packages/6f/75/3ea7ec29de0bbf42f21f812f48781d41e627d57a634f3f23947c9a46e303/regex-2024.9.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98eeee2f2e63edae2181c886d7911ce502e1292794f4c5ee71e60e23e8d26b5d", size = 782468 },
-    { url = "https://files.pythonhosted.org/packages/d3/67/15519d69b52c252b270e679cb578e22e0c02b8dd4e361f2b04efcc7f2335/regex-2024.9.11-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:57fdd2e0b2694ce6fc2e5ccf189789c3e2962916fb38779d3e3521ff8fe7a822", size = 790324 },
-    { url = "https://files.pythonhosted.org/packages/9c/71/eff77d3fe7ba08ab0672920059ec30d63fa7e41aa0fb61c562726e9bd721/regex-2024.9.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d552c78411f60b1fdaafd117a1fca2f02e562e309223b9d44b7de8be451ec5e0", size = 860214 },
-    { url = "https://files.pythonhosted.org/packages/81/11/e1bdf84a72372e56f1ea4b833dd583b822a23138a616ace7ab57a0e11556/regex-2024.9.11-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:a0b2b80321c2ed3fcf0385ec9e51a12253c50f146fddb2abbb10f033fe3d049a", size = 859420 },
-    { url = "https://files.pythonhosted.org/packages/ea/75/9753e9dcebfa7c3645563ef5c8a58f3a47e799c872165f37c55737dadd3e/regex-2024.9.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:18406efb2f5a0e57e3a5881cd9354c1512d3bb4f5c45d96d110a66114d84d23a", size = 787333 },
-    { url = "https://files.pythonhosted.org/packages/bc/4e/ba1cbca93141f7416624b3ae63573e785d4bc1834c8be44a8f0747919eca/regex-2024.9.11-cp312-cp312-win32.whl", hash = "sha256:e464b467f1588e2c42d26814231edecbcfe77f5ac414d92cbf4e7b55b2c2a776", size = 262058 },
-    { url = "https://files.pythonhosted.org/packages/6e/16/efc5f194778bf43e5888209e5cec4b258005d37c613b67ae137df3b89c53/regex-2024.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:9e8719792ca63c6b8340380352c24dcb8cd7ec49dae36e963742a275dfae6009", size = 273526 },
-    { url = "https://files.pythonhosted.org/packages/93/0a/d1c6b9af1ff1e36832fe38d74d5c5bab913f2bdcbbd6bc0e7f3ce8b2f577/regex-2024.9.11-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c157bb447303070f256e084668b702073db99bbb61d44f85d811025fcf38f784", size = 483376 },
-    { url = "https://files.pythonhosted.org/packages/a4/42/5910a050c105d7f750a72dcb49c30220c3ae4e2654e54aaaa0e9bc0584cb/regex-2024.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4db21ece84dfeefc5d8a3863f101995de646c6cb0536952c321a2650aa202c36", size = 288112 },
-    { url = "https://files.pythonhosted.org/packages/8d/56/0c262aff0e9224fa7ffce47b5458d373f4d3e3ff84e99b5ff0cb15e0b5b2/regex-2024.9.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:220e92a30b426daf23bb67a7962900ed4613589bab80382be09b48896d211e92", size = 284608 },
-    { url = "https://files.pythonhosted.org/packages/b9/54/9fe8f9aec5007bbbbce28ba3d2e3eaca425f95387b7d1e84f0d137d25237/regex-2024.9.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb1ae19e64c14c7ec1995f40bd932448713d3c73509e82d8cd7744dc00e29e86", size = 795337 },
-    { url = "https://files.pythonhosted.org/packages/b2/e7/6b2f642c3cded271c4f16cc4daa7231be544d30fe2b168e0223724b49a61/regex-2024.9.11-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f47cd43a5bfa48f86925fe26fbdd0a488ff15b62468abb5d2a1e092a4fb10e85", size = 835848 },
-    { url = "https://files.pythonhosted.org/packages/cd/9e/187363bdf5d8c0e4662117b92aa32bf52f8f09620ae93abc7537d96d3311/regex-2024.9.11-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9d4a76b96f398697fe01117093613166e6aa8195d63f1b4ec3f21ab637632963", size = 823503 },
-    { url = "https://files.pythonhosted.org/packages/f8/10/601303b8ee93589f879664b0cfd3127949ff32b17f9b6c490fb201106c4d/regex-2024.9.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ea51dcc0835eea2ea31d66456210a4e01a076d820e9039b04ae8d17ac11dee6", size = 797049 },
-    { url = "https://files.pythonhosted.org/packages/ef/1c/ea200f61ce9f341763f2717ab4daebe4422d83e9fd4ac5e33435fd3a148d/regex-2024.9.11-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7aaa315101c6567a9a45d2839322c51c8d6e81f67683d529512f5bcfb99c802", size = 784144 },
-    { url = "https://files.pythonhosted.org/packages/d8/5c/d2429be49ef3292def7688401d3deb11702c13dcaecdc71d2b407421275b/regex-2024.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c57d08ad67aba97af57a7263c2d9006d5c404d721c5f7542f077f109ec2a4a29", size = 782483 },
-    { url = "https://files.pythonhosted.org/packages/12/d9/cbc30f2ff7164f3b26a7760f87c54bf8b2faed286f60efd80350a51c5b99/regex-2024.9.11-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f8404bf61298bb6f8224bb9176c1424548ee1181130818fcd2cbffddc768bed8", size = 790320 },
-    { url = "https://files.pythonhosted.org/packages/19/1d/43ed03a236313639da5a45e61bc553c8d41e925bcf29b0f8ecff0c2c3f25/regex-2024.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dd4490a33eb909ef5078ab20f5f000087afa2a4daa27b4c072ccb3cb3050ad84", size = 860435 },
-    { url = "https://files.pythonhosted.org/packages/34/4f/5d04da61c7c56e785058a46349f7285ae3ebc0726c6ea7c5c70600a52233/regex-2024.9.11-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:eee9130eaad130649fd73e5cd92f60e55708952260ede70da64de420cdcad554", size = 859571 },
-    { url = "https://files.pythonhosted.org/packages/12/7f/8398c8155a3c70703a8e91c29532558186558e1aea44144b382faa2a6f7a/regex-2024.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a2644a93da36c784e546de579ec1806bfd2763ef47babc1b03d765fe560c9f8", size = 787398 },
-    { url = "https://files.pythonhosted.org/packages/58/3a/f5903977647a9a7e46d5535e9e96c194304aeeca7501240509bde2f9e17f/regex-2024.9.11-cp313-cp313-win32.whl", hash = "sha256:e997fd30430c57138adc06bba4c7c2968fb13d101e57dd5bb9355bf8ce3fa7e8", size = 262035 },
-    { url = "https://files.pythonhosted.org/packages/ff/80/51ba3a4b7482f6011095b3a036e07374f64de180b7d870b704ed22509002/regex-2024.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:042c55879cfeb21a8adacc84ea347721d3d83a159da6acdf1116859e2427c43f", size = 273510 },
-]
-
-[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2161,42 +2076,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b", size = 47421 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539", size = 28169 },
-]
-
-[[package]]
-name = "tiktoken"
-version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "regex" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/37/02/576ff3a6639e755c4f70997b2d315f56d6d71e0d046f4fb64cb81a3fb099/tiktoken-0.8.0.tar.gz", hash = "sha256:9ccbb2740f24542534369c5635cfd9b2b3c2490754a78ac8831d99f89f94eeb2", size = 35107 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/ba/a35fad753bbca8ba0cc1b0f3402a70256a110ced7ac332cf84ba89fc87ab/tiktoken-0.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b07e33283463089c81ef1467180e3e00ab00d46c2c4bbcef0acab5f771d6695e", size = 1039905 },
-    { url = "https://files.pythonhosted.org/packages/91/05/13dab8fd7460391c387b3e69e14bf1e51ff71fe0a202cd2933cc3ea93fb6/tiktoken-0.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9269348cb650726f44dd3bbb3f9110ac19a8dcc8f54949ad3ef652ca22a38e21", size = 982417 },
-    { url = "https://files.pythonhosted.org/packages/e9/98/18ec4a8351a6cf4537e40cd6e19a422c10cce1ef00a2fcb716e0a96af58b/tiktoken-0.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e13f37bc4ef2d012731e93e0fef21dc3b7aea5bb9009618de9a4026844e560", size = 1144915 },
-    { url = "https://files.pythonhosted.org/packages/2e/28/cf3633018cbcc6deb7805b700ccd6085c9a5a7f72b38974ee0bffd56d311/tiktoken-0.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f13d13c981511331eac0d01a59b5df7c0d4060a8be1e378672822213da51e0a2", size = 1177221 },
-    { url = "https://files.pythonhosted.org/packages/57/81/8a5be305cbd39d4e83a794f9e80c7f2c84b524587b7feb27c797b2046d51/tiktoken-0.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6b2ddbc79a22621ce8b1166afa9f9a888a664a579350dc7c09346a3b5de837d9", size = 1237398 },
-    { url = "https://files.pythonhosted.org/packages/dc/da/8d1cc3089a83f5cf11c2e489332752981435280285231924557350523a59/tiktoken-0.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d8c2d0e5ba6453a290b86cd65fc51fedf247e1ba170191715b049dac1f628005", size = 884215 },
-    { url = "https://files.pythonhosted.org/packages/f6/1e/ca48e7bfeeccaf76f3a501bd84db1fa28b3c22c9d1a1f41af9fb7579c5f6/tiktoken-0.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d622d8011e6d6f239297efa42a2657043aaed06c4f68833550cac9e9bc723ef1", size = 1039700 },
-    { url = "https://files.pythonhosted.org/packages/8c/f8/f0101d98d661b34534769c3818f5af631e59c36ac6d07268fbfc89e539ce/tiktoken-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2efaf6199717b4485031b4d6edb94075e4d79177a172f38dd934d911b588d54a", size = 982413 },
-    { url = "https://files.pythonhosted.org/packages/ac/3c/2b95391d9bd520a73830469f80a96e3790e6c0a5ac2444f80f20b4b31051/tiktoken-0.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5637e425ce1fc49cf716d88df3092048359a4b3bbb7da762840426e937ada06d", size = 1144242 },
-    { url = "https://files.pythonhosted.org/packages/01/c4/c4a4360de845217b6aa9709c15773484b50479f36bb50419c443204e5de9/tiktoken-0.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fb0e352d1dbe15aba082883058b3cce9e48d33101bdaac1eccf66424feb5b47", size = 1176588 },
-    { url = "https://files.pythonhosted.org/packages/f8/a3/ef984e976822cd6c2227c854f74d2e60cf4cd6fbfca46251199914746f78/tiktoken-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:56edfefe896c8f10aba372ab5706b9e3558e78db39dd497c940b47bf228bc419", size = 1237261 },
-    { url = "https://files.pythonhosted.org/packages/1e/86/eea2309dc258fb86c7d9b10db536434fc16420feaa3b6113df18b23db7c2/tiktoken-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:326624128590def898775b722ccc327e90b073714227175ea8febbc920ac0a99", size = 884537 },
-    { url = "https://files.pythonhosted.org/packages/c1/22/34b2e136a6f4af186b6640cbfd6f93400783c9ef6cd550d9eab80628d9de/tiktoken-0.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:881839cfeae051b3628d9823b2e56b5cc93a9e2efb435f4cf15f17dc45f21586", size = 1039357 },
-    { url = "https://files.pythonhosted.org/packages/04/d2/c793cf49c20f5855fd6ce05d080c0537d7418f22c58e71f392d5e8c8dbf7/tiktoken-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fe9399bdc3f29d428f16a2f86c3c8ec20be3eac5f53693ce4980371c3245729b", size = 982616 },
-    { url = "https://files.pythonhosted.org/packages/b3/a1/79846e5ef911cd5d75c844de3fa496a10c91b4b5f550aad695c5df153d72/tiktoken-0.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a58deb7075d5b69237a3ff4bb51a726670419db6ea62bdcd8bd80c78497d7ab", size = 1144011 },
-    { url = "https://files.pythonhosted.org/packages/26/32/e0e3a859136e95c85a572e4806dc58bf1ddf651108ae8b97d5f3ebe1a244/tiktoken-0.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2908c0d043a7d03ebd80347266b0e58440bdef5564f84f4d29fb235b5df3b04", size = 1175432 },
-    { url = "https://files.pythonhosted.org/packages/c7/89/926b66e9025b97e9fbabeaa59048a736fe3c3e4530a204109571104f921c/tiktoken-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:294440d21a2a51e12d4238e68a5972095534fe9878be57d905c476017bff99fc", size = 1236576 },
-    { url = "https://files.pythonhosted.org/packages/45/e2/39d4aa02a52bba73b2cd21ba4533c84425ff8786cc63c511d68c8897376e/tiktoken-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:d8f3192733ac4d77977432947d563d7e1b310b96497acd3c196c9bddb36ed9db", size = 883824 },
-    { url = "https://files.pythonhosted.org/packages/e3/38/802e79ba0ee5fcbf240cd624143f57744e5d411d2e9d9ad2db70d8395986/tiktoken-0.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:02be1666096aff7da6cbd7cdaa8e7917bfed3467cd64b38b1f112e96d3b06a24", size = 1039648 },
-    { url = "https://files.pythonhosted.org/packages/b1/da/24cdbfc302c98663fbea66f5866f7fa1048405c7564ab88483aea97c3b1a/tiktoken-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94ff53c5c74b535b2cbf431d907fc13c678bbd009ee633a2aca269a04389f9a", size = 982763 },
-    { url = "https://files.pythonhosted.org/packages/e4/f0/0ecf79a279dfa41fc97d00adccf976ecc2556d3c08ef3e25e45eb31f665b/tiktoken-0.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b231f5e8982c245ee3065cd84a4712d64692348bc609d84467c57b4b72dcbc5", size = 1144417 },
-    { url = "https://files.pythonhosted.org/packages/ab/d3/155d2d4514f3471a25dc1d6d20549ef254e2aa9bb5b1060809b1d3b03d3a/tiktoken-0.8.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4177faa809bd55f699e88c96d9bb4635d22e3f59d635ba6fd9ffedf7150b9953", size = 1175108 },
-    { url = "https://files.pythonhosted.org/packages/19/eb/5989e16821ee8300ef8ee13c16effc20dfc26c777d05fbb6825e3c037b81/tiktoken-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5376b6f8dc4753cd81ead935c5f518fa0fbe7e133d9e25f648d8c4dabdd4bad7", size = 1236520 },
-    { url = "https://files.pythonhosted.org/packages/40/59/14b20465f1d1cb89cfbc96ec27e5617b2d41c79da12b5e04e96d689be2a7/tiktoken-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:18228d624807d66c87acd8f25fc135665617cab220671eb65b50f5d70fa51f69", size = 883849 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Open AI Adapter**

Use the much simpler OpenAI API instead of LangChain for most adapters. Keeping LangChain for some. Should be able to move of LC for all but long tail APIs soon (AWS).

**Thinking Support**

Make R1 work natively in Kiln.

 - Support for <think> tags
 - Support for open router's custom "reasoning" response
 - save thinking into intermediate_results of our data model
 - work with COT prompts: can give it custom thinking prompts using our prompt infrastructure (if none provide, a thinking model will still, think, just using it's default reasoning with no custom instructions).
