### PR TITLE
Use RunConfigProperties in run/eval requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Please ensure any new code has test coverage, and that all code is formatted and
 To confirm everything works locally, run:
 
 ```bash
-./checks.sh
+uv run ./checks.sh
 ```
 
 ## Optional Setup

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -243,10 +243,12 @@ async def test_create_task_run_config_with_freezing(
             json={
                 "name": "Test Task Run Config",
                 "description": "Test Description",
-                "model_name": "gpt-4o",
-                "model_provider_name": "openai",
-                "prompt_id": "simple_chain_of_thought_prompt_builder",
-                "temperature": 0.5,
+                "run_config_properties": {
+                    "model_name": "gpt-4o",
+                    "model_provider_name": "openai",
+                    "prompt_id": "simple_chain_of_thought_prompt_builder",
+                    "temperature": 0.5,
+                },
                 # top_p not included, should get default 1.0
             },
         )
@@ -307,9 +309,11 @@ async def test_create_task_run_config_without_freezing(
             json={
                 "name": "Test Task Run Config",
                 "description": "Test Description",
-                "model_name": "gpt-4o",
-                "model_provider_name": "openai",
-                "prompt_id": "id::prompt_123",
+                "run_config_properties": {
+                    "model_name": "gpt-4o",
+                    "model_provider_name": "openai",
+                    "prompt_id": "id::prompt_123",
+                },
             },
         )
 
@@ -1594,10 +1598,12 @@ async def test_create_task_run_config_invalid_temperature_values(
         "/api/projects/project1/tasks/task1/task_run_config",
         json={
             "name": "Test Task Run Config",
-            "model_name": "gpt-4o",
-            "model_provider_name": "openai",
-            "prompt_id": "simple_chain_of_thought_prompt_builder",
-            "temperature": -0.1,
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "temperature": -0.1,
+            },
         },
     )
     assert response.status_code == 422
@@ -1609,10 +1615,12 @@ async def test_create_task_run_config_invalid_temperature_values(
         "/api/projects/project1/tasks/task1/task_run_config",
         json={
             "name": "Test Task Run Config",
-            "model_name": "gpt-4o",
-            "model_provider_name": "openai",
-            "prompt_id": "simple_chain_of_thought_prompt_builder",
-            "temperature": 2.1,
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "temperature": 2.1,
+            },
         },
     )
     assert response.status_code == 422
@@ -1632,10 +1640,12 @@ async def test_create_task_run_config_invalid_top_p_values(
         "/api/projects/project1/tasks/task1/task_run_config",
         json={
             "name": "Test Task Run Config",
-            "model_name": "gpt-4o",
-            "model_provider_name": "openai",
-            "prompt_id": "simple_chain_of_thought_prompt_builder",
-            "top_p": -0.1,
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "top_p": -0.1,
+            },
         },
     )
     assert response.status_code == 422
@@ -1647,10 +1657,12 @@ async def test_create_task_run_config_invalid_top_p_values(
         "/api/projects/project1/tasks/task1/task_run_config",
         json={
             "name": "Test Task Run Config",
-            "model_name": "gpt-4o",
-            "model_provider_name": "openai",
-            "prompt_id": "simple_chain_of_thought_prompt_builder",
-            "top_p": 1.1,
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "top_p": 1.1,
+            },
         },
     )
     assert response.status_code == 422
@@ -1670,11 +1682,13 @@ async def test_create_task_run_config_valid_boundary_values(
         "/api/projects/project1/tasks/task1/task_run_config",
         json={
             "name": "Test Task Run Config Min",
-            "model_name": "gpt-4o",
-            "model_provider_name": "openai",
-            "prompt_id": "simple_chain_of_thought_prompt_builder",
-            "temperature": 0.0,
-            "top_p": 0.0,
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "temperature": 0.0,
+                "top_p": 0.0,
+            },
         },
     )
     assert response.status_code == 200
