### PR TITLE
Structured Output Mode + Legacy tasks bug

### DIFF
--- a/libs/core/kiln_ai/datamodel/task.py
+++ b/libs/core/kiln_ai/datamodel/task.py
@@ -145,10 +145,14 @@ class TaskRunConfig(KilnParentedModel):
 
         structured_output_mode = data.get("structured_output_mode", None)
         if structured_output_mode is None and "run_config_properties" in data:
-            # Default to unknown. Adapter will have to guess at runtime.
-            data["run_config_properties"]["structured_output_mode"] = (
-                StructuredOutputMode.unknown
-            )
+            run_config_properties = data["run_config_properties"]
+            if not isinstance(run_config_properties, dict):
+                return data
+            if "structured_output_mode" not in run_config_properties:
+                # Default to unknown. Adapter will have to guess at runtime.
+                data["run_config_properties"]["structured_output_mode"] = (
+                    StructuredOutputMode.unknown
+                )
 
         return data
 


### PR DESCRIPTION

## What does this PR do?
Using the Joke Generator dataset and in the Evaluation UI, `main` doesn't appear to pipe the structured output mode all the way through, it gets mapped to Unknown for legacy tasks, very silently. I added a logging line to verify behavior. 


`main` right now when entering in any value from the drop-down, (here I enter in JSON Schema)
`2025-06-10 11:22:27,817.817 - INFO - ModelCalls - LiteLLM using structured output mode: StructuredOutputMode.unknown`

With this fix:
` 2025-06-10 11:19:23,565.565 - INFO - ModelCalls - LiteLLM using structured output mode: StructuredOutputMode.json_schema`


## Related Issues

<!--- Link to related issues. For example: "Fixes: https://github.com/Kiln-AI/Kiln/issues/12345" -->

## Checklists

- [X] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib
