### PR TITLE
fix: hide repair for imported runs

### DIFF
--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
@@ -49,6 +49,7 @@
       )
     }
 
+    const model_id = run?.output?.source?.properties?.model_name
     model_props = Object.fromEntries(
       Object.entries({
         ID: run?.id || undefined,
@@ -56,17 +57,13 @@
           "" +
           run?.input_source?.type.charAt(0).toUpperCase() +
           run?.input_source?.type.slice(1),
-        "Output Model": model_name(
-          "" + run?.output?.source?.properties?.model_name,
-          $model_info,
-        ),
+        "Output Model": model_name(model_id, $model_info),
         "Model Provider": run?.output?.source?.properties?.model_provider,
-        Prompt: prompt_name_from_id(prompt_id),
+        Prompt: prompt_id && prompt_name_from_id(prompt_id),
         "Created By": run?.input_source?.properties?.created_by,
         "Created At": formatDate(run?.created_at),
         Topic: topic_path,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      }).filter(([_, value]) => value !== undefined),
+      }).filter(([_, value]) => value !== undefined && value !== ""),
     )
   }
 

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -12,6 +12,12 @@
   import { onMount } from "svelte"
   import TagDropdown from "./tag_dropdown.svelte"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
+  import type { components } from "../../../lib/api_schema"
+  import Warning from "../../../lib/ui/warning.svelte"
+
+  const REPAIR_ENABLED_FOR_SOURCES: Array<
+    components["schemas"]["DataSourceType"]
+  > = ["human", "synthetic"]
 
   export let project_id: string
   export let task: Task
@@ -48,6 +54,9 @@
     !repair_run // repair generated, should show repair evaluation instead
   $: repair_review_available = !!repair_run && !run?.repaired_output
   $: repair_complete = !!run?.repaired_output?.output
+  $: repair_enabled_for_source = REPAIR_ENABLED_FOR_SOURCES.some(
+    (s) => s === run?.output?.source?.type,
+  )
 
   // Use for some animations on first mount
   let mounted = false
@@ -383,7 +392,18 @@
         </div>
       </div>
 
-      {#if should_offer_repair || repair_review_available || repair_complete}
+      {#if !repair_enabled_for_source && (should_offer_repair || repair_review_available || repair_complete)}
+        <div class="grow mt-10">
+          <Warning
+            warning_message="Repair is not available for runs from {run.output
+              .source?.type || 'unknown'} sources."
+            warning_color="warning"
+            tight={true}
+          />
+        </div>
+      {/if}
+
+      {#if repair_enabled_for_source && (should_offer_repair || repair_review_available || repair_complete)}
         <div class="grow mt-10">
           <div class="text-xl font-bold mb-2">Repair Output</div>
           {#if should_offer_repair}


### PR DESCRIPTION
## What does this PR do?

Follow up on https://github.com/Kiln-AI/Kiln/pull/254 which partially resolved the issue preventing the repair UI from working on `file_import` runs. However, additional downstream issues were discovered.

This PR disables the repair UI for runs that are neither `synthetic` nor `human`. Instead of an unusable repair form, users will see a warning indicating that repair is unavailable. Even if this UI is replaced later with a working repair UI, this PR already improves the current behavior. This PR also hides the empty fields in the run `Parameters` block in the sidebar.

The warning is only displayed if the user has rated the run `< 5 stars`. The rationale for showing a warning rather than nothing is that users are more likely to report repairing imported runs as a feature they need if they know it is normally supposed to be there.

<img width="963" alt="image" src="https://github.com/user-attachments/assets/78553e85-ffdb-4c60-989c-fa3438ef44d2" />

## Related Issues

https://github.com/Kiln-AI/Kiln/issues/248

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