@@ -1687,11 +1701,13 @@ async def test_create_task_run_config_valid_boundary_values(
         "/api/projects/project1/tasks/task1/task_run_config",
         json={
             "name": "Test Task Run Config Max",
-            "model_name": "gpt-4o",
-            "model_provider_name": "openai",
-            "prompt_id": "simple_chain_of_thought_prompt_builder",
-            "temperature": 2.0,
-            "top_p": 1.0,
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "temperature": 2.0,
+                "top_p": 1.0,
+            },
         },
     )
     assert response.status_code == 200

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1222,11 +1222,7 @@ export interface components {
             name?: string | null;
             /** Description */
             description?: string | null;
-            /** Model Name */
-            model_name: string;
-            model_provider_name: components["schemas"]["ModelProviderName"];
-            /** Prompt Id */
-            prompt_id: string;
+            run_config_properties: components["schemas"]["RunConfigProperties"];
         };
         /** DataGenCategoriesApiInput */
         DataGenCategoriesApiInput: {
@@ -2338,16 +2334,11 @@ export interface components {
         };
         /** RunTaskRequest */
         RunTaskRequest: {
-            /** Model Name */
-            model_name: string;
-            /** Provider */
-            provider: string;
+            run_config_properties: components["schemas"]["RunConfigProperties"];
             /** Plaintext Input */
             plaintext_input?: string | null;
             /** Structured Input */
             structured_input?: Record<string, never> | null;
-            /** Ui Prompt Method */
-            ui_prompt_method?: string | null;
             /** Tags */
             tags?: string[] | null;
         };

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2032,7 +2032,7 @@ export interface components {
          *     Where models have instruct and raw versions, instruct is default and raw is specified.
          * @enum {string}
          */
-        ModelName: "llama_3_1_8b" | "llama_3_1_70b" | "llama_3_1_405b" | "llama_3_2_1b" | "llama_3_2_3b" | "llama_3_2_11b" | "llama_3_2_90b" | "llama_3_3_70b" | "gpt_4o_mini" | "gpt_4o" | "gpt_4_1" | "gpt_4_1_mini" | "gpt_4_1_nano" | "gpt_o3_low" | "gpt_o3_medium" | "gpt_o3_high" | "gpt_o1_low" | "gpt_o1_medium" | "gpt_o1_high" | "gpt_o4_mini_low" | "gpt_o4_mini_medium" | "gpt_o4_mini_high" | "gpt_o3_mini_low" | "gpt_o3_mini_medium" | "gpt_o3_mini_high" | "phi_3_5" | "phi_4" | "phi_4_5p6b" | "phi_4_mini" | "mistral_large" | "mistral_nemo" | "gemma_2_2b" | "gemma_2_9b" | "gemma_2_27b" | "gemma_3_1b" | "gemma_3_4b" | "gemma_3_12b" | "gemma_3_27b" | "claude_3_5_haiku" | "claude_3_5_sonnet" | "claude_3_7_sonnet" | "claude_3_7_sonnet_thinking" | "gemini_1_5_flash" | "gemini_1_5_flash_8b" | "gemini_1_5_pro" | "gemini_2_0_flash" | "gemini_2_0_flash_lite" | "gemini_2_5_pro" | "gemini_2_5_flash" | "nemotron_70b" | "mixtral_8x7b" | "qwen_2p5_7b" | "qwen_2p5_14b" | "qwen_2p5_72b" | "qwq_32b" | "deepseek_3" | "deepseek_r1" | "mistral_small_3" | "deepseek_r1_distill_qwen_32b" | "deepseek_r1_distill_llama_70b" | "deepseek_r1_distill_qwen_14b" | "deepseek_r1_distill_qwen_1p5b" | "deepseek_r1_distill_qwen_7b" | "deepseek_r1_distill_llama_8b" | "dolphin_2_9_8x22b" | "grok_2";
+        ModelName: "llama_3_1_8b" | "llama_3_1_70b" | "llama_3_1_405b" | "llama_3_2_1b" | "llama_3_2_3b" | "llama_3_2_11b" | "llama_3_2_90b" | "llama_3_3_70b" | "gpt_4o_mini" | "gpt_4o" | "gpt_4_1" | "gpt_4_1_mini" | "gpt_4_1_nano" | "gpt_o3_low" | "gpt_o3_medium" | "gpt_o3_high" | "gpt_o1_low" | "gpt_o1_medium" | "gpt_o1_high" | "gpt_o4_mini_low" | "gpt_o4_mini_medium" | "gpt_o4_mini_high" | "gpt_o3_mini_low" | "gpt_o3_mini_medium" | "gpt_o3_mini_high" | "phi_3_5" | "phi_4" | "phi_4_5p6b" | "phi_4_mini" | "mistral_large" | "mistral_nemo" | "gemma_2_2b" | "gemma_2_9b" | "gemma_2_27b" | "gemma_3_1b" | "gemma_3_4b" | "gemma_3_12b" | "gemma_3_27b" | "claude_3_5_haiku" | "claude_3_5_sonnet" | "claude_3_7_sonnet" | "claude_3_7_sonnet_thinking" | "claude_sonnet_4" | "claude_opus_4" | "gemini_1_5_flash" | "gemini_1_5_flash_8b" | "gemini_1_5_pro" | "gemini_2_0_flash" | "gemini_2_0_flash_lite" | "gemini_2_5_pro" | "gemini_2_5_flash" | "nemotron_70b" | "mixtral_8x7b" | "qwen_2p5_7b" | "qwen_2p5_14b" | "qwen_2p5_72b" | "qwq_32b" | "deepseek_3" | "deepseek_r1" | "mistral_small_3" | "deepseek_r1_distill_qwen_32b" | "deepseek_r1_distill_llama_70b" | "deepseek_r1_distill_qwen_14b" | "deepseek_r1_distill_qwen_1p5b" | "deepseek_r1_distill_qwen_7b" | "deepseek_r1_distill_llama_8b" | "dolphin_2_9_8x22b" | "grok_2" | "qwen_3_0p6b" | "qwen_3_0p6b_no_thinking" | "qwen_3_1p7b" | "qwen_3_1p7b_no_thinking" | "qwen_3_4b" | "qwen_3_4b_no_thinking" | "qwen_3_8b" | "qwen_3_8b_no_thinking" | "qwen_3_14b" | "qwen_3_14b_no_thinking" | "qwen_3_30b_a3b" | "qwen_3_30b_a3b_no_thinking" | "qwen_3_32b" | "qwen_3_32b_no_thinking" | "qwen_3_235b_a22b" | "qwen_3_235b_a22b_no_thinking";
         /**
          * ModelProviderName
          * @description Enumeration of supported AI model providers.
@@ -2298,16 +2298,30 @@ export interface components {
              * @description The model to use for this run config.
              */
             model_name: string;
-            /**
-             * Model Provider Name
-             * @description The provider to use for this run config.
-             */
-            model_provider_name: string;
+            /** @description The provider to use for this run config. */
+            model_provider_name: components["schemas"]["ModelProviderName"];
             /**
              * Prompt Id
              * @description The prompt to use for this run config. Defaults to building a simple prompt from the task if not provided.
              */
             prompt_id: string;
+            /**
+             * Top P
+             * @description The top-p value to use for this run config. Defaults to 1.0.
+             * @default 1
+             */
+            top_p: number;
+            /**
+             * Temperature
+             * @description The temperature to use for this run config. Defaults to 1.0.
+             * @default 1
+             */
+            temperature: number;
+            /**
+             * @description The structured output mode to use for this run config. Defaults to 'default', which means the model will use its default structured output mode.
+             * @default default
+             */
+            structured_output_mode: components["schemas"]["StructuredOutputMode"];
         };
         /** RunSummary */
         RunSummary: {
@@ -2332,7 +2346,10 @@ export interface components {
             /** Tags */
             tags?: string[] | null;
         };
-        /** RunTaskRequest */
+        /**
+         * RunTaskRequest
+         * @description Request model for running a task.
+         */
         RunTaskRequest: {
             run_config_properties: components["schemas"]["RunConfigProperties"];
             /** Plaintext Input */

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -374,12 +374,14 @@
             },
           },
           body: {
-            model_name: task_run_config_model_name,
-            // @ts-expect-error not checking types here, server will check them
-            model_provider_name: task_run_config_provider_name,
-            prompt_id: task_run_config_prompt_method,
-            temperature: task_run_config_temperature,
-            top_p: task_run_config_top_p,
+            run_config_properties: {
+              model_name: task_run_config_model_name,
+              // @ts-expect-error not checking types here, server will check them
+              model_provider_name: task_run_config_provider_name,
+              prompt_id: task_run_config_prompt_method,
+              temperature: task_run_config_temperature,
+              top_p: task_run_config_top_p,
+            },
           },
         },
       )

