### PR TITLE
Create signed windows builds via CI action

### DIFF
--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -37,8 +37,8 @@ jobs:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://eus.codesigning.azure.net/
-          trusted-signing-account-name: vscx-codesigning
-          certificate-profile-name: vscx-certificate-profile
+          trusted-signing-account-name: Kiln-Steve-Signing
+          certificate-profile-name: Kiln-AI-Signing
           files-folder: ${{ github.workspace }}/app/desktop/build/dist
           files-folder-recurse: true
           files-folder-filter: exe

--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -33,14 +33,17 @@ jobs:
       - name: Sign internal files with Trusted Signing
         uses: azure/trusted-signing-action@v0.5.1
         with:
-          azure-username: ${{ secrets.AZURE_USERNAME }}
-          azure-password: ${{ secrets.AZURE_PASSWORD }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://eus.codesigning.azure.net/
           trusted-signing-account-name: vscx-codesigning
           certificate-profile-name: vscx-certificate-profile
           files-folder: ${{ github.workspace }}/app/desktop/build/dist
           files-folder-recurse: true
-          files-folder-filter: exe,dll
+          files-folder-filter: exe
+          # TODO: consider signing dlls as well. But for testing, we don't want to use all our quota.
+          # files-folder-filter: exe,dll
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256

--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -53,6 +53,22 @@ jobs:
         with:
           path: ./app/desktop/WinInnoSetup.iss
 
+      - name: Sign Windows Installer exe
+        uses: azure/trusted-signing-action@v0.5.1
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: https://eus.codesigning.azure.net/
+          trusted-signing-account-name: Kiln-Steve-Signing
+          certificate-profile-name: Kiln-AI-Signing
+          files-folder: ${{ github.workspace }}/app/desktop/Output
+          files-folder-recurse: true
+          files-folder-filter: kilnsetup.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
       - name: Copy Windows Installer
         run: cp ./app/desktop/Output/kilnsetup.exe ./app/desktop/build/dist/Kiln.Windows.Installer.exe
 

--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -1,0 +1,45 @@
+name: Build Signed Windows Release
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      # Use 3.12 - 3.13 not working yet (Numpy verion too old)
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+
+      # Use GH python version (includes TK/TCL)
+      - name: Set up Python using GH python version
+        run: uv venv --python 3.12 --python-preference only-system
+
+      - name: Install the project
+        run: uv sync
+
+      - name: Build Desktop App
+        run: uv run bash ./app/desktop/build_desktop_app.sh
+
+      - name: Build Windows Installer
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
+        with:
+          path: ./app/desktop/WinInnoSetup.iss
+
+      - name: Copy Windows Installer
+        run: cp ./app/desktop/Output/kilnsetup.exe ./app/desktop/build/dist/Kiln.Windows.Installer.exe
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: kiln-desktop-windows-signed-installer
+          path: ./app/desktop/build/dist/*

--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -30,6 +30,21 @@ jobs:
       - name: Build Desktop App
         run: uv run bash ./app/desktop/build_desktop_app.sh
 
+      - name: Sign internal files with Trusted Signing
+        uses: azure/trusted-signing-action@v0.5.1
+        with:
+          azure-username: ${{ secrets.AZURE_USERNAME }}
+          azure-password: ${{ secrets.AZURE_PASSWORD }}
+          endpoint: https://eus.codesigning.azure.net/
+          trusted-signing-account-name: vscx-codesigning
+          certificate-profile-name: vscx-certificate-profile
+          files-folder: ${{ github.workspace }}/app/desktop/build/dist
+          files-folder-recurse: true
+          files-folder-filter: exe,dll
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
       - name: Build Windows Installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
         with:


### PR DESCRIPTION
This guide is the way. [[Code Signing With Azure Trusted Signing on GitHub Actions](https://www.hendrik-erz.de/post/code-signing-with-azure-trusted-signing-on-github-actions)](https://www.hendrik-erz.de/post/code-signing-with-azure-trusted-signing-on-github-actions)

Azure docs and UX are no good awful bad.