### PR TITLE
Improve PostHog page tracking

### DIFF
--- a/app/web_ui/src/routes/+layout.svelte
+++ b/app/web_ui/src/routes/+layout.svelte
@@ -24,12 +24,12 @@
 
   if (browser) {
     beforeNavigate(() => {
-      const route_id = get(page).route.id
+      const route_id = get(page).route.id || "unknown"
       const url = window.location.origin + route_id
       posthog.capture("$pageleave", { $current_url: url, $pathname: route_id })
     })
     afterNavigate(() => {
-      const route_id = get(page).route.id
+      const route_id = get(page).route.id || "unknown"
       const url = window.location.origin + route_id
       posthog.capture("$pageview", { $current_url: url, $pathname: route_id })
     })

--- a/app/web_ui/src/routes/+layout.svelte
+++ b/app/web_ui/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
   import { get } from "svelte/store"
   import { KilnError } from "$lib/utils/error_handlers"
   import { createKilnError } from "$lib/utils/error_handlers"
+  import { page } from "$app/stores"
   let loading = true
   let load_error: string | null = null
   import posthog from "posthog-js"
@@ -22,8 +23,16 @@
   import { beforeNavigate, afterNavigate } from "$app/navigation"
 
   if (browser) {
-    beforeNavigate(() => posthog.capture("$pageleave"))
-    afterNavigate(() => posthog.capture("$pageview"))
+    beforeNavigate(() => {
+      const route_id = get(page).route.id
+      const url = window.location.origin + route_id
+      posthog.capture("$pageleave", { $current_url: url, $pathname: route_id })
+    })
+    afterNavigate(() => {
+      const route_id = get(page).route.id
+      const url = window.location.origin + route_id
+      posthog.capture("$pageview", { $current_url: url, $pathname: route_id })
+    })
   }
 
   // Our (app) routes expect a current project and task.


### PR DESCRIPTION
## Summary
- sanitize route names when capturing page views in PostHog

## Testing
- `npm run format_check`
- `npm run lint`
- `npm run check`
- `npm run test_run`
- `npm run build > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_685566eddb7c83329e042987a84cf52f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced analytics tracking for page navigation, providing more detailed context such as full URLs and route paths in analytics events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->