### PR TITLE
Fireworks Fine-tuning: all model support

### DIFF
--- a/app/desktop/studio_server/finetune_api.py
+++ b/app/desktop/studio_server/finetune_api.py
@@ -460,15 +460,19 @@ async def fetch_fireworks_finetune_models() -> list[FinetuneProviderModel]:
     tuneable_models = []
     for model in models:
         if model.get("tunable", False) and "displayName" in model and "name" in model:
+            id = model["name"]
             # Display name is sometimes empty, so use the name from the API name if needed
-            name = model["displayName"]
-            if name.strip() == "":
-                name = model["name"].split("/")[-1]
+            display_name = model["displayName"]
+            id_tail = id.split("/")[-1]
+            if display_name.strip() == "":
+                name = id_tail
+            else:
+                name = display_name + " (" + id_tail + ")"
 
             tuneable_models.append(
                 FinetuneProviderModel(
                     name=name,
-                    id=model["name"],
+                    id=id,
                 )
             )
 

--- a/app/desktop/studio_server/finetune_api.py
+++ b/app/desktop/studio_server/finetune_api.py
@@ -1,5 +1,7 @@
+import logging
 from enum import Enum
 
+import httpx
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from kiln_ai.adapters.fine_tune.base_finetune import FineTuneParameter, FineTuneStatus
@@ -33,9 +35,12 @@ from kiln_ai.datamodel.dataset_split import (
     Train80Test10Val10SplitDefinition,
     Train80Test20SplitDefinition,
 )
+from kiln_ai.utils.config import Config
 from kiln_ai.utils.name_generator import generate_memorable_name
 from kiln_server.task_api import task_from_id
 from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
 
 
 class FinetuneProviderModel(BaseModel):
@@ -184,6 +189,10 @@ def connect_fine_tune_api(app: FastAPI):
         # Collect models by provider
         for model in built_in_models:
             for provider in model.providers:
+                # Skip Fireworks models, as they are added separately
+                if provider.name == ModelProviderName.fireworks_ai:
+                    continue
+
                 if provider.provider_finetune_id:
                     if provider.name not in provider_models:
                         provider_models[provider.name] = []
@@ -192,6 +201,13 @@ def connect_fine_tune_api(app: FastAPI):
                             name=model.friendly_name, id=provider.provider_finetune_id
                         )
                     )
+
+        # Add models from Fireworks
+        try:
+            fireworks_models = await fetch_fireworks_finetune_models()
+            provider_models[ModelProviderName.fireworks_ai] = fireworks_models
+        except Exception as e:
+            logger.error(f"Error fetching Fireworks models: {e}")
 
         # Create provider entries
         providers: list[FinetuneProvider] = []
