### PR TITLE
feat: async remote config loading

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -51,6 +51,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: ${{ vars.KILN_CONFIG_REPO != 'true' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish_remote_config.yml
+++ b/.github/workflows/publish_remote_config.yml
@@ -1,0 +1,49 @@
+name: Publish Remote Config
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Generate Config
+        run: uv run python -m kiln_ai.adapters.remote_config kiln_config.json
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload to Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./kiln_config.json
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish_remote_config.yml
+++ b/.github/workflows/publish_remote_config.yml
@@ -26,8 +26,11 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
 
+      - name: Make static dir
+        run: mkdir -p static
+
       - name: Generate Config
-        run: uv run python -m kiln_ai.adapters.remote_config kiln_config.json
+        run: uv run python -m kiln_ai.adapters.remote_config static/kiln_config.json
 
       - name: Setup Pages
         id: pages
@@ -36,7 +39,7 @@ jobs:
       - name: Upload to Pages
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./kiln_config.json
+          path: ./static/
 
   deploy:
     if: ${{ vars.KILN_CONFIG_REPO == 'true' }}

--- a/.github/workflows/publish_remote_config.yml
+++ b/.github/workflows/publish_remote_config.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ vars.KILN_CONFIG_REPO == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +39,7 @@ jobs:
           path: ./kiln_config.json
 
   deploy:
+    if: ${{ vars.KILN_CONFIG_REPO == 'true' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/publish_remote_config.yml
+++ b/.github/workflows/publish_remote_config.yml
@@ -1,7 +1,9 @@
 name: Publish Remote Config
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/app/desktop/desktop_server.py
+++ b/app/desktop/desktop_server.py
@@ -25,7 +25,7 @@ from app.desktop.studio_server.webhost import connect_webhost
 # Loads github pages hosted JSON config.
 # You can see public config build logs here: https://github.com/Kiln-AI/remote_config/actions/workflows/publish_remote_config.yml
 # URL is Cloudflare proxy to Github Pages: https://kiln-ai.github.io/remote_config/kiln_config.json
-REMOTE_MODEL_LIST_URL = "https://remote_config.getkiln.ai/kiln_config.json"
+REMOTE_MODEL_LIST_URL = "https://remote-config.getkiln.ai/kiln_config.json"
 
 
 @asynccontextmanager

--- a/app/desktop/desktop_server.py
+++ b/app/desktop/desktop_server.py
@@ -22,7 +22,8 @@ from app.desktop.studio_server.repair_api import connect_repair_api
 from app.desktop.studio_server.settings_api import connect_settings
 from app.desktop.studio_server.webhost import connect_webhost
 
-REMOTE_MODEL_LIST_URL = "https://example.com/kiln_model_list.json"
+# CNAME to (w CF proxy for load): https://kiln-ai.github.io/remote_config/kiln_config.json
+REMOTE_MODEL_LIST_URL = "https://remote_config.getkiln.ai/kiln_config.json"
 
 
 @asynccontextmanager

--- a/app/desktop/desktop_server.py
+++ b/app/desktop/desktop_server.py
@@ -9,6 +9,7 @@ import kiln_ai.datamodel.strict_mode as datamodel_strict_mode
 import kiln_server.server as kiln_server
 import uvicorn
 from fastapi import FastAPI
+from kiln_ai.adapters.remote_config import load_remote_models
 from kiln_ai.utils.logging import setup_litellm_logging
 
 from app.desktop.log_config import log_config
@@ -20,6 +21,8 @@ from app.desktop.studio_server.provider_api import connect_provider_api
 from app.desktop.studio_server.repair_api import connect_repair_api
 from app.desktop.studio_server.settings_api import connect_settings
 from app.desktop.studio_server.webhost import connect_webhost
+
+REMOTE_MODEL_LIST_URL = "https://example.com/kiln_model_list.json"
 
 
 @asynccontextmanager
@@ -40,6 +43,8 @@ async def lifespan(app: FastAPI):
 
 def make_app():
     setup_litellm_logging()
+
+    load_remote_models(REMOTE_MODEL_LIST_URL)
 
     app = kiln_server.make_app(lifespan=lifespan)
     connect_provider_api(app)

--- a/app/desktop/desktop_server.py
+++ b/app/desktop/desktop_server.py
@@ -22,7 +22,9 @@ from app.desktop.studio_server.repair_api import connect_repair_api
 from app.desktop.studio_server.settings_api import connect_settings
 from app.desktop.studio_server.webhost import connect_webhost
 
-# CNAME to (w CF proxy for load): https://kiln-ai.github.io/remote_config/kiln_config.json
+# Loads github pages hosted JSON config.
+# You can see public config build logs here: https://github.com/Kiln-AI/remote_config/actions/workflows/publish_remote_config.yml
+# URL is Cloudflare proxy to Github Pages: https://kiln-ai.github.io/remote_config/kiln_config.json
 REMOTE_MODEL_LIST_URL = "https://remote_config.getkiln.ai/kiln_config.json"
 
 

--- a/app/desktop/dev_server.py
+++ b/app/desktop/dev_server.py
@@ -7,8 +7,8 @@ import uvicorn
 
 from app.desktop.desktop_server import make_app
 
-# Skip remote model loading when running the dev server
-os.environ["KILN_SKIP_REMOTE_MODEL_LIST"] = "true"
+# Skip remote model loading when running the dev server (unless explicitly set)
+os.environ.setdefault("KILN_SKIP_REMOTE_MODEL_LIST", "true")
 
 # top level app object, as that's needed by auto-reload
 dev_app = make_app()

--- a/app/desktop/dev_server.py
+++ b/app/desktop/dev_server.py
@@ -7,6 +7,9 @@ import uvicorn
 
 from app.desktop.desktop_server import make_app
 
+# Skip remote model loading when running the dev server
+os.environ["KILN_SKIP_REMOTE_MODEL_LIST"] = "true"
+
 # top level app object, as that's needed by auto-reload
 dev_app = make_app()
 

--- a/libs/core/kiln_ai/adapters/remote_config.py
+++ b/libs/core/kiln_ai/adapters/remote_config.py
@@ -12,7 +12,7 @@ from .ml_model_list import KilnModel, built_in_models
 
 def serialize_config(models: List[KilnModel], path: str | Path) -> None:
     data = {"model_list": [m.model_dump(mode="json") for m in models]}
-    Path(path).write_text(json.dumps(data))
+    Path(path).write_text(json.dumps(data, indent=2, sort_keys=True))
 
 
 def deserialize_config(path: str | Path) -> List[KilnModel]:

--- a/libs/core/kiln_ai/adapters/remote_config.py
+++ b/libs/core/kiln_ai/adapters/remote_config.py
@@ -44,8 +44,13 @@ def load_remote_models(url: str) -> None:
         try:
             models = await asyncio.to_thread(load_from_url, url)
             built_in_models[:] = models
-        except Exception:
-            pass
+        except Exception as exc:
+            # Do not crash startup, but surface the issue
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Failed to fetch remote model list from %s: %s", url, exc
+            )
 
     asyncio.get_event_loop().create_task(fetch_and_replace())
 

--- a/libs/core/kiln_ai/adapters/test_remote_config.py
+++ b/libs/core/kiln_ai/adapters/test_remote_config.py
@@ -1,0 +1,78 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from kiln_ai.adapters.ml_model_list import built_in_models
+from kiln_ai.adapters.remote_config import (
+    deserialize_config,
+    dump_builtin_config,
+    load_from_url,
+    load_remote_models,
+    serialize_config,
+)
+
+
+def test_round_trip(tmp_path):
+    path = tmp_path / "models.json"
+    serialize_config(built_in_models, path)
+    loaded = deserialize_config(path)
+    assert [m.model_dump(mode="json") for m in loaded] == [
+        m.model_dump(mode="json") for m in built_in_models
+    ]
+
+
+def test_load_from_url():
+    sample = [built_in_models[0].model_dump(mode="json")]
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"model_list": sample}
+
+    with patch(
+        "kiln_ai.adapters.remote_config.requests.get", return_value=FakeResponse()
+    ):
+        models = load_from_url("http://example.com/models.json")
+    assert [m.model_dump(mode="json") for m in models] == sample
+
+
+def test_dump_builtin_config(tmp_path):
+    path = tmp_path / "out.json"
+    dump_builtin_config(path)
+    loaded = deserialize_config(path)
+    assert [m.model_dump(mode="json") for m in loaded] == [
+        m.model_dump(mode="json") for m in built_in_models
+    ]
+
+
+@pytest.mark.asyncio
+async def test_load_remote_models_success(monkeypatch):
+    original = built_in_models.copy()
+    sample_models = [built_in_models[0]]
+
+    def fake_fetch(url):
+        return sample_models
+
+    monkeypatch.setattr("kiln_ai.adapters.remote_config.load_from_url", fake_fetch)
+
+    load_remote_models("http://example.com/models.json")
+    await asyncio.sleep(0.01)
+    assert built_in_models == sample_models
+    built_in_models[:] = original
+
+
+@pytest.mark.asyncio
+async def test_load_remote_models_failure(monkeypatch):
+    original = built_in_models.copy()
+
+    def fake_fetch(url):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr("kiln_ai.adapters.remote_config.load_from_url", fake_fetch)
+
+    load_remote_models("http://example.com/models.json")
+    await asyncio.sleep(0.01)
+    assert built_in_models == original


### PR DESCRIPTION
## Summary
- rename remote_model_list to remote_config
- publish serialized config via GitHub workflow
- fetch remote config in the background on server startup
- update tests for new remote_config module

## Testing
- `uvx ruff check --select I`
- `uvx ruff format --check .`
- `uv run pyright .`
- `uv run python3 -m pytest --benchmark-quiet -q .`


------
https://chatgpt.com/codex/tasks/task_e_6852c057d8b88332a720fad80305cc38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for loading AI model configurations from a remote source during application setup.
  - Added a command-line tool for exporting built-in model configurations to a file.

- **Chores**
  - Added a manual workflow to publish remote configuration files and deploy them to GitHub Pages.
  - Updated documentation deployment to conditionally skip when remote config publishing is enabled.

- **Tests**
  - Implemented unit tests for serialization, deserialization, and remote loading of model configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->