### PR TITLE
fix: disable 1password on text input field

### DIFF
--- a/app/web_ui/src/lib/utils/form_element.svelte
+++ b/app/web_ui/src/lib/utils/form_element.svelte
@@ -127,6 +127,7 @@
         bind:value
         on:input={run_validator}
         autocomplete="off"
+        data-op-ignore="true"
         {disabled}
       />
     {:else if inputType === "select"}


### PR DESCRIPTION
## What does this PR do?

Workaround:
- add `data-op-ignore="true"` field on `FormElement` text input to prevent 1password from overlaying its buttons on top of form fields contained in modals that are present in the DOM but not visible.

A cleaner fix would be to remove the `dialog` from the DOM when not shown, but this workaround should be sufficient for now.

## Related Issues

Fixes: https://github.com/Kiln-AI/Kiln/issues/298

## Contributor License Agreement

I, @leonardmq, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
