### PR TITLE
chore: improve logs around litellm and eval failure

### DIFF
--- a/app/desktop/log_config.py
+++ b/app/desktop/log_config.py
@@ -165,9 +165,11 @@ class CustomLiteLLMLogger(CustomLogger):
         )
 
     def log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        # This logging method is supposed to be called by Litellm in synchronous error cases (Kiln should use async calls instead)
+        # but it appears to also be getting called in async calls that fail early (e.g. UnsupportedParamsError).
         litellm_logger = logging.getLogger("LiteLLM")
         litellm_logger.error(
-            "Used a sync call in Litellm. Kiln should use async calls."
+            "LiteLLM logged a synchronous failure event. This may result from a sync call, or from an async call failing early (e.g. invalid parameters). Make sure you are using async calls.",
         )
 
     #### ASYNC #### - for acompletion/aembeddings

--- a/libs/core/kiln_ai/adapters/eval/base_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/base_eval.py
@@ -2,8 +2,6 @@ import json
 from abc import abstractmethod
 from typing import Dict
 
-import jsonschema
-
 from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -207,5 +207,8 @@ class EvalRunner:
 
             return True
         except Exception as e:
-            logger.error(f"Error running eval job for dataset item {job.item.id}: {e}")
+            logger.error(
+                f"Error running eval job for dataset item {job.item.id}: {e}",
+                exc_info=True,
+            )
             return False


### PR DESCRIPTION
## What does this PR do?

1. clarifies the log message in `log_failure_event()` method, which warns that a sync call was used, because that call can also be triggered by *async* calls that fail early due to client-side errors like parameter validation inside LiteLLM (`litellm.UnsupportedParamsError`)
2. log stack trace (`exc_info=True`) in the `eval_runner`, otherwise we get the error message without its origin
3. removed an unused import

Example of when `await litellm.acompletion()` can call the sync `log_failure_event` logging method:
- while running a `g_eval` using a Gemini model, LiteLLM raises `litellm.UnsupportedParamsError` because `top_logprobs` is not supported for that model (they raise in `_check_valid_arg()`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved comments and error messages to clarify the handling of synchronous and asynchronous error cases.

- **Chores**
  - Removed an unused import to streamline the codebase.

- **Bug Fixes**
  - Enhanced error logging to include detailed exception tracebacks for better diagnostics during evaluation jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->