@@ -400,3 +416,60 @@ def thinking_instructions_from_request(
 
     # default for this task
     return chain_of_thought_prompt(task)
+
+
+async def fetch_fireworks_finetune_models() -> list[FinetuneProviderModel]:
+    api_key = Config.shared().fireworks_api_key
+    if not api_key:
+        return []
+
+    url = "https://api.fireworks.ai/v1/accounts/fireworks/models"
+
+    params = {
+        "pageSize": 200,  # Max allowed
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+    }
+
+    models = []
+
+    # Paginate through all models
+    async with httpx.AsyncClient() as client:
+        while True:
+            response = await client.get(url, params=params, headers=headers)
+            json = response.json()
+            if "models" not in json or not isinstance(json["models"], list):
+                raise ValueError(
+                    f"Invalid response from Fireworks. Expected list of models in 'models' key: [{response.status_code}] {response.text}"
+                )
+            models.extend(json["models"])
+            next_page_token = json.get("nextPageToken")
+            if (
+                next_page_token
+                and isinstance(next_page_token, str)
+                and len(next_page_token) > 0
+            ):
+                params = {
+                    "pageSize": 200,
+                    "pageToken": next_page_token,
+                }
+            else:
+                break
+
+    tuneable_models = []
+    for model in models:
+        if model.get("tunable", False) and "displayName" in model and "name" in model:
+            # Display name is sometimes empty, so use the name from the API name if needed
+            name = model["displayName"]
+            if name.strip() == "":
+                name = model["name"].split("/")[-1]
+
+            tuneable_models.append(
+                FinetuneProviderModel(
+                    name=name,
+                    id=model["name"],
+                )
+            )
+
+    return tuneable_models

--- a/app/desktop/studio_server/test_finetune_api.py
+++ b/app/desktop/studio_server/test_finetune_api.py
@@ -1188,17 +1188,18 @@ async def test_fetch_fireworks_finetune_models_success(mock_config, mock_httpx_c
     assert len(result) == 3
 
     # Check model details
-    assert result[0].name == "Model One"
+    assert result[0].name == "Model One (model1)"
     assert result[0].id == "accounts/fireworks/models/model1"
 
     # Check that model2 (non-tunable) is not included
     assert all(model.id != "accounts/fireworks/models/model2" for model in result)
 
     # Check that empty display name is handled correctly
+    # Should use the last part of the id as the name
     model3 = next(
         model for model in result if model.id == "accounts/fireworks/models/model3"
     )
-    assert model3.name == "model3"  # Should use the last part of the name
+    assert model3.name == "model3"
 
 
 @pytest.mark.asyncio

--- a/libs/core/kiln_ai/adapters/fine_tune/base_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/base_finetune.py
@@ -72,8 +72,6 @@ class BaseFinetuneAdapter(ABC):
         Create and start a fine-tune.
         """
 
-        cls.check_valid_provider_model(provider_id, provider_base_model_id)
-
         if not dataset.id:
             raise ValueError("Dataset must have an id")
 
@@ -184,21 +182,3 @@ class BaseFinetuneAdapter(ABC):
         for parameter_key in parameters:
             if parameter_key not in allowed_parameters:
                 raise ValueError(f"Parameter {parameter_key} is not available")
-
-    @classmethod
-    def check_valid_provider_model(
-        cls, provider_id: str, provider_base_model_id: str
-    ) -> None:
-        """
-        Check if the provider and base model are valid.
-        """
-        for model in built_in_models:
-            for provider in model.providers:
-                if (
-                    provider.name == provider_id
-                    and provider.provider_finetune_id == provider_base_model_id
-                ):
-                    return
-        raise ValueError(
-            f"Provider {provider_id} with base model {provider_base_model_id} is not available"
-        )

--- a/libs/core/kiln_ai/adapters/fine_tune/fireworks_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/fireworks_finetune.py
@@ -16,6 +16,7 @@ from kiln_ai.utils.config import Config
 
 logger = logging.getLogger(__name__)
 
+# https://docs.fireworks.ai/fine-tuning/fine-tuning-models#supported-base-models-loras-on-serverless
 serverless_models = [
     "accounts/fireworks/models/llama-v3p1-8b-instruct",
     "accounts/fireworks/models/llama-v3p1-70b-instruct",

--- a/libs/core/kiln_ai/adapters/fine_tune/fireworks_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/fireworks_finetune.py
@@ -1,4 +1,5 @@
-from typing import Tuple
+import logging
+from typing import List, Tuple
 from uuid import uuid4
 
 import httpx
@@ -12,6 +13,13 @@ from kiln_ai.adapters.fine_tune.base_finetune import (
 from kiln_ai.adapters.fine_tune.dataset_formatter import DatasetFormat, DatasetFormatter
 from kiln_ai.datamodel import DatasetSplit, StructuredOutputMode, Task
 from kiln_ai.utils.config import Config
+
+logger = logging.getLogger(__name__)
+
+serverless_models = [
+    "accounts/fireworks/models/llama-v3p1-8b-instruct",
+    "accounts/fireworks/models/llama-v3p1-70b-instruct",
+]
 
 
 class FireworksFinetune(BaseFinetuneAdapter):
@@ -283,6 +291,35 @@ class FireworksFinetune(BaseFinetuneAdapter):
         return {k: v for k, v in payload.items() if v is not None}
 
     async def _deploy(self) -> bool:
+        if self.datamodel.base_model_id in serverless_models:
+            return await self._deploy_serverless()
+        else:
+            return await self._check_or_deploy_server()
+
+    def api_key_and_account_id(self) -> Tuple[str, str]:
+        api_key = Config.shared().fireworks_api_key
+        account_id = Config.shared().fireworks_account_id
+        if not api_key or not account_id:
+            raise ValueError("Fireworks API key or account ID not set")
+        return api_key, account_id
+
+    def deployment_display_name(self) -> str:
+        # Limit the display name to 60 characters
+        display_name = f"Kiln AI fine-tuned model [ID:{self.datamodel.id}][name:{self.datamodel.name}]"[
+            :60
+        ]
+        return display_name
+
+    async def model_id_checking_status(self) -> str | None:
+        # Model ID != fine tune ID on Fireworks. Model is the result of the tune job. Call status to get it.
+        status, model_id = await self._status()
+        if status.status != FineTuneStatusType.completed:
+            return None
+        if not model_id or not isinstance(model_id, str):
+            return None
+        return model_id
+
+    async def _deploy_serverless(self) -> bool:
         # Now we "deploy" the model using PEFT serverless.
         # A bit complicated: most fireworks deploys are server based.
         # However, a Lora can be serverless (PEFT).
@@ -290,25 +327,18 @@ class FireworksFinetune(BaseFinetuneAdapter):
         # https://docs.fireworks.ai/models/deploying#deploying-to-serverless
         # This endpoint will return 400 if already deployed with code 9, so we consider that a success.
 
-        api_key = Config.shared().fireworks_api_key
-        account_id = Config.shared().fireworks_account_id
-        if not api_key or not account_id:
-            raise ValueError("Fireworks API key or account ID not set")
-
-        # Model ID != fine tune ID on Fireworks. Model is the result of the tune job. Call status to get it.
-        status, model_id = await self._status()
-        if status.status != FineTuneStatusType.completed:
-            return False
-        if not model_id or not isinstance(model_id, str):
-            return False
+        api_key, account_id = self.api_key_and_account_id()
 
         url = f"https://api.fireworks.ai/v1/accounts/{account_id}/deployedModels"
-        # Limit the display name to 60 characters
-        display_name = f"Kiln AI fine-tuned model [ID:{self.datamodel.id}][name:{self.datamodel.name}]"[
-            :60
-        ]
+        model_id = await self.model_id_checking_status()
+        if not model_id:
+            logger.error(
+                "Model ID not found - can't deploy model to Fireworks serverless"
+            )
+            return False
+
         payload = {
-            "displayName": display_name,
+            "displayName": self.deployment_display_name(),
             "model": model_id,
         }
         headers = {
@@ -327,4 +357,120 @@ class FireworksFinetune(BaseFinetuneAdapter):
                     self.datamodel.save_to_file()
             return True
 
+        logger.error(
+            f"Failed to deploy model to Fireworks serverless: [{response.status_code}] {response.text}"
+        )
         return False
+
+    async def _check_or_deploy_server(self) -> bool:
+        """
+        Check if the model is already deployed. If not, deploy it to a dedicated server.
+        """
+
+        # Check if the model is already deployed
+        # If it's fine_tune_model_id is set, it might be deployed. However, Fireworks deletes them over time so we need to check.
+        if self.datamodel.fine_tune_model_id:
+            deployments = await self._fetch_all_deployments()
+            for deployment in deployments:
+                if deployment[
+                    "baseModel"
+                ] == self.datamodel.fine_tune_model_id and deployment["state"] in [
+                    "READY",
+                    "CREATING",
+                ]:
+                    return True
+
+        # If the model is not deployed, deploy it
+        return await self._deploy_server()
+
+    async def _deploy_server(self) -> bool:
+        # For models that are not serverless, we just need to deploy the model to a server.
+        # We use a scale-to-zero on-demand deployment. If you stop using it, it
+        # will scale to zero and charges will stop.
+        model_id = await self.model_id_checking_status()
+        if not model_id:
+            logger.error("Model ID not found - can't deploy model to Fireworks server")
+            return False
+
+        api_key, account_id = self.api_key_and_account_id()
+        url = f"https://api.fireworks.ai/v1/accounts/{account_id}/deployments"
+
+        payload = {
+            "displayName": self.deployment_display_name(),
+            "description": "Deployed by Kiln AI",
+            # Allow scale to zero
+            "minReplicaCount": 0,
+            "autoscalingPolicy": {
+                "scaleUpWindow": "30s",
+                "scaleDownWindow": "300s",
+                # Scale to zero after 5 minutes of inactivity - this is the minimum allowed
+                "scaleToZeroWindow": "300s",
+            },
+            "baseModel": model_id,
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, json=payload, headers=headers)
+
+        if response.status_code == 200:
+            basemodel = response.json().get("baseModel")
+            if basemodel is not None and isinstance(basemodel, str):
+                self.datamodel.fine_tune_model_id = basemodel
+                if self.datamodel.path:
+                    self.datamodel.save_to_file()
+                return True
+
+        logger.error(
+            f"Failed to deploy model to Fireworks server: [{response.status_code}] {response.text}"
+        )
+        return False
+
+    async def _fetch_all_deployments(self) -> List[dict]:
+        """
+        Fetch all deployments for an account.
+        """
+        api_key, account_id = self.api_key_and_account_id()
+
+        url = f"https://api.fireworks.ai/v1/accounts/{account_id}/deployments"
+
+        params = {
+            # Note: filter param does not work for baseModel, which would have been ideal, and ideally would have been documented. Instead we'll fetch all and filter.
+            # Max page size
+            "pageSize": 200,
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+        }
+
+        deployments = []
+
+        # Paginate through all deployments
+        async with httpx.AsyncClient() as client:
+            while True:
+                response = await client.get(url, params=params, headers=headers)
+                json = response.json()
+                if "deployments" not in json or not isinstance(
+                    json["deployments"], list
+                ):
+                    raise ValueError(
+                        f"Invalid response from Fireworks. Expected list of deployments in 'deployments' key: [{response.status_code}] {response.text}"
+                    )
+                deployments.extend(json["deployments"])
+                next_page_token = json.get("nextPageToken")
+                if (
+                    next_page_token
+                    and isinstance(next_page_token, str)
+                    and len(next_page_token) > 0
+                ):
+                    params = {
+                        "pageSize": 200,
+                        "pageToken": next_page_token,
+                    }
+                else:
+                    break
+
+        return deployments

--- a/libs/core/kiln_ai/adapters/fine_tune/test_base_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/test_base_finetune.py
@@ -261,15 +261,6 @@ async def test_create_and_start_no_parent_task_path():
         )
 
 
-def test_check_valid_provider_model():
-    MockFinetune.check_valid_provider_model("openai", "gpt-4o-mini-2024-07-18")
-
-    with pytest.raises(
-        ValueError, match="Provider openai with base model gpt-99 is not available"
-    ):
-        MockFinetune.check_valid_provider_model("openai", "gpt-99")
-
-
 async def test_create_and_start_invalid_train_split(mock_dataset):
     # Test with an invalid train split name
     mock_dataset.split_contents = {"valid_train": [], "valid_test": []}

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -1197,6 +1197,11 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.ollama,
                 model_id="qwen2.5",
             ),
+            KilnModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                provider_finetune_id="accounts/fireworks/models/qwen2p5-7b",
+            ),
         ],
     ),
     # Qwen 2.5 14B

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -133,7 +133,7 @@ class KilnModelProvider(BaseModel):
         supports_structured_output: Whether the provider supports structured output formats
         supports_data_gen: Whether the provider supports data generation
         untested_model: Whether the model is untested (typically user added). The supports_ fields are not applicable.
-        provider_finetune_id: The finetune ID for the provider, if applicable
+        provider_finetune_id: The finetune ID for the provider, if applicable. Some providers like Fireworks load these from an API.
         structured_output_mode: The mode we should use to call the model for structured output, if it was trained with structured output.
         parser: A parser to use for the model, if applicable
         reasoning_capable: Whether the model is designed to output thinking in a structured format (eg <think></think>). If so we don't use COT across 2 calls, and ask for thinking and final response in the same call.
@@ -576,7 +576,6 @@ built_in_models: List[KilnModel] = [
                 # JSON mode not ideal (no schema), but tool calling doesn't work on 8b
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=False,
-                provider_finetune_id="accounts/fireworks/models/llama-v3p1-8b-instruct",
                 model_id="accounts/fireworks/models/llama-v3p1-8b-instruct",
             ),
             KilnModelProvider(
@@ -618,7 +617,6 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.fireworks_ai,
                 # Tool calling forces schema -- fireworks doesn't support json_schema, just json_mode
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
-                provider_finetune_id="accounts/fireworks/models/llama-v3p1-70b-instruct",
                 model_id="accounts/fireworks/models/llama-v3p1-70b-instruct",
             ),
             KilnModelProvider(
@@ -764,7 +762,6 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
-                provider_finetune_id="accounts/fireworks/models/llama-v3p2-3b-instruct",
                 supports_structured_output=False,
                 supports_data_gen=False,
                 model_id="accounts/fireworks/models/llama-v3p2-3b-instruct",
@@ -890,8 +887,6 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
-                # Finetuning not live yet
-                # provider_finetune_id="accounts/fireworks/models/llama-v3p3-70b-instruct",
                 # Tool calling forces schema -- fireworks doesn't support json_schema, just json_mode
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
                 model_id="accounts/fireworks/models/llama-v3p3-70b-instruct",
@@ -1200,7 +1195,6 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
-                provider_finetune_id="accounts/fireworks/models/qwen2p5-7b",
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -1192,10 +1192,6 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.ollama,
                 model_id="qwen2.5",
             ),
-            KilnModelProvider(
-                name=ModelProviderName.fireworks_ai,
-                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
-            ),
         ],
     ),
     # Qwen 2.5 14B


### PR DESCRIPTION
Allow fine-tuning and easily using over 60 LLMs with fireworks

 - Dynamically fetch the list of available models
 - Add FW on-demand deployment server support to Kiln, including checking for existing deploys before deploying
 - Configure servers for scale-to-zero after 5 mins, making them reasonable cost and dev-ex