### PR TITLE
Okay: fix the root of my 2 prompt issue

### DIFF
--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -84,7 +84,6 @@ class CreateEvalConfigRequest(BaseModel):
     properties: dict[str, Any]
     model_name: str
     provider: ModelProviderName
-    prompt_id: PromptId
 
 
 class CreateTaskRunConfigRequest(BaseModel):

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
@@ -316,6 +316,13 @@
         eval_config.model.properties["model_provider"] + "",
       ),
     })
+    const task_description = eval_config.properties["task_description"]
+    if (task_description) {
+      properties.push({
+        name: "Task Description",
+        value: task_description,
+      })
+    }
     return properties
   }
 

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -200,6 +200,12 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
                 self.properties["eval_steps"], list
             ):
                 raise ValueError("eval_steps is required and must be a list for g_eval")
+            if "task_description" in self.properties and not isinstance(
+                self.properties["task_description"], str
+            ):
+                raise ValueError(
+                    "task_description is optional, but if provided must be a string"
+                )
             return self
         else:
             raise ValueError(f"Invalid eval config type: {self.config_type}")

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -69,6 +69,14 @@ def test_eval_config_missing_eval_steps(valid_eval_config):
         valid_eval_config.properties = {}
 
 
+def test_eval_config_missing_task_description(valid_eval_config):
+    with pytest.raises(
+        ValueError,
+        match="task_description is optional, but if provided must be a string",
+    ):
+        valid_eval_config.properties = {"task_description": 123, "eval_steps": []}
+
+
 def test_eval_config_invalid_json(valid_eval_config):
     class InvalidClass:
         pass


### PR DESCRIPTION
 - Want the evaluator to have some context on what the goal is.
 - Don't want to give it the prompt, as we're testing prompts, so it's biasing the evaluator
 - Instead, give a short task-desription, which is locked across the eval_config, so no bias for a given prompt.
