### PR TITLE
Configure pytest to hide known warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,5 +8,12 @@ markers =
     paid: marks tests as requring paid APIs. Not run by default, run with '--runpaid' option.
     ollama: marks tests as requring ollama server. Not run by default, run with '--ollama' option.
 
+filterwarnings =
+    ignore:File system does not support fine-grained timestamps
+    ignore::pydantic.PydanticDeprecatedSince20
+    ignore:Benchmark fixture was not used at all in this test
+    ignore::scipy.stats.ConstantInputWarning
+    ignore:coroutine '.*' was never awaited:RuntimeWarning
+
 # Enable parallel testing. Disabled for now as single tests are much faster without it on. It's enabled in checks.sh
 # addopts = -n auto


### PR DESCRIPTION
## Summary
- hide model caching warnings by default
- suppress pydantic deprecation and other dependency warnings during tests

## Testing
- `uvx ruff check --select I`
- `uvx ruff format --check .`
- `uv run pyright .`
- `uv run python3 -m pytest --benchmark-quiet -q`

------
https://chatgpt.com/codex/tasks/task_e_685592d09f748332bbf35ae136942f9d