### PR TITLE
Add chat formatter utility with tests

### DIFF
--- a/libs/core/kiln_ai/adapters/__init__.py
+++ b/libs/core/kiln_ai/adapters/__init__.py
@@ -17,6 +17,7 @@ The eval submodule contains the code for evaluating the performance of a model.
 """
 
 from . import (
+    chat,
     data_gen,
     eval,
     fine_tune,
@@ -28,6 +29,7 @@ from . import (
 
 __all__ = [
     "model_adapters",
+    "chat",
     "data_gen",
     "fine_tune",
     "ml_model_list",

--- a/libs/core/kiln_ai/adapters/chat/__init__.py
+++ b/libs/core/kiln_ai/adapters/chat/__init__.py
@@ -1,0 +1,8 @@
+from .chat_formatter import (
+    ChatFormatter,
+    ChatMessage,
+    ChatStrategy,
+    get_chat_formatter,
+)
+
+__all__ = ["ChatFormatter", "ChatMessage", "ChatStrategy", "get_chat_formatter"]

--- a/libs/core/kiln_ai/adapters/chat/chat_formatter.py
+++ b/libs/core/kiln_ai/adapters/chat/chat_formatter.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Literal, Optional
+
+from kiln_ai.adapters.model_adapters.base_adapter import COT_FINAL_ANSWER_PROMPT
+
+
+class ChatStrategy(str, Enum):
+    """Strategy for how a chat is structured."""
+
+    final_only = "final_only"
+    final_and_intermediate = "final_and_intermediate"
+    final_and_intermediate_r1_compatible = "final_and_intermediate_r1_compatible"
+
+
+@dataclass
+class ChatMessage:
+    role: Literal["system", "assistant", "user"]
+    content: Optional[str]
+
+
+class ChatFormatter(ABC):
+    def __init__(
+        self,
+        system_message: str,
+        user_input: str,
+        thinking_instructions: str | None = None,
+    ) -> None:
+        self.system_message = system_message
+        self.user_input = user_input
+        self.thinking_instructions = thinking_instructions
+        self._messages: List[ChatMessage] = []
+        self._state = "start"
+
+    @property
+    def messages(self) -> List[ChatMessage]:
+        return list(self._messages)
+
+    def message_dicts(self) -> List[dict[str, str | None]]:
+        return [{"role": m.role, "content": m.content} for m in self._messages]
+
+    @abstractmethod
+    def next_turn(
+        self, previous_output: str | None = None
+    ) -> Optional[List[ChatMessage]]:
+        """Advance the conversation and return the next messages if any."""
+        raise NotImplementedError
+
+
+class FinalOnlyFormatter(ChatFormatter):
+    def next_turn(
+        self, previous_output: str | None = None
+    ) -> Optional[List[ChatMessage]]:
+        if self._state == "start":
+            msgs = [
+                ChatMessage("system", self.system_message),
+                ChatMessage("user", self.user_input),
+            ]
+            self._state = "awaiting_final"
+            self._messages.extend(msgs)
+            return msgs
+
+        if self._state == "awaiting_final":
+            if previous_output is None:
+                raise ValueError("previous_output required for final step")
+            self._messages.append(ChatMessage("assistant", previous_output))
+            self._state = "done"
+            return None
+
+        return None
+
+
+class FinalAndIntermediateFormatter(ChatFormatter):
+    def __init__(
+        self, system_message: str, user_input: str, thinking_instructions: str | None
+    ) -> None:
+        super().__init__(system_message, user_input, thinking_instructions)
+        if self.thinking_instructions is None:
+            raise ValueError(
+                "thinking_instructions are required when strategy is final_and_intermediate"
+            )
+
+    def next_turn(
+        self, previous_output: str | None = None
+    ) -> Optional[List[ChatMessage]]:
+        if self._state == "start":
+            msgs = [
+                ChatMessage("system", self.system_message),
+                ChatMessage("user", self.user_input),
+                ChatMessage("user", self.thinking_instructions),
+            ]
+            self._state = "awaiting_thinking"
+            self._messages.extend(msgs)
+            return msgs
+
+        if self._state == "awaiting_thinking":
+            if previous_output is None:
+                raise ValueError("previous_output required for thinking step")
+            msgs = [
+                ChatMessage("assistant", previous_output),
+                ChatMessage("user", COT_FINAL_ANSWER_PROMPT),
+            ]
+            self._state = "awaiting_final"
+            self._messages.extend(msgs)
+            return msgs
+
+        if self._state == "awaiting_final":
+            if previous_output is None:
+                raise ValueError("previous_output required for final step")
+            self._messages.append(ChatMessage("assistant", previous_output))
+            self._state = "done"
+            return None
+
+        return None
+
+
+class R1Formatter(ChatFormatter):
+    def next_turn(
+        self, previous_output: str | None = None
+    ) -> Optional[List[ChatMessage]]:
+        if self._state == "start":
+            msgs = [
+                ChatMessage("system", self.system_message),
+                ChatMessage("user", self.user_input),
+            ]
+            self._state = "awaiting_final"
+            self._messages.extend(msgs)
+            return msgs
+
+        if self._state == "awaiting_final":
+            if previous_output is None:
+                raise ValueError("previous_output required for final step")
+            self._messages.append(ChatMessage("assistant", previous_output))
+            self._state = "done"
+            return None
+
+        return None
+
+
+def get_chat_formatter(
+    *,
+    strategy: ChatStrategy,
+    system_message: str,
+    user_input: str,
+    thinking_instructions: str | None = None,
+) -> ChatFormatter:
+    if strategy == ChatStrategy.final_only:
+        return FinalOnlyFormatter(system_message, user_input)
+    if strategy == ChatStrategy.final_and_intermediate:
+        return FinalAndIntermediateFormatter(
+            system_message, user_input, thinking_instructions
+        )
+    if strategy == ChatStrategy.final_and_intermediate_r1_compatible:
+        return R1Formatter(system_message, user_input)
+
+    raise ValueError(f"Unsupported strategy {strategy}")

--- a/libs/core/kiln_ai/adapters/chat/test_chat_formatter.py
+++ b/libs/core/kiln_ai/adapters/chat/test_chat_formatter.py
@@ -1,0 +1,83 @@
+import pytest
+
+from kiln_ai.adapters.chat import ChatStrategy, get_chat_formatter
+from kiln_ai.adapters.fine_tune.dataset_formatter import (
+    ModelTrainingData,
+    generate_chat_message_response,
+)
+from kiln_ai.adapters.model_adapters.base_adapter import COT_FINAL_ANSWER_PROMPT
+
+
+def test_chat_formatter_final_only():
+    training_data = ModelTrainingData(
+        input="test input",
+        system_message="system message",
+        final_output="test output",
+    )
+    expected = generate_chat_message_response(training_data)["messages"]
+
+    formatter = get_chat_formatter(
+        strategy=ChatStrategy.final_only,
+        system_message="system message",
+        user_input="test input",
+    )
+
+    first = formatter.next_turn()
+    assert [m.__dict__ for m in first] == expected[:2]
+
+    assert formatter.next_turn("test output") is None
+    assert formatter.message_dicts() == expected
+
+
+def test_chat_formatter_final_and_intermediate():
+    training_data = ModelTrainingData(
+        input="test input",
+        system_message="system message",
+        final_output="test output",
+        thinking="thinking output",
+        thinking_instructions="thinking instructions",
+        thinking_final_answer_prompt=COT_FINAL_ANSWER_PROMPT,
+    )
+    expected = generate_chat_message_response(training_data)["messages"]
+
+    formatter = get_chat_formatter(
+        strategy=ChatStrategy.final_and_intermediate,
+        system_message="system message",
+        user_input="test input",
+        thinking_instructions="thinking instructions",
+    )
+
+    first = formatter.next_turn()
+    assert [m.__dict__ for m in first] == expected[:3]
+
+    second = formatter.next_turn("thinking output")
+    assert [m.__dict__ for m in second] == expected[3:5]
+
+    assert formatter.next_turn("test output") is None
+    assert formatter.message_dicts() == expected
+
+
+def test_chat_formatter_r1_style():
+    training_data = ModelTrainingData(
+        input="test input",
+        system_message="system message",
+        final_output="test output",
+        thinking="thinking output",
+        thinking_instructions=None,
+        thinking_final_answer_prompt=None,
+        thinking_r1_style=True,
+    )
+    expected = generate_chat_message_response(training_data)["messages"]
+    combined = expected[-1]["content"]
+
+    formatter = get_chat_formatter(
+        strategy=ChatStrategy.final_and_intermediate_r1_compatible,
+        system_message="system message",
+        user_input="test input",
+    )
+
+    first = formatter.next_turn()
+    assert [m.__dict__ for m in first] == expected[:2]
+
+    assert formatter.next_turn(combined) is None
+    assert formatter.message_dicts() == expected


### PR DESCRIPTION
## Summary
- add base ChatFormatter abstraction and individual formatters per strategy
- expose `get_chat_formatter` helper via adapters package
- update unit tests for new formatter classes

## Testing
- `uvx ruff check --select I`
- `uvx ruff format --check .`
- `uv run pyright . --stats`
- `uv run python3 -m pytest --benchmark-quiet -q libs/core/kiln_ai/adapters/chat/test_chat_formatter.py`


------
https://chatgpt.com/codex/tasks/task_e_68485c4e38288332890092f9c28521d7