### PR TITLE
refactor: extract job runner into own class

### DIFF
--- a/libs/core/kiln_ai/utils/async_job_runner.py
+++ b/libs/core/kiln_ai/utils/async_job_runner.py
@@ -93,14 +93,14 @@ class AsyncJobRunner:
 
             try:
                 success = await run_job(job)
-            except Exception as exc:
-                logger.exception("Job failed to complete", exc_info=exc)
+            except Exception:
+                logger.error("Job failed to complete", exc_info=True)
                 success = False
 
             try:
                 await status_queue.put(success)
-            except Exception as e:
-                logger.exception("Failed to enqueue status for job", exc_info=e)
+            except Exception:
+                logger.error("Failed to enqueue status for job", exc_info=True)
             finally:
                 # Always mark the dequeued task as done, even on exceptions
                 worker_queue.task_done()

--- a/libs/core/kiln_ai/utils/async_job_runner.py
+++ b/libs/core/kiln_ai/utils/async_job_runner.py
@@ -14,8 +14,9 @@ class Progress:
 
 class AsyncJobRunner:
     def __init__(self, concurrency: int = 1):
+        if concurrency < 1:
+            raise ValueError("concurrency must be ≥ 1")
         self.concurrency = concurrency
-
     async def run(
         self,
         jobs: List[T],

--- a/libs/core/kiln_ai/utils/async_job_runner.py
+++ b/libs/core/kiln_ai/utils/async_job_runner.py
@@ -17,6 +17,7 @@ class AsyncJobRunner:
         if concurrency < 1:
             raise ValueError("concurrency must be ≥ 1")
         self.concurrency = concurrency
+
     async def run(
         self,
         jobs: List[T],

--- a/libs/core/kiln_ai/utils/async_job_runner.py
+++ b/libs/core/kiln_ai/utils/async_job_runner.py
@@ -1,0 +1,86 @@
+import asyncio
+from dataclasses import dataclass
+from typing import AsyncGenerator, Awaitable, Callable, List, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass
+class Progress:
+    complete: int | None = None
+    total: int | None = None
+    errors: int | None = None
+
+
+class AsyncJobRunner:
+    def __init__(self, concurrency: int = 1):
+        self.concurrency = concurrency
+
+    async def run(
+        self,
+        jobs: List[T],
+        run_job: Callable[[T], Awaitable[bool]],
+    ) -> AsyncGenerator[Progress, None]:
+        """
+        Runs the jobs with parallel workers and yields progress updates.
+        """
+        complete = 0
+        errors = 0
+        total = len(jobs)
+
+        # Send initial status
+        yield Progress(complete=complete, total=total, errors=errors)
+
+        worker_queue: asyncio.Queue[T] = asyncio.Queue()
+        for job in jobs:
+            worker_queue.put_nowait(job)
+
+        # simple status queue to return progress. True=success, False=error
+        status_queue: asyncio.Queue[bool] = asyncio.Queue()
+
+        workers = []
+        for _ in range(self.concurrency):
+            task = asyncio.create_task(
+                self._run_worker(worker_queue, status_queue, run_job)
+            )
+            workers.append(task)
+
+        # Send status updates until workers are done, and they are all sent
+        while not status_queue.empty() or not all(worker.done() for worker in workers):
+            try:
+                # Use timeout to prevent hanging if all workers complete
+                # between our while condition check and get()
+                success = await asyncio.wait_for(status_queue.get(), timeout=0.1)
+                if success:
+                    complete += 1
+                else:
+                    errors += 1
+
+                yield Progress(complete=complete, total=total, errors=errors)
+            except asyncio.TimeoutError:
+                # Timeout is expected, just continue to recheck worker status
+                # Don't love this but beats sentinels for reliability
+                continue
+
+        # These are redundant, but keeping them will catch async errors
+        await asyncio.gather(*workers)
+        await worker_queue.join()
+
+    async def _run_worker(
+        self,
+        worker_queue: asyncio.Queue[T],
+        status_queue: asyncio.Queue[bool],
+        run_job: Callable[[T], Awaitable[bool]],
+    ):
+        while True:
+            try:
+                job = worker_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                # worker can end when the queue is empty
+                break
+            try:
+                success = await run_job(job)
+                await status_queue.put(success)
+            finally:
+                # Always mark the dequeued task as done, even on exceptions
+                worker_queue.task_done()

--- a/libs/core/kiln_ai/utils/test_async_job_runner.py
+++ b/libs/core/kiln_ai/utils/test_async_job_runner.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kiln_ai.utils.async_job_runner import AsyncJobRunner
+
+
+# Test with and without concurrency
+@pytest.mark.parametrize("concurrency", [1, 25])
+@pytest.mark.asyncio
+async def test_async_job_runner_status_updates(concurrency):
+    job_count = 50
+    jobs = [{"id": i} for i in range(job_count)]
+
+    runner = AsyncJobRunner(concurrency=concurrency)
+
+    # fake run_job that succeeds
+    mock_run_job_success = AsyncMock(return_value=True)
+
+    # Expect the status updates in order, and 1 for each job
+    expected_completed_count = 0
+    async for progress in runner.run(jobs, mock_run_job_success):
+        assert progress.complete == expected_completed_count
+        expected_completed_count += 1
+        assert progress.errors == 0
+        assert progress.total == job_count
+
+    # Verify last status update was complete
+    assert expected_completed_count == job_count + 1
+
+    # Verify run_job was called for each job
+    assert mock_run_job_success.call_count == job_count
+
+    # Verify run_job was called with the correct arguments
+    for i in range(job_count):
+        mock_run_job_success.assert_any_await(jobs[i])

--- a/libs/core/kiln_ai/utils/test_async_job_runner.py
+++ b/libs/core/kiln_ai/utils/test_async_job_runner.py
@@ -34,3 +34,101 @@ async def test_async_job_runner_status_updates(concurrency):
     # Verify run_job was called with the correct arguments
     for i in range(job_count):
         mock_run_job_success.assert_any_await(jobs[i])
+
+
+@pytest.mark.parametrize("concurrency", [1, 25])
+@pytest.mark.asyncio
+async def test_async_job_runner_all_failures(concurrency):
+    job_count = 50
+    jobs = [{"id": i} for i in range(job_count)]
+
+    runner = AsyncJobRunner(concurrency=concurrency)
+
+    # fake run_job that fails
+    mock_run_job_failure = AsyncMock(return_value=False)
+
+    # Expect the status updates in order, and 1 for each job
+    expected_error_count = 0
+    async for progress in runner.run(jobs, mock_run_job_failure):
+        assert progress.complete == 0
+        assert progress.errors == expected_error_count
+        expected_error_count += 1
+        assert progress.total == job_count
+
+    # Verify last status update was complete
+    assert expected_error_count == job_count + 1
+
+    # Verify run_job was called for each job
+    assert mock_run_job_failure.call_count == job_count
+
+    # Verify run_job was called with the correct arguments
+    for i in range(job_count):
+        mock_run_job_failure.assert_any_await(jobs[i])
+
+
+@pytest.mark.parametrize("concurrency", [1, 25])
+@pytest.mark.asyncio
+async def test_async_job_runner_partial_failures(concurrency):
+    job_count = 50
+    jobs = [{"id": i} for i in range(job_count)]
+
+    # we want to fail on some jobs and succeed on others
+    jobs_to_fail = (0, 2, 4, 6, 8, 20, 25)
+
+    runner = AsyncJobRunner(concurrency=concurrency)
+
+    # fake run_job that fails
+    mock_run_job_partial_success = AsyncMock(
+        # return True for jobs that should succeed
+        side_effect=lambda job: job["id"] not in jobs_to_fail
+    )
+
+    # Expect the status updates in order, and 1 for each job
+    async for progress in runner.run(jobs, mock_run_job_partial_success):
+        assert progress.total == job_count
+
+    # Verify last status update was complete
+    expected_error_count = len([job for job in jobs if job["id"] in jobs_to_fail])
+    expected_success_count = len(jobs) - expected_error_count
+    assert progress.errors == expected_error_count
+    assert progress.complete == expected_success_count
+
+    # Verify run_job was called for each job
+    assert mock_run_job_partial_success.call_count == job_count
+
+    # Verify run_job was called with the correct arguments
+    for i in range(job_count):
+        mock_run_job_partial_success.assert_any_await(jobs[i])
+
+
+@pytest.mark.asyncio
+async def test_async_job_runner_partial_raises():
+    job_count = 50
+    jobs = [{"id": i} for i in range(job_count)]
+
+    # we use concurrency=1 to avoid having the other workers complete jobs
+    # concurrently as that would make it hard to verify when the runner exits
+    runner = AsyncJobRunner(concurrency=1)
+
+    id_to_fail = 10
+
+    def failure_fn(job):
+        if job["id"] == id_to_fail:
+            raise Exception("job failed unexpectedly")
+        return True
+
+    # fake run_job that fails
+    mock_run_job_partial_success = AsyncMock(side_effect=failure_fn)
+
+    # Expect the status updates in order, and 1 for each job
+    # until we hit the job that raises an exception
+    with pytest.raises(Exception, match="job failed unexpectedly"):
+        expected_complete = 0
+        async for progress in runner.run(jobs, mock_run_job_partial_success):
+            assert progress.complete == expected_complete
+            assert progress.errors == 0
+            assert progress.total == job_count
+            expected_complete += 1
+
+    # verify that we yielded progress for jobs all the way up to the job that raised an exception
+    assert expected_complete == id_to_fail + 1


### PR DESCRIPTION
## What does this PR do?

Extract job runner logic out of `EvalRunner` to make the same pattern reusable.

## Related Issues

N/A

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an asynchronous job runner utility with progress tracking for concurrent job execution.
- **Refactor**
  - Updated evaluation runner to use the new asynchronous job runner for improved progress reporting and concurrency management.
- **Tests**
  - Added tests to verify correct progress updates and job execution behavior for the asynchronous job runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->