### PR TITLE
fix: allow non-ascii in model names

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1064,7 +1064,7 @@ export interface components {
         ApiPrompt: {
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the prompt.
              */
             name: string;
             /**
@@ -1112,7 +1112,7 @@ export interface components {
         BasePrompt: {
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the prompt.
              */
             name: string;
             /**
@@ -1447,7 +1447,7 @@ export interface components {
             created_by?: string;
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the dataset split.
              */
             name: string;
             /**
@@ -1484,7 +1484,7 @@ export interface components {
         DatasetSplitDefinition: {
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the dataset split definition.
              */
             name: string;
             /**
@@ -1524,7 +1524,7 @@ export interface components {
             created_by?: string;
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the eval.
              */
             name: string;
             /**
@@ -1601,7 +1601,7 @@ export interface components {
             created_by?: string;
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the eval config.
              */
             name: string;
             /**
@@ -1861,7 +1861,7 @@ export interface components {
             created_by?: string;
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the fine-tune.
              */
             name: string;
             /**
@@ -2169,7 +2169,7 @@ export interface components {
             created_by?: string;
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the project.
              */
             name: string;
             /**
@@ -2204,7 +2204,7 @@ export interface components {
             created_by?: string;
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the project.
              */
             name: string;
             /**
@@ -2222,7 +2222,7 @@ export interface components {
         Prompt: {
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the prompt.
              */
             name: string;
             /**
@@ -2497,7 +2497,7 @@ export interface components {
             created_by?: string;
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the task.
              */
             name: string;
             /**
@@ -2707,7 +2707,7 @@ export interface components {
             id?: string | null;
             /**
              * Name
-             * @description A name for this entity
+             * @description The name of the task requirement.
              */
             name: string;
             /** Description */
@@ -2861,7 +2861,7 @@ export interface components {
             created_by?: string;
             /**
              * Name
-             * @description A name for this entity.
+             * @description The name of the task run config.
              */
             name: string;
             /**

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -2,22 +2,17 @@ import json
 import os
 import re
 import shutil
+import unicodedata
 import uuid
 from abc import ABCMeta
 from builtins import classmethod
 from datetime import datetime
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Type,
-    TypeVar,
-)
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar
 
 from pydantic import (
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     ValidationError,
@@ -26,7 +21,7 @@ from pydantic import (
     model_validator,
 )
 from pydantic_core import ErrorDetails
-from typing_extensions import Self
+from typing_extensions import Annotated, Self
 
 from kiln_ai.datamodel.model_cache import ModelCache
 from kiln_ai.utils.config import Config
@@ -44,31 +39,62 @@ PT = TypeVar("PT", bound="KilnParentedModel")
 
 # Naming conventions:
 # 1) Names are filename safe as they may be used as file names. They are informational and not to be used in prompts/training/validation.
-# 2) Descrptions are for Kiln users to describe/understanding the purpose of this object. They must never be used in prompts/training/validation. Use "instruction/requirements" instead.
+# 2) Descriptions are for Kiln users to describe/understanding the purpose of this object. They must never be used in prompts/training/validation. Use "instruction/requirements" instead.
 
-# Filename compatible names
-NAME_REGEX = r"^[A-Za-z0-9 _-]+$"
-NAME_FIELD = Field(
-    min_length=1,
-    max_length=120,
-    pattern=NAME_REGEX,
-    description="A name for this entity.",
-)
-SHORT_NAME_FIELD = Field(
-    min_length=1,
-    max_length=32,
-    pattern=NAME_REGEX,
-    description="A name for this entity",
-)
+# Forbidden chars are not allowed in filenames on one or more platforms.
+# ref: https://en.wikipedia.org/wiki/Filename#Problematic_characters
+FORBIDDEN_CHARS_REGEX = r"[/\\?%*:|\"<>.,;=\n]"
+FORBIDDEN_CHARS = "/ \\ ? % * : | < > . , ; = \\n"
+
+
+def name_validator(*, min_length: int, max_length: int) -> Callable[[Any], str]:
+    def fn(name: Any) -> str:
+        if name is None:
+            raise ValueError("Name is required")
+        if not isinstance(name, str):
+            raise ValueError(f"Input should be a valid string, got {type(name)}")
+        if len(name) < min_length:
+            raise ValueError(
+                f"Name is too short. Min length is {min_length} characters, got {len(name)}"
+            )
+        if len(name) > max_length:
+            raise ValueError(
+                f"Name is too long. Max length is {max_length} characters, got {len(name)}"
+            )
+        if string_to_valid_name(name) != name:
+            raise ValueError(
+                f"Name is invalid. The name cannot contain any of the following characters: {FORBIDDEN_CHARS}"
+            )
+        return name
+
+    return fn
 
 
 def string_to_valid_name(name: str) -> str:
-    # Replace any character not allowed by NAME_REGEX with an underscore
-    valid_name = re.sub(r"[^A-Za-z0-9 _-]", "_", name)
+    # https://docs.python.org/3/library/unicodedata.html#unicodedata.normalize
+    valid_name = unicodedata.normalize("NFKD", name)
+    # Replace any forbidden chars with an underscore
+    valid_name = re.sub(FORBIDDEN_CHARS_REGEX, "_", valid_name)
+    # Replace control characters with an underscore
+    valid_name = re.sub(r"[\x00-\x1F]", "_", valid_name)
+    # Replace consecutive whitespace with a single space
+    valid_name = re.sub(r"\s+", " ", valid_name)
     # Replace consecutive underscores with a single underscore
     valid_name = re.sub(r"_+", "_", valid_name)
     # Remove leading and trailing underscores or whitespace
     return valid_name.strip("_").strip()
+
+
+# Usage:
+# class MyModel(KilnBaseModel):
+#     name: FilenameString = Field(description="The name of the model.")
+#     name_short: FilenameStringShort = Field(description="The short name of the model.")
+FilenameString = Annotated[
+    str, BeforeValidator(name_validator(min_length=1, max_length=120))
+]
+FilenameStringShort = Annotated[
+    str, BeforeValidator(name_validator(min_length=1, max_length=32))
+]
 
 
 class KilnBaseModel(BaseModel):

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -63,7 +63,7 @@ def name_validator(*, min_length: int, max_length: int) -> Callable[[Any], str]:
             )
         if string_to_valid_name(name) != name:
             raise ValueError(
-                f"Name is invalid. The name cannot contain any of the following characters: {FORBIDDEN_CHARS}"
+                f"Name is invalid. The name cannot contain any of the following characters: {FORBIDDEN_CHARS}, consecutive whitespace/underscores, or leading/trailing whitespace/underscores"
             )
         return name
 

--- a/libs/core/kiln_ai/datamodel/dataset_split.py
+++ b/libs/core/kiln_ai/datamodel/dataset_split.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field, model_validator
 
-from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentedModel
+from kiln_ai.datamodel.basemodel import FilenameString, KilnParentedModel
 from kiln_ai.datamodel.dataset_filters import (
     DatasetFilter,
     DatasetFilterId,
@@ -26,7 +26,9 @@ class DatasetSplitDefinition(BaseModel):
     Example: name="train", description="The training set", percentage=0.8 (80% of the dataset)
     """
 
-    name: str = NAME_FIELD
+    name: FilenameString = Field(
+        description="The name of the dataset split definition."
+    )
     description: str | None = Field(
         default=None,
         description="A description of the dataset for you and your team. Not used in training.",
@@ -70,7 +72,7 @@ class DatasetSplit(KilnParentedModel):
     Maintains a list of IDs for each split, to avoid data duplication.
     """
 
-    name: str = NAME_FIELD
+    name: FilenameString = Field(description="The name of the dataset split.")
     description: str | None = Field(
         default=None,
         description="A description of the dataset for you and your team. Not used in training.",

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 
 from kiln_ai.datamodel.basemodel import (
     ID_TYPE,
-    NAME_FIELD,
+    FilenameString,
     KilnParentedModel,
     KilnParentModel,
 )
@@ -202,7 +202,7 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
     A eval might have many configs, example running the same eval with 2 different models. Comparing eval results is only valid within the scope of the same config.
     """
 
-    name: str = NAME_FIELD
+    name: FilenameString = Field(description="The name of the eval config.")
     model_name: str = Field(
         description="The name of the model to use for this eval config. ",
     )
@@ -257,7 +257,7 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
 
 
 class Eval(KilnParentedModel, KilnParentModel, parent_of={"configs": EvalConfig}):
-    name: str = NAME_FIELD
+    name: FilenameString = Field(description="The name of the eval.")
     description: str | None = Field(
         default=None, description="The description of the eval"
     )

--- a/libs/core/kiln_ai/datamodel/finetune.py
+++ b/libs/core/kiln_ai/datamodel/finetune.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Dict, Union
 from pydantic import Field, model_validator
 from typing_extensions import Self
 
-from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentedModel
+from kiln_ai.datamodel.basemodel import FilenameString, KilnParentedModel
 from kiln_ai.datamodel.datamodel_enums import (
     ChatStrategy,
     FineTuneStatusType,
@@ -26,7 +26,7 @@ class Finetune(KilnParentedModel):
     Initially holds a reference to a training job, with needed identifiers to update the status. When complete, contains the new model ID.
     """
 
-    name: str = NAME_FIELD
+    name: FilenameString = Field(description="The name of the fine-tune.")
     description: str | None = Field(
         default=None,
         description="A description of the fine-tune for you and your team. Not used in training.",

--- a/libs/core/kiln_ai/datamodel/project.py
+++ b/libs/core/kiln_ai/datamodel/project.py
@@ -1,6 +1,6 @@
 from pydantic import Field
 
-from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentModel
+from kiln_ai.datamodel.basemodel import FilenameString, KilnParentModel
 from kiln_ai.datamodel.task import Task
 
 
@@ -12,7 +12,7 @@ class Project(KilnParentModel, parent_of={"tasks": Task}):
     of the overall goals.
     """
 
-    name: str = NAME_FIELD
+    name: FilenameString = Field(description="The name of the project.")
     description: str | None = Field(
         default=None,
         description="A description of the project for you and your team. Will not be used in prompts/training/validation.",

--- a/libs/core/kiln_ai/datamodel/prompt.py
+++ b/libs/core/kiln_ai/datamodel/prompt.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 
-from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentedModel
+from kiln_ai.datamodel.basemodel import FilenameString, KilnParentedModel
 
 
 class BasePrompt(BaseModel):
@@ -10,7 +10,7 @@ class BasePrompt(BaseModel):
     The "Prompt" model name is reserved for the custom prompts parented by a task.
     """
 
-    name: str = NAME_FIELD
+    name: FilenameString = Field(description="The name of the prompt.")
     description: str | None = Field(
         default=None,
         description="A more detailed description of the prompt.",

--- a/libs/core/kiln_ai/datamodel/task.py
+++ b/libs/core/kiln_ai/datamodel/task.py
@@ -7,8 +7,8 @@ from kiln_ai.datamodel import Finetune
 from kiln_ai.datamodel.basemodel import (
     ID_FIELD,
     ID_TYPE,
-    NAME_FIELD,
-    SHORT_NAME_FIELD,
+    FilenameString,
+    FilenameStringShort,
     KilnParentedModel,
     KilnParentModel,
 )
@@ -38,7 +38,7 @@ class TaskRequirement(BaseModel):
     """
 
     id: ID_TYPE = ID_FIELD
-    name: str = SHORT_NAME_FIELD
+    name: FilenameStringShort = Field(description="The name of the task requirement.")
     description: str | None = Field(default=None)
     instruction: str = Field(min_length=1)
     priority: Priority = Field(default=Priority.p2)
@@ -103,7 +103,7 @@ class TaskRunConfig(KilnParentedModel):
     A run config includes everything needed to run a task, except the input. Running the same RunConfig with the same input should make identical calls to the model (output may vary as models are non-deterministic).
     """
 
-    name: str = NAME_FIELD
+    name: FilenameString = Field(description="The name of the task run config.")
     description: str | None = Field(
         default=None, description="The description of the task run config."
     )
@@ -189,7 +189,7 @@ class Task(
     a collection of task runs.
     """
 
-    name: str = NAME_FIELD
+    name: FilenameString = Field(description="The name of the task.")
     description: str | None = Field(
         default=None,
         description="A description of the task for you and your team. Will not be used in prompts/training/validation.",

--- a/libs/core/kiln_ai/datamodel/test_task.py
+++ b/libs/core/kiln_ai/datamodel/test_task.py
@@ -323,3 +323,8 @@ def test_run_config_upgrade_old_entries():
     assert parsed.name == "test name"
     assert parsed.created_by == "scosman"
     assert parsed.run_config_properties.structured_output_mode == "unknown"
+
+
+def test_task_name_unicode_name():
+    task = Task(name="你好", instruction="Do something")
+    assert task.name == "你好"

--- a/libs/server/kiln_server/test_task_api.py
+++ b/libs/server/kiln_server/test_task_api.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/libs/server/kiln_server/test_task_api.py
+++ b/libs/server/kiln_server/test_task_api.py
@@ -1,13 +1,10 @@
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
-from kiln_ai.datamodel import (
-    Project,
-    Task,
-    TaskRequirement,
-)
+from kiln_ai.datamodel import Project, Task, TaskRequirement
 
 from kiln_server.custom_errors import connect_custom_errors
 from kiln_server.task_api import connect_task_api, task_from_id
@@ -49,7 +46,7 @@ def test_create_task_success(client, tmp_path):
     project_path.mkdir()
 
     task_data = {
-        "name": "Test Task",
+        "name": "Test Task 啊",
         "description": "This is a test task",
         "instruction": "This is a test instruction",
     }
@@ -67,7 +64,7 @@ def test_create_task_success(client, tmp_path):
 
     assert response.status_code == 200
     res = response.json()
-    assert res["name"] == "Test Task"
+    assert res["name"] == "Test Task 啊"
     assert res["description"] == "This is a test task"
     assert res["id"] is not None
 


### PR DESCRIPTION
## What does this PR do?

The `NAME_FIELD` and `SHORT_NAME_FIELD` Pydantic fields we reuse across different `KilnBaseModel` implementations are more restrictive than they need to be as they reject a range of values that would be valid filenames (e.g. non-ASCII letters from other languages like Chinese, Japanese, etc.).

According to: https://en.wikipedia.org/wiki/Filename#Problematic_characters - only a dozen or so special characters are problematic in filenames.

Note: I intentionally kept the validator and sanitization separate. But we could also merge them together to automatically sanitize. We could also use a library like: https://pypi.org/project/pathvalidate/ that validates paths and can normalize them.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated descriptions for name fields to provide clearer, entity-specific guidance.

- **Bug Fixes**
  - Improved validation and normalization of names to prevent invalid or unsupported characters.

- **Tests**
  - Enhanced and expanded test coverage for name validation and Unicode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->