### PR TITLE
Add a Filter, Sort, Run individual methods, and Delete methods to compare_run_methods

### DIFF
--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any, Dict, List, Set, Tuple
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 from kiln_ai.adapters.eval.eval_runner import EvalRunner
 from kiln_ai.adapters.ml_model_list import ModelProviderName
@@ -394,15 +394,17 @@ def connect_evals_api(app: FastAPI):
         return task_run_config
 
     @app.delete(
-        "/api/projects/{project_id}/tasks/{task_id}/task_run_config/{run_config_id}"
+        "/api/projects/{project_id}/tasks/{task_id}/task_run_config/{run_config_id}",
+        status_code=204,
     )
     async def delete_task_run_config(
         project_id: str,
         task_id: str,
         run_config_id: str,
-    ) -> None:
+    ) -> Response:
         task_run_config = task_run_config_from_id(project_id, task_id, run_config_id)
         task_run_config.delete()
+        return Response(status_code=204)
 
     @app.post(
         "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/create_eval_config"

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -393,6 +393,17 @@ def connect_evals_api(app: FastAPI):
         task_run_config.save_to_file()
         return task_run_config
 
+    @app.delete(
+        "/api/projects/{project_id}/tasks/{task_id}/task_run_config/{run_config_id}"
+    )
+    async def delete_task_run_config(
+        project_id: str,
+        task_id: str,
+        run_config_id: str,
+    ) -> None:
+        task_run_config = task_run_config_from_id(project_id, task_id, run_config_id)
+        task_run_config.delete()
+
     @app.post(
         "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/create_eval_config"
     )

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -4926,13 +4926,11 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            200: {
+            204: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": unknown;
-                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -886,6 +886,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/projects/{project_id}/tasks/{task_id}/task_run_config/{run_config_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Task Run Config */
+        delete: operations["delete_task_run_config_api_projects__project_id__tasks__task_id__task_run_config__run_config_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/create_eval_config": {
         parameters: {
             query?: never;
@@ -2373,16 +2390,17 @@ export interface components {
          * StructuredOutputMode
          * @description Enumeration of supported structured output modes.
          *
-         *     - default: let the adapter decide
          *     - json_schema: request json using API capabilities for json_schema
          *     - function_calling: request json using API capabilities for function calling
          *     - json_mode: request json using API's JSON mode, which should return valid JSON, but isn't checking/passing the schema
          *     - json_instructions: append instructions to the prompt to request json matching the schema. No API capabilities are used. You should have a custom parser on these models as they will be returning strings.
          *     - json_instruction_and_object: append instructions to the prompt to request json matching the schema. Also request the response as json_mode via API capabilities (returning dictionaries).
          *     - json_custom_instructions: The model should output JSON, but custom instructions are already included in the system prompt. Don't append additional JSON instructions.
+         *     - default: let the adapter decide (legacy, do not use for new use cases)
+         *     - unknown: used for cases where the structured output mode is not known (on old models where it wasn't saved). Should lookup best option at runtime.
          * @enum {string}
          */
-        StructuredOutputMode: "default" | "json_schema" | "function_calling_weak" | "function_calling" | "json_mode" | "json_instructions" | "json_instruction_and_object" | "json_custom_instructions";
+        StructuredOutputMode: "default" | "json_schema" | "function_calling_weak" | "function_calling" | "json_mode" | "json_instructions" | "json_instruction_and_object" | "json_custom_instructions" | "unknown";
         /**
          * Task
          * @description Represents a specific task to be performed, with associated requirements and validation rules.
@@ -4881,6 +4899,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TaskRunConfig"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_task_run_config_api_projects__project_id__tasks__task_id__task_run_config__run_config_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                run_config_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/app/web_ui/src/lib/services/eval-service.ts
+++ b/app/web_ui/src/lib/services/eval-service.ts
@@ -1,0 +1,259 @@
+import { client } from "$lib/api_client"
+import type {
+  Eval,
+  EvalConfig,
+  TaskRunConfig,
+  EvalResultSummary,
+} from "$lib/types"
+import { createKilnError } from "$lib/utils/error_handlers"
+import type { components } from "$lib/api_schema"
+import { KilnError } from "$lib/utils/error_handlers"
+
+export async function getEval(
+  projectId: string,
+  taskId: string,
+  evalId: string,
+): Promise<{ data: Eval | null; error: KilnError | null }> {
+  try {
+    const { data, error } = await client.GET(
+      "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}",
+      {
+        params: {
+          path: {
+            project_id: projectId,
+            task_id: taskId,
+            eval_id: evalId,
+          },
+        },
+      },
+    )
+    if (error) {
+      throw error
+    }
+    return { data, error: null }
+  } catch (error) {
+    return { data: null, error: createKilnError(error) }
+  }
+}
+
+export async function getEvalConfigs(
+  projectId: string,
+  taskId: string,
+  evalId: string,
+): Promise<{ data: EvalConfig[] | null; error: KilnError | null }> {
+  try {
+    const { data, error } = await client.GET(
+      "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_configs",
+      {
+        params: {
+          path: {
+            project_id: projectId,
+            task_id: taskId,
+            eval_id: evalId,
+          },
+        },
+      },
+    )
+    if (error) {
+      throw error
+    }
+    return { data, error: null }
+  } catch (error) {
+    return { data: null, error: createKilnError(error) }
+  }
+}
+
+export async function getTaskRunConfigs(
+  projectId: string,
+  taskId: string,
+): Promise<{ data: TaskRunConfig[] | null; error: KilnError | null }> {
+  try {
+    const { data, error } = await client.GET(
+      "/api/projects/{project_id}/tasks/{task_id}/task_run_configs",
+      {
+        params: {
+          path: {
+            project_id: projectId,
+            task_id: taskId,
+          },
+        },
+      },
+    )
+    if (error) {
+      throw error
+    }
+    return { data, error: null }
+  } catch (error) {
+    return { data: null, error: createKilnError(error) }
+  }
+}
+
+export async function getScoreSummary(
+  projectId: string,
+  taskId: string,
+  evalId: string,
+  evalConfigId: string | null,
+): Promise<{ data: EvalResultSummary | null; error: KilnError | null }> {
+  if (!evalConfigId) {
+    return {
+      data: null,
+      error: new KilnError("No evaluation method selected", null),
+    }
+  }
+
+  try {
+    const { data, error } = await client.GET(
+      "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_config/{eval_config_id}/score_summary",
+      {
+        params: {
+          path: {
+            project_id: projectId,
+            task_id: taskId,
+            eval_id: evalId,
+            eval_config_id: evalConfigId,
+          },
+        },
+      },
+    )
+    if (error) {
+      throw error
+    }
+    return { data, error: null }
+  } catch (error) {
+    return { data: null, error: createKilnError(error) }
+  }
+}
+
+export async function setCurrentRunConfig(
+  projectId: string,
+  taskId: string,
+  evalId: string,
+  runConfigId: string,
+): Promise<{ data: Eval | null; error: KilnError | null }> {
+  if (!runConfigId) {
+    return { data: null, error: null }
+  }
+
+  try {
+    const { data, error } = await client.POST(
+      "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/set_current_run_config/{run_config_id}",
+      {
+        params: {
+          path: {
+            project_id: projectId,
+            task_id: taskId,
+            eval_id: evalId,
+            run_config_id: runConfigId,
+          },
+        },
+      },
+    )
+    if (error) {
+      throw error
+    }
+    return { data, error: null }
+  } catch (error) {
+    return { data: null, error: createKilnError(error) }
+  }
+}
+
+export async function deleteTaskRunConfig(
+  projectId: string,
+  taskId: string,
+  runConfigId: string,
+): Promise<{ success: boolean; error: KilnError | null }> {
+  if (!runConfigId) {
+    return { success: false, error: null }
+  }
+
+  try {
+    const { error } = await client.DELETE(
+      "/api/projects/{project_id}/tasks/{task_id}/task_run_config/{run_config_id}",
+      {
+        params: {
+          path: {
+            project_id: projectId,
+            task_id: taskId,
+            run_config_id: runConfigId,
+          },
+        },
+      },
+    )
+    if (error) {
+      throw error
+    }
+    return { success: true, error: null }
+  } catch (error) {
+    const errorMessage =
+      error && typeof error === "object" && "message" in error
+        ? String(error.message)
+        : "Unknown error"
+    return {
+      success: false,
+      error: new KilnError("Failed to delete run method", [errorMessage]),
+    }
+  }
+}
+
+export async function addTaskRunConfig(
+  projectId: string,
+  taskId: string,
+  runConfigProperties: components["schemas"]["CreateTaskRunConfigRequest"]["run_config_properties"],
+): Promise<{ error: Error | null }> {
+  try {
+    const { error } = await client.POST(
+      "/api/projects/{project_id}/tasks/{task_id}/task_run_config",
+      {
+        params: {
+          path: {
+            project_id: projectId,
+            task_id: taskId,
+          },
+        },
+        body: {
+          run_config_properties: runConfigProperties,
+        },
+      },
+    )
+    if (error) {
+      throw error
+    }
+    return { error: null }
+  } catch (error) {
+    return { error: createKilnError(error) }
+  }
+}
+
+export async function getFinetuneBaseModel(
+  modelName: string,
+): Promise<{ baseModelId: string | null; error: KilnError | null }> {
+  try {
+    const parts = modelName.split("::")
+    if (parts.length !== 3) {
+      return { baseModelId: null, error: null }
+    }
+
+    const [ftProjectId, ftTaskId, finetuneId] = parts
+
+    const { data, error } = await client.GET(
+      "/api/projects/{project_id}/tasks/{task_id}/finetunes/{finetune_id}",
+      {
+        params: {
+          path: {
+            project_id: ftProjectId,
+            task_id: ftTaskId,
+            finetune_id: finetuneId,
+          },
+        },
+      },
+    )
+
+    if (error || !data) {
+      return { baseModelId: null, error: createKilnError(error) }
+    }
+
+    return { baseModelId: data.finetune.base_model_id, error: null }
+  } catch (error) {
+    return { baseModelId: null, error: createKilnError(error) }
+  }
+}

--- a/app/web_ui/src/lib/ui/dialog.svelte
+++ b/app/web_ui/src/lib/ui/dialog.svelte
@@ -128,8 +128,10 @@
           <form method="dialog">
             <button
               class="btn btn-sm h-10 btn-outline min-w-24"
-              on:click|stopPropagation>Close</button
+              on:click|stopPropagation
             >
+              Close
+            </button>
           </form>
         {:else}
           {#each action_buttons as button}
@@ -137,8 +139,10 @@
               <form method="dialog">
                 <button
                   class="btn btn-sm h-10 btn-outline min-w-24"
-                  on:click|stopPropagation>{button.label || "Cancel"}</button
+                  on:click|stopPropagation
                 >
+                  {button.label || "Cancel"}
+                </button>
               </form>
             {:else}
               <button

--- a/app/web_ui/src/lib/ui/dialog.svelte
+++ b/app/web_ui/src/lib/ui/dialog.svelte
@@ -71,7 +71,7 @@
       {#each header_buttons as button}
         <button
           class="btn btn-sm h-8 w-8 btn-circle btn-ghost focus:outline-none"
-          on:click={button.action}
+          on:click|stopPropagation={button.action}
         >
           <img
             class="h-6 w-6 mb-[1px]"
@@ -83,6 +83,7 @@
       <form method="dialog">
         <button
           class="btn btn-sm h-8 w-8 btn-circle btn-ghost focus:outline-none"
+          on:click|stopPropagation
         >
           <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
           <svg
@@ -125,14 +126,18 @@
       <div class="flex flex-row gap-2 justify-end mt-6">
         {#if error}
           <form method="dialog">
-            <button class="btn btn-sm h-10 btn-outline min-w-24">Close</button>
+            <button
+              class="btn btn-sm h-10 btn-outline min-w-24"
+              on:click|stopPropagation>Close</button
+            >
           </form>
         {:else}
           {#each action_buttons as button}
             {#if button.isCancel}
               <form method="dialog">
-                <button class="btn btn-sm h-10 btn-outline min-w-24"
-                  >{button.label || "Cancel"}</button
+                <button
+                  class="btn btn-sm h-10 btn-outline min-w-24"
+                  on:click|stopPropagation>{button.label || "Cancel"}</button
                 >
               </form>
             {:else}
@@ -142,7 +147,7 @@
                   : ''}
                   {button.isError ? 'btn-error' : ''}"
                 disabled={button.disabled}
-                on:click={() => perform_button_action(button)}
+                on:click|stopPropagation={() => perform_button_action(button)}
               >
                 {button.label || "Confirm"}
               </button>

--- a/app/web_ui/src/lib/utils/eval-helpers.ts
+++ b/app/web_ui/src/lib/utils/eval-helpers.ts
@@ -267,3 +267,22 @@ export function getAvailableFilterModels(
 
   return { base_models, finetune_base_models: finetune_base_models_result }
 }
+
+export async function load_finetune_details(
+  task_run_configs: TaskRunConfig[] | null,
+  get_finetune_base_model: (model_name: string) => Promise<string | null>,
+): Promise<void> {
+  if (!task_run_configs) return
+
+  const finetune_models = task_run_configs
+    .map((config) => config.run_config_properties?.model_name)
+    .filter((model_name) => model_name && isFinetuneModel(model_name))
+
+  await Promise.all(
+    finetune_models.map(async (model_name) => {
+      if (model_name) {
+        await get_finetune_base_model(model_name)
+      }
+    }),
+  )
+}

--- a/app/web_ui/src/lib/utils/eval-helpers.ts
+++ b/app/web_ui/src/lib/utils/eval-helpers.ts
@@ -1,0 +1,269 @@
+import type {
+  EvalConfig,
+  ProviderModels,
+  TaskRunConfig,
+  EvalResultSummary,
+  Eval,
+} from "$lib/types"
+import { model_name, provider_name_from_id } from "$lib/stores"
+import { eval_config_to_ui_name } from "$lib/utils/formatters"
+import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
+
+export type UiProperty = {
+  name: string
+  value: string
+}
+
+export function getEvalConfigName(
+  evalConfig: EvalConfig,
+  modelInfo: ProviderModels | null,
+): string {
+  const parts = []
+  parts.push(eval_config_to_ui_name(evalConfig.config_type))
+  parts.push(model_name(evalConfig.model_name, modelInfo))
+  return evalConfig.name + " — " + parts.join(", ")
+}
+
+export function formatDate(dateString: string | undefined): string {
+  if (!dateString) return "Unknown"
+  const date = new Date(dateString)
+  const datePart = date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  })
+  const timePart = date.toLocaleString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  })
+  return `${datePart}\n${timePart}`
+}
+
+export function isFinetuneModel(modelName: string | undefined): boolean {
+  if (!modelName) return false
+  // Finetune IDs are in format: project_id::task_id::finetune_id
+  const parts = modelName.split("::")
+  return parts.length === 3
+}
+
+export function getEnhancedModelName(
+  modelNameParam: string | undefined,
+  modelInfo: ProviderModels | null,
+): string {
+  if (!modelNameParam) return "Unknown"
+  return model_name(modelNameParam, modelInfo)
+}
+
+export function getEnhancedProviderName(
+  modelNameParam: string | undefined,
+  providerNameParam: string | undefined,
+  finetuneBaseModels: Record<string, string>,
+): string {
+  const baseProvider = provider_name_from_id(providerNameParam || "")
+
+  if (isFinetuneModel(modelNameParam) && modelNameParam) {
+    const baseModel = finetuneBaseModels[modelNameParam]
+    if (baseModel) {
+      return `${baseProvider} (base: ${baseModel})`
+    }
+  }
+
+  return baseProvider
+}
+
+export function getEvalConfigProperties(
+  evalConfigId: string | null,
+  evalConfigs: EvalConfig[] | null,
+  modelInfo: ProviderModels | null,
+): UiProperty[] {
+  const evalConfig = evalConfigs?.find((config) => config.id === evalConfigId)
+  if (!evalConfig) {
+    return [
+      {
+        name: "No Config Selected",
+        value: "Select a config from dropdown above",
+      },
+    ]
+  }
+
+  const properties: UiProperty[] = []
+
+  properties.push({
+    name: "Algorithm",
+    value: eval_config_to_ui_name(evalConfig.config_type),
+  })
+  properties.push({
+    name: "Eval Model",
+    value: model_name(evalConfig.model_name, modelInfo),
+  })
+  properties.push({
+    name: "Model Provider",
+    value: provider_name_from_id(evalConfig.model_provider),
+  })
+  return properties
+}
+
+export function sortTaskRunConfigs(
+  configs: TaskRunConfig[] | null,
+  evaluator: Eval | null,
+  scoreSummary: EvalResultSummary | null,
+  currentSortColumn: "created_at" | "score" | "name" | string | null,
+  currentSortDirection: "asc" | "desc",
+): TaskRunConfig[] {
+  if (!configs || !configs.length) return []
+
+  return [...configs].sort((a, b) => {
+    // Default run config always comes first
+    if (a.id === evaluator?.current_run_config_id) return -1
+    if (b.id === evaluator?.current_run_config_id) return 1
+
+    // If sorting by created_at
+    if (currentSortColumn === "created_at") {
+      const dateA = a.created_at ? new Date(a.created_at).getTime() : 0
+      const dateB = b.created_at ? new Date(b.created_at).getTime() : 0
+      return currentSortDirection === "asc" ? dateA - dateB : dateB - dateA
+    }
+
+    // If sorting by name
+    if (currentSortColumn === "name") {
+      return currentSortDirection === "asc"
+        ? a.name.localeCompare(b.name)
+        : b.name.localeCompare(a.name)
+    }
+
+    // If sorting by score (either "score" or a specific score column)
+    if (evaluator?.output_scores && scoreSummary?.results) {
+      // If currentSortColumn is "score", use the first score column
+      const scoreKey =
+        currentSortColumn === "score"
+          ? evaluator.output_scores.length
+            ? string_to_json_key(evaluator.output_scores[0].name)
+            : null
+          : string_to_json_key(currentSortColumn || "")
+
+      // Skip score-based sorting if no score key is available
+      if (!scoreKey) {
+        return a.name.localeCompare(b.name)
+      }
+
+      const scoreA = scoreSummary.results["" + a.id]?.[scoreKey]?.mean_score
+      const scoreB = scoreSummary.results["" + b.id]?.[scoreKey]?.mean_score
+
+      // If both have scores, sort by score
+      if (
+        scoreA !== null &&
+        scoreA !== undefined &&
+        scoreB !== null &&
+        scoreB !== undefined
+      ) {
+        return currentSortDirection === "asc"
+          ? scoreA - scoreB
+          : scoreB - scoreA
+      }
+
+      // If only one has a score, it comes first
+      if (scoreA !== null && scoreA !== undefined) return -1
+      if (scoreB !== null && scoreB !== undefined) return 1
+    }
+
+    // Fallback to sort by name if no scores available
+    return a.name.localeCompare(b.name)
+  })
+}
+
+export function applyFilters(
+  configs: TaskRunConfig[],
+  modelFilters: string[],
+  finetuneBaseModels: Record<string, string>,
+): TaskRunConfig[] {
+  if (modelFilters.length === 0) {
+    return configs
+  }
+
+  return configs.filter((config) => {
+    const modelName = config.run_config_properties?.model_name
+    if (!modelName) return false
+
+    // Check if the model name itself is in the filters (for base models)
+    if (modelFilters.includes(modelName)) return true
+
+    // Check if the base model is in the filters (for finetunes)
+    if (isFinetuneModel(modelName)) {
+      const baseModel = finetuneBaseModels[modelName]
+      return baseModel && modelFilters.includes(baseModel)
+    }
+
+    return false
+  })
+}
+
+export function showIncompleteWarning(
+  scoreSummary: EvalResultSummary | null,
+): boolean {
+  if (!scoreSummary?.run_config_percent_complete) {
+    return false
+  }
+
+  const values = Object.values(scoreSummary.run_config_percent_complete)
+  const minComplete =
+    values.length > 0
+      ? values.reduce((min, val) => Math.min(min, val), 1.0)
+      : 1.0
+  return minComplete < 1.0
+}
+
+export function getEvalConfigSelectOptions(
+  configs: EvalConfig[] | null,
+  modelInfo: ProviderModels | null,
+): [string, [unknown, string][]][] {
+  const configs_options: [string, string][] = []
+  for (const c of configs || []) {
+    if (c.id) {
+      configs_options.push([c.id, getEvalConfigName(c, modelInfo)])
+    }
+  }
+
+  const results: [string, [unknown, string][]][] = []
+  if (configs_options.length > 0) {
+    results.push(["Select Eval Method", configs_options])
+  }
+  results.push(["Manage Eval Methods", [["add_config", "Add Eval Method"]]])
+  return results
+}
+
+export function getAvailableFilterModels(
+  configs: TaskRunConfig[],
+  currentFilters: string[],
+  finetuneBaseModels: Record<string, string>,
+): {
+  base_models: Record<string, number>
+  finetune_base_models: Record<string, number>
+} {
+  if (!configs) return { base_models: {}, finetune_base_models: {} }
+
+  const base_models: Record<string, number> = {}
+  const finetune_base_models_result: Record<string, number> = {}
+
+  configs.forEach((config) => {
+    const modelName = config.run_config_properties?.model_name
+    if (!modelName || currentFilters.includes(modelName)) return
+
+    if (isFinetuneModel(modelName)) {
+      // For finetunes, group by base model
+      const base_model = finetuneBaseModels[modelName]
+      if (base_model && !currentFilters.includes(base_model)) {
+        const current = finetune_base_models_result[base_model]
+        finetune_base_models_result[base_model] = current ? current + 1 : 1
+      }
+    } else {
+      // For regular models, group by model name
+      if (!currentFilters.includes(modelName)) {
+        const current = base_models[modelName]
+        base_models[modelName] = current ? current + 1 : 1
+      }
+    }
+  })
+
+  return { base_models, finetune_base_models: finetune_base_models_result }
+}

--- a/app/web_ui/src/lib/utils/eval-helpers.ts
+++ b/app/web_ui/src/lib/utils/eval-helpers.ts
@@ -167,8 +167,9 @@ export function sortTaskRunConfigs(
       if (scoreB !== null && scoreB !== undefined) return 1
     }
 
-    // Fallback to sort by name if no scores available
-    return a.name.localeCompare(b.name)
+    // Fallback to sort by name while respecting the requested order
+    const cmp = a.name.localeCompare(b.name)
+    return currentSortDirection === "asc" ? cmp : -cmp
   })
 }
 

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -269,7 +269,8 @@
   let filter_models: string[] = []
 
   // Sort state
-  let sortColumn: "created_at" | "score" | "name" | string | null = "score"
+  let sortColumn: "created_at" | "score" | "name" | string | null =
+    "Overall Rating"
   let sortDirection: "asc" | "desc" = "desc"
 
   // Make sort state reactive
@@ -319,9 +320,14 @@
           : b.name.localeCompare(a.name)
       }
 
-      // If sorting by a specific score column
+      // If sorting by score (either "score" or a specific score column)
       if (evaluator?.output_scores && score_summary?.results) {
-        const scoreKey = string_to_json_key(currentSortColumn || "")
+        // If currentSortColumn is "score", use the first score column
+        const scoreKey =
+          currentSortColumn === "score"
+            ? string_to_json_key(evaluator.output_scores[0].name)
+            : string_to_json_key(currentSortColumn || "")
+
         const scoreA = score_summary.results["" + a.id]?.[scoreKey]?.mean_score
         const scoreB = score_summary.results["" + b.id]?.[scoreKey]?.mean_score
 

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -494,7 +494,7 @@
   let add_task_config_dialog: Dialog | null = null
   let add_task_config_error: KilnError | null = null
   let delete_dialog: Dialog | null = null
-  let delete_url: string | null = null
+  let delete_run_config_id: string | null = null
   let after_delete: (() => void) | null = null
   let filter_dialog: Dialog | null = null
 
@@ -592,7 +592,7 @@
 
   function show_delete_dialog(run_config_id: string) {
     if (!run_config_id) return
-    delete_url = `/api/projects/${project_id}/tasks/${task_id}/task_run_config/${run_config_id}`
+    delete_run_config_id = run_config_id
     after_delete = () => {
       get_task_run_configs()
     }
@@ -600,7 +600,7 @@
   }
 
   async function handleDelete() {
-    if (!delete_url) {
+    if (!delete_run_config_id) {
       return false
     }
     try {
@@ -611,7 +611,7 @@
             path: {
               project_id: project_id,
               task_id: task_id,
-              run_config_id: delete_url.split("/").pop() || "",
+              run_config_id: delete_run_config_id,
             },
           },
         },

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -949,10 +949,10 @@
                     {:else if score_summary}
                       <div class="text-sm text-error">Progress: 0%</div>
                     {/if}
-                    <div class="flex flex-row gap-2 mt-2">
+                    <div class="flex flex-row gap-2 mt-2 items-center">
                       {#if task_run_config.id == evaluator.current_run_config_id}
                         <button
-                          class="badge badge-primary"
+                          class="badge badge-primary min-h-[2rem] h-auto px-3 py-1"
                           on:click={(event) => {
                             event.stopPropagation()
                             set_current_run_config("None")
@@ -964,7 +964,7 @@
                         <button
                           class="badge {focus_select_eval_config
                             ? 'badge-primary'
-                            : 'badge-secondary badge-outline'}"
+                            : 'badge-secondary badge-outline'} min-h-[2rem] h-auto px-3 py-1"
                           on:click={(event) => {
                             event.stopPropagation()
                             set_current_run_config(task_run_config.id)
@@ -984,7 +984,7 @@
                         button_text="Run"
                       />
                       <button
-                        class="btn btn-sm btn-error"
+                        class="btn btn-sm btn-error min-h-[2rem]"
                         on:click={(event) => {
                           event.stopPropagation()
                           if (task_run_config.id) {

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -325,8 +325,15 @@
         // If currentSortColumn is "score", use the first score column
         const scoreKey =
           currentSortColumn === "score"
-            ? string_to_json_key(evaluator.output_scores[0].name)
+            ? evaluator.output_scores.length
+              ? string_to_json_key(evaluator.output_scores[0].name)
+              : null
             : string_to_json_key(currentSortColumn || "")
+
+        // Skip score-based sorting if no score key is available
+        if (!scoreKey) {
+          return a.name.localeCompare(b.name)
+        }
 
         const scoreA = score_summary.results["" + a.id]?.[scoreKey]?.mean_score
         const scoreB = score_summary.results["" + b.id]?.[scoreKey]?.mean_score

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -690,12 +690,6 @@
                 <tr
                   class="hover cursor-pointer"
                   on:click={() => {
-                    // Don't navigate if any modal dialogs are open
-                    const openModals = document.querySelectorAll("dialog[open]")
-                    if (openModals.length > 0) {
-                      return
-                    }
-
                     goto(
                       `/evals/${project_id}/${task_id}/${eval_id}/${current_eval_config_id}/${task_run_config.id}/run_result`,
                     )

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/run_eval.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/run_eval.svelte
@@ -69,9 +69,6 @@
       on_run_complete()
     }
 
-    // Wait a moment to ensure dialog is properly closed before showing progress
-    await new Promise((resolve) => setTimeout(resolve, 50))
-
     // Switch over to the progress dialog
     running_progress_dialog?.show()
     return true


### PR DESCRIPTION
## What does this PR do?

Some quality of life changes that make evaluation a little easier to move fast. Although its quite a refactor of the Compare Run Methods page 😓 

https://github.com/user-attachments/assets/708eb159-aef1-4b00-8ab9-5c034f822087

1. Pulling in the base model ID for fine-tuned runs into the UI
2. Adding the ability to click on a column header to sort asc/desc
3. Adding filters, lifting from the Dataset design patterns for filters. Chose to filter on Base model IDs for fine-tuned runs rather than their string names
4. Added a date created + filters 
5. Adding individual run buttons to methods
6. Adding delete buttons (and adding a DELETE endpoint)



## Checklists

- [X] Tests have been run locally and passed
- [] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to filter, sort, and delete run methods in the evaluation UI, including filtering by base model and fine-tuned models.
  - Introduced a confirmation dialog for deleting run methods.
  - Added a new API endpoint to delete task run configurations.

- **Improvements**
  - Enhanced the display of run methods with improved date formatting and additional model/provider information.
  - Updated run evaluation controls with customizable button text, a new small button size, and improved dialog titles.
  - Prevented click events on dialog buttons from bubbling up to parent elements for better interaction handling.
  - Improved modularity by introducing a dedicated evaluation service and utility helpers for managing evaluation data.

- **Bug Fixes**
  - None specifically noted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->