### PR TITLE
FW has changed their URLs to start with `app`. update base URL

### DIFF
--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
@@ -121,7 +121,7 @@
       const url_id = finetune.finetune.provider_id?.split("/").pop()
       if (finetune.finetune.properties["endpoint_version"] === "v2") {
         // V2 style URL
-        return `https://fireworks.ai/dashboard/fine-tuning/supervised/${url_id}`
+        return `https://app.fireworks.ai/dashboard/fine-tuning/supervised/${url_id}`
       } else {
         // V1 style URL
         return `https://fireworks.ai/dashboard/fine-tuning/v1/${url_id}`


### PR DESCRIPTION
## What does this PR do?

Small change to add `app` to the URL
eg. old link: https://fireworks.ai/dashboard/fine-tuning/supervised/o7ka5pcp
new link: https://app.fireworks.ai/dashboard/fine-tuning/supervised/o7ka5pcp

clicking on the FW link in the UI routes to the URL and it seems like FW changed the paths to start with `app`?
![Screenshot 2025-05-28 at 9 46 54 AM](https://github.com/user-attachments/assets/adbaaa5f-30c4-438b-b547-619b2bbdb298)

## Related Issues

N/A

## Checklists

- [X] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib
