### PR TITLE
refactor: ExtractionConfig datamodel

### DIFF
--- a/libs/core/kiln_ai/adapters/__init__.py
+++ b/libs/core/kiln_ai/adapters/__init__.py
@@ -19,6 +19,7 @@ The eval submodule contains the code for evaluating the performance of a model.
 from . import (
     data_gen,
     eval,
+    extraction,
     fine_tune,
     ml_model_list,
     model_adapters,
@@ -34,4 +35,5 @@ __all__ = [
     "prompt_builders",
     "repair",
     "eval",
+    "extraction",
 ]

--- a/libs/core/kiln_ai/adapters/extraction/__init__.py
+++ b/libs/core/kiln_ai/adapters/extraction/__init__.py
@@ -5,9 +5,10 @@ This package provides a framework for extracting content from files
 using different extraction methods.
 """
 
-from . import base_extractor, gemini_extractor
+from . import base_extractor, gemini_extractor, registry
 
 __all__ = [
     "base_extractor",
     "gemini_extractor",
+    "registry",
 ]

--- a/libs/core/kiln_ai/adapters/extraction/registry.py
+++ b/libs/core/kiln_ai/adapters/extraction/registry.py
@@ -1,0 +1,15 @@
+from kiln_ai.adapters.extraction.base_extractor import BaseExtractor
+from kiln_ai.adapters.extraction.gemini_extractor import GeminiExtractor
+from kiln_ai.datamodel.extraction import ExtractorType
+from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
+
+
+def extractor_adapter_from_type(
+    extractor_config_type: ExtractorType,
+) -> type[BaseExtractor]:
+    match extractor_config_type:
+        case ExtractorType.gemini:
+            return GeminiExtractor
+        case _:
+            # type checking will catch missing cases
+            raise_exhaustive_enum_error(extractor_config_type)

--- a/libs/core/kiln_ai/adapters/extraction/test_registry.py
+++ b/libs/core/kiln_ai/adapters/extraction/test_registry.py
@@ -1,0 +1,14 @@
+import pytest
+
+from kiln_ai.adapters.extraction.gemini_extractor import GeminiExtractor
+from kiln_ai.adapters.extraction.registry import extractor_adapter_from_type
+from kiln_ai.datamodel.extraction import ExtractorType
+
+
+def test_extractor_adapter_from_type():
+    assert extractor_adapter_from_type(ExtractorType.gemini) == GeminiExtractor
+
+
+def test_extractor_adapter_from_type_invalid():
+    with pytest.raises(ValueError):
+        extractor_adapter_from_type("invalid-type")  # type: ignore

--- a/libs/core/kiln_ai/datamodel/__init__.py
+++ b/libs/core/kiln_ai/datamodel/__init__.py
@@ -11,7 +11,7 @@ User docs: https://docs.getkiln.ai/developers/kiln-datamodel
 
 from __future__ import annotations
 
-from kiln_ai.datamodel import dataset_split, eval, strict_mode
+from kiln_ai.datamodel import dataset_split, eval, extraction, strict_mode
 from kiln_ai.datamodel.datamodel_enums import (
     FinetuneDataStrategy,
     FineTuneStatusType,
@@ -19,13 +19,8 @@ from kiln_ai.datamodel.datamodel_enums import (
     StructuredOutputMode,
     TaskOutputRatingType,
 )
-from kiln_ai.datamodel.dataset_split import (
-    DatasetSplit,
-    DatasetSplitDefinition,
-)
-from kiln_ai.datamodel.finetune import (
-    Finetune,
-)
+from kiln_ai.datamodel.dataset_split import DatasetSplit, DatasetSplitDefinition
+from kiln_ai.datamodel.finetune import Finetune
 from kiln_ai.datamodel.project import Project
 from kiln_ai.datamodel.prompt import BasePrompt, Prompt
 from kiln_ai.datamodel.prompt_id import (
@@ -42,15 +37,13 @@ from kiln_ai.datamodel.task_output import (
     TaskOutput,
     TaskOutputRating,
 )
-from kiln_ai.datamodel.task_run import (
-    TaskRun,
-    Usage,
-)
+from kiln_ai.datamodel.task_run import TaskRun, Usage
 
 __all__ = [
     "strict_mode",
     "dataset_split",
     "eval",
+    "extraction",
     "Task",
     "Project",
     "TaskRun",

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -1,0 +1,88 @@
+import json
+from enum import Enum
+from typing import Any, List
+
+from pydantic import BaseModel, Field, ValidationError, model_validator
+from typing_extensions import Self
+
+from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnBaseModel
+
+
+def format_properties_errors(e: ValidationError) -> str:
+    errors: List[str] = []
+    for error in e.errors():
+        loc = error["loc"][0]
+        msg = error["msg"]
+        errors.append(f"{loc}: {msg}.")
+    return "\n".join(errors)
+
+
+class OutputFormat(str, Enum):
+    TEXT = "text/plain"
+    MARKDOWN = "text/markdown"
+
+
+class ExtractorType(str, Enum):
+    gemini = "gemini"
+
+
+class Kind(str, Enum):
+    DOCUMENT = "document"
+    IMAGE = "image"
+    VIDEO = "video"
+    AUDIO = "audio"
+
+
+class GeminiProperties(BaseModel):
+    prompt_for_kind: dict[Kind, str] = Field(
+        description="A dictionary of prompts for each kind of content to extract.",
+    )
+
+    model_name: str = Field(
+        description="The name of the model to use for this extractor config. ",
+    )
+
+
+class ExtractorConfig(KilnBaseModel):
+    name: str = NAME_FIELD
+
+    output_format: OutputFormat = Field(
+        default=OutputFormat.MARKDOWN,
+        description="The format to use for the output.",
+    )
+    passthrough_mimetypes: list[OutputFormat] = Field(
+        default_factory=list,
+        description="If the mimetype is in this list, the extractor will not be used and the text content of the file will be returned as is.",
+    )
+    extractor_type: ExtractorType = Field(
+        default=ExtractorType.gemini,
+        description="This is used to determine the type of extractor to use.",
+    )
+    properties: dict[str, Any] = Field(
+        default={},
+        description="Properties to be used to execute the extractor config. This is config_type specific and should serialize to a json dict.",
+    )
+
+    @model_validator(mode="after")
+    def validate_properties(self) -> Self:
+        if self.extractor_type == ExtractorType.gemini:
+            # This will raise an error if the properties are invalid
+            try:
+                GeminiProperties(**self.properties)
+            except ValidationError as e:
+                raise ValueError(format_properties_errors(e))
+            return self
+        else:
+            raise ValueError(f"Invalid extractor type: {self.extractor_type}")
+
+    @model_validator(mode="after")
+    def validate_json_serializable(self) -> Self:
+        try:
+            # This will raise a TypeError if the dict contains non-JSON-serializable objects
+            json.dumps(self.properties)
+        except TypeError as e:
+            raise ValueError(f"Properties must be JSON serializable: {str(e)}")
+        return self
+
+    def gemini_properties(self) -> GeminiProperties:
+        return GeminiProperties(**self.properties)

--- a/libs/core/kiln_ai/datamodel/test_extraction_model.py
+++ b/libs/core/kiln_ai/datamodel/test_extraction_model.py
@@ -1,0 +1,94 @@
+import pytest
+
+from kiln_ai.datamodel.extraction import ExtractorConfig, ExtractorType
+
+
+@pytest.fixture
+def valid_extractor_config_data():
+    return {
+        "name": "Test Extractor Config",
+        "extractor_type": ExtractorType.gemini,
+        "properties": {
+            "prompt_for_kind": {
+                "document": "Transcribe the document.",
+                "audio": "Transcribe the audio.",
+                "video": "Transcribe the video.",
+                "image": "Describe the image.",
+            },
+            "model_name": "gemini-2.0-flash",
+        },
+    }
+
+
+@pytest.fixture
+def valid_extractor_config(valid_extractor_config_data):
+    return ExtractorConfig(**valid_extractor_config_data)
+
+
+def test_extractor_config_valid(valid_extractor_config):
+    assert valid_extractor_config.name == "Test Extractor Config"
+    assert valid_extractor_config.extractor_type == ExtractorType.gemini
+    assert valid_extractor_config.properties["prompt_for_kind"] == {
+        "document": "Transcribe the document.",
+        "audio": "Transcribe the audio.",
+        "video": "Transcribe the video.",
+        "image": "Describe the image.",
+    }
+    assert valid_extractor_config.properties["model_name"] == "gemini-2.0-flash"
+
+
+def test_extractor_config_empty_properties(valid_extractor_config):
+    with pytest.raises(ValueError, match="prompt_for_kind: Field required."):
+        valid_extractor_config.properties = {}
+
+
+def test_extractor_config_missing_model_name(
+    valid_extractor_config, valid_extractor_config_data
+):
+    with pytest.raises(ValueError, match="model_name: Field required."):
+        valid_extractor_config.properties = {
+            "prompt_for_kind": valid_extractor_config_data["properties"][
+                "prompt_for_kind"
+            ],
+        }
+
+
+def test_extractor_config_missing_prompt_for_kind(valid_extractor_config):
+    with pytest.raises(
+        ValueError,
+        match="prompt_for_kind: Field required.",
+    ):
+        valid_extractor_config.properties = {"model_name": "gemini-2.0-flash"}
+
+
+def test_extractor_config_invalid_json(
+    valid_extractor_config, valid_extractor_config_data
+):
+    class InvalidClass:
+        pass
+
+    with pytest.raises(ValueError, match="Properties must be JSON serializable"):
+        valid_extractor_config.properties = {
+            "prompt_for_kind": valid_extractor_config_data["properties"][
+                "prompt_for_kind"
+            ],
+            "model_name": "gemini-2.0-flash",
+            "invalid_key": InvalidClass(),
+        }
+
+
+def test_extractor_config_invalid_prompt_for_kind(valid_extractor_config):
+    with pytest.raises(
+        ValueError,
+        match="prompt_for_kind: Input should be a valid dictionary.",
+    ):
+        valid_extractor_config.properties = {
+            "prompt_for_kind": "not a dict",
+            "model_name": "gemini-2.0-flash",
+        }
+
+
+def test_extractor_config_invalid_config_type(valid_extractor_config):
+    # Create an invalid config type using string
+    with pytest.raises(ValueError):
+        valid_extractor_config.extractor_type = "invalid_type"


### PR DESCRIPTION
## What does this PR do?

- add datamodel for `ExtractorConfig` (inheriting from `KilnBaseModel`)
- refactor `BaseExtractor` and `GeminiExtractor` to use `ExtractorConfig`
- update tests

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
