### PR TITLE
Make prompt_id required for adapters. 

### DIFF
--- a/app/desktop/studio_server/data_gen_api.py
+++ b/app/desktop/studio_server/data_gen_api.py
@@ -9,6 +9,7 @@ from kiln_ai.adapters.data_gen.data_gen_task import (
 )
 from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig
 from kiln_ai.datamodel import DataSource, DataSourceType, PromptId, TaskRun
+from kiln_ai.datamodel.prompt_id import PromptGenerators
 from kiln_server.run_api import model_provider_from_string
 from kiln_server.task_api import task_from_id
 from pydantic import BaseModel, ConfigDict, Field
@@ -94,6 +95,7 @@ def connect_data_gen_api(app: FastAPI):
             categories_task,
             model_name=input.model_name,
             provider=model_provider_from_string(input.provider),
+            prompt_id=PromptGenerators.SIMPLE,
         )
 
         categories_run = await adapter.invoke(task_input.model_dump())
@@ -117,6 +119,7 @@ def connect_data_gen_api(app: FastAPI):
             sample_task,
             model_name=input.model_name,
             provider=model_provider_from_string(input.provider),
+            prompt_id=PromptGenerators.SIMPLE,
         )
 
         samples_run = await adapter.invoke(task_input.model_dump())

--- a/app/desktop/studio_server/repair_api.py
+++ b/app/desktop/studio_server/repair_api.py
@@ -5,6 +5,7 @@ from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.repair.repair_task import RepairTaskRun
 from kiln_ai.datamodel import TaskRun
 from kiln_ai.datamodel.json_schema import validate_schema
+from kiln_ai.datamodel.prompt_id import PromptGenerators
 from kiln_ai.datamodel.task_output import DataSource, DataSourceType
 from kiln_ai.utils.config import Config
 from kiln_server.run_api import model_provider_from_string, task_and_run_from_id
@@ -68,6 +69,7 @@ def connect_repair_api(app: FastAPI):
             repair_task,
             model_name=model_name,
             provider=model_provider_from_string(provider),
+            prompt_id=PromptGenerators.SIMPLE,
         )
 
         repair_run = await adapter.invoke(repair_task_input.model_dump())

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -17,7 +17,7 @@ def adapter_for_task(
     kiln_task: datamodel.Task,
     model_name: str,
     provider: ModelProviderName,
-    prompt_id: PromptId | None = None,
+    prompt_id: PromptId,
     base_adapter_config: AdapterConfig | None = None,
 ) -> BaseAdapter:
     # Get the provider to run. For things like the fine-tune provider, we want to run the underlying provider

--- a/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
+++ b/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
@@ -112,6 +112,7 @@ async def test_data_gen_all_models_providers(
         data_gen_task,
         model_name=model_name,
         provider=provider_name,
+        prompt_id="simple_prompt_builder",
     )
 
     input_dict = data_gen_input.model_dump()
@@ -256,6 +257,7 @@ async def test_data_gen_sample_all_models_providers(
         data_gen_task,
         model_name=model_name,
         provider=provider_name,
+        prompt_id="simple_prompt_builder",
     )
 
     input_dict = data_gen_input.model_dump()
@@ -306,6 +308,7 @@ async def test_data_gen_sample_all_models_providers_with_structured_output(
         data_gen_task,
         model_name=model_name,
         provider=provider_name,
+        prompt_id="simple_prompt_builder",
     )
 
     input_dict = data_gen_input.model_dump()

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -31,7 +31,7 @@ class LiteLlmAdapter(BaseAdapter):
         self,
         config: LiteLlmConfig,
         kiln_task: datamodel.Task,
-        prompt_id: PromptId | None = None,
+        prompt_id: PromptId,
         base_adapter_config: AdapterConfig | None = None,
     ):
         self.config = config
@@ -44,7 +44,7 @@ class LiteLlmAdapter(BaseAdapter):
             task=kiln_task,
             model_name=config.model_name,
             model_provider_name=config.provider_name,
