### PR TITLE
fix: Fireworks AI Dashboard URL on fine-tune detail UI

### DIFF
--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
@@ -121,7 +121,7 @@
       const url_id = finetune.finetune.provider_id?.split("/").pop()
       if (finetune.finetune.properties["endpoint_version"] === "v2") {
         // V2 style URL
-        return `https://fireworks.ai/dashboard/fine-tuning/${url_id}`
+        return `https://fireworks.ai/dashboard/fine-tuning/supervised/${url_id}`
       } else {
         // V1 style URL
         return `https://fireworks.ai/dashboard/fine-tuning/v1/${url_id}`


### PR DESCRIPTION
## What does this PR do?

**Bug: 
On the fine-tune page: the `Fireworks AI Dashboard` link leads to a `404`** for `v2` fine-tunes and maybe `v1` fine-tunes. 

---

The current URL for `v2` fine-tunes is `https://fireworks.ai/dashboard/fine-tuning/XXX`, but leads to this screen:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/33008503-404a-47d6-8798-4d642dadc5e3" />

The new URL format is: `https://fireworks.ai/dashboard/fine-tuning/supervised/XXX` - and at least `v2` fine-tunes are available there.

---

Getting `404` on the `v1` URLs too, but that could be because I legitimately deleted those `v1` fine-tunes I tested with - they are so old that I cannot remember. So not able to confirm for sure what the situation with `v1` ones is.