### PR TITLE
super small change, should check the input schema not the output

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/base_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/base_eval.py
@@ -69,7 +69,7 @@ class BaseEval:
 
         # Parse structured input if needed
         parsed_input = input
-        if self.target_task.output_json_schema is not None:
+        if self.target_task.input_json_schema is not None:
             parsed_input = json.loads(input)
 
         # we don't save by default here. We'll save manually after validating the output


### PR DESCRIPTION
## What does this PR do?
Small bug, we have a lot of test coverage on JSON as input in our toy tests but when pipe-cleaning an example without JSON as input, it does not work! its due to this check here where we are loading the input if the output is JSON

## Checklists

- [X] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib
