### PR TITLE
WIP: document, extraction datamodels

### DIFF
--- a/libs/core/kiln_ai/datamodel/document.py
+++ b/libs/core/kiln_ai/datamodel/document.py
@@ -1,0 +1,68 @@
+from typing import TYPE_CHECKING, List, Union
+
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self
+
+from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentedModel, KilnParentModel
+from kiln_ai.datamodel.extraction import Extraction, Kind
+
+if TYPE_CHECKING:
+    from kiln_ai.datamodel.project import Project
+
+
+class FileInfo(BaseModel):
+    filename: str = Field(description="The filename of the file")
+
+    size: int = Field(description="The size of the file in bytes")
+
+    mime_type: str = Field(description="The MIME type of the file")
+
+    # TODO: add attachment
+    # attachment: KilnModelAttachment = Field(
+    #     description="The attachment to the file",
+    # )
+
+
+class Document(
+    KilnParentedModel, KilnParentModel, parent_of={"extractions": Extraction}
+):
+    name: str = NAME_FIELD
+
+    description: str = Field(description="A description for the file")
+
+    original_file: FileInfo = Field(description="The original file")
+
+    # TODO: move {mime_type:kind} mapping out of GeminiExtractor and into here
+    #   - will also need to have models specify which mimetypes they support
+    # TODO: move Kind enum into this file (instead of in extraction.py)
+    #   - waiting for ExtractionConfig PR merged to do this
+    kind: Kind = Field(
+        description="The kind of document. The kind is a broad family of filetypes that can be handled in a similar way"
+    )
+
+    # NOTE: could extract {tags + validate_tags} into a reusable Taggable model and inherit from that here
+    # and in TaskRun
+    # thoughts?
+    tags: List[str] = Field(
+        default_factory=list,
+        description="Tags for the document. Tags are used to categorize documents for filtering and reporting.",
+    )
+
+    @model_validator(mode="after")
+    def validate_tags(self) -> Self:
+        for tag in self.tags:
+            if not tag:
+                raise ValueError("Tags cannot be empty strings")
+            if " " in tag:
+                raise ValueError("Tags cannot contain spaces. Try underscores.")
+
+        return self
+
+    # Workaround to return typed parent without importing Project
+    def parent_project(self) -> Union["Project", None]:
+        if self.parent is None or self.parent.__class__.__name__ != "Project":
+            return None
+        return self.parent  # type: ignore
+
+    def extractions(self) -> list[Extraction]:
+        return super().extractions()  # type: ignore

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -1,11 +1,14 @@
 import json
 from enum import Enum
-from typing import Any, List
+from typing import TYPE_CHECKING, Any, List, Union
 
 from pydantic import BaseModel, Field, ValidationError, model_validator
 from typing_extensions import Self
 
-from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnBaseModel, KilnParentedModel
+from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentedModel
+
+if TYPE_CHECKING:
+    from kiln_ai.datamodel.project import Project
 
 
 def format_properties_errors(e: ValidationError) -> str:
@@ -54,7 +57,7 @@ class GeminiProperties(BaseModel):
         return self
 
 
-class ExtractorConfig(KilnBaseModel):
+class ExtractorConfig(KilnParentedModel):
     name: str = NAME_FIELD
 
     output_format: OutputFormat = Field(
@@ -97,6 +100,12 @@ class ExtractorConfig(KilnBaseModel):
 
     def gemini_properties(self) -> GeminiProperties:
         return GeminiProperties(**self.properties)
+
+    # Workaround to return typed parent without importing Project
+    def parent_project(self) -> Union["Project", None]:
+        if self.parent is None or self.parent.__class__.__name__ != "Project":
+            return None
+        return self.parent  # type: ignore
 
 
 class ExtractionSource(str, Enum):

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -5,7 +5,7 @@ from typing import Any, List
 from pydantic import BaseModel, Field, ValidationError, model_validator
 from typing_extensions import Self
 
-from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnBaseModel
+from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnBaseModel, KilnParentedModel
 
 
 def format_properties_errors(e: ValidationError) -> str:
@@ -97,3 +97,22 @@ class ExtractorConfig(KilnBaseModel):
 
     def gemini_properties(self) -> GeminiProperties:
         return GeminiProperties(**self.properties)
+
+
+class ExtractionSource(str, Enum):
+    PROCESSED = "processed"
+    PASSTHROUGH = "passthrough"
+
+
+class Extraction(KilnParentedModel):
+    source: ExtractionSource = Field(
+        description="The source of the extraction.",
+    )
+    extractor_config_id: str = Field(
+        description="The ID of the extractor config that was used to extract the data.",
+    )
+
+    # TODO: add extracted data as attachment
+    # output: KilnModelAttachment = Field(
+    #     description="The attachment that was used to extract the data.",
+    # )

--- a/libs/core/kiln_ai/datamodel/project.py
+++ b/libs/core/kiln_ai/datamodel/project.py
@@ -2,10 +2,18 @@ from pydantic import Field
 
 from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentModel
 from kiln_ai.datamodel.document import Document
+from kiln_ai.datamodel.extraction import ExtractorConfig
 from kiln_ai.datamodel.task import Task
 
 
-class Project(KilnParentModel, parent_of={"tasks": Task, "documents": Document}):
+class Project(
+    KilnParentModel,
+    parent_of={
+        "tasks": Task,
+        "documents": Document,
+        "extractor_configs": ExtractorConfig,
+    },
+):
     """
     A collection of related tasks.
 
@@ -25,3 +33,6 @@ class Project(KilnParentModel, parent_of={"tasks": Task, "documents": Document})
 
     def documents(self) -> list[Document]:
         return super().documents()  # type: ignore
+
+    def extractor_configs(self) -> list[ExtractorConfig]:
+        return super().extractor_configs()  # type: ignore

--- a/libs/core/kiln_ai/datamodel/project.py
+++ b/libs/core/kiln_ai/datamodel/project.py
@@ -1,10 +1,11 @@
 from pydantic import Field
 
 from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentModel
+from kiln_ai.datamodel.document import Document
 from kiln_ai.datamodel.task import Task
 
 
-class Project(KilnParentModel, parent_of={"tasks": Task}):
+class Project(KilnParentModel, parent_of={"tasks": Task, "documents": Document}):
     """
     A collection of related tasks.
 
@@ -21,3 +22,6 @@ class Project(KilnParentModel, parent_of={"tasks": Task}):
     # Needed for typechecking. TODO P2: fix this in KilnParentModel
     def tasks(self) -> list[Task]:
         return super().tasks()  # type: ignore
+
+    def documents(self) -> list[Document]:
+        return super().documents()  # type: ignore


### PR DESCRIPTION
## What does this PR do?

Add datamodel for `Document` (a file usable downstream in RAG), for `Extraction` (the output of an extractor), and set up the relationships between models.

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib
