### PR TITLE
refactor!: remove support for CSV in RAG

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/upload_file_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/upload_file_dialog.svelte
@@ -12,7 +12,6 @@
   let description: string | null = null
   const supported_file_types = [
     ".pdf",
-    ".csv",
     ".txt",
     ".md",
     ".html",
@@ -140,7 +139,7 @@
           are supported:
         </p>
         <ul class="list-disc list-inside mt-2">
-          <li>Documents: .pdf, .csv, .txt, .md, .html</li>
+          <li>Documents: .pdf, .txt, .md, .html</li>
           <li>Images: .jpg, .jpeg, .png</li>
           <li>Videos: .mp4, .mov</li>
           <li>Audio: .mp3, .wav, .ogg</li>

--- a/libs/core/kiln_ai/adapters/extractors/test_base_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/test_base_extractor.py
@@ -159,7 +159,6 @@ async def test_extract_passthrough_output_format(mock_gemini_properties, output_
         ("test.txt", "text/plain", OutputFormat.MARKDOWN),
         ("test.txt", "text/markdown", OutputFormat.MARKDOWN),
         ("test.html", "text/html", OutputFormat.MARKDOWN),
-        ("test.csv", "text/csv", OutputFormat.MARKDOWN),
     ],
 )
 async def test_extract_non_passthrough(

--- a/libs/core/kiln_ai/adapters/extractors/test_gemini_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/test_gemini_extractor.py
@@ -54,7 +54,6 @@ def mock_gemini_extractor(mock_gemini_client):
         ("text/plain", Kind.DOCUMENT),
         ("text/html", Kind.DOCUMENT),
         ("text/css", Kind.DOCUMENT),
-        ("text/csv", Kind.DOCUMENT),
         ("text/xml", Kind.DOCUMENT),
         ("text/rtf", Kind.DOCUMENT),
         # images
@@ -235,20 +234,6 @@ async def test_extract_document_pdf(model_name, mock_file_factory):
     output = await extractor.extract(
         path=str(test_pdf_file),
         mime_type="application/pdf",
-    )
-    assert not output.is_passthrough
-    assert output.content_format == OutputFormat.MARKDOWN
-    assert "Document summary:" in output.content
-
-
-@pytest.mark.paid
-@pytest.mark.parametrize("model_name", SUPPORTED_MODELS)
-async def test_extract_csv(model_name, mock_file_factory):
-    test_csv_file = mock_file_factory(MockFileFactoryMimeType.CSV)
-    extractor = paid_gemini_extractor(model_name=model_name)
-    output = await extractor.extract(
-        path=str(test_csv_file),
-        mime_type="text/csv",
     )
     assert not output.is_passthrough
     assert output.content_format == OutputFormat.MARKDOWN

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -53,7 +53,6 @@ SUPPORTED_MIME_TYPES = {
         "text/markdown",
         "text/html",
         "text/md",
-        "text/csv",
     },
     Kind.IMAGE: {
         "image/png",

--- a/libs/core/kiln_ai/datamodel/test_extraction_model.py
+++ b/libs/core/kiln_ai/datamodel/test_extraction_model.py
@@ -480,7 +480,6 @@ def test_extraction_prompt_builder_invalid_kind():
         ("file.txt", "text/plain"),
         ("file.md", "text/markdown"),
         ("file.html", "text/html"),
-        ("file.csv", "text/csv"),
         ("file.png", "image/png"),
         ("file.jpeg", "image/jpeg"),
         ("file.mp4", "video/mp4"),
@@ -531,6 +530,10 @@ def test_document_valid_mime_type(
         (
             "file.avi",
             "video/x-msvideo",
+        ),
+        (
+            "file.csv",
+            "text/csv",
         ),
     ],
 )


### PR DESCRIPTION
## What does this PR do?

CSV files require a special chunking strategy to be useful in RAG - best to remove support for uploading CSV files altogether for the time being.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
