### PR TITLE
feat: allow manual repair edit

### DIFF
--- a/app/desktop/studio_server/repair_api.py
+++ b/app/desktop/studio_server/repair_api.py
@@ -85,7 +85,8 @@ def connect_repair_api(app: FastAPI):
             validate_schema(json.loads(output), task.output_json_schema)
 
         # manually edited runs are human but the user id is not set
-        if input.repair_run.output.source.type == DataSourceType.human:
+        source = input.repair_run.output.source
+        if not source or source.type == DataSourceType.human:
             input.repair_run.output.source = DataSource(
                 type=DataSourceType.human,
                 properties={"created_by": Config.shared().user_id},

--- a/app/desktop/studio_server/repair_api.py
+++ b/app/desktop/studio_server/repair_api.py
@@ -79,11 +79,6 @@ def connect_repair_api(app: FastAPI):
     ) -> TaskRun:
         task, run = task_and_run_from_id(project_id, task_id, run_id)
 
-        # the repair must match the task's output schema if structured output is enabled
-        if task.output_json_schema:
-            output = input.repair_run.output.model_dump().get("output", "")
-            validate_schema(json.loads(output), task.output_json_schema)
-
         # manually edited runs are human but the user id is not set
         source = input.repair_run.output.source
         if not source or source.type == DataSourceType.human:

--- a/app/web_ui/src/lib/utils/form_container.svelte
+++ b/app/web_ui/src/lib/utils/form_container.svelte
@@ -12,7 +12,6 @@
   export let error: KilnError | null = null
   export let submitting = false
   export let saved = false
-  export let disabled = false
   export let keyboard_submit = true
   export let submit_visible = true
   export let gap: number = 6