--- a/app/web_ui/src/routes/(app)/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/run/+page.svelte
@@ -64,6 +64,7 @@
         body: {
           run_config_properties: {
             model_name: model_name,
+            // @ts-expect-error server will catch if enum is not valid
             model_provider_name: provider,
             prompt_id: prompt_method,
             temperature: temperature,

--- a/app/web_ui/src/routes/(app)/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/run/+page.svelte
@@ -62,14 +62,16 @@
           },
         },
         body: {
-          model_name: model_name,
-          provider: provider,
+          run_config_properties: {
+            model_name: model_name,
+            model_provider_name: provider,
+            prompt_id: prompt_method,
+            temperature: temperature,
+            top_p: top_p,
+          },
           plaintext_input: input_form.get_plaintext_input_data(),
           // @ts-expect-error openapi-fetch generates the wrong type for this: Record<string, never>
           structured_input: input_form.get_structured_input_data(),
-          ui_prompt_method: prompt_method,
-          temperature: temperature,
-          top_p: top_p,
           tags: ["manual_run"],
         },
       })

--- a/libs/server/kiln_server/test_run_api.py
+++ b/libs/server/kiln_server/test_run_api.py
@@ -66,8 +66,11 @@ def task_run_setup(tmp_path):
     task.save_to_file()
 
     run_task_request = {
-        "model_name": "gpt_4o",
-        "provider": "ollama",
+        "run_config_properties": {
+            "model_name": "gpt_4o",
+            "model_provider_name": "ollama",
+            "prompt_id": "simple_prompt_builder",
+        },
         "plaintext_input": "Test input",
     }
 
