### PR TITLE
fix: repaired run message should be source-specific

### DIFF
--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -59,6 +59,13 @@
     (s) => s === run?.output?.source?.type,
   )
 
+  $: repair_source =
+    run?.repaired_output?.source?.type === "human"
+      ? { type: "user", name: run.repaired_output.source.properties.created_by }
+      : run?.repaired_output?.source?.type === "synthetic"
+        ? { type: "synthetic" }
+        : null
+
   // Use for some animations on first mount
   let mounted = false
   onMount(() => {
@@ -470,13 +477,19 @@
             </p>
             <Output raw_output={repair_run?.output.output || ""} />
           {:else if repair_complete}
-            <p class="text-sm text-gray-500 mb-4">
-              The model has fixed the output given <span
-                class="tooltip link"
-                data-tip="The instructions you provided to the model: {repair_instructions ||
-                  'No instruction provided'}">your instructions</span
-              >.
-            </p>
+            {#if repair_source?.type === "user"}
+              <p class="text-sm text-gray-500 mb-4">
+                This repaired output was provided by {repair_source.name}.
+              </p>
+            {:else}
+              <p class="text-sm text-gray-500 mb-4">
+                The model has fixed the output given <span
+                  class="tooltip link"
+                  data-tip="The instructions you provided to the model: {repair_instructions ||
+                    'No instruction provided'}">your instructions</span
+                >.
+              </p>
+            {/if}
             <Output raw_output={run?.repaired_output?.output || ""} />
             <div class="mt-2 text-xs text-gray-500 text-right">
               {#if delete_repair_submitting}


### PR DESCRIPTION
## What does this PR do?

The message under `Repair Output` should be specific to the repair source (`human` or `synthetic`).

UI when the run was manually repaired:
<img width="701" alt="image" src="https://github.com/user-attachments/assets/e499da35-027f-4d60-980b-f176ae675670" />

UI when the run was repaired by the model:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/2e5ad848-6435-4a0f-afe0-255004ca8cf1" />

## Related Issues

Tangential to https://github.com/Kiln-AI/Kiln/issues/115

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