-            prompt_id=prompt_id or PromptGenerators.SIMPLE,
+            prompt_id=prompt_id,
         )
 
         super().__init__(

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -68,7 +68,9 @@ def test_initialization(config, mock_task):
 
 
 def test_adapter_info(config, mock_task):
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     assert adapter.adapter_name() == "kiln_openai_compatible_adapter"
 
@@ -79,7 +81,9 @@ def test_adapter_info(config, mock_task):
 
 @pytest.mark.asyncio
 async def test_response_format_options_unstructured(config, mock_task):
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     # Mock has_structured_output to return False
     with patch.object(adapter, "has_structured_output", return_value=False):
@@ -96,7 +100,9 @@ async def test_response_format_options_unstructured(config, mock_task):
 )
 @pytest.mark.asyncio
 async def test_response_format_options_json_mode(config, mock_task, mode):
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     with (
         patch.object(adapter, "has_structured_output", return_value=True),
@@ -117,7 +123,9 @@ async def test_response_format_options_json_mode(config, mock_task, mode):
 )
 @pytest.mark.asyncio
 async def test_response_format_options_function_calling(config, mock_task, mode):
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     with (
         patch.object(adapter, "has_structured_output", return_value=True),
@@ -139,7 +147,9 @@ async def test_response_format_options_function_calling(config, mock_task, mode)
 )
 @pytest.mark.asyncio
 async def test_response_format_options_json_instructions(config, mock_task, mode):
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     with (
         patch.object(adapter, "has_structured_output", return_value=True),
@@ -154,7 +164,9 @@ async def test_response_format_options_json_instructions(config, mock_task, mode
 
 @pytest.mark.asyncio
 async def test_response_format_options_json_schema(config, mock_task):
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     with (
         patch.object(adapter, "has_structured_output", return_value=True),
@@ -176,7 +188,9 @@ async def test_response_format_options_json_schema(config, mock_task):
 
 
 def test_tool_call_params_weak(config, mock_task):
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     params = adapter.tool_call_params(strict=False)
     expected_schema = mock_task.output_schema()
@@ -201,7 +215,9 @@ def test_tool_call_params_weak(config, mock_task):
 
 def test_tool_call_params_strict(config, mock_task):
     config.provider_name = "openai"
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     params = adapter.tool_call_params(strict=True)
     expected_schema = mock_task.output_schema()
@@ -246,7 +262,9 @@ def test_litellm_model_id_standard_providers(
     config, mock_task, provider_name, expected_prefix
 ):
     """Test litellm_model_id for standard providers"""
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     # Mock the model_provider method to return a provider with the specified name
     mock_provider = Mock()
@@ -272,7 +290,9 @@ def test_litellm_model_id_standard_providers(
 def test_litellm_model_id_custom_providers(config, mock_task, provider_name):
     """Test litellm_model_id for custom providers that require a base URL"""
     config.base_url = "https://api.custom.com"
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     # Mock the model_provider method
     mock_provider = Mock()
@@ -290,7 +310,9 @@ def test_litellm_model_id_custom_providers(config, mock_task, provider_name):
 def test_litellm_model_id_custom_provider_no_base_url(config, mock_task):
     """Test litellm_model_id raises error for custom providers without base URL"""
     config.base_url = None
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     # Mock the model_provider method
     mock_provider = Mock()
@@ -304,7 +326,9 @@ def test_litellm_model_id_custom_provider_no_base_url(config, mock_task):
 
 def test_litellm_model_id_no_model_id(config, mock_task):
     """Test litellm_model_id raises error when provider has no model_id"""
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     # Mock the model_provider method to return a provider with no model_id
     mock_provider = Mock()
@@ -318,7 +342,9 @@ def test_litellm_model_id_no_model_id(config, mock_task):
 
 def test_litellm_model_id_caching(config, mock_task):
     """Test that litellm_model_id caches the result"""
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     # Set the cached value directly
     adapter._litellm_model_id = "cached-value"
@@ -333,7 +359,9 @@ def test_litellm_model_id_caching(config, mock_task):
 
 def test_litellm_model_id_unknown_provider(config, mock_task):
     """Test litellm_model_id raises error for unknown provider"""
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     # Create a mock provider with an unknown name
     mock_provider = Mock()
@@ -372,7 +400,9 @@ async def test_build_completion_kwargs(
     config, mock_task, top_logprobs, response_format, extra_body
 ):
     """Test build_completion_kwargs with various configurations"""
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
     mock_provider = Mock()
     messages = [{"role": "user", "content": "Hello"}]
 
@@ -443,7 +473,9 @@ async def test_build_completion_kwargs(
 )
 def test_usage_from_response(config, mock_task, litellm_usage, cost, expected_usage):
     """Test usage_from_response with various combinations of usage data and cost"""
-    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    adapter = LiteLlmAdapter(
+        config=config, kiln_task=mock_task, prompt_id="simple_prompt_builder"
+    )
 
     # Create a mock response
     response = Mock(spec=litellm.types.utils.ModelResponse)

--- a/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
@@ -146,7 +146,12 @@ def build_structured_output_test_task(tmp_path: Path):
 
 async def run_structured_output_test(tmp_path: Path, model_name: str, provider: str):
     task = build_structured_output_test_task(tmp_path)
-    a = adapter_for_task(task, model_name=model_name, provider=provider)
+    a = adapter_for_task(
+        task,
+        model_name=model_name,
+        provider=provider,
+        prompt_id="simple_prompt_builder",
+    )
     try:
         run = await a.invoke("Cows")  # a joke about cows
         parsed = json.loads(run.output.output)
@@ -197,10 +202,12 @@ def build_structured_input_test_task(tmp_path: Path):
     return task
 
 
-async def run_structured_input_test(tmp_path: Path, model_name: str, provider: str):
+async def run_structured_input_test(
+    tmp_path: Path, model_name: str, provider: str, prompt_id: PromptId
+):
     task = build_structured_input_test_task(tmp_path)
     try:
-        await run_structured_input_task(task, model_name, provider)
+        await run_structured_input_task(task, model_name, provider, prompt_id)
     except ValueError as e:
         if str(e) == "Failed to connect to Ollama. Ensure Ollama is running.":
             pytest.skip(
@@ -209,11 +216,11 @@ async def run_structured_input_test(tmp_path: Path, model_name: str, provider: s
         raise e
 
 
-async def run_structured_input_task(
+async def run_structured_input_task_no_validation(
     task: datamodel.Task,
     model_name: str,
     provider: str,
-    prompt_id: PromptId | None = None,
+    prompt_id: PromptId,
 ):
     a = adapter_for_task(
         task,
@@ -231,18 +238,29 @@ async def run_structured_input_task(
     try:
         run = await a.invoke({"a": 2, "b": 2, "c": 2})
         response = run.output.output
+        return response
     except ValueError as e:
         if str(e) == "Failed to connect to Ollama. Ensure Ollama is running.":
             pytest.skip(
                 f"Skipping {model_name} {provider} because Ollama is not running"
             )
         raise e
+
+
+async def run_structured_input_task(
+    task: datamodel.Task,
+    model_name: str,
+    provider: str,
+    prompt_id: PromptId,
+):
+    response = await run_structured_input_task_no_validation(
+        task, model_name, provider, prompt_id
+    )
     assert response is not None
     if isinstance(response, str):
         assert "[[equilateral]]" in response
     else:
         assert response["is_equilateral"] is True
-
     expected_pb_name = "simple_prompt_builder"
     if prompt_id is not None:
         expected_pb_name = prompt_id
@@ -269,7 +287,9 @@ async def test_structured_input_gpt_4o_mini(tmp_path):
 async def test_all_built_in_models_structured_input(
     tmp_path, model_name, provider_name
 ):
-    await run_structured_input_test(tmp_path, model_name, provider_name)
+    await run_structured_input_test(
+        tmp_path, model_name, provider_name, "simple_prompt_builder"
+    )
 
 
 @pytest.mark.paid
@@ -323,6 +343,11 @@ When asked for a final result, this is the format (for an equilateral example):
 """
     task.output_json_schema = json.dumps(triangle_schema)
     task.save_to_file()
-    await run_structured_input_task(
+    response = await run_structured_input_task_no_validation(
         task, model_name, provider_name, "simple_chain_of_thought_prompt_builder"
     )
+
+    formatted_response = json.loads(response)
+    assert formatted_response["is_equilateral"] is True
+    assert formatted_response["is_scalene"] is False
+    assert formatted_response["is_obtuse"] is False

--- a/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
@@ -238,7 +238,7 @@ async def run_structured_input_task_no_validation(
     try:
         run = await a.invoke({"a": 2, "b": 2, "c": 2})
         response = run.output.output
-        return response
+        return response, a
     except ValueError as e:
         if str(e) == "Failed to connect to Ollama. Ensure Ollama is running.":
             pytest.skip(
@@ -253,7 +253,7 @@ async def run_structured_input_task(
     provider: str,
     prompt_id: PromptId,
 ):
-    response = await run_structured_input_task_no_validation(
+    response, a = await run_structured_input_task_no_validation(
         task, model_name, provider, prompt_id
     )
     assert response is not None

--- a/libs/core/kiln_ai/adapters/repair/test_repair_task.py
+++ b/libs/core/kiln_ai/adapters/repair/test_repair_task.py
@@ -224,7 +224,10 @@ async def test_mocked_repair_task_run(sample_task, sample_task_run, sample_repai
         )
 
         adapter = adapter_for_task(
-            repair_task, model_name="llama_3_1_8b", provider="ollama"
+            repair_task,
+            model_name="llama_3_1_8b",
+            provider="ollama",
+            prompt_id="simple_prompt_builder",
         )
 
         run = await adapter.invoke(repair_task_input.model_dump())

--- a/libs/core/kiln_ai/adapters/test_adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/test_adapter_registry.py
@@ -40,7 +40,10 @@ def mock_finetune_from_id():
 
 def test_openai_adapter_creation(mock_config, basic_task):
     adapter = adapter_for_task(
-        kiln_task=basic_task, model_name="gpt-4", provider=ModelProviderName.openai
+        kiln_task=basic_task,
+        model_name="gpt-4",
+        provider=ModelProviderName.openai,
+        prompt_id="simple_prompt_builder",
     )
 
     assert isinstance(adapter, LiteLlmAdapter)
@@ -56,6 +59,7 @@ def test_openrouter_adapter_creation(mock_config, basic_task):
         kiln_task=basic_task,
         model_name="anthropic/claude-3-opus",
         provider=ModelProviderName.openrouter,
+        prompt_id="simple_prompt_builder",
     )
 
     assert isinstance(adapter, LiteLlmAdapter)
@@ -79,7 +83,10 @@ def test_openrouter_adapter_creation(mock_config, basic_task):
 )
 def test_openai_compatible_adapter_creation(mock_config, basic_task, provider):
     adapter = adapter_for_task(
-        kiln_task=basic_task, model_name="test-model", provider=provider
+        kiln_task=basic_task,
+        model_name="test-model",
+        provider=provider,
+        prompt_id="simple_prompt_builder",
     )
 
     assert isinstance(adapter, LiteLlmAdapter)
@@ -108,6 +115,7 @@ def test_tags_passed_through(mock_config, basic_task):
         base_adapter_config=AdapterConfig(
             default_tags=tags,
         ),
+        prompt_id="simple_prompt_builder",
     )
 
     assert adapter.base_adapter_config.default_tags == tags
@@ -116,7 +124,10 @@ def test_tags_passed_through(mock_config, basic_task):
 def test_invalid_provider(mock_config, basic_task):
     with pytest.raises(ValueError, match="Unhandled enum value"):
         adapter_for_task(
-            kiln_task=basic_task, model_name="test-model", provider="invalid"
+            kiln_task=basic_task,
+            model_name="test-model",
+            provider="invalid",
+            prompt_id="simple_prompt_builder",
         )
 
 
@@ -133,6 +144,7 @@ def test_openai_compatible_adapter(mock_compatible_config, mock_config, basic_ta
         kiln_task=basic_task,
         model_name="provider::test-model",
         provider=ModelProviderName.openai_compatible,
+        prompt_id="simple_prompt_builder",
     )
 
     assert isinstance(adapter, LiteLlmAdapter)
@@ -145,6 +157,7 @@ def test_custom_openai_compatible_provider(mock_config, basic_task):
         kiln_task=basic_task,
         model_name="openai::test-model",
         provider=ModelProviderName.kiln_custom_registry,
+        prompt_id="simple_prompt_builder",
     )
 
     assert isinstance(adapter, LiteLlmAdapter)
@@ -159,6 +172,7 @@ async def test_fine_tune_provider(mock_config, basic_task, mock_finetune_from_id
         kiln_task=basic_task,
         model_name="proj::task::tune",
         provider=ModelProviderName.kiln_fine_tune,
+        prompt_id="simple_prompt_builder",
     )
 
     mock_finetune_from_id.assert_called_once_with("proj::task::tune")

--- a/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
@@ -57,7 +57,7 @@ async def test_groq(tmp_path):
 )
 @pytest.mark.paid
 async def test_openrouter(tmp_path, model_name):
-    await run_simple_test(tmp_path, model_name, "openrouter", "simple_prompt_builder")
+    await run_simple_test(tmp_path, model_name, "openrouter")
 
 
 @pytest.mark.ollama
@@ -154,7 +154,7 @@ async def test_mock_returning_run(tmp_path):
 @pytest.mark.parametrize("model_name,provider_name", get_all_models_and_providers())
 async def test_all_models_providers_plaintext(tmp_path, model_name, provider_name):
     task = build_test_task(tmp_path)
-    await run_simple_task(task, model_name, provider_name, "simple_prompt_builder")
+    await run_simple_task(task, model_name, provider_name)
 
 
 @pytest.mark.paid
@@ -210,10 +210,13 @@ async def run_simple_task(
     task: datamodel.Task,
     model_name: str,
     provider: str,
-    prompt_id: PromptId,
+    prompt_id: PromptId | None = None,
 ) -> datamodel.TaskRun:
     adapter = adapter_for_task(
-        task, model_name=model_name, provider=provider, prompt_id=prompt_id
+        task,
+        model_name=model_name,
+        provider=provider,
+        prompt_id=prompt_id or "simple_prompt_builder",
     )
 
     run = await adapter.invoke(

--- a/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
@@ -57,7 +57,7 @@ async def test_groq(tmp_path):
 )
 @pytest.mark.paid
 async def test_openrouter(tmp_path, model_name):
-    await run_simple_test(tmp_path, model_name, "openrouter")
+    await run_simple_test(tmp_path, model_name, "openrouter", "simple_prompt_builder")
 
 
 @pytest.mark.ollama
@@ -130,6 +130,7 @@ async def test_mock_returning_run(tmp_path):
                 additional_body_options={"api_key": "test_key"},
             ),
             kiln_task=task,
+            prompt_id="simple_prompt_builder",
         )
 
         run = await adapter.invoke("You are a mock, send me the response!")
@@ -153,7 +154,7 @@ async def test_mock_returning_run(tmp_path):
 @pytest.mark.parametrize("model_name,provider_name", get_all_models_and_providers())
 async def test_all_models_providers_plaintext(tmp_path, model_name, provider_name):
     task = build_test_task(tmp_path)
-    await run_simple_task(task, model_name, provider_name)
+    await run_simple_task(task, model_name, provider_name, "simple_prompt_builder")
 
 
 @pytest.mark.paid
@@ -209,7 +210,7 @@ async def run_simple_task(
     task: datamodel.Task,
     model_name: str,
     provider: str,
-    prompt_id: PromptId | None = None,
+    prompt_id: PromptId,
 ) -> datamodel.TaskRun:
     adapter = adapter_for_task(
         task, model_name=model_name, provider=provider, prompt_id=prompt_id


### PR DESCRIPTION
Making it optional led to a major bug in evals -- we want to caller to provide it, and never default. Caller can decide if default is appropriate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Introduced explicit prompt selection for AI task adapters to ensure consistent prompt usage across data generation, repair, and model adapter functionalities.
- **Tests**
	- Updated tests to include explicit prompt identifiers, improving validation and consistency in AI task and adapter testing.
- **Bug Fixes**
	- Improved structured input tests by separating raw response retrieval from validation and adding explicit prompt handling for more reliable test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->