### PR TITLE
fix: newlines in together_ai thinking output

### DIFF
--- a/libs/core/kiln_ai/adapters/parsers/r1_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/r1_parser.py
@@ -27,6 +27,14 @@ class R1ThinkingParser(BaseParser):
             original_output.intermediate_outputs is not None
             and "reasoning" in original_output.intermediate_outputs
         ):
+            # sometimes the output and reasoning are wrapped in newlines
+            if isinstance(original_output.output, str):
+                original_output.output = original_output.output.strip()
+
+            original_output.intermediate_outputs["reasoning"] = (
+                original_output.intermediate_outputs["reasoning"].strip()
+            )
+
             return original_output
 
         # This parser only works for strings

--- a/libs/core/kiln_ai/adapters/parsers/test_r1_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/test_r1_parser.py
@@ -154,3 +154,31 @@ def test_intermediate_outputs(parser):
         )
     )
     assert out.intermediate_outputs["reasoning"] == "Some content"
+
+
+def test_strip_newlines(parser):
+    # certain providers via LiteLLM for example, add newlines to the output
+    # and to the reasoning. This tests that we strip those newlines.
+    response = RunOutput(
+        output="\n\nSome content",
+        intermediate_outputs={
+            "reasoning": "\n\nSome thinking\n\n",
+        },
+    )
+    parsed = parser.parse_output(response)
+    assert parsed.output == "Some content"
+    assert parsed.intermediate_outputs["reasoning"] == "Some thinking"
+
+
+def test_strip_newlines_with_structured_output(parser):
+    # certain providers via LiteLLM for example, add newlines to the output
+    # and to the reasoning. This tests that we strip those newlines.
+    response = RunOutput(
+        output={"some_key": "Some content"},
+        intermediate_outputs={
+            "reasoning": "\n\nSome thinking\n\n",
+        },
+    )
+    parsed = parser.parse_output(response)
+    assert parsed.output == {"some_key": "Some content"}
+    assert parsed.intermediate_outputs["reasoning"] == "Some thinking"


### PR DESCRIPTION
## What does this PR do?

The `output` and `intermediate_outputs.reasoning` from thinking models from `together_ai` and possibly other providers come with leading and / or trailing newlines. 

This PR `strip()` both `output` and `intermediate_outputs.reasoning` in the R1 parser.

Example raw data for such a `Run` using `DeepSeek R1 Distill Qwen 32B` on `together_ai`:
```json
{
  "v": 1,
  "id": "XXX",
  "input": "What is your name?",
  "output": {
    "v": 1,
    "id": "XXX",
    ...
    "output": "\n\nMy name is Bob",
    "source": {
      "type": "synthetic",
      "properties": {
        "adapter_name": "kiln_openai_compatible_adapter",
        "model_name": "deepseek_r1_distill_qwen_32b",
        "model_provider": "together_ai",
        "prompt_id": "simple_prompt_builder"
      }
    },
    ...
  },
  ...
  "intermediate_outputs": {
    "reasoning": "\nOkay the user is asking for my name.\n"
  },
  "tags": [
    "manual_run"
  ],
  "model_type": "task_run"
}
```

## Related Issues

N/A

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
