### PR TITLE
Add View Logs button

### DIFF
--- a/app/desktop/studio_server/test_settings_api.py
+++ b/app/desktop/studio_server/test_settings_api.py
@@ -154,3 +154,10 @@ def test_settings_endpoints(client, mock_config):
     response = client.get("/api/settings/sensitive_setting")
     assert response.status_code == 200
     assert response.json() == {"sensitive_setting": "[hidden]"}
+
+
+def test_open_logs_endpoint(client):
+    with patch("app.desktop.studio_server.settings_api.open_logs_folder") as m:
+        response = client.post("/api/open_logs")
+        assert response.status_code == 200
+        m.assert_called_once()

--- a/app/web_ui/src/routes/(app)/settings/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/+page.svelte
@@ -2,6 +2,18 @@
   import AppPage from "../app_page.svelte"
   import { ui_state } from "$lib/stores"
 
+  async function view_logs() {
+    try {
+      const res = await fetch("/api/open_logs", { method: "POST" })
+      if (!res.ok) {
+        const msg = await res.text()
+        alert(`Failed to open logs: ${msg}`)
+      }
+    } catch (e) {
+      alert("Failed to open logs: " + e)
+    }
+  }
+
   let sections = [
     {
       name: "Edit Task",
@@ -28,6 +40,12 @@
       description: "Edit the currently selected project.",
       button_text: "Edit Current Project",
       href: "/settings/edit_project/" + $ui_state.current_project_id,
+    },
+    {
+      name: "View Logs",
+      description: "View logs of the LLM calls or the application logs.",
+      button_text: "View Logs",
+      on_click: view_logs,
     },
     {
       name: "App Updates",
@@ -59,14 +77,24 @@
           <h3 class="font-medium">{section.name}</h3>
           <p class="text-sm text-gray-500">{section.description}</p>
         </div>
-        <a
-          href={section.href}
-          class="btn"
-          style="min-width: 14rem"
-          target={section.is_external ? "_blank" : "_self"}
-        >
-          {section.button_text}
-        </a>
+        {#if section.href}
+          <a
+            href={section.href}
+            class="btn"
+            style="min-width: 14rem"
+            target={section.is_external ? "_blank" : "_self"}
+          >
+            {section.button_text}
+          </a>
+        {:else if section.on_click}
+          <button
+            class="btn"
+            style="min-width: 14rem"
+            on:click={section.on_click}
+          >
+            {section.button_text}
+          </button>
+        {/if}
       </div>
     {/each}
   </div>


### PR DESCRIPTION
## Summary
- show a new 'View Logs' item on the Settings page
- allow opening the logs folder via `/api/open_logs`
- test the open logs endpoint
- use existing log path helper and ensure single click handler

## Testing
- `uv run bash checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68464d2b131c8332ab5c69c5e444515f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "View Logs" button in the settings page, allowing users to open the logs folder directly from the app interface.

- **Bug Fixes**
  - Improved error handling when attempting to open the logs folder, providing user alerts if the action fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->