### PR TITLE
chore: fix typo in menu description

### DIFF
--- a/app/web_ui/src/routes/(app)/settings/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/+page.svelte
@@ -23,7 +23,7 @@
     {
       name: "Edit Task",
       description:
-        "Edit the currently task, including the prompt and requirements.",
+        "Edit the currently selected task, including the prompt and requirements.",
       button_text: "Edit Current Task",
       href: `/settings/edit_task/${$ui_state?.current_project_id}/${$ui_state?.current_task_id}`,
     },


### PR DESCRIPTION
## What does this PR do?

Missing word in menu description in the `Settings` page:
<img width="740" alt="image" src="https://github.com/user-attachments/assets/83afa53a-ae50-4aad-a5c3-f20a9ebb7a50" />

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
