### PR TITLE
Use persistent lock for Config.update_settings

### DIFF
--- a/libs/core/kiln_ai/utils/config.py
+++ b/libs/core/kiln_ai/utils/config.py
@@ -138,6 +138,7 @@ class Config:
                 sensitive_keys=["api_key"],
             ),
         }
+        self._lock = threading.Lock()
         self._settings = self.load_settings()
 
     @classmethod
@@ -180,7 +181,7 @@ class Config:
         return None if value is None else property_config.type(value)
 
     def __setattr__(self, name, value):
-        if name in ("_properties", "_settings"):
+        if name in ("_properties", "_settings", "_lock"):
             super().__setattr__(name, value)
         elif name in self._properties:
             self.update_settings({name: value})
@@ -234,7 +235,7 @@ class Config:
 
     def update_settings(self, new_settings: Dict[str, Any]):
         # Lock to prevent race conditions in multi-threaded scenarios
-        with threading.Lock():
+        with self._lock:
             # Fresh load to avoid clobbering changes from other instances
             current_settings = self.load_settings()
             current_settings.update(new_settings)


### PR DESCRIPTION
## Summary
- maintain a per-instance lock inside `Config`
- ensure updates use the instance lock
- test concurrent calls to `Config.update_settings`

## Testing
- `pytest libs/core/kiln_ai/utils/test_config.py::test_update_settings_thread_safety -q`

------
https://chatgpt.com/codex/tasks/task_e_68464da6a16c83329de74294e91f32f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved thread safety when updating configuration settings to prevent race conditions in multi-threaded scenarios.

- **Tests**
	- Added a test to verify that configuration updates remain thread-safe during concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->