### PR TITLE
small string change to explain that the JSON descriptions are not sent anywhere

### DIFF
--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -365,7 +365,8 @@
         Part {show_requirements ? "3" : "2"}: Input Schema
       </div>
       <div class="text-xs text-gray-500">
-        What kind of input will the model receive?
+        What kind of input will the model receive? This is a description for you
+        and your team, not used by the model.
       </div>
     </div>
 
@@ -404,7 +405,8 @@
         Part {show_requirements ? "4" : "3"}: Output Schema
       </div>
       <div class="text-xs text-gray-500">
-        What kind of output will the model produce?
+        What kind of output will the model produce? This is a description for
+        you and your team, not used by the model.
       </div>
     </div>
 


### PR DESCRIPTION
## What does this PR do?

Small user experience fix needs to be made here. it's not obvious that the input/output schema description is not sent to a model. wasted some time carefully crafting those descriptions only to realize its more suited to live in the main training prompt.

Used the UI Copy from the other elements. Any suggestions to make it smaller? Ideally it only pops up for Structured JSON
![Screenshot 2025-05-28 at 10 17 38 AM](https://github.com/user-attachments/assets/10a93be5-dc2e-4fed-a597-fdc82569d243)

## Checklists

- [X] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the descriptive text in the task creation and editing form to clarify that input and output schema descriptions are for team reference only and not used by the model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->