@@ -137,7 +136,7 @@
   })
 
   function handleKeydown(event: KeyboardEvent) {
-    if (!keyboard_submit || !submit_visible || disabled) {
+    if (!keyboard_submit || !submit_visible) {
       return
     }
     // Command+Enter (Mac) or Ctrl+Enter (Windows/Linux)
@@ -184,7 +183,7 @@
         ? 'btn-success'
         : ''} {submit_visible ? '' : 'hidden'}"
       on:click={validate_and_submit}
-      disabled={submitting || disabled}
+      disabled={submitting}
     >
       {#if ui_saved_indicator}
         ✔ Saved

--- a/app/web_ui/src/lib/utils/form_container.svelte
+++ b/app/web_ui/src/lib/utils/form_container.svelte
@@ -12,6 +12,7 @@
   export let error: KilnError | null = null
   export let submitting = false
   export let saved = false
+  export let disabled = false
   export let keyboard_submit = true
   export let submit_visible = true
   export let gap: number = 6
@@ -136,7 +137,7 @@
   })
 
   function handleKeydown(event: KeyboardEvent) {
-    if (!keyboard_submit) {
+    if (!keyboard_submit || !submit_visible || disabled) {
       return
     }
     // Command+Enter (Mac) or Ctrl+Enter (Windows/Linux)
@@ -183,7 +184,7 @@
         ? 'btn-success'
         : ''} {submit_visible ? '' : 'hidden'}"
       on:click={validate_and_submit}
-      disabled={submitting}
+      disabled={submitting || disabled}
     >
       {#if ui_saved_indicator}
         ✔ Saved

--- a/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
+++ b/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
@@ -2,26 +2,17 @@
   import FormElement from "$lib/utils/form_element.svelte"
   import type { Task, TaskRun } from "$lib/types"
   import FormContainer from "../../../lib/utils/form_container.svelte"
+  import { createKilnError, KilnError } from "../../../lib/utils/error_handlers"
+  import { client } from "../../../lib/api_client"
 
   export let on_submit: (run: TaskRun) => void
   export let on_cancel: () => void
 
+  export let project_id: string
   export let task: Task
+  export let run: TaskRun
   export let repair_run: TaskRun
-
-  function validate_output(text: string) {
-    if (task.output_json_schema) {
-      try {
-        // TODO: validate against the JSON schema instead of just checking if it is valid JSON
-        JSON.parse(text)
-        return true
-      } catch (err) {
-        return false
-      }
-    }
-
-    return true
-  }
+  export let repair_instructions: string
 
   function prettify_output(text: string) {
     if (task.output_json_schema) {
@@ -34,11 +25,12 @@
     return text
   }
 
-  $: repair_output_edited_valid = validate_output(repair_output_edited)
   let repair_output_edited = prettify_output(repair_run.output.output) || ""
 
-  function handle_submit() {
-    const human_edited_run: TaskRun = {
+  let post_repair_error: KilnError | null = null
+  let post_repair_submitting = false
+  async function handle_submit() {
+    repair_run = {
       ...repair_run,
       output: {
         ...repair_run.output,
@@ -47,12 +39,53 @@
           type: "human",
           properties: {
             // the user name will be replaced with the actual user name on the server side
-            created_by: "user",
+            created_by: "unknown",
           },
         },
       },
     }
-    on_submit(human_edited_run)
+
+    post_repair_error = null
+    post_repair_submitting = true
+
+    try {
+      if (!repair_run) {
+        throw new KilnError("No repair to edit", null)
+      }
+      if (!task.id || !run.id) {
+        throw new KilnError(
+          "This task run isn't saved. Enable Auto-save. You can't edit repairs for unsaved runs.",
+          null,
+        )
+      }
+      const {
+        data, // only present if 2XX response
+        error: fetch_error, // only present if 4XX or 5XX response
+      } = await client.POST(
+        "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}/repair",
+        {
+          params: {
+            path: {
+              project_id: project_id,
+              task_id: task.id,
+              run_id: run.id,
+            },
+          },
+          body: {
+            repair_run: repair_run,
+            evaluator_feedback: repair_instructions || "",
+          },
+        },
+      )
+      if (fetch_error) {
+        throw fetch_error
+      }
+      on_submit(data)
+    } catch (err) {
+      post_repair_error = createKilnError(err)
+    } finally {
+      post_repair_submitting = false
+    }
   }
 
   function handle_cancel() {
@@ -61,56 +94,32 @@
 </script>
 
 <div>
-  {#if task.output_json_schema}
-    {#if repair_output_edited_valid}
-      <div class="text-xs font-medium text-gray-500 flex flex-row mb-2">
-        <svg
-          fill="currentColor"
-          class="w-4 h-4 mr-[2px]"
-          viewBox="0 0 56 56"
-          xmlns="http://www.w3.org/2000/svg"
-          ><path
-            d="M 27.9999 51.9063 C 41.0546 51.9063 51.9063 41.0781 51.9063 28 C 51.9063 14.9453 41.0312 4.0937 27.9765 4.0937 C 14.8983 4.0937 4.0937 14.9453 4.0937 28 C 4.0937 41.0781 14.9218 51.9063 27.9999 51.9063 Z M 24.7655 40.0234 C 23.9687 40.0234 23.3593 39.6719 22.6796 38.8750 L 15.9296 30.5312 C 15.5780 30.0859 15.3671 29.5234 15.3671 29.0078 C 15.3671 27.9063 16.2343 27.0625 17.2655 27.0625 C 17.9452 27.0625 18.5077 27.3203 19.0702 28.0469 L 24.6718 35.2890 L 35.5702 17.8281 C 36.0155 17.1016 36.6249 16.75 37.2343 16.75 C 38.2655 16.75 39.2733 17.4297 39.2733 18.5547 C 39.2733 19.0703 38.9687 19.6328 38.6640 20.1016 L 26.7577 38.8750 C 26.2421 39.6484 25.5858 40.0234 24.7655 40.0234 Z"
-          /></svg
-        >
-        Structure Valid
-      </div>
-    {:else}
-      <div
-        class="text-xs font-medium text-error flex flex-row mb-2 items-center"
-      >
-        <svg
-          class="w-4 h-4 mr-[2px] text-error"
-          fill="currentColor"
-          viewBox="0 0 256 256"
-          id="Flat"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M128,20.00012a108,108,0,1,0,108,108A108.12217,108.12217,0,0,0,128,20.00012Zm0,192a84,84,0,1,1,84-84A84.0953,84.0953,0,0,1,128,212.00012Zm-12-80v-52a12,12,0,1,1,24,0v52a12,12,0,1,1-24,0Zm28,40a16,16,0,1,1-16-16A16.018,16.018,0,0,1,144,172.00012Z"
-          />
-        </svg>
-        Structure does not match required schema
-      </div>
-    {/if}
-  {/if}
-
   <FormContainer
-    submit_label="Apply"
+    submit_label="Save Repair (5 stars)"
     on:submit={handle_submit}
-    disabled={!repair_output_edited_valid}
+    submitting={post_repair_submitting}
   >
     <FormElement
       id={"repair_manual_output"}
       label="Manual Repair"
+      info_description="Provide a improvement or correction to the task's output"
       inputType="textarea"
       tall={true}
       bind:value={repair_output_edited}
     />
 
+    {#if post_repair_error}
+      <p class="text-error font-medium text-sm">
+        Error Saving Repair<br />
+        <span class="text-error text-xs font-normal">
+          {post_repair_error.getMessage()}</span
+        >
+      </p>
+    {/if}
+
     <button
       class="link text-gray-500 text-sm text-right"
-      on:click={handle_cancel}>Cancel edit</button
+      on:click={handle_cancel}>Cancel</button
     >
   </FormContainer>
 </div>

--- a/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
+++ b/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import FormElement from "$lib/utils/form_element.svelte"
+  import type { Task, TaskRun } from "$lib/types"
+  import FormContainer from "../../../lib/utils/form_container.svelte"
+
+  export let on_submit: (run: TaskRun) => void
+  export let on_cancel: () => void
+
+  export let task: Task
+  export let repair_run: TaskRun
+
+  function validate_output(text: string) {
+    if (task.output_json_schema) {
+      try {
+        // TODO: validate against the JSON schema instead of just checking if it is valid JSON
+        JSON.parse(text)
+        return true
+      } catch (err) {
+        return false
+      }
+    }
+
+    return true
+  }
+
+  function prettify_output(text: string) {
+    if (task.output_json_schema) {
+      try {
+        return JSON.stringify(JSON.parse(text), null, 2)
+      } catch (err) {
+        return text
+      }
+    }
+    return text
+  }
+
+  $: repair_output_edited_valid = validate_output(repair_output_edited)
+  let repair_output_edited = prettify_output(repair_run.output.output) || ""
+
+  function handle_submit() {
+    const human_edited_run: TaskRun = {
+      ...repair_run,
+      output: {
+        ...repair_run.output,
+        output: repair_output_edited,
+        source: {
+          type: "human",
+          properties: {
+            // the user name will be replaced with the actual user name on the server side
+            created_by: "user",
+          },
+        },
+      },
+    }
+    on_submit(human_edited_run)
+  }
+
+  function handle_cancel() {
+    on_cancel()
+  }
+</script>
+
+<div>
+  {#if task.output_json_schema}
+    {#if repair_output_edited_valid}
+      <div class="text-xs font-medium text-gray-500 flex flex-row mb-2">
+        <svg
+          fill="currentColor"
+          class="w-4 h-4 mr-[2px]"
+          viewBox="0 0 56 56"
+          xmlns="http://www.w3.org/2000/svg"
+          ><path
+            d="M 27.9999 51.9063 C 41.0546 51.9063 51.9063 41.0781 51.9063 28 C 51.9063 14.9453 41.0312 4.0937 27.9765 4.0937 C 14.8983 4.0937 4.0937 14.9453 4.0937 28 C 4.0937 41.0781 14.9218 51.9063 27.9999 51.9063 Z M 24.7655 40.0234 C 23.9687 40.0234 23.3593 39.6719 22.6796 38.8750 L 15.9296 30.5312 C 15.5780 30.0859 15.3671 29.5234 15.3671 29.0078 C 15.3671 27.9063 16.2343 27.0625 17.2655 27.0625 C 17.9452 27.0625 18.5077 27.3203 19.0702 28.0469 L 24.6718 35.2890 L 35.5702 17.8281 C 36.0155 17.1016 36.6249 16.75 37.2343 16.75 C 38.2655 16.75 39.2733 17.4297 39.2733 18.5547 C 39.2733 19.0703 38.9687 19.6328 38.6640 20.1016 L 26.7577 38.8750 C 26.2421 39.6484 25.5858 40.0234 24.7655 40.0234 Z"
+          /></svg
+        >
+        Structure Valid
+      </div>
+    {:else}
+      <div
+        class="text-xs font-medium text-error flex flex-row mb-2 items-center"
+      >
+        <svg
+          class="w-4 h-4 mr-[2px] text-error"
+          fill="currentColor"
+          viewBox="0 0 256 256"
+          id="Flat"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M128,20.00012a108,108,0,1,0,108,108A108.12217,108.12217,0,0,0,128,20.00012Zm0,192a84,84,0,1,1,84-84A84.0953,84.0953,0,0,1,128,212.00012Zm-12-80v-52a12,12,0,1,1,24,0v52a12,12,0,1,1-24,0Zm28,40a16,16,0,1,1-16-16A16.018,16.018,0,0,1,144,172.00012Z"
+          />
+        </svg>
+        Structure does not match required schema
+      </div>
+    {/if}
+  {/if}
+
+  <FormContainer
+    submit_label="Apply"
+    on:submit={handle_submit}
+    disabled={!repair_output_edited_valid}
+  >
+    <FormElement
+      id={"repair_manual_output"}
+      label="Manual Repair"
+      inputType="textarea"
+      tall={true}
+      bind:value={repair_output_edited}
+    />
+
+    <button
+      class="link text-gray-500 text-sm text-right"
+      on:click={handle_cancel}>Cancel edit</button
+    >
+  </FormContainer>
+</div>

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -523,7 +523,7 @@
             {/if}
 
             {#if accept_repair_error}
-              <p class="text-error font-medium text-sm">
+              <p class="mt-2 text-error font-medium text-sm">
                 Error Accepting Repair<br />
                 <span class="text-error text-xs font-normal">
                   {accept_repair_error.getMessage()}</span

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -362,6 +362,8 @@
   function handle_manual_edit_submit(repair_run_edited: TaskRun) {
     repair_run = repair_run_edited
     repair_edit_mode = false
+    updated_run = repair_run_edited
+    repair_run = null
   }
 </script>
 
@@ -445,7 +447,20 @@
                 bind:value={repair_instructions}
               />
             </FormContainer>
-          {:else if repair_review_available || repair_edit_mode}
+          {:else if repair_edit_mode && repair_run}
+            <p class="text-sm text-gray-500 mb-4">
+              Manually improve or correct the response.
+            </p>
+            <OutputRepairEditForm
+              {task}
+              {run}
+              {repair_run}
+              {project_id}
+              repair_instructions={repair_instructions || ""}
+              on_submit={handle_manual_edit_submit}
+              on_cancel={handle_manual_edit_cancel}
+            />
+          {:else if repair_review_available}
             <p class="text-sm text-gray-500 mb-4">
               The model has attempted to fix the output given <span
                 class="tooltip link"
@@ -453,16 +468,7 @@
                   'No instruction provided'}">your instructions</span
               >. Review the result.
             </p>
-            {#if repair_edit_mode && repair_run}
-              <OutputRepairEditForm
-                {task}
-                {repair_run}
-                on_submit={handle_manual_edit_submit}
-                on_cancel={handle_manual_edit_cancel}
-              />
-            {:else}
-              <Output raw_output={repair_run?.output.output || ""} />
-            {/if}
+            <Output raw_output={repair_run?.output.output || ""} />
           {:else if repair_complete}
             <p class="text-sm text-gray-500 mb-4">
               The model has fixed the output given <span

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -343,6 +343,25 @@
       }[name] || name
     )
   }
+
+  $: repair_edit_mode = false
+  let repair_output_edited = ""
+  function show_repair_edit() {
+    repair_edit_mode = true
+    repair_output_edited = repair_run?.output.output || ""
+  }
+
+  function hide_repair_edit() {
+    repair_edit_mode = false
+  }
+
+  function apply_manual_edit() {
+    if (!repair_run) {
+      return
+    }
+    repair_run.output.output = repair_output_edited
+    repair_edit_mode = false
+  }
 </script>
 
 <div>
@@ -433,7 +452,18 @@
                   'No instruction provided'}">your instructions</span
               >. Review the result.
             </p>
-            <Output raw_output={repair_run?.output.output || ""} />
+            {#if repair_edit_mode}
+              <FormElement
+                id={"repair_manual_output"}
+                label="Edit repair attempt"
+                info_description="Enter the repaired output here. This will override the automatic repair."
+                inputType="textarea"
+                tall={true}
+                bind:value={repair_output_edited}
+              />
+            {:else}
+              <Output raw_output={repair_run?.output.output || ""} />
+            {/if}
           {:else if repair_complete}
             <p class="text-sm text-gray-500 mb-4">
               The model has fixed the output given <span
@@ -460,21 +490,38 @@
           {/if}
         </div>
         {#if repair_review_available}
-          <div class="flex flex-row gap-4 mt-4 justify-end">
-            <button class="btn" on:click={() => (repair_run = null)}
-              >Retry Repair</button
-            >
-            <button
-              class="btn btn-primary"
-              on:click={accept_repair}
-              disabled={accept_repair_submitting}
-            >
-              {#if accept_repair_submitting}
-                <span class="loading loading-spinner loading-sm"></span>
-              {:else}
-                Accept Repair (5 Stars)
-              {/if}
-            </button>
+          <div class="mt-4">
+            {#if repair_edit_mode}
+              <div class="flex flex-row gap-4 justify-end">
+                <button class="btn btn-secondary" on:click={hide_repair_edit}
+                  >Cancel</button
+                >
+                <button class="btn btn-primary" on:click={apply_manual_edit}>
+                  Save
+                </button>
+              </div>
+            {:else}
+              <div class="flex flex-row gap-4 justify-between">
+                <button class="btn" on:click={show_repair_edit}>Edit</button>
+                <div class="flex flex-row gap-4">
+                  <button class="btn" on:click={() => (repair_run = null)}
+                    >Retry Repair</button
+                  >
+                  <button
+                    class="btn btn-primary"
+                    on:click={accept_repair}
+                    disabled={accept_repair_submitting}
+                  >
+                    {#if accept_repair_submitting}
+                      <span class="loading loading-spinner loading-sm"></span>
+                    {:else}
+                      Accept Repair (5 Stars)
+                    {/if}
+                  </button>
+                </div>
+              </div>
+            {/if}
+
             {#if accept_repair_error}
               <p class="text-error font-medium text-sm">
                 Error Accepting Repair<br />

--- a/libs/core/kiln_ai/datamodel/task_run.py
+++ b/libs/core/kiln_ai/datamodel/task_run.py
@@ -93,6 +93,7 @@ class TaskRun(KilnParentedModel):
                 validate_schema(json.loads(self.input), task.input_json_schema)
             except json.JSONDecodeError:
                 raise ValueError("Input is not a valid JSON object")
+            # TODO: jsonschema.exceptions.ValidationError is never raised by validate_schema
             except jsonschema.exceptions.ValidationError as e:
                 raise ValueError(f"Input does not match task input schema: {e}")
         self._last_validated_input = self.input
@@ -131,6 +132,20 @@ class TaskRun(KilnParentedModel):
                 raise ValueError(
                     "Repaired output rating must be None. Repaired outputs are assumed to have a perfect rating, as they have been fixed."
                 )
+
+            task = self.parent_task()
+            if (
+                task is not None
+                and self.repaired_output.output is not None
+                and task.output_json_schema is not None
+            ):
+                try:
+                    validate_schema(
+                        json.loads(self.repaired_output.output), task.output_json_schema
+                    )
+                except json.JSONDecodeError:
+                    raise ValueError("Repaired output is not a valid JSON object")
+
         if self.repair_instructions is None and self.repaired_output is not None:
             raise ValueError(
                 "Repair instructions are required if providing a repaired output."
@@ -139,6 +154,7 @@ class TaskRun(KilnParentedModel):
             raise ValueError(
                 "A repaired output is required if providing repair instructions."
             )
+
         return self
 
     @model_validator(mode="after")


### PR DESCRIPTION
## What does this PR do?

This PR adds support for manually editing a task run repair. After `Attempt repair`, the user has a new button (`Edit`) that turns the repair output display into a text area that allows users editing the repair attempt.

This PR also fixes the missing validation of the repair output in the repair API. There was a bug that allowed repair outputs that do not match the structured output schema, which might have caused downstream problems due to corrupt shapes.

This is an acceptable solution but it has a major limitation due to requiring the user to first `Attempt (automatic) repair`. In the case of a `TaskRun` accessed from the `Dataset` page, the user does not have the ability to select the model used during the repair - it is by default the same as the one that generated the original run output. If a run used a small model (e.g. the small Llama models), the user may be stuck as the small model may fail to even pass validation during `Attempt repair`, which means the user then never gets access to the `Edit`.

New `Edit` button:
<img width="746" alt="image" src="https://github.com/user-attachments/assets/cdb65979-b46d-4079-bde0-3c736cb53bee" />

`Edit` mode:
<img width="752" alt="image" src="https://github.com/user-attachments/assets/d4e69274-3e30-4949-992b-774c833c6251" />

Error state (if JSON does not match schema):
<img width="757" alt="image" src="https://github.com/user-attachments/assets/120cfe7c-5e7b-453f-b025-f0fab478b9ad" />


## Related Issues

Manual edit requested: https://github.com/Kiln-AI/Kiln/issues/115

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
