### PR TITLE
chore: clean up unused raw_schema in UI

### DIFF
--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
@@ -257,7 +257,6 @@ describe("model_from_schema", () => {
           description: "The user's full name",
           type: "string",
           required: true,
-          raw_schema: schema.properties.user_name,
         },
         {
           id: "age",
@@ -265,7 +264,6 @@ describe("model_from_schema", () => {
           description: "User's age in years",
           type: "integer",
           required: false,
-          raw_schema: schema.properties.age,
         },
         {
           id: "contact_emails",
@@ -273,7 +271,6 @@ describe("model_from_schema", () => {
           description: "The user's contact emails",
           type: "array",
           required: false,
-          raw_schema: schema.properties.contact_emails,
         },
         {
           id: "siblings",
@@ -281,7 +278,6 @@ describe("model_from_schema", () => {
           description: "The user's siblings",
           type: "array",
           required: false,
-          raw_schema: schema.properties.siblings,
         },
       ],
     }
@@ -374,16 +370,6 @@ describe("model_from_schema", () => {
 
     const result = model_from_schema(schema)
     expect(result.properties[0].type).toBe("array")
-    expect(result.properties[0].raw_schema).toEqual({
-      type: "array",
-      title: "Ingredients",
-      description: "The ingredients to be used",
-      items: {
-        type: "string",
-        title: "Ingredient",
-        description: "The name of the ingredient to be used",
-      },
-    })
   })
 })
 

--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.ts
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.ts
@@ -21,11 +21,6 @@ export type SchemaModelProperty = {
   description: string
   type: "number" | "string" | "integer" | "boolean" | "array" | "object"
   required: boolean
-
-  /**
-   * The original JSON schema property, if model is derived from a JSON schema.
-   */
-  raw_schema?: JsonSchemaProperty
 }
 
 export type SchemaModel = {
@@ -40,7 +35,6 @@ export function model_from_schema(s: JsonSchema): SchemaModel {
       description: options.description,
       type: options.type,
       required: !!s.required.includes(id),
-      raw_schema: options,
     })),
   }
 }


### PR DESCRIPTION
## What does this PR do?

Remove the `raw_schema` introduced in https://github.com/Kiln-AI/Kiln/pull/286 because it is now unused.

## Related Issues

N/A

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
