### PR TITLE
Fix dataset CSV import encoding

### DIFF
--- a/libs/core/kiln_ai/utils/dataset_import.py
+++ b/libs/core/kiln_ai/utils/dataset_import.py
@@ -221,7 +221,7 @@ def import_csv(
     optional_headers = {"reasoning", "tags", "chain_of_thought"}  # optional headers
 
     rows: list[TaskRun] = []
-    with open(dataset_path, "r", newline="") as csvfile:
+    with open(dataset_path, "r", newline="", encoding="utf-8") as csvfile:
         reader = csv.DictReader(csvfile)
 
         # Check if we have headers

--- a/libs/core/kiln_ai/utils/test_dataset_import.py
+++ b/libs/core/kiln_ai/utils/test_dataset_import.py
@@ -261,6 +261,44 @@ def test_import_csv_plain_text_missing_output(base_task: Task, tmp_path):
     assert "Missing required headers" in str(e.value)
 
 
+def test_import_csv_utf8_encoding(base_task: Task, tmp_path):
+    """Ensure UTF-8 encoded files are read correctly."""
+
+    row_data = [
+        {
+            "input": "Español entrada 你好👋",
+            "output": "salida áéí 你好👋",
+            "tags": "",
+        },
+    ]
+
+    file_path = dicts_to_file_as_csv(row_data, "utf8.csv", tmp_path)
+
+    with patch("kiln_ai.utils.dataset_import.open", wraps=open) as mock_open:
+        importer = DatasetFileImporter(
+            base_task,
+            ImportConfig(
+                dataset_type=DatasetImportFormat.CSV,
+                dataset_path=file_path,
+                dataset_name="utf8.csv",
+            ),
+        )
+
+        importer.create_runs_from_file()
+
+        mock_open.assert_called_once_with(
+            file_path,
+            "r",
+            newline="",
+            encoding="utf-8",
+        )
+
+    assert len(base_task.runs()) == 1
+    run = base_task.runs()[0]
+    assert run.input == row_data[0]["input"]
+    assert run.output.output == row_data[0]["output"]
+
+
 def test_import_csv_structured_output(task_with_structured_output: Task, tmp_path):
     row_data = [
         {

--- a/libs/core/kiln_ai/utils/test_dataset_import.py
+++ b/libs/core/kiln_ai/utils/test_dataset_import.py
@@ -274,29 +274,21 @@ def test_import_csv_utf8_encoding(base_task: Task, tmp_path):
 
     file_path = dicts_to_file_as_csv(row_data, "utf8.csv", tmp_path)
 
-    with patch("kiln_ai.utils.dataset_import.open", wraps=open) as mock_open:
-        importer = DatasetFileImporter(
-            base_task,
-            ImportConfig(
-                dataset_type=DatasetImportFormat.CSV,
-                dataset_path=file_path,
-                dataset_name="utf8.csv",
-            ),
-        )
+    importer = DatasetFileImporter(
+        base_task,
+        ImportConfig(
+            dataset_type=DatasetImportFormat.CSV,
+            dataset_path=file_path,
+            dataset_name="utf8.csv",
+        ),
+    )
 
-        importer.create_runs_from_file()
-
-        mock_open.assert_called_once_with(
-            file_path,
-            "r",
-            newline="",
-            encoding="utf-8",
-        )
+    importer.create_runs_from_file()
 
     assert len(base_task.runs()) == 1
     run = base_task.runs()[0]
-    assert run.input == row_data[0]["input"]
-    assert run.output.output == row_data[0]["output"]
+    assert run.input == "Español entrada 你好👋"
+    assert run.output.output == "salida áéí 你好👋"
 
 
 def test_import_csv_structured_output(task_with_structured_output: Task, tmp_path):


### PR DESCRIPTION
## Summary
- ensure CSV imports read files as UTF-8
- add regression test for UTF-8 CSV imports
- use real UTF-8 characters in test

------
https://chatgpt.com/codex/tasks/task_e_6846fb1558b48325998b51f0eaa3dd35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CSV file import to ensure proper handling of Unicode characters by explicitly using UTF-8 encoding.

- **Tests**
  - Added a new test to verify correct import of CSV files containing Unicode and special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->