@@ -164,8 +167,14 @@ async def test_run_task_structured_output(client, task_run_setup):
 async def test_run_task_no_input(client, task_run_setup, mock_config):
     task = task_run_setup["task"]
 
-    # Misisng input
-    run_task_request = {"model_name": "gpt_4o", "provider": "openai"}
+    # Missing input
+    run_task_request = {
+        "run_config_properties": {
+            "model_name": "gpt_4o",
+            "model_provider_name": "openai",
+            "prompt_id": "simple_prompt_builder",
+        }
+    }
 
     with patch("kiln_server.run_api.task_from_id") as mock_task_from_id:
         mock_task_from_id.return_value = task
@@ -190,8 +199,11 @@ async def test_run_task_structured_input(client, task_run_setup):
         },
     ):
         run_task_request = {
-            "model_name": "gpt_4o",
-            "provider": "ollama",
+            "run_config_properties": {
+                "model_name": "gpt_4o",
+                "model_provider_name": "ollama",
+                "prompt_id": "simple_prompt_builder",
+            },
             "structured_input": {"key": "value"},
         }
 
@@ -1241,10 +1253,13 @@ async def test_run_task_invalid_temperature_values(client, task_run_setup):
         response = client.post(
             f"/api/projects/{project.id}/tasks/{task.id}/run",
             json={
-                "model_name": "gpt-4o",
-                "provider": "openai",
+                "run_config_properties": {
+                    "model_name": "gpt-4o",
+                    "model_provider_name": "openai",
+                    "prompt_id": "simple_prompt_builder",
+                    "temperature": -0.1,
+                },
                 "plaintext_input": "Test input",
-                "temperature": -0.1,
             },
         )
         assert response.status_code == 422
@@ -1255,10 +1270,13 @@ async def test_run_task_invalid_temperature_values(client, task_run_setup):
         response = client.post(
             f"/api/projects/{project.id}/tasks/{task.id}/run",
             json={
-                "model_name": "gpt-4o",
-                "provider": "openai",
+                "run_config_properties": {
+                    "model_name": "gpt-4o",
+                    "model_provider_name": "openai",
+                    "prompt_id": "simple_prompt_builder",
+                    "temperature": 2.1,
+                },
                 "plaintext_input": "Test input",
-                "temperature": 2.1,
             },
         )
         assert response.status_code == 422
@@ -1279,10 +1297,13 @@ async def test_run_task_invalid_top_p_values(client, task_run_setup):
         response = client.post(
             f"/api/projects/{project.id}/tasks/{task.id}/run",
             json={
-                "model_name": "gpt-4o",
-                "provider": "openai",
+                "run_config_properties": {
+                    "model_name": "gpt-4o",
+                    "model_provider_name": "openai",
+                    "prompt_id": "simple_prompt_builder",
+                    "top_p": -0.1,
+                },
                 "plaintext_input": "Test input",
-                "top_p": -0.1,
             },
         )
         assert response.status_code == 422
@@ -1293,10 +1314,13 @@ async def test_run_task_invalid_top_p_values(client, task_run_setup):
         response = client.post(
             f"/api/projects/{project.id}/tasks/{task.id}/run",
             json={
-                "model_name": "gpt-4o",
-                "provider": "openai",
+                "run_config_properties": {
+                    "model_name": "gpt-4o",
+                    "model_provider_name": "openai",
+                    "prompt_id": "simple_prompt_builder",
+                    "top_p": 1.1,
+                },
                 "plaintext_input": "Test input",
-                "top_p": 1.1,
             },
         )
         assert response.status_code == 422
@@ -1327,11 +1351,14 @@ async def test_run_task_valid_boundary_values(client, task_run_setup):
         response = client.post(
             f"/api/projects/{project.id}/tasks/{task.id}/run",
             json={
-                "model_name": "gpt-4o",
-                "provider": "openai",
+                "run_config_properties": {
+                    "model_name": "gpt-4o",
+                    "model_provider_name": "openai",
+                    "prompt_id": "simple_prompt_builder",
+                    "temperature": 0.0,
+                    "top_p": 0.0,
+                },
                 "plaintext_input": "Test input",
-                "temperature": 0.0,
-                "top_p": 0.0,
             },
         )
         assert response.status_code == 200
@@ -1340,11 +1367,14 @@ async def test_run_task_valid_boundary_values(client, task_run_setup):
         response = client.post(
             f"/api/projects/{project.id}/tasks/{task.id}/run",
             json={
-                "model_name": "gpt-4o",
-                "provider": "openai",
+                "run_config_properties": {
+                    "model_name": "gpt-4o",
+                    "model_provider_name": "openai",
+                    "prompt_id": "simple_prompt_builder",
+                    "temperature": 2.0,
+                    "top_p": 1.0,
+                },
                 "plaintext_input": "Test input",
-                "temperature": 2.0,
-                "top_p": 1.0,
             },
         )
         assert response.status_code == 200


### PR DESCRIPTION
## Summary
- simplify run and eval APIs by directly validating `RunConfigProperties`
- update API tests for validation error messages
- adjust Svelte callers for new request schema
- refresh API type definitions
- restore `top_p` error message assertions in run API tests

## Testing
- `uvx ruff check --select I`
- `uvx ruff format --check .`
- `uv run pyright .`
- `uv run python3 -m pytest --benchmark-quiet -q .`

------
https://chatgpt.com/codex/tasks/task_e_68464c3e41b08332a00841dd67440a08

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configuration options for model, provider, prompt, temperature, and top_p are now grouped into a single "run_config_properties" object in the user interface and API requests.

- **Refactor**
  - Request and response payloads for creating and running tasks have been reorganized to use a nested structure for configuration parameters, improving clarity and consistency across the application.

- **Tests**
  - Updated test cases to reflect the new nested configuration structure in API requests and responses.

- **Chores**
  - Updated contributing guide to run local checks within the managed environment for improved developer experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->