### PR TITLE
final and intermediate still requires two calls (COT)

### DIFF
--- a/libs/core/kiln_ai/adapters/provider_tools.py
+++ b/libs/core/kiln_ai/adapters/provider_tools.py
@@ -279,7 +279,6 @@ def finetune_provider_model(
         reasoning_capable=(
             fine_tune.data_strategy
             in [
-                FinetuneDataStrategy.final_and_intermediate,
                 FinetuneDataStrategy.final_and_intermediate_r1_compatible,
             ]
         ),

--- a/libs/core/kiln_ai/adapters/test_provider_tools.py
+++ b/libs/core/kiln_ai/adapters/test_provider_tools.py
@@ -474,7 +474,7 @@ def test_finetune_provider_model_success_final_and_intermediate(
     assert provider.name == ModelProviderName.openai
     assert provider.model_id == "ft:gpt-3.5-turbo:custom:model-123"
     assert provider.structured_output_mode == StructuredOutputMode.json_schema
-    assert provider.reasoning_capable is True
+    assert provider.reasoning_capable is False
     assert provider.parser == None
 
 


### PR DESCRIPTION
being "thinking" != being "reasoning". Naming could be improved, as reasoning really means "thinking and answer in one message", at least for the use case this was breaking. Might need to split these two concepts up?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated logic to more accurately determine when a fine-tuned model is considered reasoning capable.

- **Tests**
  - Adjusted test expectations to reflect the updated reasoning capability criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->