### PR TITLE
QoL: Add recently used 5 models to the Eval dropdown at the very top

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2373,16 +2373,17 @@ export interface components {
          * StructuredOutputMode
          * @description Enumeration of supported structured output modes.
          *
-         *     - default: let the adapter decide
          *     - json_schema: request json using API capabilities for json_schema
          *     - function_calling: request json using API capabilities for function calling
          *     - json_mode: request json using API's JSON mode, which should return valid JSON, but isn't checking/passing the schema
          *     - json_instructions: append instructions to the prompt to request json matching the schema. No API capabilities are used. You should have a custom parser on these models as they will be returning strings.
          *     - json_instruction_and_object: append instructions to the prompt to request json matching the schema. Also request the response as json_mode via API capabilities (returning dictionaries).
          *     - json_custom_instructions: The model should output JSON, but custom instructions are already included in the system prompt. Don't append additional JSON instructions.
+         *     - default: let the adapter decide (legacy, do not use for new use cases)
+         *     - unknown: used for cases where the structured output mode is not known (on old models where it wasn't saved). Should lookup best option at runtime.
          * @enum {string}
          */
-        StructuredOutputMode: "default" | "json_schema" | "function_calling_weak" | "function_calling" | "json_mode" | "json_instructions" | "json_instruction_and_object" | "json_custom_instructions";
+        StructuredOutputMode: "default" | "json_schema" | "function_calling_weak" | "function_calling" | "json_mode" | "json_instructions" | "json_instruction_and_object" | "json_custom_instructions" | "unknown";
         /**
          * Task
          * @description Represents a specific task to be performed, with associated requirements and validation rules.

--- a/app/web_ui/src/lib/stores.ts
+++ b/app/web_ui/src/lib/stores.ts
@@ -46,6 +46,23 @@ export const current_task_prompts = writable<PromptResponse | null>(null)
 export const fine_tune_target_model: Writable<string | null> =
   localStorageStore("fine_tune_target_model", null)
 
+// Store for recently used models (last 5)
+export const recently_used_models: Writable<string[]> = localStorageStore(
+  "recently_used_models",
+  [],
+)
+
+// Function to add a model to recently used
+export function add_recently_used_model(model_id: string) {
+  const current = get(recently_used_models)
+  // Remove if already exists
+  const filtered = current.filter((m) => m !== model_id)
+  // Add to front
+  filtered.unshift(model_id)
+  // Keep only last 5
+  recently_used_models.set(filtered.slice(0, 5))
+}
+
 // Rating options for the current task
 export const current_task_rating_options =
   writable<RatingOptionResponse | null>(null)

--- a/app/web_ui/src/lib/stores.ts
+++ b/app/web_ui/src/lib/stores.ts
@@ -64,11 +64,16 @@ export function add_recently_used_model(model_id: string) {
   if (!project_id || !task_id) return
 
   const key = `${project_id}/${task_id}`
-  const current = get(_recently_used_models)
+  const raw = get(_recently_used_models)
+  const current =
+    raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {}
   const task_models = Array.isArray(current[key]) ? current[key] : []
 
+  // Short-circuit if model is already at front of list
+  if (task_models[0] === model_id) return
+
   // Remove if already exists
-  const filtered = task_models.filter((m: string) => m !== model_id)
+  const filtered = task_models.filter((m) => m !== model_id)
   // Add to front
   filtered.unshift(model_id)
   // Keep only last 5

--- a/app/web_ui/src/lib/stores.ts
+++ b/app/web_ui/src/lib/stores.ts
@@ -1,4 +1,4 @@
-import { writable, get } from "svelte/store"
+import { writable, get, derived } from "svelte/store"
 import { dev } from "$app/environment"
 import type {
   Project,
@@ -47,20 +47,23 @@ export const fine_tune_target_model: Writable<string | null> =
   localStorageStore("fine_tune_target_model", null)
 
 // Store for recently used models (last 5)
-export const recently_used_models: Writable<string[]> = localStorageStore(
-  "recently_used_models",
-  [],
+const _recently_used_models = localStorageStore("recently_used_models", [])
+
+export const recently_used_models = derived(_recently_used_models, ($store) =>
+  Array.isArray($store) ? $store : [],
 )
 
 // Function to add a model to recently used
 export function add_recently_used_model(model_id: string) {
-  const current = get(recently_used_models)
+  const current = Array.isArray(get(_recently_used_models))
+    ? get(_recently_used_models)
+    : []
   // Remove if already exists
-  const filtered = current.filter((m) => m !== model_id)
+  const filtered = current.filter((m: string) => m !== model_id)
   // Add to front
   filtered.unshift(model_id)
   // Keep only last 5
-  recently_used_models.set(filtered.slice(0, 5))
+  _recently_used_models.set(filtered.slice(0, 5))
 }
 
 // Rating options for the current task

--- a/app/web_ui/src/lib/stores.ts
+++ b/app/web_ui/src/lib/stores.ts
@@ -57,6 +57,10 @@ export const recently_used_models = derived(
   ($store) => $store,
 )
 
+// TEST-ONLY: Export the writable store for test reset
+// Do not use in production code
+export const _recently_used_models_test_only = _recently_used_models
+
 // Function to add a model to recently used
 export function add_recently_used_model(model_id: string) {
   const project_id = get(ui_state).current_project_id

--- a/app/web_ui/src/lib/stores.ts
+++ b/app/web_ui/src/lib/stores.ts
@@ -63,6 +63,9 @@ export const _recently_used_models_test_only = _recently_used_models
 
 // Function to add a model to recently used
 export function add_recently_used_model(model_id: string) {
+  if (!model_id || typeof model_id !== "string" || !model_id.includes("/")) {
+    return // ignore bad inputs early
+  }
   const project_id = get(ui_state).current_project_id
   const task_id = get(ui_state).current_task_id
   if (!project_id || !task_id) return

--- a/app/web_ui/src/routes/(app)/run/__tests__/recently_used_models.test.ts
+++ b/app/web_ui/src/routes/(app)/run/__tests__/recently_used_models.test.ts
@@ -1,0 +1,161 @@
+// Mock localStorage for vitest/node environment
+if (typeof globalThis.localStorage === "undefined") {
+  let store: Record<string, string> = {}
+  globalThis.localStorage = {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+    key: (i: number) => Object.keys(store)[i] || null,
+    get length() {
+      return Object.keys(store).length
+    },
+  }
+}
+
+import { describe, it, expect, beforeEach } from "vitest"
+import { get } from "svelte/store"
+import {
+  ui_state,
+  recently_used_models,
+  add_recently_used_model,
+  _recently_used_models_test_only,
+} from "$lib/stores"
+
+describe("Recently Used Models", () => {
+  beforeEach(() => {
+    // Reset stores before each test
+    ui_state.update(() => ({
+      current_project_id: null,
+      current_task_id: null,
+      selected_model: null,
+    }))
+    // Reset recently_used_models by setting it to an empty object
+    _recently_used_models_test_only.set({})
+  })
+
+  it("should add a model to recently used models", () => {
+    // Set current project and task
+    ui_state.update((state) => ({
+      ...state,
+      current_project_id: "project1",
+      current_task_id: "task1",
+    }))
+
+    // Add a model
+    add_recently_used_model("openai/gpt-4")
+
+    // Get the current state
+    const currentState = get(recently_used_models)
+    const key = "project1/task1"
+
+    // Verify the model was added
+    expect(currentState[key]).toBeDefined()
+    expect(currentState[key]).toContain("openai/gpt-4")
+  })
+
+  it("should move model to front when added again", () => {
+    // Set current project and task
+    ui_state.update((state) => ({
+      ...state,
+      current_project_id: "project1",
+      current_task_id: "task1",
+    }))
+
+    // Add models in sequence
+    add_recently_used_model("openai/gpt-3.5")
+    add_recently_used_model("openai/gpt-4")
+    add_recently_used_model("openai/gpt-3.5") // Add again
+
+    // Get the current state
+    const currentState = get(recently_used_models)
+    const key = "project1/task1"
+
+    // Verify the model was moved to front
+    expect(currentState[key][0]).toBe("openai/gpt-3.5")
+    expect(currentState[key][1]).toBe("openai/gpt-4")
+  })
+
+  it("should limit to 5 models per project/task", () => {
+    // Set current project and task
+    ui_state.update((state) => ({
+      ...state,
+      current_project_id: "project1",
+      current_task_id: "task1",
+    }))
+
+    // Add 6 models
+    add_recently_used_model("model1")
+    add_recently_used_model("model2")
+    add_recently_used_model("model3")
+    add_recently_used_model("model4")
+    add_recently_used_model("model5")
+    add_recently_used_model("model6")
+
+    // Get the current state
+    const currentState = get(recently_used_models)
+    const key = "project1/task1"
+
+    // Verify only 5 models are kept
+    expect(currentState[key].length).toBe(5)
+    expect(currentState[key][0]).toBe("model6") // Most recent
+    expect(currentState[key][4]).toBe("model2") // Oldest kept
+    expect(currentState[key]).not.toContain("model1") // First one should be removed
+  })
+
+  it("should handle different project/task combinations", () => {
+    // Add models for different project/task combinations
+    ui_state.update((state) => ({
+      ...state,
+      current_project_id: "project1",
+      current_task_id: "task1",
+    }))
+    add_recently_used_model("model1")
+
+    ui_state.update((state) => ({
+      ...state,
+      current_project_id: "project1",
+      current_task_id: "task2",
+    }))
+    add_recently_used_model("model2")
+
+    ui_state.update((state) => ({
+      ...state,
+      current_project_id: "project2",
+      current_task_id: "task1",
+    }))
+    add_recently_used_model("model3")
+
+    // Get the current state
+    const currentState = get(recently_used_models)
+
+    // Verify each project/task combination has its own list
+    expect(currentState["project1/task1"]).toContain("model1")
+    expect(currentState["project1/task2"]).toContain("model2")
+    expect(currentState["project2/task1"]).toContain("model3")
+  })
+
+  it("should handle null project or task ID", () => {
+    // Set null project and task
+    ui_state.update((state) => ({
+      ...state,
+      current_project_id: null,
+      current_task_id: null,
+    }))
+
+    // Add a model
+    add_recently_used_model("model1")
+
+    // Get the current state
+    const currentState = get(recently_used_models)
+
+    // Verify no models were added
+    expect(Object.keys(currentState).length).toBe(0)
+  })
+})

--- a/app/web_ui/src/routes/(app)/run/__tests__/recently_used_models.test.ts
+++ b/app/web_ui/src/routes/(app)/run/__tests__/recently_used_models.test.ts
@@ -91,12 +91,12 @@ describe("Recently Used Models", () => {
     }))
 
     // Add 6 models
-    add_recently_used_model("model1")
-    add_recently_used_model("model2")
-    add_recently_used_model("model3")
-    add_recently_used_model("model4")
-    add_recently_used_model("model5")
-    add_recently_used_model("model6")
+    add_recently_used_model("provider/model1")
+    add_recently_used_model("provider/model2")
+    add_recently_used_model("provider/model3")
+    add_recently_used_model("provider/model4")
+    add_recently_used_model("provider/model5")
+    add_recently_used_model("provider/model6")
 
     // Get the current state
     const currentState = get(recently_used_models)
@@ -104,9 +104,9 @@ describe("Recently Used Models", () => {
 
     // Verify only 5 models are kept
     expect(currentState[key].length).toBe(5)
-    expect(currentState[key][0]).toBe("model6") // Most recent
-    expect(currentState[key][4]).toBe("model2") // Oldest kept
-    expect(currentState[key]).not.toContain("model1") // First one should be removed
+    expect(currentState[key][0]).toBe("provider/model6") // Most recent
+    expect(currentState[key][4]).toBe("provider/model2") // Oldest kept
+    expect(currentState[key]).not.toContain("provider/model1") // First one should be removed
   })
 
   it("should handle different project/task combinations", () => {
@@ -116,29 +116,29 @@ describe("Recently Used Models", () => {
       current_project_id: "project1",
       current_task_id: "task1",
     }))
-    add_recently_used_model("model1")
+    add_recently_used_model("provider/model1")
 
     ui_state.update((state) => ({
       ...state,
       current_project_id: "project1",
       current_task_id: "task2",
     }))
-    add_recently_used_model("model2")
+    add_recently_used_model("provider/model2")
 
     ui_state.update((state) => ({
       ...state,
       current_project_id: "project2",
       current_task_id: "task1",
     }))
-    add_recently_used_model("model3")
+    add_recently_used_model("provider/model3")
 
     // Get the current state
     const currentState = get(recently_used_models)
 
     // Verify each project/task combination has its own list
-    expect(currentState["project1/task1"]).toContain("model1")
-    expect(currentState["project1/task2"]).toContain("model2")
-    expect(currentState["project2/task1"]).toContain("model3")
+    expect(currentState["project1/task1"]).toContain("provider/model1")
+    expect(currentState["project1/task2"]).toContain("provider/model2")
+    expect(currentState["project2/task1"]).toContain("provider/model3")
   })
 
   it("should handle null project or task ID", () => {

--- a/app/web_ui/src/routes/(app)/run/available_models_dropdown.svelte
+++ b/app/web_ui/src/routes/(app)/run/available_models_dropdown.svelte
@@ -76,7 +76,10 @@
               ) {
                 continue
               }
-              recent_model_list.push([model_id, model.name])
+              recent_model_list.push([
+                model_id,
+                provider.provider_name + " / " + model.name,
+              ])
               break
             }
           }
@@ -121,9 +124,13 @@
         }
         let model_name = model.name
         if (suggested_mode === "data_gen" && model.suggested_for_data_gen) {
-          model_name = model.name + "  —  Recommended"
+          model_name =
+            provider.provider_name + " / " + model.name + "  —  Recommended"
         } else if (suggested_mode === "evals" && model.suggested_for_evals) {
-          model_name = model.name + "  —  Recommended"
+          model_name =
+            provider.provider_name + " / " + model.name + "  —  Recommended"
+        } else {
+          model_name = provider.provider_name + " / " + model.name
         }
         model_list.push([id, model_name])
       }

--- a/app/web_ui/src/routes/(app)/run/available_models_dropdown.svelte
+++ b/app/web_ui/src/routes/(app)/run/available_models_dropdown.svelte
@@ -25,6 +25,7 @@
     requires_data_gen,
     requires_logprobs,
     $ui_state.current_task_id,
+    $recently_used_models,
   )
 
   // Export the parsed model name and provider name
@@ -50,13 +51,13 @@
     requires_data_gen: boolean,
     requires_logprobs: boolean,
     current_task_id: string | null,
+    recent_models: string[],
   ): [string, [string, string][]][] {
     let options: [string, [string, string][]][] = []
     unsupported_models = []
     untested_models = []
 
     // Add recently used models section if there are any
-    const recent_models = $recently_used_models
     if (recent_models.length > 0) {
       const recent_model_list: [string, string][] = []
       for (const model_id of recent_models) {
@@ -124,13 +125,9 @@
         }
         let model_name = model.name
         if (suggested_mode === "data_gen" && model.suggested_for_data_gen) {
-          model_name =
-            provider.provider_name + " / " + model.name + "  —  Recommended"
+          model_name = model.name + "  —  Recommended"
         } else if (suggested_mode === "evals" && model.suggested_for_evals) {
-          model_name =
-            provider.provider_name + " / " + model.name + "  —  Recommended"
-        } else {
-          model_name = provider.provider_name + " / " + model.name
+          model_name = model.name + "  —  Recommended"
         }
         model_list.push([id, model_name])
       }

--- a/app/web_ui/src/routes/(app)/run/available_models_dropdown.svelte
+++ b/app/web_ui/src/routes/(app)/run/available_models_dropdown.svelte
@@ -82,7 +82,7 @@
         // Find the model details
         for (const provider of providers) {
           if (provider.provider_id === provider_id) {
-            const model = provider.models.find(
+            const model = (provider.models ?? []).find(
               (m: { id: string }) => m.id === model_name,
             )
             if (model) {

--- a/app/web_ui/src/routes/(app)/run/available_models_dropdown.svelte
+++ b/app/web_ui/src/routes/(app)/run/available_models_dropdown.svelte
@@ -12,7 +12,7 @@
   import FormElement from "$lib/utils/form_element.svelte"
   import Warning from "$lib/ui/warning.svelte"
 
-  export let model: string = $ui_state.selected_model
+  export let model: string | null = $ui_state.selected_model
   export let requires_structured_output: boolean = false
   export let requires_data_gen: boolean = false
   export let requires_logprobs: boolean = false
@@ -23,6 +23,7 @@
   let previous_task_id: string | null = null
   $: {
     if ($ui_state.current_task_id !== previous_task_id) {
+      model = null
       ui_state.update((state) => ({ ...state, selected_model: null }))
       previous_task_id = $ui_state.current_task_id
     }
@@ -34,6 +35,7 @@
     requires_data_gen,
     requires_logprobs,
     $ui_state.current_task_id,
+    $ui_state.current_project_id,
     $recently_used_models,
   )
 
@@ -41,7 +43,7 @@
   export let model_name: string | null = null
   export let provider_name: string | null = null
   $: get_model_provider(model)
-  function get_model_provider(model_provider: string) {
+  function get_model_provider(model_provider: string | null) {
     model_name = model_provider
       ? model_provider.split("/").slice(1).join("/")
       : null
@@ -60,6 +62,7 @@
     requires_data_gen: boolean,
     requires_logprobs: boolean,
     current_task_id: string | null,
+    current_project_id: string | null,
     recent_models: Record<string, string[]>,
   ): [string, [string, string][]][] {
     let options: [string, [string, string][]][] = []
@@ -67,9 +70,10 @@
     untested_models = []
 
     // Add recently used models section if there are any
-    const project_id = $ui_state.current_project_id
     const key =
-      project_id && current_task_id ? `${project_id}/${current_task_id}` : null
+      current_project_id && current_task_id
+        ? `${current_project_id}/${current_task_id}`
+        : null
     const task_recent_models = key ? recent_models[key] || [] : []
     if (task_recent_models.length > 0) {
       const recent_model_list: [string, string][] = []


### PR DESCRIPTION
## What does this PR do?
<img width="623" alt="Screenshot 2025-06-10 at 11 29 13 AM" src="https://github.com/user-attachments/assets/ba5160ba-1424-491d-b65f-f110966a01fb" />

Small QoL change to add the most recently used 5 models to the top of the list. confirmed that if you select 6 things, the oldest are popped off.

<!--- Link to related issues. For example: "Fixes: https://github.com/Kiln-AI/Kiln/issues/12345" -->

## Checklists

- [X] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a "Recently Used" section in the model selection dropdown, displaying up to five of your most recently selected models for quicker access.
  - Added automatic tracking of recently used models per project-task to improve model selection relevance.

- **Enhancements**
  - The dropdown now updates the "Recently Used" list automatically whenever you select a different model.
  - Model names in the dropdown now consistently include their provider prefix for clearer identification.

- **Bug Fixes**
  - Improved handling of model selection state when switching tasks to prevent stale selections.

- **Documentation**
  - Updated structured output mode descriptions to clarify legacy and unknown modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->