### PR TITLE
feat: chunking datamodel and chunker

### DIFF
--- a/libs/core/kiln_ai/adapters/__init__.py
+++ b/libs/core/kiln_ai/adapters/__init__.py
@@ -18,6 +18,7 @@ The eval submodule contains the code for evaluating the performance of a model.
 
 from . import (
     chat,
+    chunkers,
     data_gen,
     eval,
     extractors,
@@ -29,6 +30,7 @@ from . import (
 )
 
 __all__ = [
+    "chunkers",
     "model_adapters",
     "chat",
     "data_gen",

--- a/libs/core/kiln_ai/adapters/chunkers/__init__.py
+++ b/libs/core/kiln_ai/adapters/chunkers/__init__.py
@@ -1,0 +1,13 @@
+"""
+Chunkers for processing different document types.
+
+This package provides a framework for chunking text into smaller chunks.
+"""
+
+from . import base_chunker, fixed_window_chunker, registry
+
+__all__ = [
+    "base_chunker",
+    "fixed_window_chunker",
+    "registry",
+]

--- a/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
@@ -1,0 +1,37 @@
+import logging
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, Field
+
+from kiln_ai.datamodel.chunk import ChunkerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class Chunk(BaseModel):
+    text: str = Field(description="The text of the chunk.")
+
+
+class ChunkOutput(BaseModel):
+    chunks: list[Chunk] = Field(description="The chunks of the text.")
+
+
+class BaseChunker(ABC):
+    """
+    Base class for all chunkers.
+
+    Should be subclassed by each chunker.
+    """
+
+    def __init__(self, chunker_config: ChunkerConfig):
+        self.chunker_config = chunker_config
+
+    async def chunk(self, text: str) -> ChunkOutput:
+        if not text:
+            return ChunkOutput(chunks=[])
+
+        return await self._chunk(text)
+
+    @abstractmethod
+    async def _chunk(self, text: str) -> ChunkOutput:
+        pass

--- a/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
@@ -8,12 +8,12 @@ from kiln_ai.datamodel.chunk import ChunkerConfig
 logger = logging.getLogger(__name__)
 
 
-class Chunk(BaseModel):
+class TextChunk(BaseModel):
     text: str = Field(description="The text of the chunk.")
 
 
-class ChunkOutput(BaseModel):
-    chunks: list[Chunk] = Field(description="The chunks of the text.")
+class ChunkingResult(BaseModel):
+    chunks: list[TextChunk] = Field(description="The chunks of the text.")
 
 
 class BaseChunker(ABC):
@@ -26,12 +26,12 @@ class BaseChunker(ABC):
     def __init__(self, chunker_config: ChunkerConfig):
         self.chunker_config = chunker_config
 
-    async def chunk(self, text: str) -> ChunkOutput:
+    async def chunk(self, text: str) -> ChunkingResult:
         if not text:
-            return ChunkOutput(chunks=[])
+            return ChunkingResult(chunks=[])
 
         return await self._chunk(text)
 
     @abstractmethod
-    async def _chunk(self, text: str) -> ChunkOutput:
+    async def _chunk(self, text: str) -> ChunkingResult:
         pass

--- a/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
@@ -2,7 +2,11 @@ from typing import List
 
 from llama_index.core.text_splitter import SentenceSplitter
 
-from kiln_ai.adapters.chunkers.base_chunker import BaseChunker, Chunk, ChunkOutput
+from kiln_ai.adapters.chunkers.base_chunker import (
+    BaseChunker,
+    ChunkingResult,
+    TextChunk,
+)
 from kiln_ai.datamodel.chunk import ChunkerConfig
 
 
@@ -14,11 +18,11 @@ class FixedWindowChunker(BaseChunker):
             chunk_overlap=self.chunker_config.properties.chunk_overlap,
         )
 
-    async def _chunk(self, text: str) -> ChunkOutput:
+    async def _chunk(self, text: str) -> ChunkingResult:
         sentences = self.splitter.split_text(text)
 
-        chunks: List[Chunk] = []
+        chunks: List[TextChunk] = []
         for sentence in sentences:
-            chunks.append(Chunk(text=sentence))
+            chunks.append(TextChunk(text=sentence))
 
-        return ChunkOutput(chunks=chunks)
+        return ChunkingResult(chunks=chunks)

--- a/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
@@ -7,15 +7,26 @@ from kiln_ai.adapters.chunkers.base_chunker import (
     ChunkingResult,
     TextChunk,
 )
-from kiln_ai.datamodel.chunk import ChunkerConfig
+from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
 
 
 class FixedWindowChunker(BaseChunker):
     def __init__(self, chunker_config: ChunkerConfig):
+        if chunker_config.chunker_type != ChunkerType.FIXED_WINDOW:
+            raise ValueError("Chunker type must be FIXED_WINDOW")
+
+        chunk_size = chunker_config.chunk_size()
+        if chunk_size is None:
+            raise ValueError("Chunk size must be set")
+
+        chunk_overlap = chunker_config.chunk_overlap()
+        if chunk_overlap is None:
+            raise ValueError("Chunk overlap must be set")
+
         super().__init__(chunker_config)
         self.splitter = SentenceSplitter(
-            chunk_size=self.chunker_config.properties.chunk_size,
-            chunk_overlap=self.chunker_config.properties.chunk_overlap,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
         )
 
     async def _chunk(self, text: str) -> ChunkingResult:

--- a/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
@@ -1,0 +1,24 @@
+from typing import List
+
+from llama_index.core.text_splitter import SentenceSplitter
+
+from kiln_ai.adapters.chunkers.base_chunker import BaseChunker, Chunk, ChunkOutput
+from kiln_ai.datamodel.chunk import ChunkerConfig
+
+
+class FixedWindowChunker(BaseChunker):
+    def __init__(self, chunker_config: ChunkerConfig):
+        super().__init__(chunker_config)
+        self.splitter = SentenceSplitter(
+            chunk_size=self.chunker_config.properties.chunk_size,
+            chunk_overlap=self.chunker_config.properties.chunk_overlap,
+        )
+
+    async def _chunk(self, text: str) -> ChunkOutput:
+        sentences = self.splitter.split_text(text)
+
+        chunks: List[Chunk] = []
+        for sentence in sentences:
+            chunks.append(Chunk(text=sentence))
+
+        return ChunkOutput(chunks=chunks)

--- a/libs/core/kiln_ai/adapters/chunkers/registry.py
+++ b/libs/core/kiln_ai/adapters/chunkers/registry.py
@@ -1,0 +1,16 @@
+from kiln_ai.adapters.chunkers.base_chunker import BaseChunker
+from kiln_ai.adapters.chunkers.fixed_window_chunker import FixedWindowChunker
+from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
+from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
+
+
+def chunker_adapter_from_type(
+    chunker_type: ChunkerType,
+    chunker_config: ChunkerConfig,
+) -> BaseChunker:
+    match chunker_type:
+        case ChunkerType.FIXED_WINDOW:
+            return FixedWindowChunker(chunker_config)
+        case _:
+            # type checking will catch missing cases
+            raise_exhaustive_enum_error(chunker_type)

--- a/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
@@ -5,11 +5,7 @@ from kiln_ai.adapters.chunkers.base_chunker import (
     ChunkingResult,
     TextChunk,
 )
-from kiln_ai.datamodel.chunk import (
-    ChunkerConfig,
-    ChunkerType,
-    FixedWindowChunkerProperties,
-)
+from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
 
 
 @pytest.fixture
@@ -17,7 +13,7 @@ def config() -> ChunkerConfig:
     return ChunkerConfig(
         name="test-chunker",
         chunker_type=ChunkerType.FIXED_WINDOW,
-        properties=FixedWindowChunkerProperties(chunk_size=100, chunk_overlap=10),
+        properties={"chunk_size": 100, "chunk_overlap": 10},
     )
 
 

--- a/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
@@ -1,0 +1,36 @@
+import pytest
+
+from kiln_ai.adapters.chunkers.base_chunker import BaseChunker, Chunk, ChunkOutput
+from kiln_ai.datamodel.chunk import (
+    ChunkerConfig,
+    ChunkerType,
+    FixedWindowChunkerProperties,
+)
+
+
+@pytest.fixture
+def config() -> ChunkerConfig:
+    return ChunkerConfig(
+        name="test-chunker",
+        chunker_type=ChunkerType.FIXED_WINDOW,
+        properties=FixedWindowChunkerProperties(chunk_size=100, chunk_overlap=10),
+    )
+
+
+class WhitespaceChunker(BaseChunker):
+    async def _chunk(self, text: str) -> ChunkOutput:
+        return ChunkOutput(chunks=[Chunk(text=chunk) for chunk in text.split()])
+
+
+@pytest.fixture
+def chunker(config: ChunkerConfig) -> WhitespaceChunker:
+    return WhitespaceChunker(config)
+
+
+async def test_base_chunker_chunk_empty_text(chunker: WhitespaceChunker):
+    assert await chunker.chunk("") == ChunkOutput(chunks=[])
+
+
+async def test_base_chunker_concrete_chunker(chunker: WhitespaceChunker):
+    output = await chunker.chunk("Hello, world!")
+    assert len(output.chunks) == 2

--- a/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
@@ -1,6 +1,10 @@
 import pytest
 
-from kiln_ai.adapters.chunkers.base_chunker import BaseChunker, Chunk, ChunkOutput
+from kiln_ai.adapters.chunkers.base_chunker import (
+    BaseChunker,
+    ChunkingResult,
+    TextChunk,
+)
 from kiln_ai.datamodel.chunk import (
     ChunkerConfig,
     ChunkerType,
@@ -18,8 +22,8 @@ def config() -> ChunkerConfig:
 
 
 class WhitespaceChunker(BaseChunker):
-    async def _chunk(self, text: str) -> ChunkOutput:
-        return ChunkOutput(chunks=[Chunk(text=chunk) for chunk in text.split()])
+    async def _chunk(self, text: str) -> ChunkingResult:
+        return ChunkingResult(chunks=[TextChunk(text=chunk) for chunk in text.split()])
 
 
 @pytest.fixture
@@ -28,7 +32,7 @@ def chunker(config: ChunkerConfig) -> WhitespaceChunker:
 
 
 async def test_base_chunker_chunk_empty_text(chunker: WhitespaceChunker):
-    assert await chunker.chunk("") == ChunkOutput(chunks=[])
+    assert await chunker.chunk("") == ChunkingResult(chunks=[])
 
 
 async def test_base_chunker_concrete_chunker(chunker: WhitespaceChunker):

--- a/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from llama_index.core.text_splitter import SentenceSplitter
 
-from kiln_ai.adapters.chunkers.base_chunker import ChunkOutput
+from kiln_ai.adapters.chunkers.base_chunker import ChunkingResult
 from kiln_ai.adapters.chunkers.fixed_window_chunker import FixedWindowChunker
 from kiln_ai.datamodel.chunk import (
     ChunkerConfig,
@@ -35,7 +35,7 @@ async def test_fixed_window_chunker_chunk_empty_text(
     # we should not even be calling the splitter if the text is empty
     chunker = mock_fixed_window_chunker_factory(100, 10)
     with patch.object(SentenceSplitter, "split_text") as mock_split_text:
-        assert await chunker.chunk("") == ChunkOutput(chunks=[])
+        assert await chunker.chunk("") == ChunkingResult(chunks=[])
         mock_split_text.assert_not_called()
 
 

--- a/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
@@ -6,11 +6,7 @@ from llama_index.core.text_splitter import SentenceSplitter
 
 from kiln_ai.adapters.chunkers.base_chunker import ChunkingResult
 from kiln_ai.adapters.chunkers.fixed_window_chunker import FixedWindowChunker
-from kiln_ai.datamodel.chunk import (
-    ChunkerConfig,
-    ChunkerType,
-    FixedWindowChunkerProperties,
-)
+from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
 
 
 @pytest.fixture
@@ -20,13 +16,24 @@ def mock_fixed_window_chunker_factory() -> Callable[[int, int], FixedWindowChunk
             ChunkerConfig(
                 name="test-chunker",
                 chunker_type=ChunkerType.FIXED_WINDOW,
-                properties=FixedWindowChunkerProperties(
-                    chunk_size=chunk_size, chunk_overlap=chunk_overlap
-                ),
+                properties={"chunk_size": chunk_size, "chunk_overlap": chunk_overlap},
             )
         )
 
     return create_chunker
+
+
+async def test_fixed_window_chunker_wrong_chunker_type(
+    mock_fixed_window_chunker_factory,
+):
+    with pytest.raises(ValueError):
+        FixedWindowChunker(
+            ChunkerConfig(
+                name="test-chunker",
+                chunker_type="wrong-chunker-type",
+                properties={"chunk_size": 100, "chunk_overlap": 10},
+            )
+        )
 
 
 async def test_fixed_window_chunker_chunk_empty_text(

--- a/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
@@ -1,0 +1,265 @@
+from typing import Callable
+from unittest.mock import patch
+
+import pytest
+from llama_index.core.text_splitter import SentenceSplitter
+
+from kiln_ai.adapters.chunkers.base_chunker import ChunkOutput
+from kiln_ai.adapters.chunkers.fixed_window_chunker import FixedWindowChunker
+from kiln_ai.datamodel.chunk import (
+    ChunkerConfig,
+    ChunkerType,
+    FixedWindowChunkerProperties,
+)
+
+
+@pytest.fixture
+def mock_fixed_window_chunker_factory() -> Callable[[int, int], FixedWindowChunker]:
+    def create_chunker(chunk_size: int, chunk_overlap: int) -> FixedWindowChunker:
+        return FixedWindowChunker(
+            ChunkerConfig(
+                name="test-chunker",
+                chunker_type=ChunkerType.FIXED_WINDOW,
+                properties=FixedWindowChunkerProperties(
+                    chunk_size=chunk_size, chunk_overlap=chunk_overlap
+                ),
+            )
+        )
+
+    return create_chunker
+
+
+async def test_fixed_window_chunker_chunk_empty_text(
+    mock_fixed_window_chunker_factory,
+):
+    # we should not even be calling the splitter if the text is empty
+    chunker = mock_fixed_window_chunker_factory(100, 10)
+    with patch.object(SentenceSplitter, "split_text") as mock_split_text:
+        assert await chunker.chunk("") == ChunkOutput(chunks=[])
+        mock_split_text.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "chunk_size,chunk_overlap,expected_chunks",
+    [(12, 6, 43), (256, 12, 2), (1024, 64, 1), (2048, 128, 1)],
+)
+async def test_fixed_window_chunker_concrete_chunker(
+    chunk_size, chunk_overlap, expected_chunks, mock_fixed_window_chunker_factory
+):
+    """
+    This test is to ensure that the chunker can split text (with markdown syntax). The specific values are just an illustration rather than values we
+    particularly care about.
+    """
+    chunker = mock_fixed_window_chunker_factory(chunk_size, chunk_overlap)
+    text_to_chunk = """# How Ice Cubes Make Drinks Colder
+
+## Introduction
+
+When you drop an ice cube into a drink, it does more than just float and look refreshing. It changes the thermal state of the liquid in a precise and physically predictable way. While it may seem like a simple act, the science behind how ice cubes make drinks colder is a fascinating interplay of thermodynamics, phase change, and heat transfer.
+
+## The Science of Cooling
+
+### Heat Transfer Basics
+
+At the core of the process is the concept of **heat exchange**. Heat naturally flows from warmer objects to colder ones until thermal equilibrium is reached. When an ice cube, which is at 0°C (32°F), is placed in a drink that is warmer than that, heat begins to flow from the liquid to the ice. This transfer of energy cools the drink while simultaneously warming the ice.
+
+### Latent Heat of Fusion
+
+However, it’s not just about the ice warming up. The real magic happens because of **latent heat**—specifically, the heat of fusion. When ice melts, it doesn’t instantly become the same temperature as the liquid around it. Instead, it absorbs a significant amount of energy just to change from a solid to a liquid, without its temperature rising. This phase change requires approximately 334 joules per gram of ice, all taken from the drink, which cools as a result."""
+
+    output = await chunker.chunk(text_to_chunk)
+    assert len(output.chunks) == expected_chunks, (
+        f"Expected {expected_chunks} chunks, got {len(output.chunks)}. If this is the result of an intentional change to chunk boundaries, please update the expected number of chunks in the test. Note that changes to chunk boundaries can have a downstream impact on retrieval."
+    )
+
+
+@pytest.mark.parametrize(
+    "chunk_size,chunk_overlap,expected_chunks",
+    [(12, 6, 120), (256, 12, 4), (1024, 64, 1), (2048, 128, 1)],
+)
+async def test_fixed_window_chunker_concrete_chunker_zh(
+    chunk_size, chunk_overlap, expected_chunks, mock_fixed_window_chunker_factory
+):
+    """
+    This test is to ensure that the chunker can split Chinese text. The specific values are just an illustration rather than values we
+    particularly care about.
+    """
+    chunker = mock_fixed_window_chunker_factory(chunk_size, chunk_overlap)
+    text_to_chunk = """火山是地表下在岩浆库中的高温岩浆及其有关的气体、碎屑从行星的地壳中喷出而形成的，具有特殊形態的地质结构。
+
+岩石圈由若干板块组成，它们漂浮在地幔的软流层之上，在板块的交界处岩石圈比较破碎，地下岩浆容易在此喷发形成火山。[1] 火山可以分为死火山、休眠火山和活火山。在一段时间内，没有出現喷发事件的活火山叫做睡火山（休眠火山）。另外还有一种泥火山，它在科学上严格来说不属于火山，但是许多社会大众也把它看作是火山的一种类型。
+
+火山爆发可能会造成许多危害，常伴有地震，影响范围不仅在火山爆发附近。其中一个危险是火山灰可能对飞机构成威胁，特别是那些喷气发动机，其中灰尘颗粒可以在高温下熔化; 熔化的颗粒随后粘附到涡轮机叶片并改变它们的形状，从而中断涡轮发动机的操作。大型爆发可能会影响气温，火山灰和硫酸液滴遮挡太阳辐射并冷却地球的低层大气（或对流层）; 然而，它们也吸收地球辐射的热量，从而使高层大气（或平流层）变暖。 历史上，火山冬天造成了灾难性的饥荒。
+
+虽然火山喷发会对人类造成危害，但同时它也带来一些好处。例如：可以促进宝石的形成；扩大陆地的面积（夏威夷群岛就是由火山喷发而形成的）；作为观光旅游考察景点，推动旅游业，如日本的富士山。[2] 专门研究火山活动的学科称为火山学[3]。
+"""
+
+    output = await chunker.chunk(text_to_chunk)
+    assert len(output.chunks) == expected_chunks, (
+        f"Expected {expected_chunks} chunks, got {len(output.chunks)}. If this is the result of an intentional change to chunk boundaries, please update the expected number of chunks in the test. Note that changes to chunk boundaries can have a downstream impact on retrieval."
+    )
+
+
+@pytest.mark.parametrize(
+    "chunk_size,chunk_overlap,expected_chunks",
+    [(12, 6, 39), (256, 12, 1), (1024, 64, 1), (2048, 128, 1)],
+)
+async def test_fixed_window_chunker_concrete_chunker_no_punctuation(
+    chunk_size, chunk_overlap, expected_chunks, mock_fixed_window_chunker_factory
+):
+    """
+    This test is to ensure that the chunker still does some splitting even if there is no punctuation. The specific values are just an illustration rather than values we
+    particularly care about.
+    """
+    chunker = mock_fixed_window_chunker_factory(chunk_size, chunk_overlap)
+    text_to_chunk = """how ice cubes make drinks colder introduction when you drop an ice cube into a drink it does more than just float and look refreshing it changes the thermal state of the liquid in a precise and physically predictable way while it may seem like a simple act the science behind how ice cubes make drinks colder is a fascinating interplay of thermodynamics phase change and heat transfer the science of cooling heat transfer basics at the core of the process is the concept of heat exchange heat naturally flows from warmer objects to colder ones until thermal equilibrium is reached when an ice cube which is at 0c 32f is placed in a drink that is warmer than that heat begins to flow from the liquid to the ice this transfer of energy cools the drink while simultaneously warming the ice latent heat of fusion however its not just about the ice warming up the real magic happens because of latent heat specifically the heat of fusion when ice melts it doesnt instantly become the same temperature as the liquid around it instead it absorbs a significant amount of energy just to change from a solid to a liquid without its temperature rising this phase change requires approximately 334 joules per gram of ice all taken from the drink which cools as a result"""
+
+    output = await chunker.chunk(text_to_chunk)
+    assert len(output.chunks) == expected_chunks, (
+        f"Expected {expected_chunks} chunks, got {len(output.chunks)}. If this is the result of an intentional change to chunk boundaries, please update the expected number of chunks in the test. Note that changes to chunk boundaries can have a downstream impact on retrieval."
+    )
+
+
+@pytest.mark.parametrize(
+    "chunk_size,chunk_overlap,expected_chunks",
+    [(12, 6, 106), (256, 12, 3), (1024, 64, 1), (2048, 128, 1)],
+)
+async def test_fixed_window_chunker_concrete_chunker_no_punctuation_zh(
+    chunk_size, chunk_overlap, expected_chunks, mock_fixed_window_chunker_factory
+):
+    """
+    This test is to ensure that the chunker still does some splitting even if there is no punctuation. The specific values are just an illustration rather than values we
+    particularly care about.
+    """
+    text_to_chunk = "火山是地表下在岩浆库中的高温岩浆及其有关的气体碎屑从行星的地壳中喷出而形成的具有特殊形態的地质结构岩石圈由若干板块组成它们漂浮在地幔的软流层之上在板块的交界处岩石圈比较破碎地下岩浆容易在此喷发形成火山火山可以分为死火山休眠火山和活火山在一段时间内没有出現喷发事件的活火山叫做睡火山休眠火山另外还有一种泥火山它在科学上严格来说不属于火山但是许多社会大众也把它看作是火山的一种类型火山爆发可能会造成许多危害常伴有地震影响范围不仅在火山爆发附近其中一个危险是火山灰可能对飞机构成威胁特别是那些喷气发动机其中灰尘颗粒可以在高温下熔化熔化的颗粒随后粘附到涡轮机叶片并改变它们的形状从而中断涡轮发动机的操作大型爆发可能会影响气温火山灰和硫酸液滴遮挡太阳辐射并冷却地球的低层大气或对流层然而它们也吸收地球辐射的热量从而使高层大气或平流层变暖历史上火山冬天造成了灾难性的饥荒虽然火山喷发会对人类造成危害但同时它也带来一些好处例如可以促进宝石的形成扩大陆地的面积夏威夷群岛就是由火山喷发而形成的作为观光旅游考察景点推动旅游业如日本的富士山专门研究火山活动的学科称为火山学"
+    chunker = mock_fixed_window_chunker_factory(chunk_size, chunk_overlap)
+    output = await chunker.chunk(text_to_chunk)
+    assert len(output.chunks) == expected_chunks, (
+        f"Expected {expected_chunks} chunks, got {len(output.chunks)}. If this is the result of an intentional change to chunk boundaries, please update the expected number of chunks in the test. Note that changes to chunk boundaries can have a downstream impact on retrieval."
+    )
+
+
+async def test_fixed_window_chunker_preserves_text_content(
+    mock_fixed_window_chunker_factory,
+):
+    """
+    Test that the chunker preserves the original text content when reassembled.
+    """
+    chunker = mock_fixed_window_chunker_factory(100, 10)
+    text_to_chunk = (
+        "This is a test sentence. This is another test sentence. And a third one."
+    )
+
+    output = await chunker.chunk(text_to_chunk)
+
+    # Reassemble the text from chunks
+    reassembled_text = " ".join(chunk.text for chunk in output.chunks)
+
+    # The reassembled text should contain all the original content
+    # (though spacing might differ due to chunking)
+    assert "This is a test sentence" in reassembled_text
+    assert "This is another test sentence" in reassembled_text
+    assert "And a third one" in reassembled_text
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["   ", "\n\n\n", "\t\t\t", " \n\t "],
+)
+async def test_fixed_window_chunker_handles_whitespace_only(
+    mock_fixed_window_chunker_factory,
+    text,
+):
+    """
+    Test that the chunker handles whitespace-only text appropriately.
+    """
+    chunker = mock_fixed_window_chunker_factory(100, 10)
+
+    output = await chunker.chunk(text)
+
+    # Should return empty chunks for whitespace-only text
+    assert len(output.chunks) == 0
+
+
+async def test_fixed_window_chunker_handles_special_characters(
+    mock_fixed_window_chunker_factory,
+):
+    """
+    Test that the chunker handles special characters and unicode properly.
+    """
+    chunker = mock_fixed_window_chunker_factory(50, 5)
+    text_with_special_chars = (
+        "Hello 🌍! This has emojis 🚀 and symbols ©®™. Also unicode: αβγδε."
+    )
+
+    output = await chunker.chunk(text_with_special_chars)
+
+    # Should create at least one chunk
+    assert len(output.chunks) > 0
+
+    # Reassemble and check that special characters are preserved
+    reassembled = " ".join(chunk.text for chunk in output.chunks)
+    assert "Hello" in reassembled
+    assert "This has emojis" in reassembled
+    assert "🌍" in reassembled
+    assert "🚀" in reassembled
+    assert "©®™" in reassembled
+    assert "αβγδε" in reassembled
+
+
+async def test_fixed_window_chunker_handles_single_character(
+    mock_fixed_window_chunker_factory,
+):
+    """
+    Test that the chunker handles single character text.
+    """
+    chunker = mock_fixed_window_chunker_factory(100, 10)
+
+    output = await chunker.chunk("A")
+    assert len(output.chunks) == 1
+    assert output.chunks[0].text == "A"
+
+
+async def test_fixed_window_chunker_handles_single_word(
+    mock_fixed_window_chunker_factory,
+):
+    """
+    Test that the chunker handles single word text.
+    """
+    chunker = mock_fixed_window_chunker_factory(100, 10)
+
+    output = await chunker.chunk("Hello")
+    assert len(output.chunks) == 1
+    assert output.chunks[0].text == "Hello"
+
+
+async def test_fixed_window_chunker_handles_single_sentence(
+    mock_fixed_window_chunker_factory,
+):
+    """
+    Test that the chunker handles single sentence text.
+    """
+    chunker = mock_fixed_window_chunker_factory(100, 10)
+
+    output = await chunker.chunk("This is a single sentence.")
+    assert len(output.chunks) == 1
+    assert output.chunks[0].text == "This is a single sentence."
+
+
+async def test_fixed_window_chunker_very_large_text(mock_fixed_window_chunker_factory):
+    """
+    Test that the chunker can handle very large text without issues.
+    """
+    chunker = mock_fixed_window_chunker_factory(100, 10)
+
+    # Create a large text by repeating a sentence
+    large_text = "This is a test sentence. " * 1000
+
+    output = await chunker.chunk(large_text)
+
+    # Should produce multiple chunks
+    assert len(output.chunks) > 1
+
+    # All chunks should have content
+    for chunk in output.chunks:
+        assert chunk.text.strip() != ""

--- a/libs/core/kiln_ai/adapters/chunkers/test_registry.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_registry.py
@@ -5,7 +5,7 @@ from kiln_ai.adapters.chunkers.registry import chunker_adapter_from_type
 from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
 
 
-def test_extractor_adapter_from_type():
+def test_chunker_adapter_from_type():
     chunker = chunker_adapter_from_type(
         ChunkerType.FIXED_WINDOW,
         ChunkerConfig(

--- a/libs/core/kiln_ai/adapters/chunkers/test_registry.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_registry.py
@@ -1,0 +1,28 @@
+import pytest
+
+from kiln_ai.adapters.chunkers.fixed_window_chunker import FixedWindowChunker
+from kiln_ai.adapters.chunkers.registry import chunker_adapter_from_type
+from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
+
+
+def test_extractor_adapter_from_type():
+    chunker = chunker_adapter_from_type(
+        ChunkerType.FIXED_WINDOW,
+        ChunkerConfig(
+            name="test-chunker",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties={
+                # do not use these values in production!
+                "chunk_size": 5555,
+                "chunk_overlap": 1111,
+            },
+        ),
+    )
+    assert isinstance(chunker, FixedWindowChunker)
+    assert chunker.chunker_config.properties.chunk_size == 5555
+    assert chunker.chunker_config.properties.chunk_overlap == 1111
+
+
+def test_chunker_adapter_from_type_invalid():
+    with pytest.raises(ValueError):
+        chunker_adapter_from_type("invalid-type", {})

--- a/libs/core/kiln_ai/adapters/chunkers/test_registry.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_registry.py
@@ -19,8 +19,8 @@ def test_chunker_adapter_from_type():
         ),
     )
     assert isinstance(chunker, FixedWindowChunker)
-    assert chunker.chunker_config.properties.chunk_size == 5555
-    assert chunker.chunker_config.properties.chunk_overlap == 1111
+    assert chunker.chunker_config.chunk_size() == 5555
+    assert chunker.chunker_config.chunk_overlap() == 1111
 
 
 def test_chunker_adapter_from_type_invalid():

--- a/libs/core/kiln_ai/datamodel/__init__.py
+++ b/libs/core/kiln_ai/datamodel/__init__.py
@@ -11,7 +11,7 @@ User docs: https://docs.getkiln.ai/developers/kiln-datamodel
 
 from __future__ import annotations
 
-from kiln_ai.datamodel import dataset_split, eval, extraction, strict_mode
+from kiln_ai.datamodel import chunk, dataset_split, eval, extraction, strict_mode
 from kiln_ai.datamodel.datamodel_enums import (
     FineTuneStatusType,
     Priority,
@@ -41,6 +41,7 @@ from kiln_ai.datamodel.task_run import TaskRun, Usage
 __all__ = [
     "strict_mode",
     "dataset_split",
+    "chunk",
     "eval",
     "extraction",
     "Task",

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -5,9 +5,12 @@ from pydantic import (
     BaseModel,
     Field,
     SerializationInfo,
+    ValidationInfo,
     field_serializer,
+    field_validator,
     model_validator,
 )
+from typing_extensions import Self
 
 from kiln_ai.datamodel.basemodel import (
     ID_TYPE,
@@ -20,26 +23,47 @@ if TYPE_CHECKING:
     from kiln_ai.datamodel.extraction import Extraction
     from kiln_ai.datamodel.project import Project
 
+DEFAULT_CHUNK_SIZE = 256
+DEFAULT_CHUNK_OVERLAP = 10
 
-class FixedWindowChunkerProperties(BaseModel):
-    chunk_size: int = Field(
-        description="The size of the chunk (in tokens) to use for chunking.",
-        default=256,
-    )
-    chunk_overlap: int = Field(
-        description="The overlap of the chunk to use for chunking.",
-        default=10,
-    )
 
-    @model_validator(mode="after")
-    def validate_chunk_overlap(self):
-        if self.chunk_overlap < 0:
+def validate_fixed_window_chunker_properties(
+    properties: dict[str, str | int | float | bool],
+) -> dict[str, str | int | float | bool]:
+    """Validate the properties for the fixed window chunker and set defaults if needed."""
+    chunk_overlap = properties.get("chunk_overlap")
+    chunk_size = properties.get("chunk_size")
+
+    # avoid a situation where user provides a chunk_overlap > DEFAULT_CHUNK_SIZE
+    if chunk_overlap is not None and chunk_size is None:
+        raise ValueError("Chunk size is required if chunk overlap is provided.")
+
+    if chunk_overlap is not None:
+        if not isinstance(chunk_overlap, int):
+            raise ValueError("Chunk overlap must be an integer.")
+        if chunk_overlap < 0:
             raise ValueError("Chunk overlap must be greater than or equal to 0.")
-        if self.chunk_size < 0:
+
+    if chunk_size is not None:
+        if not isinstance(chunk_size, int):
+            raise ValueError("Chunk size must be an integer.")
+        if chunk_size < 0:
             raise ValueError("Chunk size must be greater than 0.")
-        if self.chunk_overlap >= self.chunk_size:
-            raise ValueError("Chunk overlap must be less than chunk size.")
-        return self
+
+    if (
+        isinstance(chunk_overlap, int)
+        and isinstance(chunk_size, int)
+        and chunk_overlap >= chunk_size
+    ):
+        raise ValueError("Chunk overlap must be less than chunk size.")
+
+    def default_if_none(value: int | None, default: int) -> int:
+        return value if value is not None else default
+
+    return {
+        "chunk_overlap": default_if_none(chunk_overlap, DEFAULT_CHUNK_OVERLAP),
+        "chunk_size": default_if_none(chunk_size, DEFAULT_CHUNK_SIZE),
+    }
 
 
 class ChunkerType(str, Enum):
@@ -54,7 +78,7 @@ class ChunkerConfig(KilnParentedModel):
     chunker_type: ChunkerType = Field(
         description="This is used to determine the type of chunker to use.",
     )
-    properties: FixedWindowChunkerProperties = Field(
+    properties: dict[str, str | int | float | bool] = Field(
         description="Properties to be used to execute the chunker config. This is chunker_type specific and should serialize to a json dict.",
     )
 
@@ -63,6 +87,30 @@ class ChunkerConfig(KilnParentedModel):
         if self.parent is None or self.parent.__class__.__name__ != "Project":
             return None
         return self.parent  # type: ignore
+
+    @field_validator("properties")
+    @classmethod
+    def validate_properties(
+        cls, properties: dict[str, str | int | float | bool], info: ValidationInfo
+    ) -> dict[str, str | int | float | bool]:
+        if info.data.get("chunker_type") == ChunkerType.FIXED_WINDOW:
+            # do not trigger revalidation of properties
+            return validate_fixed_window_chunker_properties(properties)
+        return properties
+
+    def chunk_size(self) -> int | None:
+        if self.properties.get("chunk_size") is None:
+            return None
+        if not isinstance(self.properties["chunk_size"], int):
+            raise ValueError("Chunk size must be an integer.")
+        return self.properties["chunk_size"]
+
+    def chunk_overlap(self) -> int | None:
+        if self.properties.get("chunk_overlap") is None:
+            return None
+        if not isinstance(self.properties["chunk_overlap"], int):
+            raise ValueError("Chunk overlap must be an integer.")
+        return self.properties["chunk_overlap"]
 
 
 class Chunk(BaseModel):

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -125,7 +125,7 @@ class Chunk(BaseModel):
         return attachment.model_dump(mode="json", context=context)
 
 
-class DocumentChunked(KilnParentedModel):
+class ChunkedDocument(KilnParentedModel):
     name: str = NAME_FIELD
     description: str | None = Field(
         default=None,

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -1,0 +1,94 @@
+from enum import Enum
+from typing import TYPE_CHECKING, List, Union
+
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializationInfo,
+    field_serializer,
+    model_validator,
+)
+
+from kiln_ai.datamodel.basemodel import (
+    ID_TYPE,
+    NAME_FIELD,
+    KilnAttachmentModel,
+    KilnParentedModel,
+)
+
+if TYPE_CHECKING:
+    from kiln_ai.datamodel.extraction import Extraction
+    from kiln_ai.datamodel.project import Project
+
+
+class FixedWindowChunkerProperties(BaseModel):
+    chunk_size: int = Field(
+        description="The size of the chunk (in tokens) to use for chunking.",
+        default=256,
+    )
+    chunk_overlap: int = Field(
+        description="The overlap of the chunk to use for chunking.",
+        default=10,
+    )
+
+    @model_validator(mode="after")
+    def validate_chunk_overlap(self):
+        if self.chunk_overlap < 0:
+            raise ValueError("Chunk overlap must be greater than 0.")
+        if self.chunk_size < 0:
+            raise ValueError("Chunk size must be greater than 0.")
+        if self.chunk_overlap >= self.chunk_size:
+            raise ValueError("Chunk overlap must be less than chunk size.")
+        return self
+
+
+class ChunkerType(str, Enum):
+    FIXED_WINDOW = "fixed_window"
+
+
+class ChunkerConfig(KilnParentedModel):
+    name: str = NAME_FIELD
+    description: str | None = Field(
+        default=None, description="The description of the chunker config"
+    )
+    chunker_type: ChunkerType = Field(
+        description="This is used to determine the type of chunker to use.",
+    )
+    properties: FixedWindowChunkerProperties = Field(
+        description="Properties to be used to execute the chunker config. This is chunker_type specific and should serialize to a json dict.",
+    )
+
+    # Workaround to return typed parent without importing Project
+    def parent_project(self) -> Union["Project", None]:
+        if self.parent is None or self.parent.__class__.__name__ != "Project":
+            return None
+        return self.parent  # type: ignore
+
+
+class Chunk(BaseModel):
+    attachment: KilnAttachmentModel = Field(description="The attachment of the chunk.")
+
+    @field_serializer("attachment")
+    def serialize_attachment(
+        self, attachment: KilnAttachmentModel, info: SerializationInfo
+    ) -> dict:
+        context = info.context or {}
+        context["filename_prefix"] = "chunk_attachment"
+        return attachment.model_dump(mode="json", context=context)
+
+
+class DocumentChunked(KilnParentedModel):
+    name: str = NAME_FIELD
+    description: str | None = Field(
+        default=None,
+        description="The description of the document chunked.",
+    )
+    chunker_config_id: ID_TYPE = Field(
+        description="The ID of the chunker config that was used to chunk the document.",
+    )
+    chunks: List[Chunk] = Field(description="The chunks of the document.")
+
+    def parent_extraction(self) -> Union["Extraction", None]:
+        if self.parent is None or self.parent.__class__.__name__ != "Extraction":
+            return None
+        return self.parent  # type: ignore

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -8,9 +8,7 @@ from pydantic import (
     ValidationInfo,
     field_serializer,
     field_validator,
-    model_validator,
 )
-from typing_extensions import Self
 
 from kiln_ai.datamodel.basemodel import (
     ID_TYPE,

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -21,47 +21,33 @@ if TYPE_CHECKING:
     from kiln_ai.datamodel.extraction import Extraction
     from kiln_ai.datamodel.project import Project
 
-DEFAULT_CHUNK_SIZE = 256
-DEFAULT_CHUNK_OVERLAP = 10
-
 
 def validate_fixed_window_chunker_properties(
     properties: dict[str, str | int | float | bool],
 ) -> dict[str, str | int | float | bool]:
     """Validate the properties for the fixed window chunker and set defaults if needed."""
     chunk_overlap = properties.get("chunk_overlap")
+    if chunk_overlap is None:
+        raise ValueError("Chunk overlap is required.")
+
     chunk_size = properties.get("chunk_size")
+    if chunk_size is None:
+        raise ValueError("Chunk size is required.")
 
-    # avoid a situation where user provides a chunk_overlap > DEFAULT_CHUNK_SIZE
-    if chunk_overlap is not None and chunk_size is None:
-        raise ValueError("Chunk size is required if chunk overlap is provided.")
+    if not isinstance(chunk_overlap, int):
+        raise ValueError("Chunk overlap must be an integer.")
+    if chunk_overlap < 0:
+        raise ValueError("Chunk overlap must be greater than or equal to 0.")
 
-    if chunk_overlap is not None:
-        if not isinstance(chunk_overlap, int):
-            raise ValueError("Chunk overlap must be an integer.")
-        if chunk_overlap < 0:
-            raise ValueError("Chunk overlap must be greater than or equal to 0.")
+    if not isinstance(chunk_size, int):
+        raise ValueError("Chunk size must be an integer.")
+    if chunk_size <= 0:
+        raise ValueError("Chunk size must be greater than 0.")
 
-    if chunk_size is not None:
-        if not isinstance(chunk_size, int):
-            raise ValueError("Chunk size must be an integer.")
-        if chunk_size <= 0:
-            raise ValueError("Chunk size must be greater than 0.")
-
-    if (
-        isinstance(chunk_overlap, int)
-        and isinstance(chunk_size, int)
-        and chunk_overlap >= chunk_size
-    ):
+    if chunk_overlap >= chunk_size:
         raise ValueError("Chunk overlap must be less than chunk size.")
 
-    def default_if_none(value: int | None, default: int) -> int:
-        return value if value is not None else default
-
-    return {
-        "chunk_overlap": default_if_none(chunk_overlap, DEFAULT_CHUNK_OVERLAP),
-        "chunk_size": default_if_none(chunk_size, DEFAULT_CHUNK_SIZE),
-    }
+    return properties
 
 
 class ChunkerType(str, Enum):

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -126,11 +126,6 @@ class Chunk(BaseModel):
 
 
 class ChunkedDocument(KilnParentedModel):
-    name: str = NAME_FIELD
-    description: str | None = Field(
-        default=None,
-        description="The description of the document chunked.",
-    )
     chunker_config_id: ID_TYPE = Field(
         description="The ID of the chunker config that was used to chunk the document.",
     )

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -98,15 +98,17 @@ class ChunkerConfig(KilnParentedModel):
 
 
 class Chunk(BaseModel):
-    attachment: KilnAttachmentModel = Field(description="The attachment of the chunk.")
+    content: KilnAttachmentModel = Field(
+        description="The content of the chunk, stored as an attachment."
+    )
 
-    @field_serializer("attachment")
-    def serialize_attachment(
-        self, attachment: KilnAttachmentModel, info: SerializationInfo
+    @field_serializer("content")
+    def serialize_content(
+        self, content: KilnAttachmentModel, info: SerializationInfo
     ) -> dict:
         context = info.context or {}
-        context["filename_prefix"] = "chunk_attachment"
-        return attachment.model_dump(mode="json", context=context)
+        context["filename_prefix"] = "content"
+        return content.model_dump(mode="json", context=context)
 
 
 class ChunkedDocument(KilnParentedModel):

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -34,7 +34,7 @@ class FixedWindowChunkerProperties(BaseModel):
     @model_validator(mode="after")
     def validate_chunk_overlap(self):
         if self.chunk_overlap < 0:
-            raise ValueError("Chunk overlap must be greater than 0.")
+            raise ValueError("Chunk overlap must be greater than or equal to 0.")
         if self.chunk_size < 0:
             raise ValueError("Chunk size must be greater than 0.")
         if self.chunk_overlap >= self.chunk_size:

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -45,7 +45,7 @@ def validate_fixed_window_chunker_properties(
     if chunk_size is not None:
         if not isinstance(chunk_size, int):
             raise ValueError("Chunk size must be an integer.")
-        if chunk_size < 0:
+        if chunk_size <= 0:
             raise ValueError("Chunk size must be greater than 0.")
 
     if (

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -26,7 +26,6 @@ from kiln_ai.datamodel.chunk import DocumentChunked
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from kiln_ai.datamodel.chunk import DocumentChunked
     from kiln_ai.datamodel.project import Project
 
 logger = logging.getLogger(__name__)

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -21,7 +21,7 @@ from kiln_ai.datamodel.basemodel import (
     KilnParentedModel,
     KilnParentModel,
 )
-from kiln_ai.datamodel.chunk import DocumentChunked
+from kiln_ai.datamodel.chunk import ChunkedDocument
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +118,7 @@ class ExtractionSource(str, Enum):
 
 
 class Extraction(
-    KilnParentedModel, KilnParentModel, parent_of={"documents_chunked": DocumentChunked}
+    KilnParentedModel, KilnParentModel, parent_of={"chunked_documents": ChunkedDocument}
 ):
     source: ExtractionSource = Field(
         description="The source of the extraction.",
@@ -151,8 +151,8 @@ class Extraction(
             )
             raise ValueError(f"Failed to read extraction output: {e}")
 
-    def documents_chunked(self, readonly: bool = False) -> list[DocumentChunked]:
-        return super().documents_chunked(readonly=readonly)  # type: ignore
+    def chunked_documents(self, readonly: bool = False) -> list[ChunkedDocument]:
+        return super().chunked_documents(readonly=readonly)  # type: ignore
 
 
 class ExtractorConfig(KilnParentedModel):

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -21,10 +21,12 @@ from kiln_ai.datamodel.basemodel import (
     KilnParentedModel,
     KilnParentModel,
 )
+from kiln_ai.datamodel.chunk import DocumentChunked
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from kiln_ai.datamodel.chunk import DocumentChunked
     from kiln_ai.datamodel.project import Project
 
 logger = logging.getLogger(__name__)
@@ -116,7 +118,9 @@ class ExtractionSource(str, Enum):
     PASSTHROUGH = "passthrough"
 
 
-class Extraction(KilnParentedModel):
+class Extraction(
+    KilnParentedModel, KilnParentModel, parent_of={"documents_chunked": DocumentChunked}
+):
     source: ExtractionSource = Field(
         description="The source of the extraction.",
     )
@@ -147,6 +151,9 @@ class Extraction(KilnParentedModel):
                 f"Failed to read extraction output for {full_path}: {e}", exc_info=True
             )
             raise ValueError(f"Failed to read extraction output: {e}")
+
+    def documents_chunked(self, readonly: bool = False) -> list[DocumentChunked]:
+        return super().documents_chunked(readonly=readonly)  # type: ignore
 
 
 class ExtractorConfig(KilnParentedModel):

--- a/libs/core/kiln_ai/datamodel/project.py
+++ b/libs/core/kiln_ai/datamodel/project.py
@@ -1,6 +1,7 @@
 from pydantic import Field
 
 from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentModel
+from kiln_ai.datamodel.chunk import ChunkerConfig
 from kiln_ai.datamodel.extraction import Document, ExtractorConfig
 from kiln_ai.datamodel.task import Task
 
@@ -11,6 +12,7 @@ class Project(
         "tasks": Task,
         "documents": Document,
         "extractor_configs": ExtractorConfig,
+        "chunker_configs": ChunkerConfig,
     },
 ):
     """
@@ -35,3 +37,6 @@ class Project(
 
     def extractor_configs(self, readonly: bool = False) -> list[ExtractorConfig]:
         return super().extractor_configs(readonly=readonly)  # type: ignore
+
+    def chunker_configs(self, readonly: bool = False) -> list[ChunkerConfig]:
+        return super().chunker_configs(readonly=readonly)  # type: ignore

--- a/libs/core/kiln_ai/datamodel/test_chunk_models.py
+++ b/libs/core/kiln_ai/datamodel/test_chunk_models.py
@@ -1,0 +1,255 @@
+import tempfile
+import uuid
+from enum import Enum
+from pathlib import Path
+
+import pytest
+
+from kiln_ai.datamodel.basemodel import KilnAttachmentModel
+from kiln_ai.datamodel.chunk import (
+    Chunk,
+    ChunkerConfig,
+    ChunkerType,
+    DocumentChunked,
+    FixedWindowChunkerProperties,
+)
+from kiln_ai.datamodel.project import Project
+
+
+@pytest.fixture
+def mock_project(tmp_path):
+    project_root = tmp_path / str(uuid.uuid4())
+    project_root.mkdir()
+    project = Project(
+        name="Test Project",
+        description="Test description",
+        path=project_root / "project.kiln",
+    )
+    project.save_to_file()
+    return project
+
+
+class TestFixedWindowChunkerProperties:
+    """Test the FixedWindowChunkerProperties class."""
+
+    def test_default_values(self):
+        """Test that default values are set correctly."""
+        props = FixedWindowChunkerProperties()
+        assert props.chunk_size == 256
+        assert props.chunk_overlap == 10
+
+    def test_custom_values(self):
+        """Test that custom values can be set."""
+        props = FixedWindowChunkerProperties(chunk_size=512, chunk_overlap=20)
+        assert props.chunk_size == 512
+        assert props.chunk_overlap == 20
+
+    def test_validation_positive_values(self):
+        """Test that positive values are accepted."""
+        props = FixedWindowChunkerProperties(chunk_size=1, chunk_overlap=0)
+        assert props.chunk_size == 1
+        assert props.chunk_overlap == 0
+
+    def test_validation_negative_values(self):
+        """Test that negative values are rejected."""
+        with pytest.raises(ValueError):
+            FixedWindowChunkerProperties(chunk_size=-1, chunk_overlap=-1)
+
+    def test_validation_overlap_greater_than_chunk_size(self):
+        """Test that overlap is greater than chunk size."""
+        with pytest.raises(ValueError):
+            FixedWindowChunkerProperties(chunk_size=100, chunk_overlap=101)
+
+    def test_validation_overlap_less_than_zero(self):
+        """Test that overlap is less than zero."""
+        with pytest.raises(ValueError):
+            FixedWindowChunkerProperties(chunk_size=100, chunk_overlap=-1)
+
+
+class TestChunkerType:
+    """Test the ChunkerType enum."""
+
+    def test_enum_values(self):
+        """Test that enum has the expected values."""
+        assert ChunkerType.FIXED_WINDOW == "fixed_window"
+
+    def test_enum_inheritance(self):
+        """Test that ChunkerType inherits from str and Enum."""
+        assert issubclass(ChunkerType, str)
+        assert issubclass(ChunkerType, Enum)
+
+    def test_enum_comparison(self):
+        """Test enum comparison operations."""
+        assert ChunkerType.FIXED_WINDOW == "fixed_window"
+        assert ChunkerType.FIXED_WINDOW.value == "fixed_window"
+
+
+class TestChunkerConfig:
+    """Test the ChunkerConfig class."""
+
+    def test_required_fields(self):
+        """Test that required fields are properly validated."""
+        # Should work with all required fields
+        config = ChunkerConfig(
+            name="test-chunker",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties=FixedWindowChunkerProperties(),
+        )
+        assert config.name == "test-chunker"
+        assert config.chunker_type == ChunkerType.FIXED_WINDOW
+        assert isinstance(config.properties, FixedWindowChunkerProperties)
+
+    def test_optional_description(self):
+        """Test that description is optional."""
+        config = ChunkerConfig(
+            name="test-chunker",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties=FixedWindowChunkerProperties(),
+        )
+        assert config.description is None
+
+        config_with_desc = ChunkerConfig(
+            name="test-chunker",
+            description="A test chunker",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties=FixedWindowChunkerProperties(),
+        )
+        assert config_with_desc.description == "A test chunker"
+
+    def test_name_validation(self):
+        """Test name field validation."""
+        # Test valid name
+        config = ChunkerConfig(
+            name="valid-name_123",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties=FixedWindowChunkerProperties(),
+        )
+        assert config.name == "valid-name_123"
+
+        # Test invalid name (contains special characters)
+        with pytest.raises(ValueError):
+            ChunkerConfig(
+                name="invalid@name",
+                chunker_type=ChunkerType.FIXED_WINDOW,
+                properties=FixedWindowChunkerProperties(),
+            )
+
+        # Test empty name
+        with pytest.raises(ValueError):
+            ChunkerConfig(
+                name="",
+                chunker_type=ChunkerType.FIXED_WINDOW,
+                properties=FixedWindowChunkerProperties(),
+            )
+
+    def test_parent_project_method_no_parent(self):
+        """Test parent_project method when no parent is set."""
+        config = ChunkerConfig(
+            name="test-chunker",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties=FixedWindowChunkerProperties(),
+        )
+        assert config.parent_project() is None
+
+
+class TestChunk:
+    """Test the Chunk class."""
+
+    def test_required_fields(self):
+        """Test that required fields are properly validated."""
+        # Create a temporary file for the attachment
+        with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
+            tmp_file.write(b"test content")
+            tmp_path = Path(tmp_file.name)
+
+            attachment = KilnAttachmentModel.from_file(tmp_path)
+            chunk = Chunk(attachment=attachment)
+            assert chunk.attachment == attachment
+
+    def test_attachment_validation(self):
+        """Test that attachment field is properly validated."""
+        # Create a temporary file for the attachment
+        with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
+            tmp_file.write(b"test content")
+            tmp_path = Path(tmp_file.name)
+
+            # Test with valid attachment
+            attachment = KilnAttachmentModel.from_file(tmp_path)
+            chunk = Chunk(attachment=attachment)
+            assert chunk.attachment == attachment
+
+            # Test that attachment is required
+            with pytest.raises(ValueError):
+                Chunk(attachment=None)
+
+
+class TestDocumentChunked:
+    """Test the DocumentChunked class."""
+
+    def test_required_fields(self):
+        """Test that required fields are properly validated."""
+        chunks = []
+        doc = DocumentChunked(
+            chunks=chunks, chunker_config_id="fake-id", name="test-document-chunked"
+        )
+        assert doc.chunks == chunks
+
+    def test_with_chunks(self):
+        """Test with actual chunks."""
+        # Create a temporary file for the attachment
+        with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
+            tmp_file.write(b"test content")
+            tmp_path = Path(tmp_file.name)
+
+            attachment = KilnAttachmentModel.from_file(tmp_path)
+            chunk1 = Chunk(attachment=attachment)
+            chunk2 = Chunk(attachment=attachment)
+
+            chunks = [chunk1, chunk2]
+            doc = DocumentChunked(
+                chunks=chunks, chunker_config_id="fake-id", name="test-document-chunked"
+            )
+            assert doc.chunks == chunks
+            assert len(doc.chunks) == 2
+
+    def test_parent_extraction_method_no_parent(self):
+        """Test parent_extraction method when no parent is set."""
+        doc = DocumentChunked(
+            chunks=[], chunker_config_id="fake-id", name="test-document-chunked"
+        )
+        assert doc.parent_extraction() is None
+
+    def test_empty_chunks_list(self):
+        """Test that empty chunks list is valid."""
+        doc = DocumentChunked(
+            chunks=[], chunker_config_id="fake-id", name="test-document-chunked"
+        )
+        assert doc.chunks == []
+        assert len(doc.chunks) == 0
+
+    def test_chunks_validation(self):
+        """Test that chunks field validation works correctly."""
+        # Create a temporary file for the attachment
+        with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
+            tmp_file.write(b"test content")
+            tmp_path = Path(tmp_file.name)
+
+            # Test with valid list of chunks
+            attachment = KilnAttachmentModel.from_file(tmp_path)
+            chunk = Chunk(attachment=attachment)
+            chunks = [chunk]
+
+            doc = DocumentChunked(
+                chunks=chunks,
+                chunker_config_id="fake-id",
+                name="test-document-chunked",
+            )
+            assert doc.chunks == chunks
+
+            # Test that chunks must be a list
+            with pytest.raises(ValueError):
+                DocumentChunked(
+                    chunks=chunk,
+                    chunker_config_id="fake-id",
+                    name="test-document-chunked",
+                )

--- a/libs/core/kiln_ai/datamodel/test_chunk_models.py
+++ b/libs/core/kiln_ai/datamodel/test_chunk_models.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from kiln_ai.datamodel.basemodel import KilnAttachmentModel
-from kiln_ai.datamodel.chunk import Chunk, ChunkerConfig, ChunkerType, DocumentChunked
+from kiln_ai.datamodel.chunk import Chunk, ChunkedDocument, ChunkerConfig, ChunkerType
 from kiln_ai.datamodel.project import Project
 
 
@@ -258,13 +258,13 @@ class TestChunk:
                 Chunk(attachment=None)
 
 
-class TestDocumentChunked:
-    """Test the DocumentChunked class."""
+class TestChunkedDocument:
+    """Test the ChunkedDocument class."""
 
     def test_required_fields(self):
         """Test that required fields are properly validated."""
         chunks = []
-        doc = DocumentChunked(
+        doc = ChunkedDocument(
             chunks=chunks, chunker_config_id="fake-id", name="test-document-chunked"
         )
         assert doc.chunks == chunks
@@ -281,7 +281,7 @@ class TestDocumentChunked:
             chunk2 = Chunk(attachment=attachment)
 
             chunks = [chunk1, chunk2]
-            doc = DocumentChunked(
+            doc = ChunkedDocument(
                 chunks=chunks, chunker_config_id="fake-id", name="test-document-chunked"
             )
             assert doc.chunks == chunks
@@ -289,14 +289,14 @@ class TestDocumentChunked:
 
     def test_parent_extraction_method_no_parent(self):
         """Test parent_extraction method when no parent is set."""
-        doc = DocumentChunked(
+        doc = ChunkedDocument(
             chunks=[], chunker_config_id="fake-id", name="test-document-chunked"
         )
         assert doc.parent_extraction() is None
 
     def test_empty_chunks_list(self):
         """Test that empty chunks list is valid."""
-        doc = DocumentChunked(
+        doc = ChunkedDocument(
             chunks=[], chunker_config_id="fake-id", name="test-document-chunked"
         )
         assert doc.chunks == []
@@ -314,7 +314,7 @@ class TestDocumentChunked:
             chunk = Chunk(attachment=attachment)
             chunks = [chunk]
 
-            doc = DocumentChunked(
+            doc = ChunkedDocument(
                 chunks=chunks,
                 chunker_config_id="fake-id",
                 name="test-document-chunked",
@@ -323,7 +323,7 @@ class TestDocumentChunked:
 
             # Test that chunks must be a list
             with pytest.raises(ValueError):
-                DocumentChunked(
+                ChunkedDocument(
                     chunks=chunk,
                     chunker_config_id="fake-id",
                     name="test-document-chunked",

--- a/libs/core/kiln_ai/datamodel/test_chunk_models.py
+++ b/libs/core/kiln_ai/datamodel/test_chunk_models.py
@@ -26,20 +26,14 @@ def mock_project(tmp_path):
 class TestFixedWindowChunkerProperties:
     """Test the FixedWindowChunkerProperties class."""
 
-    def test_default_values(self):
-        """Test that default values are set correctly."""
-        config = ChunkerConfig(
-            name="test-chunker",
-            chunker_type=ChunkerType.FIXED_WINDOW,
-            properties={},
-        )
-        assert config.properties == {
-            "chunk_size": 256,
-            "chunk_overlap": 10,
-        }
-
-        assert config.chunk_size() == 256
-        assert config.chunk_overlap() == 10
+    def test_required_fields(self):
+        """Test that required fields are set correctly."""
+        with pytest.raises(ValueError):
+            ChunkerConfig(
+                name="test-chunker",
+                chunker_type=ChunkerType.FIXED_WINDOW,
+                properties={},
+            )
 
     def test_custom_values(self):
         """Test that custom values can be set."""
@@ -117,16 +111,13 @@ class TestFixedWindowChunkerProperties:
             )
 
     def test_validation_chunk_size_without_overlap(self):
-        """Test that chunk size without overlap will set overlap to default."""
-        config = ChunkerConfig(
-            name="test-chunker",
-            chunker_type=ChunkerType.FIXED_WINDOW,
-            properties={"chunk_size": 100},
-        )
-        assert config.properties == {
-            "chunk_size": 100,
-            "chunk_overlap": 10,
-        }
+        """Test that chunk size without overlap will raise an error."""
+        with pytest.raises(ValueError, match="Chunk overlap is required."):
+            ChunkerConfig(
+                name="test-chunker",
+                chunker_type=ChunkerType.FIXED_WINDOW,
+                properties={"chunk_size": 100},
+            )
 
     def test_validation_wrong_type(self):
         """Test that wrong type is rejected."""
@@ -168,27 +159,15 @@ class TestChunkerType:
 class TestChunkerConfig:
     """Test the ChunkerConfig class."""
 
-    def test_required_fields(self):
-        """Test that required fields are properly validated."""
-        # Should work with all required fields
-        config = ChunkerConfig(
-            name="test-chunker",
-            chunker_type=ChunkerType.FIXED_WINDOW,
-            properties={},
-        )
-        assert config.name == "test-chunker"
-        assert config.chunker_type == ChunkerType.FIXED_WINDOW
-        assert config.properties == {
-            "chunk_size": 256,
-            "chunk_overlap": 10,
-        }
-
     def test_optional_description(self):
         """Test that description is optional."""
         config = ChunkerConfig(
             name="test-chunker",
             chunker_type=ChunkerType.FIXED_WINDOW,
-            properties={},
+            properties={
+                "chunk_size": 100,
+                "chunk_overlap": 10,
+            },
         )
         assert config.description is None
 
@@ -196,7 +175,10 @@ class TestChunkerConfig:
             name="test-chunker",
             description="A test chunker",
             chunker_type=ChunkerType.FIXED_WINDOW,
-            properties={},
+            properties={
+                "chunk_size": 100,
+                "chunk_overlap": 10,
+            },
         )
         assert config_with_desc.description == "A test chunker"
 
@@ -206,7 +188,10 @@ class TestChunkerConfig:
         config = ChunkerConfig(
             name="valid-name_123",
             chunker_type=ChunkerType.FIXED_WINDOW,
-            properties={},
+            properties={
+                "chunk_size": 100,
+                "chunk_overlap": 10,
+            },
         )
         assert config.name == "valid-name_123"
 
@@ -231,7 +216,10 @@ class TestChunkerConfig:
         config = ChunkerConfig(
             name="test-chunker",
             chunker_type=ChunkerType.FIXED_WINDOW,
-            properties={},
+            properties={
+                "chunk_size": 100,
+                "chunk_overlap": 10,
+            },
         )
         assert config.parent_project() is None
 

--- a/libs/core/kiln_ai/datamodel/test_chunk_models.py
+++ b/libs/core/kiln_ai/datamodel/test_chunk_models.py
@@ -229,17 +229,17 @@ class TestChunk:
 
     def test_required_fields(self):
         """Test that required fields are properly validated."""
-        # Create a temporary file for the attachment
+        # Create a temporary file for the content
         with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
             tmp_file.write(b"test content")
             tmp_path = Path(tmp_file.name)
 
             attachment = KilnAttachmentModel.from_file(tmp_path)
-            chunk = Chunk(attachment=attachment)
-            assert chunk.attachment == attachment
+            chunk = Chunk(content=attachment)
+            assert chunk.content == attachment
 
-    def test_attachment_validation(self):
-        """Test that attachment field is properly validated."""
+    def test_content_validation(self):
+        """Test that content field is properly validated."""
         # Create a temporary file for the attachment
         with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
             tmp_file.write(b"test content")
@@ -247,12 +247,12 @@ class TestChunk:
 
             # Test with valid attachment
             attachment = KilnAttachmentModel.from_file(tmp_path)
-            chunk = Chunk(attachment=attachment)
-            assert chunk.attachment == attachment
+            chunk = Chunk(content=attachment)
+            assert chunk.content == attachment
 
             # Test that attachment is required
             with pytest.raises(ValueError):
-                Chunk(attachment=None)
+                Chunk(content=None)
 
 
 class TestChunkedDocument:
@@ -272,8 +272,8 @@ class TestChunkedDocument:
             tmp_path = Path(tmp_file.name)
 
             attachment = KilnAttachmentModel.from_file(tmp_path)
-            chunk1 = Chunk(attachment=attachment)
-            chunk2 = Chunk(attachment=attachment)
+            chunk1 = Chunk(content=attachment)
+            chunk2 = Chunk(content=attachment)
 
             chunks = [chunk1, chunk2]
             doc = ChunkedDocument(chunks=chunks, chunker_config_id="fake-id")
@@ -300,7 +300,7 @@ class TestChunkedDocument:
 
             # Test with valid list of chunks
             attachment = KilnAttachmentModel.from_file(tmp_path)
-            chunk = Chunk(attachment=attachment)
+            chunk = Chunk(content=attachment)
             chunks = [chunk]
 
             doc = ChunkedDocument(

--- a/libs/core/kiln_ai/datamodel/test_chunk_models.py
+++ b/libs/core/kiln_ai/datamodel/test_chunk_models.py
@@ -80,6 +80,15 @@ class TestFixedWindowChunkerProperties:
                 properties={"chunk_size": -1, "chunk_overlap": -1},
             )
 
+    def test_validation_zero_chunk_size(self):
+        """Test that zero chunk size is rejected."""
+        with pytest.raises(ValueError):
+            ChunkerConfig(
+                name="test-chunker",
+                chunker_type=ChunkerType.FIXED_WINDOW,
+                properties={"chunk_size": 0, "chunk_overlap": 0},
+            )
+
     def test_validation_overlap_greater_than_chunk_size(self):
         """Test that overlap is greater than chunk size."""
         with pytest.raises(ValueError):

--- a/libs/core/kiln_ai/datamodel/test_chunk_models.py
+++ b/libs/core/kiln_ai/datamodel/test_chunk_models.py
@@ -264,9 +264,7 @@ class TestChunkedDocument:
     def test_required_fields(self):
         """Test that required fields are properly validated."""
         chunks = []
-        doc = ChunkedDocument(
-            chunks=chunks, chunker_config_id="fake-id", name="test-document-chunked"
-        )
+        doc = ChunkedDocument(chunks=chunks, chunker_config_id="fake-id")
         assert doc.chunks == chunks
 
     def test_with_chunks(self):
@@ -281,24 +279,18 @@ class TestChunkedDocument:
             chunk2 = Chunk(attachment=attachment)
 
             chunks = [chunk1, chunk2]
-            doc = ChunkedDocument(
-                chunks=chunks, chunker_config_id="fake-id", name="test-document-chunked"
-            )
+            doc = ChunkedDocument(chunks=chunks, chunker_config_id="fake-id")
             assert doc.chunks == chunks
             assert len(doc.chunks) == 2
 
     def test_parent_extraction_method_no_parent(self):
         """Test parent_extraction method when no parent is set."""
-        doc = ChunkedDocument(
-            chunks=[], chunker_config_id="fake-id", name="test-document-chunked"
-        )
+        doc = ChunkedDocument(chunks=[], chunker_config_id="fake-id")
         assert doc.parent_extraction() is None
 
     def test_empty_chunks_list(self):
         """Test that empty chunks list is valid."""
-        doc = ChunkedDocument(
-            chunks=[], chunker_config_id="fake-id", name="test-document-chunked"
-        )
+        doc = ChunkedDocument(chunks=[], chunker_config_id="fake-id")
         assert doc.chunks == []
         assert len(doc.chunks) == 0
 
@@ -317,7 +309,6 @@ class TestChunkedDocument:
             doc = ChunkedDocument(
                 chunks=chunks,
                 chunker_config_id="fake-id",
-                name="test-document-chunked",
             )
             assert doc.chunks == chunks
 
@@ -326,5 +317,4 @@ class TestChunkedDocument:
                 ChunkedDocument(
                     chunks=chunk,
                     chunker_config_id="fake-id",
-                    name="test-document-chunked",
                 )

--- a/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
+++ b/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
@@ -1,0 +1,178 @@
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+
+from kiln_ai.datamodel.basemodel import KilnAttachmentModel
+from kiln_ai.datamodel.chunk import (
+    Chunk,
+    ChunkerConfig,
+    ChunkerType,
+    DocumentChunked,
+    FixedWindowChunkerProperties,
+)
+from kiln_ai.datamodel.extraction import (
+    Document,
+    Extraction,
+    ExtractionSource,
+    FileInfo,
+    Kind,
+)
+from kiln_ai.datamodel.project import Project
+
+
+@pytest.fixture
+def mock_project(tmp_path):
+    project_root = tmp_path / str(uuid.uuid4())
+    project_root.mkdir()
+    project = Project(
+        name="Test Project",
+        description="Test description",
+        path=project_root / "project.kiln",
+    )
+    project.save_to_file()
+    return project
+
+
+class TestIntegration:
+    """Integration tests for the chunk module."""
+
+    def test_full_workflow(self):
+        """Test a complete workflow with all classes."""
+        # Create chunker properties
+        properties = FixedWindowChunkerProperties(chunk_size=256, chunk_overlap=10)
+
+        # Create chunker config
+        config = ChunkerConfig(
+            name="test-chunker",
+            description="A test chunker configuration",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties=properties,
+        )
+
+        # Create a temporary file for the attachment
+        with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
+            tmp_file.write(b"test content")
+            tmp_path = Path(tmp_file.name)
+
+            # Create attachment
+            attachment = KilnAttachmentModel.from_file(tmp_path)
+
+            # Create chunks
+            chunk1 = Chunk(attachment=attachment)
+            chunk2 = Chunk(attachment=attachment)
+
+            # Create chunk document
+            doc = DocumentChunked(
+                chunks=[chunk1, chunk2],
+                chunker_config_id=config.id,
+                name="test-document-chunked",
+            )
+
+            # Verify the complete structure
+            assert config.name == "test-chunker"
+            assert config.chunker_type == ChunkerType.FIXED_WINDOW
+            assert config.properties.chunk_size == 256
+            assert len(doc.chunks) == 2
+            assert doc.chunks[0].attachment == attachment
+            assert doc.chunks[1].attachment == attachment
+
+    def test_serialization(self, mock_project):
+        """Test that models can be serialized and deserialized."""
+        properties = FixedWindowChunkerProperties(chunk_size=512, chunk_overlap=20)
+        config = ChunkerConfig(
+            name="serialization-test",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties=properties,
+            parent=mock_project,
+        )
+
+        # Save to file
+        config.save_to_file()
+
+        # Load from file
+        config_restored = ChunkerConfig.load_from_file(config.path)
+
+        assert config_restored.name == config.name
+        assert config_restored.chunker_type == config.chunker_type
+        assert config_restored.properties.chunk_size == config.properties.chunk_size
+        assert (
+            config_restored.properties.chunk_overlap == config.properties.chunk_overlap
+        )
+        assert config_restored.parent_project().id == mock_project.id
+
+    def test_enum_serialization(self):
+        """Test that ChunkerType enum serializes correctly."""
+        config = ChunkerConfig(
+            name="enum-test",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties=FixedWindowChunkerProperties(),
+        )
+
+        config_dict = config.model_dump()
+        assert config_dict["chunker_type"] == "fixed_window"
+
+        config_restored = ChunkerConfig.model_validate(config_dict)
+        assert config_restored.chunker_type == ChunkerType.FIXED_WINDOW
+
+    def test_relationships(self, mock_project):
+        """Test that relationships are properly validated."""
+
+        # Create a config
+        config = ChunkerConfig(
+            name="test-chunker",
+            chunker_type=ChunkerType.FIXED_WINDOW,
+            properties=FixedWindowChunkerProperties(),
+            parent=mock_project,
+        )
+        config.save_to_file()
+
+        # Dummy file we will use as attachment
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+            tmp_file.write(b"test content")
+            tmp_path = Path(tmp_file.name)
+
+        # Create a document
+        document = Document(
+            name="test-document",
+            description="Test document",
+            parent=mock_project,
+            original_file=FileInfo(
+                filename="test.txt",
+                size=100,
+                mime_type="text/plain",
+                attachment=KilnAttachmentModel.from_file(tmp_path),
+            ),
+            kind=Kind.DOCUMENT,
+        )
+        document.save_to_file()
+
+        # Create an extraction
+        extraction = Extraction(
+            source=ExtractionSource.PROCESSED,
+            extractor_config_id=config.id,
+            output=KilnAttachmentModel.from_file(tmp_path),
+            parent=document,
+        )
+        extraction.save_to_file()
+
+        # Create some chunks
+        chunks = [Chunk(attachment=KilnAttachmentModel.from_file(tmp_path))] * 3
+
+        document_chunked = DocumentChunked(
+            parent=extraction,
+            chunks=chunks,
+            chunker_config_id=config.id,
+            name="test-document-chunked",
+            description="Test document chunked",
+        )
+        document_chunked.save_to_file()
+
+        # Check that the document chunked is associated with the correct extraction
+        assert document_chunked.parent_extraction().id == extraction.id
+
+        for document_chunked_found in extraction.documents_chunked():
+            assert document_chunked.id == document_chunked_found.id
+
+        assert len(extraction.documents_chunked()) == 1

--- a/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
+++ b/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
@@ -5,13 +5,7 @@ from pathlib import Path
 import pytest
 
 from kiln_ai.datamodel.basemodel import KilnAttachmentModel
-from kiln_ai.datamodel.chunk import (
-    Chunk,
-    ChunkerConfig,
-    ChunkerType,
-    DocumentChunked,
-    FixedWindowChunkerProperties,
-)
+from kiln_ai.datamodel.chunk import Chunk, ChunkerConfig, ChunkerType, DocumentChunked
 from kiln_ai.datamodel.extraction import (
     Document,
     Extraction,
@@ -41,7 +35,7 @@ class TestIntegration:
     def test_full_workflow(self):
         """Test a complete workflow with all classes."""
         # Create chunker properties
-        properties = FixedWindowChunkerProperties(chunk_size=256, chunk_overlap=10)
+        properties = {"chunk_size": 256, "chunk_overlap": 10}
 
         # Create chunker config
         config = ChunkerConfig(
@@ -73,14 +67,15 @@ class TestIntegration:
             # Verify the complete structure
             assert config.name == "test-chunker"
             assert config.chunker_type == ChunkerType.FIXED_WINDOW
-            assert config.properties.chunk_size == 256
+            assert config.chunk_size() == 256
+            assert config.chunk_overlap() == 10
             assert len(doc.chunks) == 2
             assert doc.chunks[0].attachment == attachment
             assert doc.chunks[1].attachment == attachment
 
     def test_serialization(self, mock_project):
         """Test that models can be serialized and deserialized."""
-        properties = FixedWindowChunkerProperties(chunk_size=512, chunk_overlap=20)
+        properties = {"chunk_size": 512, "chunk_overlap": 20}
         config = ChunkerConfig(
             name="serialization-test",
             chunker_type=ChunkerType.FIXED_WINDOW,
@@ -96,10 +91,8 @@ class TestIntegration:
 
         assert config_restored.name == config.name
         assert config_restored.chunker_type == config.chunker_type
-        assert config_restored.properties.chunk_size == config.properties.chunk_size
-        assert (
-            config_restored.properties.chunk_overlap == config.properties.chunk_overlap
-        )
+        assert config_restored.chunk_size() == config.chunk_size()
+        assert config_restored.chunk_overlap() == config.chunk_overlap()
         assert config_restored.parent_project().id == mock_project.id
 
     def test_enum_serialization(self):
@@ -107,7 +100,7 @@ class TestIntegration:
         config = ChunkerConfig(
             name="enum-test",
             chunker_type=ChunkerType.FIXED_WINDOW,
-            properties=FixedWindowChunkerProperties(),
+            properties={"chunk_size": 512, "chunk_overlap": 20},
         )
 
         config_dict = config.model_dump()
@@ -123,7 +116,7 @@ class TestIntegration:
         config = ChunkerConfig(
             name="test-chunker",
             chunker_type=ChunkerType.FIXED_WINDOW,
-            properties=FixedWindowChunkerProperties(),
+            properties={"chunk_size": 512, "chunk_overlap": 20},
             parent=mock_project,
         )
         config.save_to_file()

--- a/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
+++ b/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
@@ -121,55 +121,55 @@ class TestIntegration:
         config.save_to_file()
 
         # Dummy file we will use as attachment
-        with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+        with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
             tmp_file.write(b"test content")
             tmp_path = Path(tmp_file.name)
 
-        # Create a document
-        document = Document(
-            name="test-document",
-            description="Test document",
-            parent=mock_project,
-            original_file=FileInfo(
-                filename="test.txt",
-                size=100,
-                mime_type="text/plain",
-                attachment=KilnAttachmentModel.from_file(tmp_path),
-            ),
-            kind=Kind.DOCUMENT,
-        )
-        document.save_to_file()
+            # Create a document
+            document = Document(
+                name="test-document",
+                description="Test document",
+                parent=mock_project,
+                original_file=FileInfo(
+                    filename="test.txt",
+                    size=100,
+                    mime_type="text/plain",
+                    attachment=KilnAttachmentModel.from_file(tmp_path),
+                ),
+                kind=Kind.DOCUMENT,
+            )
+            document.save_to_file()
 
-        # Create an extraction
-        extraction = Extraction(
-            source=ExtractionSource.PROCESSED,
-            extractor_config_id=config.id,
-            output=KilnAttachmentModel.from_file(tmp_path),
-            parent=document,
-        )
-        extraction.save_to_file()
+            # Create an extraction
+            extraction = Extraction(
+                source=ExtractionSource.PROCESSED,
+                extractor_config_id=config.id,
+                output=KilnAttachmentModel.from_file(tmp_path),
+                parent=document,
+            )
+            extraction.save_to_file()
 
-        # Create some chunks
-        chunks = [Chunk(content=KilnAttachmentModel.from_file(tmp_path))] * 3
+            # Create some chunks
+            chunks = [Chunk(content=KilnAttachmentModel.from_file(tmp_path))] * 3
 
-        chunked_document = ChunkedDocument(
-            parent=extraction,
-            chunks=chunks,
-            chunker_config_id=config.id,
-        )
-        chunked_document.save_to_file()
+            chunked_document = ChunkedDocument(
+                parent=extraction,
+                chunks=chunks,
+                chunker_config_id=config.id,
+            )
+            chunked_document.save_to_file()
 
-        assert len(chunked_document.chunks) == 3
+            assert len(chunked_document.chunks) == 3
 
-        # Check that the document chunked is associated with the correct extraction
-        assert chunked_document.parent_extraction().id == extraction.id
+            # Check that the document chunked is associated with the correct extraction
+            assert chunked_document.parent_extraction().id == extraction.id
 
-        for chunked_document_found in extraction.chunked_documents():
-            assert chunked_document.id == chunked_document_found.id
+            for chunked_document_found in extraction.chunked_documents():
+                assert chunked_document.id == chunked_document_found.id
 
-        assert len(extraction.chunked_documents()) == 1
+            assert len(extraction.chunked_documents()) == 1
 
-        # the chunks should have a filename prefixed with content_
-        for chunk in chunked_document.chunks:
-            filename = chunk.content.path.name
-            assert filename.startswith("content_")
+            # the chunks should have a filename prefixed with content_
+            for chunk in chunked_document.chunks:
+                filename = chunk.content.path.name
+                assert filename.startswith("content_")

--- a/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
+++ b/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
@@ -61,7 +61,6 @@ class TestIntegration:
             doc = ChunkedDocument(
                 chunks=[chunk1, chunk2],
                 chunker_config_id=config.id,
-                name="test-document-chunked",
             )
 
             # Verify the complete structure
@@ -157,8 +156,6 @@ class TestIntegration:
             parent=extraction,
             chunks=chunks,
             chunker_config_id=config.id,
-            name="test-document-chunked",
-            description="Test document chunked",
         )
         chunked_document.save_to_file()
 

--- a/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
+++ b/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
@@ -54,8 +54,8 @@ class TestIntegration:
             attachment = KilnAttachmentModel.from_file(tmp_path)
 
             # Create chunks
-            chunk1 = Chunk(attachment=attachment)
-            chunk2 = Chunk(attachment=attachment)
+            chunk1 = Chunk(content=attachment)
+            chunk2 = Chunk(content=attachment)
 
             # Create chunk document
             doc = ChunkedDocument(
@@ -69,8 +69,8 @@ class TestIntegration:
             assert config.chunk_size() == 256
             assert config.chunk_overlap() == 10
             assert len(doc.chunks) == 2
-            assert doc.chunks[0].attachment == attachment
-            assert doc.chunks[1].attachment == attachment
+            assert doc.chunks[0].content == attachment
+            assert doc.chunks[1].content == attachment
 
     def test_serialization(self, mock_project):
         """Test that models can be serialized and deserialized."""
@@ -150,7 +150,7 @@ class TestIntegration:
         extraction.save_to_file()
 
         # Create some chunks
-        chunks = [Chunk(attachment=KilnAttachmentModel.from_file(tmp_path))] * 3
+        chunks = [Chunk(content=KilnAttachmentModel.from_file(tmp_path))] * 3
 
         chunked_document = ChunkedDocument(
             parent=extraction,

--- a/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
+++ b/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from kiln_ai.datamodel.basemodel import KilnAttachmentModel
-from kiln_ai.datamodel.chunk import Chunk, ChunkerConfig, ChunkerType, DocumentChunked
+from kiln_ai.datamodel.chunk import Chunk, ChunkedDocument, ChunkerConfig, ChunkerType
 from kiln_ai.datamodel.extraction import (
     Document,
     Extraction,
@@ -58,7 +58,7 @@ class TestIntegration:
             chunk2 = Chunk(attachment=attachment)
 
             # Create chunk document
-            doc = DocumentChunked(
+            doc = ChunkedDocument(
                 chunks=[chunk1, chunk2],
                 chunker_config_id=config.id,
                 name="test-document-chunked",
@@ -153,19 +153,19 @@ class TestIntegration:
         # Create some chunks
         chunks = [Chunk(attachment=KilnAttachmentModel.from_file(tmp_path))] * 3
 
-        document_chunked = DocumentChunked(
+        chunked_document = ChunkedDocument(
             parent=extraction,
             chunks=chunks,
             chunker_config_id=config.id,
             name="test-document-chunked",
             description="Test document chunked",
         )
-        document_chunked.save_to_file()
+        chunked_document.save_to_file()
 
         # Check that the document chunked is associated with the correct extraction
-        assert document_chunked.parent_extraction().id == extraction.id
+        assert chunked_document.parent_extraction().id == extraction.id
 
-        for document_chunked_found in extraction.documents_chunked():
-            assert document_chunked.id == document_chunked_found.id
+        for chunked_document_found in extraction.chunked_documents():
+            assert chunked_document.id == chunked_document_found.id
 
-        assert len(extraction.documents_chunked()) == 1
+        assert len(extraction.chunked_documents()) == 1

--- a/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
+++ b/libs/core/kiln_ai/datamodel/test_extraction_chunk.py
@@ -159,6 +159,8 @@ class TestIntegration:
         )
         chunked_document.save_to_file()
 
+        assert len(chunked_document.chunks) == 3
+
         # Check that the document chunked is associated with the correct extraction
         assert chunked_document.parent_extraction().id == extraction.id
 
@@ -166,3 +168,8 @@ class TestIntegration:
             assert chunked_document.id == chunked_document_found.id
 
         assert len(extraction.chunked_documents()) == 1
+
+        # the chunks should have a filename prefixed with content_
+        for chunk in chunked_document.chunks:
+            filename = chunk.content.path.name
+            assert filename.startswith("content_")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "kiln-ai==0.5.3",
     "kiln-server",
     "kiln-studio-desktop",
+    "llama-index-core>=0.12.42",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -116,6 +116,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792 },
+]
+
+[[package]]
 name = "altgraph"
 version = "0.17.4"
 source = { registry = "https://pypi.org/simple" }
@@ -164,6 +176,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/0f/aafca9af9315aee06a89ffde799a10a582fe8de76c563ee80bbcdc08b3fb/attrs-24.2.0.tar.gz", hash = "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346", size = 792678 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/21/5b6702a7f963e95456c0de2d495f67bf5fd62840ac655dc451586d23d39a/attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2", size = 63001 },
+]
+
+[[package]]
+name = "banks"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "griffe" },
+    { name = "jinja2" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/34/2b6697f02ffb68bee50e5fd37d6c64432244d3245603fd62950169dfed7e/banks-2.1.2.tar.gz", hash = "sha256:a0651db9d14b57fa2e115e78f68dbb1b36fe226ad6eef96192542908b1d20c1f", size = 173332 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4a/7fdca29d1db62f5f5c3446bf8f668beacdb0b5a8aff4247574ddfddc6bcd/banks-2.1.2-py3-none-any.whl", hash = "sha256:7fba451069f6bea376483b8136a0f29cb1e6883133626d00e077e20a3d102c0e", size = 28064 },
 ]
 
 [[package]]
@@ -286,7 +314,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -367,6 +395,40 @@ toml = [
 ]
 
 [[package]]
+name = "dataclasses-json"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686 },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/97/06afe62762c9a8a86af0cfb7bfdab22a43ad17138b07af5b1a58442690a2/deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d", size = 2928744 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/c6/ac0b6c1e2d138f1002bcf799d330bd6d85084fece321e662a14223794041/Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec", size = 9998 },
+]
+
+[[package]]
+name = "dirtyjson"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/04/d24f6e645ad82ba0ef092fa17d9ef7a21953781663648a01c9371d9e8e98/dirtyjson-1.0.8.tar.gz", hash = "sha256:90ca4a18f3ff30ce849d100dcf4a003953c79d3a2348ef056f1d9c22231a25fd", size = 30782 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/69/1bcf70f81de1b4a9f21b3a62ec0c83bdff991c88d6cc2267d02408457e88/dirtyjson-1.0.8-py3-none-any.whl", hash = "sha256:125e27248435a58acace26d5c2c4c11a1c0de0a9c5124c5a94ba78e517d74f53", size = 25197 },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -432,6 +494,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dc/9c/0b15fb47b464e1b663b1acd1253a062aa5feecb07d4e597daea542ebd2b5/filelock-3.17.0.tar.gz", hash = "sha256:ee4e77401ef576ebb38cd7f13b9b28893194acc20a8e68e18730ba9c0e54660e", size = 18027 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/ec/00d68c4ddfedfe64159999e5f8a98fb8442729a63e2077eb9dcd89623d27/filelock-3.17.0-py3-none-any.whl", hash = "sha256:533dc2f7ba78dc2f0f531fc6c4940addf7b70a481e269a5a3b93be94ffbe8338", size = 16164 },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970 },
 ]
 
 [[package]]
@@ -663,7 +734,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.14.0"
+version = "1.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -671,12 +742,13 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "requests" },
+    { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/ba/c8e4c0b60c6dda40e51e2125709d097c2609fce1389b4a05f40cdd51c1ec/google_genai-1.14.0.tar.gz", hash = "sha256:7c608de5bb173486a546f5ec4562255c26bae72d33d758a3207bb26f695d0087", size = 169938 }
+sdist = { url = "https://files.pythonhosted.org/packages/49/8a/4a628e2e918f8c4a48ea778b68395b97b05b6873c6e528e78ccfb02a2c8d/google_genai-1.21.1.tar.gz", hash = "sha256:5412fde7f0b39574a4670a9a25e398824a12b3cddd632fdff66d1b9bcfdbfcb4", size = 205636 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/86/dde4cd028c8b0716b3f1f6d202647396a87a4ecbbdc7e4beb59b9d9284d3/google_genai-1.14.0-py3-none-any.whl", hash = "sha256:5916ee985bf69ac7b68c4488949225db71e21579afc7ba5ecd5321173b60d3b2", size = 168862 },
+    { url = "https://files.pythonhosted.org/packages/92/5c/659c2b992d631a873ae8fed612ce92af423fdc5f7d541dec7ce8f4b1789e/google_genai-1.21.1-py3-none-any.whl", hash = "sha256:fa6fa5311f9a757ce65cd528a938a0f309bb3032516015bf5b3022e63b2fc46b", size = 206388 },
 ]
 
 [[package]]
@@ -706,6 +778,69 @@ wheels = [
 [package.optional-dependencies]
 grpc = [
     { name = "grpcio" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/92/bb85bd6e80148a4d2e0c59f7c0c2891029f8fd510183afc7d8d2feeed9b6/greenlet-3.2.3.tar.gz", hash = "sha256:8b0dd8ae4c0d6f5e54ee55ba935eeb3d735a9b58a8a1e5b5cbab64e01a39f365", size = 185752 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/db/b4c12cff13ebac2786f4f217f06588bccd8b53d260453404ef22b121fc3a/greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be", size = 268977 },
+    { url = "https://files.pythonhosted.org/packages/52/61/75b4abd8147f13f70986df2801bf93735c1bd87ea780d70e3b3ecda8c165/greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac", size = 627351 },
+    { url = "https://files.pythonhosted.org/packages/35/aa/6894ae299d059d26254779a5088632874b80ee8cf89a88bca00b0709d22f/greenlet-3.2.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a433dbc54e4a37e4fff90ef34f25a8c00aed99b06856f0119dcf09fbafa16392", size = 638599 },
+    { url = "https://files.pythonhosted.org/packages/30/64/e01a8261d13c47f3c082519a5e9dbf9e143cc0498ed20c911d04e54d526c/greenlet-3.2.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:72e77ed69312bab0434d7292316d5afd6896192ac4327d44f3d613ecb85b037c", size = 634482 },
+    { url = "https://files.pythonhosted.org/packages/47/48/ff9ca8ba9772d083a4f5221f7b4f0ebe8978131a9ae0909cf202f94cd879/greenlet-3.2.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68671180e3849b963649254a882cd544a3c75bfcd2c527346ad8bb53494444db", size = 633284 },
+    { url = "https://files.pythonhosted.org/packages/e9/45/626e974948713bc15775b696adb3eb0bd708bec267d6d2d5c47bb47a6119/greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49c8cfb18fb419b3d08e011228ef8a25882397f3a859b9fe1436946140b6756b", size = 582206 },
+    { url = "https://files.pythonhosted.org/packages/b1/8e/8b6f42c67d5df7db35b8c55c9a850ea045219741bb14416255616808c690/greenlet-3.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efc6dc8a792243c31f2f5674b670b3a95d46fa1c6a912b8e310d6f542e7b0712", size = 1111412 },
+    { url = "https://files.pythonhosted.org/packages/05/46/ab58828217349500a7ebb81159d52ca357da747ff1797c29c6023d79d798/greenlet-3.2.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:731e154aba8e757aedd0781d4b240f1225b075b4409f1bb83b05ff410582cf00", size = 1135054 },
+    { url = "https://files.pythonhosted.org/packages/68/7f/d1b537be5080721c0f0089a8447d4ef72839039cdb743bdd8ffd23046e9a/greenlet-3.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:96c20252c2f792defe9a115d3287e14811036d51e78b3aaddbee23b69b216302", size = 296573 },
+    { url = "https://files.pythonhosted.org/packages/fc/2e/d4fcb2978f826358b673f779f78fa8a32ee37df11920dc2bb5589cbeecef/greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:784ae58bba89fa1fa5733d170d42486580cab9decda3484779f4759345b29822", size = 270219 },
+    { url = "https://files.pythonhosted.org/packages/16/24/929f853e0202130e4fe163bc1d05a671ce8dcd604f790e14896adac43a52/greenlet-3.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0921ac4ea42a5315d3446120ad48f90c3a6b9bb93dd9b3cf4e4d84a66e42de83", size = 630383 },
+    { url = "https://files.pythonhosted.org/packages/d1/b2/0320715eb61ae70c25ceca2f1d5ae620477d246692d9cc284c13242ec31c/greenlet-3.2.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d2971d93bb99e05f8c2c0c2f4aa9484a18d98c4c3bd3c62b65b7e6ae33dfcfaf", size = 642422 },
+    { url = "https://files.pythonhosted.org/packages/bd/49/445fd1a210f4747fedf77615d941444349c6a3a4a1135bba9701337cd966/greenlet-3.2.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c667c0bf9d406b77a15c924ef3285e1e05250948001220368e039b6aa5b5034b", size = 638375 },
+    { url = "https://files.pythonhosted.org/packages/7e/c8/ca19760cf6eae75fa8dc32b487e963d863b3ee04a7637da77b616703bc37/greenlet-3.2.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:592c12fb1165be74592f5de0d70f82bc5ba552ac44800d632214b76089945147", size = 637627 },
+    { url = "https://files.pythonhosted.org/packages/65/89/77acf9e3da38e9bcfca881e43b02ed467c1dedc387021fc4d9bd9928afb8/greenlet-3.2.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29e184536ba333003540790ba29829ac14bb645514fbd7e32af331e8202a62a5", size = 585502 },
+    { url = "https://files.pythonhosted.org/packages/97/c6/ae244d7c95b23b7130136e07a9cc5aadd60d59b5951180dc7dc7e8edaba7/greenlet-3.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93c0bb79844a367782ec4f429d07589417052e621aa39a5ac1fb99c5aa308edc", size = 1114498 },
+    { url = "https://files.pythonhosted.org/packages/89/5f/b16dec0cbfd3070658e0d744487919740c6d45eb90946f6787689a7efbce/greenlet-3.2.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:751261fc5ad7b6705f5f76726567375bb2104a059454e0226e1eef6c756748ba", size = 1139977 },
+    { url = "https://files.pythonhosted.org/packages/66/77/d48fb441b5a71125bcac042fc5b1494c806ccb9a1432ecaa421e72157f77/greenlet-3.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:83a8761c75312361aa2b5b903b79da97f13f556164a7dd2d5448655425bd4c34", size = 297017 },
+    { url = "https://files.pythonhosted.org/packages/f3/94/ad0d435f7c48debe960c53b8f60fb41c2026b1d0fa4a99a1cb17c3461e09/greenlet-3.2.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:25ad29caed5783d4bd7a85c9251c651696164622494c00802a139c00d639242d", size = 271992 },
+    { url = "https://files.pythonhosted.org/packages/93/5d/7c27cf4d003d6e77749d299c7c8f5fd50b4f251647b5c2e97e1f20da0ab5/greenlet-3.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88cd97bf37fe24a6710ec6a3a7799f3f81d9cd33317dcf565ff9950c83f55e0b", size = 638820 },
+    { url = "https://files.pythonhosted.org/packages/c6/7e/807e1e9be07a125bb4c169144937910bf59b9d2f6d931578e57f0bce0ae2/greenlet-3.2.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:baeedccca94880d2f5666b4fa16fc20ef50ba1ee353ee2d7092b383a243b0b0d", size = 653046 },
+    { url = "https://files.pythonhosted.org/packages/9d/ab/158c1a4ea1068bdbc78dba5a3de57e4c7aeb4e7fa034320ea94c688bfb61/greenlet-3.2.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:be52af4b6292baecfa0f397f3edb3c6092ce071b499dd6fe292c9ac9f2c8f264", size = 647701 },
+    { url = "https://files.pythonhosted.org/packages/cc/0d/93729068259b550d6a0288da4ff72b86ed05626eaf1eb7c0d3466a2571de/greenlet-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cc73378150b8b78b0c9fe2ce56e166695e67478550769536a6742dca3651688", size = 649747 },
+    { url = "https://files.pythonhosted.org/packages/f6/f6/c82ac1851c60851302d8581680573245c8fc300253fc1ff741ae74a6c24d/greenlet-3.2.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:706d016a03e78df129f68c4c9b4c4f963f7d73534e48a24f5f5a7101ed13dbbb", size = 605461 },
+    { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190 },
+    { url = "https://files.pythonhosted.org/packages/f5/e1/25297f70717abe8104c20ecf7af0a5b82d2f5a980eb1ac79f65654799f9f/greenlet-3.2.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:93d48533fade144203816783373f27a97e4193177ebaaf0fc396db19e5d61163", size = 1149055 },
+    { url = "https://files.pythonhosted.org/packages/1f/8f/8f9e56c5e82eb2c26e8cde787962e66494312dc8cb261c460e1f3a9c88bc/greenlet-3.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:7454d37c740bb27bdeddfc3f358f26956a07d5220818ceb467a483197d84f849", size = 297817 },
+    { url = "https://files.pythonhosted.org/packages/b1/cf/f5c0b23309070ae93de75c90d29300751a5aacefc0a3ed1b1d8edb28f08b/greenlet-3.2.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:500b8689aa9dd1ab26872a34084503aeddefcb438e2e7317b89b11eaea1901ad", size = 270732 },
+    { url = "https://files.pythonhosted.org/packages/48/ae/91a957ba60482d3fecf9be49bc3948f341d706b52ddb9d83a70d42abd498/greenlet-3.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a07d3472c2a93117af3b0136f246b2833fdc0b542d4a9799ae5f41c28323faef", size = 639033 },
+    { url = "https://files.pythonhosted.org/packages/6f/df/20ffa66dd5a7a7beffa6451bdb7400d66251374ab40b99981478c69a67a8/greenlet-3.2.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8704b3768d2f51150626962f4b9a9e4a17d2e37c8a8d9867bbd9fa4eb938d3b3", size = 652999 },
+    { url = "https://files.pythonhosted.org/packages/51/b4/ebb2c8cb41e521f1d72bf0465f2f9a2fd803f674a88db228887e6847077e/greenlet-3.2.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5035d77a27b7c62db6cf41cf786cfe2242644a7a337a0e155c80960598baab95", size = 647368 },
+    { url = "https://files.pythonhosted.org/packages/8e/6a/1e1b5aa10dced4ae876a322155705257748108b7fd2e4fae3f2a091fe81a/greenlet-3.2.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2d8aa5423cd4a396792f6d4580f88bdc6efcb9205891c9d40d20f6e670992efb", size = 650037 },
+    { url = "https://files.pythonhosted.org/packages/26/f2/ad51331a157c7015c675702e2d5230c243695c788f8f75feba1af32b3617/greenlet-3.2.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c724620a101f8170065d7dded3f962a2aea7a7dae133a009cada42847e04a7b", size = 608402 },
+    { url = "https://files.pythonhosted.org/packages/26/bc/862bd2083e6b3aff23300900a956f4ea9a4059de337f5c8734346b9b34fc/greenlet-3.2.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:873abe55f134c48e1f2a6f53f7d1419192a3d1a4e873bace00499a4e45ea6af0", size = 1119577 },
+    { url = "https://files.pythonhosted.org/packages/86/94/1fc0cc068cfde885170e01de40a619b00eaa8f2916bf3541744730ffb4c3/greenlet-3.2.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:024571bbce5f2c1cfff08bf3fbaa43bbc7444f580ae13b0099e95d0e6e67ed36", size = 1147121 },
+    { url = "https://files.pythonhosted.org/packages/27/1a/199f9587e8cb08a0658f9c30f3799244307614148ffe8b1e3aa22f324dea/greenlet-3.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:5195fb1e75e592dd04ce79881c8a22becdfa3e6f500e7feb059b1e6fdd54d3e3", size = 297603 },
+    { url = "https://files.pythonhosted.org/packages/d8/ca/accd7aa5280eb92b70ed9e8f7fd79dc50a2c21d8c73b9a0856f5b564e222/greenlet-3.2.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3d04332dddb10b4a211b68111dabaee2e1a073663d117dc10247b5b1642bac86", size = 271479 },
+    { url = "https://files.pythonhosted.org/packages/55/71/01ed9895d9eb49223280ecc98a557585edfa56b3d0e965b9fa9f7f06b6d9/greenlet-3.2.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8186162dffde068a465deab08fc72c767196895c39db26ab1c17c0b77a6d8b97", size = 683952 },
+    { url = "https://files.pythonhosted.org/packages/ea/61/638c4bdf460c3c678a0a1ef4c200f347dff80719597e53b5edb2fb27ab54/greenlet-3.2.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f4bfbaa6096b1b7a200024784217defedf46a07c2eee1a498e94a1b5f8ec5728", size = 696917 },
+    { url = "https://files.pythonhosted.org/packages/22/cc/0bd1a7eb759d1f3e3cc2d1bc0f0b487ad3cc9f34d74da4b80f226fde4ec3/greenlet-3.2.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ed6cfa9200484d234d8394c70f5492f144b20d4533f69262d530a1a082f6ee9a", size = 692443 },
+    { url = "https://files.pythonhosted.org/packages/67/10/b2a4b63d3f08362662e89c103f7fe28894a51ae0bc890fabf37d1d780e52/greenlet-3.2.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b0df6f63cd15012bed5401b47829cfd2e97052dc89da3cfaf2c779124eb892", size = 692995 },
+    { url = "https://files.pythonhosted.org/packages/5a/c6/ad82f148a4e3ce9564056453a71529732baf5448ad53fc323e37efe34f66/greenlet-3.2.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86c2d68e87107c1792e2e8d5399acec2487a4e993ab76c792408e59394d52141", size = 655320 },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/aab73ecaa6b3086a4c89863d94cf26fa84cbff63f52ce9bc4342b3087a06/greenlet-3.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:8c47aae8fbbfcf82cc13327ae802ba13c9c36753b67e760023fd116bc124a62a", size = 301236 },
+]
+
+[[package]]
+name = "griffe"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/3e/5aa9a61f7c3c47b0b52a1d930302992229d191bf4bc76447b324b731510a/griffe-1.7.3.tar.gz", hash = "sha256:52ee893c6a3a968b639ace8015bec9d36594961e156e23315c8e8e51401fa50b", size = 395137 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/c6/5c20af38c2a57c15d87f7f38bee77d63c1d2a3689f74fefaf35915dd12b2/griffe-1.7.3-py3-none-any.whl", hash = "sha256:c6b3ee30c2f0f17f30bcdef5068d6ab7a2a4f1b8bf1a3e74b56fffd21e1c5f75", size = 129303 },
 ]
 
 [[package]]
@@ -956,6 +1091,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/fe/0f5a938c54105553436dbff7a61dc4fed4b1b2c98852f8833beaf4d5968f/joblib-1.5.1.tar.gz", hash = "sha256:f4f86e351f39fe3d0d32a9f2c3d8af1ee4cec285aafcb27003dda5205576b444", size = 330475 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/4f/1195bbac8e0c2acc5f740661631d8d750dc38d4a32b23ee5df3cde6f4e0d/joblib-1.5.1-py3-none-any.whl", hash = "sha256:4719a31f054c7d766948dcd83e9613686b27114f190f717cec7eaa2084f8a74a", size = 307746 },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1051,6 +1195,7 @@ dependencies = [
     { name = "kiln-ai" },
     { name = "kiln-server" },
     { name = "kiln-studio-desktop" },
+    { name = "llama-index-core" },
 ]
 
 [package.dev-dependencies]
@@ -1069,6 +1214,7 @@ requires-dist = [
     { name = "kiln-ai", editable = "libs/core" },
     { name = "kiln-server", editable = "libs/server" },
     { name = "kiln-studio-desktop", virtual = "app/desktop" },
+    { name = "llama-index-core", specifier = ">=0.12.42" },
 ]
 
 [package.metadata.requires-dev]
@@ -1171,6 +1317,41 @@ wheels = [
 ]
 
 [[package]]
+name = "llama-index-core"
+version = "0.12.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiosqlite" },
+    { name = "banks" },
+    { name = "dataclasses-json" },
+    { name = "deprecated" },
+    { name = "dirtyjson" },
+    { name = "filetype" },
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "nest-asyncio" },
+    { name = "networkx" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "tenacity" },
+    { name = "tiktoken" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/67/ef1fc8c3b0676b524fd6b67a0e3e082996d768d227ed2b4b39f78119253b/llama_index_core-0.12.42.tar.gz", hash = "sha256:cff21fe15610826997c876a6b1d28d52727932c5f9c2af04b23e041a10f40a24", size = 7292833 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/92/dc47b702da141d0f617ee86d26b5bdb62ed9a52518d1a5f271e91337e4a7/llama_index_core-0.12.42-py3-none-any.whl", hash = "sha256:0534cd9a4f6113175aa406a47ae9a683b5a43fd55532e9dbbffa96838ff18e07", size = 7665930 },
+]
+
+[[package]]
 name = "macholib"
 version = "1.16.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1253,6 +1434,18 @@ wheels = [
 ]
 
 [[package]]
+name = "marshmallow"
+version = "3.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/5e/5e53d26b42ab75491cda89b871dab9e97c840bf12c63ec58a1919710cd06/marshmallow-3.26.1.tar.gz", hash = "sha256:e6d8affb6cb61d39d26402096dc0aee12d5a26d490a121f118d2e81dc0719dc6", size = 221825 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/75/51952c7b2d3873b44a0028b1bd26a25078c18f92f256608e8d1dc61b39fd/marshmallow-3.26.1-py3-none-any.whl", hash = "sha256:3350409f20a70a7e4e11a27661187b77cdcaeb20abca41c1454fe33636bea09c", size = 50878 },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1331,6 +1524,48 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/38/e0/4f5855037a72cd8a7a2f60a3952d9aa45feedb37ae7831642102604e8a37/multidict-6.1.0-cp313-cp313-win32.whl", hash = "sha256:3a37ffb35399029b45c6cc33640a92bef403c9fd388acce75cdc88f58bd19a81", size = 26426 },
     { url = "https://files.pythonhosted.org/packages/7e/a5/17ee3a4db1e310b7405f5d25834460073a8ccd86198ce044dfaf69eac073/multidict-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:e9aa71e15d9d9beaad2c6b9319edcdc0a49a43ef5c0a4c8265ca9ee7d6c67774", size = 28531 },
     { url = "https://files.pythonhosted.org/packages/99/b7/b9e70fde2c0f0c9af4cc5277782a89b66d35948ea3369ec9f598358c3ac5/multidict-6.1.0-py3-none-any.whl", hash = "sha256:48e171e52d1c4d33888e529b999e5900356b9ae588c2f09a52dcefb158b27506", size = 10051 },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963 },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195 },
+]
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263 },
+]
+
+[[package]]
+name = "nltk"
+version = "3.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/87/db8be88ad32c2d042420b6fd9ffd4a149f9a0d7f0e86b3f543be2eeeedd2/nltk-3.9.1.tar.gz", hash = "sha256:87d127bd3de4bd89a4f81265e5fa59cb1b199b27440175370f7417d2bc7ae868", size = 2904691 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl", hash = "sha256:4fa26829c5b00715afe3061398a8989dc643b92ce7dd93fb4585a70930d168a1", size = 1505442 },
 ]
 
 [[package]]
@@ -1520,6 +1755,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/00/20f40a935514037b7d3f87adfc87d2c538430ea625b63b3af8c3f5578e72/pillow-11.1.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d44ff19eea13ae4acdaaab0179fa68c0c6f2f45d66a4d8ec1eda7d6cecbcc15f", size = 3446208 },
     { url = "https://files.pythonhosted.org/packages/28/3c/7de681727963043e093c72e6c3348411b0185eab3263100d4490234ba2f6/pillow-11.1.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d3d8da4a631471dfaf94c10c85f5277b1f8e42ac42bade1ac67da4b4a7359b73", size = 3509746 },
     { url = "https://files.pythonhosted.org/packages/41/67/936f9814bdd74b2dfd4822f1f7725ab5d8ff4103919a1664eb4874c58b2f/pillow-11.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:4637b88343166249fe8aa94e7c4a62a180c4b3898283bb5d3d2fd5fe10d8e4e0", size = 2626353 },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567 },
 ]
 
 [[package]]
@@ -2397,6 +2641,56 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.41"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/66/45b165c595ec89aa7dcc2c1cd222ab269bc753f1fc7a1e68f8481bd957bf/sqlalchemy-2.0.41.tar.gz", hash = "sha256:edba70118c4be3c2b1f90754d308d0b79c6fe2c0fdc52d8ddf603916f83f4db9", size = 9689424 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/12/d7c445b1940276a828efce7331cb0cb09d6e5f049651db22f4ebb0922b77/sqlalchemy-2.0.41-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b1f09b6821406ea1f94053f346f28f8215e293344209129a9c0fcc3578598d7b", size = 2117967 },
+    { url = "https://files.pythonhosted.org/packages/6f/b8/cb90f23157e28946b27eb01ef401af80a1fab7553762e87df51507eaed61/sqlalchemy-2.0.41-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1936af879e3db023601196a1684d28e12f19ccf93af01bf3280a3262c4b6b4e5", size = 2107583 },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/eef84283a1c8164a207d898e063edf193d36a24fb6a5bb3ce0634b92a1e8/sqlalchemy-2.0.41-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2ac41acfc8d965fb0c464eb8f44995770239668956dc4cdf502d1b1ffe0d747", size = 3186025 },
+    { url = "https://files.pythonhosted.org/packages/bd/72/49d52bd3c5e63a1d458fd6d289a1523a8015adedbddf2c07408ff556e772/sqlalchemy-2.0.41-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81c24e0c0fde47a9723c81d5806569cddef103aebbf79dbc9fcbb617153dea30", size = 3186259 },
+    { url = "https://files.pythonhosted.org/packages/4f/9e/e3ffc37d29a3679a50b6bbbba94b115f90e565a2b4545abb17924b94c52d/sqlalchemy-2.0.41-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:23a8825495d8b195c4aa9ff1c430c28f2c821e8c5e2d98089228af887e5d7e29", size = 3126803 },
+    { url = "https://files.pythonhosted.org/packages/8a/76/56b21e363f6039978ae0b72690237b38383e4657281285a09456f313dd77/sqlalchemy-2.0.41-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:60c578c45c949f909a4026b7807044e7e564adf793537fc762b2489d522f3d11", size = 3148566 },
+    { url = "https://files.pythonhosted.org/packages/3b/92/11b8e1b69bf191bc69e300a99badbbb5f2f1102f2b08b39d9eee2e21f565/sqlalchemy-2.0.41-cp310-cp310-win32.whl", hash = "sha256:118c16cd3f1b00c76d69343e38602006c9cfb9998fa4f798606d28d63f23beda", size = 2086696 },
+    { url = "https://files.pythonhosted.org/packages/5c/88/2d706c9cc4502654860f4576cd54f7db70487b66c3b619ba98e0be1a4642/sqlalchemy-2.0.41-cp310-cp310-win_amd64.whl", hash = "sha256:7492967c3386df69f80cf67efd665c0f667cee67032090fe01d7d74b0e19bb08", size = 2110200 },
+    { url = "https://files.pythonhosted.org/packages/37/4e/b00e3ffae32b74b5180e15d2ab4040531ee1bef4c19755fe7926622dc958/sqlalchemy-2.0.41-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6375cd674fe82d7aa9816d1cb96ec592bac1726c11e0cafbf40eeee9a4516b5f", size = 2121232 },
+    { url = "https://files.pythonhosted.org/packages/ef/30/6547ebb10875302074a37e1970a5dce7985240665778cfdee2323709f749/sqlalchemy-2.0.41-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f8c9fdd15a55d9465e590a402f42082705d66b05afc3ffd2d2eb3c6ba919560", size = 2110897 },
+    { url = "https://files.pythonhosted.org/packages/9e/21/59df2b41b0f6c62da55cd64798232d7349a9378befa7f1bb18cf1dfd510a/sqlalchemy-2.0.41-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32f9dc8c44acdee06c8fc6440db9eae8b4af8b01e4b1aee7bdd7241c22edff4f", size = 3273313 },
+    { url = "https://files.pythonhosted.org/packages/62/e4/b9a7a0e5c6f79d49bcd6efb6e90d7536dc604dab64582a9dec220dab54b6/sqlalchemy-2.0.41-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c11ceb9a1f482c752a71f203a81858625d8df5746d787a4786bca4ffdf71c6", size = 3273807 },
+    { url = "https://files.pythonhosted.org/packages/39/d8/79f2427251b44ddee18676c04eab038d043cff0e764d2d8bb08261d6135d/sqlalchemy-2.0.41-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:911cc493ebd60de5f285bcae0491a60b4f2a9f0f5c270edd1c4dbaef7a38fc04", size = 3209632 },
+    { url = "https://files.pythonhosted.org/packages/d4/16/730a82dda30765f63e0454918c982fb7193f6b398b31d63c7c3bd3652ae5/sqlalchemy-2.0.41-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03968a349db483936c249f4d9cd14ff2c296adfa1290b660ba6516f973139582", size = 3233642 },
+    { url = "https://files.pythonhosted.org/packages/04/61/c0d4607f7799efa8b8ea3c49b4621e861c8f5c41fd4b5b636c534fcb7d73/sqlalchemy-2.0.41-cp311-cp311-win32.whl", hash = "sha256:293cd444d82b18da48c9f71cd7005844dbbd06ca19be1ccf6779154439eec0b8", size = 2086475 },
+    { url = "https://files.pythonhosted.org/packages/9d/8e/8344f8ae1cb6a479d0741c02cd4f666925b2bf02e2468ddaf5ce44111f30/sqlalchemy-2.0.41-cp311-cp311-win_amd64.whl", hash = "sha256:3d3549fc3e40667ec7199033a4e40a2f669898a00a7b18a931d3efb4c7900504", size = 2110903 },
+    { url = "https://files.pythonhosted.org/packages/3e/2a/f1f4e068b371154740dd10fb81afb5240d5af4aa0087b88d8b308b5429c2/sqlalchemy-2.0.41-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:81f413674d85cfd0dfcd6512e10e0f33c19c21860342a4890c3a2b59479929f9", size = 2119645 },
+    { url = "https://files.pythonhosted.org/packages/9b/e8/c664a7e73d36fbfc4730f8cf2bf930444ea87270f2825efbe17bf808b998/sqlalchemy-2.0.41-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:598d9ebc1e796431bbd068e41e4de4dc34312b7aa3292571bb3674a0cb415dd1", size = 2107399 },
+    { url = "https://files.pythonhosted.org/packages/5c/78/8a9cf6c5e7135540cb682128d091d6afa1b9e48bd049b0d691bf54114f70/sqlalchemy-2.0.41-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a104c5694dfd2d864a6f91b0956eb5d5883234119cb40010115fd45a16da5e70", size = 3293269 },
+    { url = "https://files.pythonhosted.org/packages/3c/35/f74add3978c20de6323fb11cb5162702670cc7a9420033befb43d8d5b7a4/sqlalchemy-2.0.41-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6145afea51ff0af7f2564a05fa95eb46f542919e6523729663a5d285ecb3cf5e", size = 3303364 },
+    { url = "https://files.pythonhosted.org/packages/6a/d4/c990f37f52c3f7748ebe98883e2a0f7d038108c2c5a82468d1ff3eec50b7/sqlalchemy-2.0.41-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b46fa6eae1cd1c20e6e6f44e19984d438b6b2d8616d21d783d150df714f44078", size = 3229072 },
+    { url = "https://files.pythonhosted.org/packages/15/69/cab11fecc7eb64bc561011be2bd03d065b762d87add52a4ca0aca2e12904/sqlalchemy-2.0.41-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41836fe661cc98abfae476e14ba1906220f92c4e528771a8a3ae6a151242d2ae", size = 3268074 },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/0c19ec16858585d37767b167fc9602593f98998a68a798450558239fb04a/sqlalchemy-2.0.41-cp312-cp312-win32.whl", hash = "sha256:a8808d5cf866c781150d36a3c8eb3adccfa41a8105d031bf27e92c251e3969d6", size = 2084514 },
+    { url = "https://files.pythonhosted.org/packages/7f/23/4c2833d78ff3010a4e17f984c734f52b531a8c9060a50429c9d4b0211be6/sqlalchemy-2.0.41-cp312-cp312-win_amd64.whl", hash = "sha256:5b14e97886199c1f52c14629c11d90c11fbb09e9334fa7bb5f6d068d9ced0ce0", size = 2111557 },
+    { url = "https://files.pythonhosted.org/packages/d3/ad/2e1c6d4f235a97eeef52d0200d8ddda16f6c4dd70ae5ad88c46963440480/sqlalchemy-2.0.41-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4eeb195cdedaf17aab6b247894ff2734dcead6c08f748e617bfe05bd5a218443", size = 2115491 },
+    { url = "https://files.pythonhosted.org/packages/cf/8d/be490e5db8400dacc89056f78a52d44b04fbf75e8439569d5b879623a53b/sqlalchemy-2.0.41-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d4ae769b9c1c7757e4ccce94b0641bc203bbdf43ba7a2413ab2523d8d047d8dc", size = 2102827 },
+    { url = "https://files.pythonhosted.org/packages/a0/72/c97ad430f0b0e78efaf2791342e13ffeafcbb3c06242f01a3bb8fe44f65d/sqlalchemy-2.0.41-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a62448526dd9ed3e3beedc93df9bb6b55a436ed1474db31a2af13b313a70a7e1", size = 3225224 },
+    { url = "https://files.pythonhosted.org/packages/5e/51/5ba9ea3246ea068630acf35a6ba0d181e99f1af1afd17e159eac7e8bc2b8/sqlalchemy-2.0.41-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc56c9788617b8964ad02e8fcfeed4001c1f8ba91a9e1f31483c0dffb207002a", size = 3230045 },
+    { url = "https://files.pythonhosted.org/packages/78/2f/8c14443b2acea700c62f9b4a8bad9e49fc1b65cfb260edead71fd38e9f19/sqlalchemy-2.0.41-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c153265408d18de4cc5ded1941dcd8315894572cddd3c58df5d5b5705b3fa28d", size = 3159357 },
+    { url = "https://files.pythonhosted.org/packages/fc/b2/43eacbf6ccc5276d76cea18cb7c3d73e294d6fb21f9ff8b4eef9b42bbfd5/sqlalchemy-2.0.41-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f67766965996e63bb46cfbf2ce5355fc32d9dd3b8ad7e536a920ff9ee422e23", size = 3197511 },
+    { url = "https://files.pythonhosted.org/packages/fa/2e/677c17c5d6a004c3c45334ab1dbe7b7deb834430b282b8a0f75ae220c8eb/sqlalchemy-2.0.41-cp313-cp313-win32.whl", hash = "sha256:bfc9064f6658a3d1cadeaa0ba07570b83ce6801a1314985bf98ec9b95d74e15f", size = 2082420 },
+    { url = "https://files.pythonhosted.org/packages/e9/61/e8c1b9b6307c57157d328dd8b8348ddc4c47ffdf1279365a13b2b98b8049/sqlalchemy-2.0.41-cp313-cp313-win_amd64.whl", hash = "sha256:82ca366a844eb551daff9d2e6e7a9e5e76d2612c8564f58db6c19a726869c1df", size = 2108329 },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/9ba22f01b5cdacc8f5ed0d22304718d2c758fce3fd49a5372b886a86f37c/sqlalchemy-2.0.41-py3-none-any.whl", hash = "sha256:57df5dc6fdb5ed1a88a1ed2195fd31927e705cad62dedd86b46972752a80f576", size = 1911224 },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.41.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2415,6 +2709,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252 },
+]
+
+[[package]]
+name = "tenacity"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4d/6a19536c50b849338fcbe9290d562b52cbdcf30d8963d3588a68a4107df1/tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78", size = 47309 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/3f/8ba87d9e287b9d385a02a7114ddcef61b26f86411e121c9003eb509a1773/tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687", size = 28165 },
 ]
 
 [[package]]
@@ -2512,7 +2815,7 @@ name = "tqdm"
 version = "4.66.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/34/bef135b27fe1864993a5284ad001157ee9b5538e859ac90f5b0e8cc8c9ec/tqdm-4.66.6.tar.gz", hash = "sha256:4bdd694238bef1485ce839d67967ab50af8f9272aab687c0d7702a01da0be090", size = 169533 }
 wheels = [
@@ -2541,6 +2844,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827 },
 ]
 
 [[package]]
@@ -2635,6 +2951,70 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155 },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884 },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/fc/e91cc220803d7bc4db93fb02facd8461c37364151b8494762cc88b0fbcef/wrapt-1.17.2.tar.gz", hash = "sha256:41388e9d4d1522446fe79d3213196bd9e3b301a336965b9e27ca2788ebd122f3", size = 55531 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/d1/1daec934997e8b160040c78d7b31789f19b122110a75eca3d4e8da0049e1/wrapt-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d57c572081fed831ad2d26fd430d565b76aa277ed1d30ff4d40670b1c0dd984", size = 53307 },
+    { url = "https://files.pythonhosted.org/packages/1b/7b/13369d42651b809389c1a7153baa01d9700430576c81a2f5c5e460df0ed9/wrapt-1.17.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b5e251054542ae57ac7f3fba5d10bfff615b6c2fb09abeb37d2f1463f841ae22", size = 38486 },
+    { url = "https://files.pythonhosted.org/packages/62/bf/e0105016f907c30b4bd9e377867c48c34dc9c6c0c104556c9c9126bd89ed/wrapt-1.17.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:80dd7db6a7cb57ffbc279c4394246414ec99537ae81ffd702443335a61dbf3a7", size = 38777 },
+    { url = "https://files.pythonhosted.org/packages/27/70/0f6e0679845cbf8b165e027d43402a55494779295c4b08414097b258ac87/wrapt-1.17.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a6e821770cf99cc586d33833b2ff32faebdbe886bd6322395606cf55153246c", size = 83314 },
+    { url = "https://files.pythonhosted.org/packages/0f/77/0576d841bf84af8579124a93d216f55d6f74374e4445264cb378a6ed33eb/wrapt-1.17.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b60fb58b90c6d63779cb0c0c54eeb38941bae3ecf7a73c764c52c88c2dcb9d72", size = 74947 },
+    { url = "https://files.pythonhosted.org/packages/90/ec/00759565518f268ed707dcc40f7eeec38637d46b098a1f5143bff488fe97/wrapt-1.17.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b870b5df5b71d8c3359d21be8f0d6c485fa0ebdb6477dda51a1ea54a9b558061", size = 82778 },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/7cffd26b1c607b0b0c8a9ca9d75757ad7620c9c0a9b4a25d3f8a1480fafc/wrapt-1.17.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4011d137b9955791f9084749cba9a367c68d50ab8d11d64c50ba1688c9b457f2", size = 81716 },
+    { url = "https://files.pythonhosted.org/packages/7e/09/dccf68fa98e862df7e6a60a61d43d644b7d095a5fc36dbb591bbd4a1c7b2/wrapt-1.17.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:1473400e5b2733e58b396a04eb7f35f541e1fb976d0c0724d0223dd607e0f74c", size = 74548 },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/067021fa3c8814952c5e228d916963c1115b983e21393289de15128e867e/wrapt-1.17.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3cedbfa9c940fdad3e6e941db7138e26ce8aad38ab5fe9dcfadfed9db7a54e62", size = 81334 },
+    { url = "https://files.pythonhosted.org/packages/4b/0d/9d4b5219ae4393f718699ca1c05f5ebc0c40d076f7e65fd48f5f693294fb/wrapt-1.17.2-cp310-cp310-win32.whl", hash = "sha256:582530701bff1dec6779efa00c516496968edd851fba224fbd86e46cc6b73563", size = 36427 },
+    { url = "https://files.pythonhosted.org/packages/72/6a/c5a83e8f61aec1e1aeef939807602fb880e5872371e95df2137142f5c58e/wrapt-1.17.2-cp310-cp310-win_amd64.whl", hash = "sha256:58705da316756681ad3c9c73fd15499aa4d8c69f9fd38dc8a35e06c12468582f", size = 38774 },
+    { url = "https://files.pythonhosted.org/packages/cd/f7/a2aab2cbc7a665efab072344a8949a71081eed1d2f451f7f7d2b966594a2/wrapt-1.17.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58", size = 53308 },
+    { url = "https://files.pythonhosted.org/packages/50/ff/149aba8365fdacef52b31a258c4dc1c57c79759c335eff0b3316a2664a64/wrapt-1.17.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4db983e7bca53819efdbd64590ee96c9213894272c776966ca6306b73e4affda", size = 38488 },
+    { url = "https://files.pythonhosted.org/packages/65/46/5a917ce85b5c3b490d35c02bf71aedaa9f2f63f2d15d9949cc4ba56e8ba9/wrapt-1.17.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9abc77a4ce4c6f2a3168ff34b1da9b0f311a8f1cfd694ec96b0603dff1c79438", size = 38776 },
+    { url = "https://files.pythonhosted.org/packages/ca/74/336c918d2915a4943501c77566db41d1bd6e9f4dbc317f356b9a244dfe83/wrapt-1.17.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b929ac182f5ace000d459c59c2c9c33047e20e935f8e39371fa6e3b85d56f4a", size = 83776 },
+    { url = "https://files.pythonhosted.org/packages/09/99/c0c844a5ccde0fe5761d4305485297f91d67cf2a1a824c5f282e661ec7ff/wrapt-1.17.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f09b286faeff3c750a879d336fb6d8713206fc97af3adc14def0cdd349df6000", size = 75420 },
+    { url = "https://files.pythonhosted.org/packages/b4/b0/9fc566b0fe08b282c850063591a756057c3247b2362b9286429ec5bf1721/wrapt-1.17.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a7ed2d9d039bd41e889f6fb9364554052ca21ce823580f6a07c4ec245c1f5d6", size = 83199 },
+    { url = "https://files.pythonhosted.org/packages/9d/4b/71996e62d543b0a0bd95dda485219856def3347e3e9380cc0d6cf10cfb2f/wrapt-1.17.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:129a150f5c445165ff941fc02ee27df65940fcb8a22a61828b1853c98763a64b", size = 82307 },
+    { url = "https://files.pythonhosted.org/packages/39/35/0282c0d8789c0dc9bcc738911776c762a701f95cfe113fb8f0b40e45c2b9/wrapt-1.17.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1fb5699e4464afe5c7e65fa51d4f99e0b2eadcc176e4aa33600a3df7801d6662", size = 75025 },
+    { url = "https://files.pythonhosted.org/packages/4f/6d/90c9fd2c3c6fee181feecb620d95105370198b6b98a0770cba090441a828/wrapt-1.17.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9a2bce789a5ea90e51a02dfcc39e31b7f1e662bc3317979aa7e5538e3a034f72", size = 81879 },
+    { url = "https://files.pythonhosted.org/packages/8f/fa/9fb6e594f2ce03ef03eddbdb5f4f90acb1452221a5351116c7c4708ac865/wrapt-1.17.2-cp311-cp311-win32.whl", hash = "sha256:4afd5814270fdf6380616b321fd31435a462019d834f83c8611a0ce7484c7317", size = 36419 },
+    { url = "https://files.pythonhosted.org/packages/47/f8/fb1773491a253cbc123c5d5dc15c86041f746ed30416535f2a8df1f4a392/wrapt-1.17.2-cp311-cp311-win_amd64.whl", hash = "sha256:acc130bc0375999da18e3d19e5a86403667ac0c4042a094fefb7eec8ebac7cf3", size = 38773 },
+    { url = "https://files.pythonhosted.org/packages/a1/bd/ab55f849fd1f9a58ed7ea47f5559ff09741b25f00c191231f9f059c83949/wrapt-1.17.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d5e2439eecc762cd85e7bd37161d4714aa03a33c5ba884e26c81559817ca0925", size = 53799 },
+    { url = "https://files.pythonhosted.org/packages/53/18/75ddc64c3f63988f5a1d7e10fb204ffe5762bc663f8023f18ecaf31a332e/wrapt-1.17.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fc7cb4c1c744f8c05cd5f9438a3caa6ab94ce8344e952d7c45a8ed59dd88392", size = 38821 },
+    { url = "https://files.pythonhosted.org/packages/48/2a/97928387d6ed1c1ebbfd4efc4133a0633546bec8481a2dd5ec961313a1c7/wrapt-1.17.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8fdbdb757d5390f7c675e558fd3186d590973244fab0c5fe63d373ade3e99d40", size = 38919 },
+    { url = "https://files.pythonhosted.org/packages/73/54/3bfe5a1febbbccb7a2f77de47b989c0b85ed3a6a41614b104204a788c20e/wrapt-1.17.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bb1d0dbf99411f3d871deb6faa9aabb9d4e744d67dcaaa05399af89d847a91d", size = 88721 },
+    { url = "https://files.pythonhosted.org/packages/25/cb/7262bc1b0300b4b64af50c2720ef958c2c1917525238d661c3e9a2b71b7b/wrapt-1.17.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d18a4865f46b8579d44e4fe1e2bcbc6472ad83d98e22a26c963d46e4c125ef0b", size = 80899 },
+    { url = "https://files.pythonhosted.org/packages/2a/5a/04cde32b07a7431d4ed0553a76fdb7a61270e78c5fd5a603e190ac389f14/wrapt-1.17.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc570b5f14a79734437cb7b0500376b6b791153314986074486e0b0fa8d71d98", size = 89222 },
+    { url = "https://files.pythonhosted.org/packages/09/28/2e45a4f4771fcfb109e244d5dbe54259e970362a311b67a965555ba65026/wrapt-1.17.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6d9187b01bebc3875bac9b087948a2bccefe464a7d8f627cf6e48b1bbae30f82", size = 86707 },
+    { url = "https://files.pythonhosted.org/packages/c6/d2/dcb56bf5f32fcd4bd9aacc77b50a539abdd5b6536872413fd3f428b21bed/wrapt-1.17.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9e8659775f1adf02eb1e6f109751268e493c73716ca5761f8acb695e52a756ae", size = 79685 },
+    { url = "https://files.pythonhosted.org/packages/80/4e/eb8b353e36711347893f502ce91c770b0b0929f8f0bed2670a6856e667a9/wrapt-1.17.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e8b2816ebef96d83657b56306152a93909a83f23994f4b30ad4573b00bd11bb9", size = 87567 },
+    { url = "https://files.pythonhosted.org/packages/17/27/4fe749a54e7fae6e7146f1c7d914d28ef599dacd4416566c055564080fe2/wrapt-1.17.2-cp312-cp312-win32.whl", hash = "sha256:468090021f391fe0056ad3e807e3d9034e0fd01adcd3bdfba977b6fdf4213ea9", size = 36672 },
+    { url = "https://files.pythonhosted.org/packages/15/06/1dbf478ea45c03e78a6a8c4be4fdc3c3bddea5c8de8a93bc971415e47f0f/wrapt-1.17.2-cp312-cp312-win_amd64.whl", hash = "sha256:ec89ed91f2fa8e3f52ae53cd3cf640d6feff92ba90d62236a81e4e563ac0e991", size = 38865 },
+    { url = "https://files.pythonhosted.org/packages/ce/b9/0ffd557a92f3b11d4c5d5e0c5e4ad057bd9eb8586615cdaf901409920b14/wrapt-1.17.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6ed6ffac43aecfe6d86ec5b74b06a5be33d5bb9243d055141e8cabb12aa08125", size = 53800 },
+    { url = "https://files.pythonhosted.org/packages/c0/ef/8be90a0b7e73c32e550c73cfb2fa09db62234227ece47b0e80a05073b375/wrapt-1.17.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35621ae4c00e056adb0009f8e86e28eb4a41a4bfa8f9bfa9fca7d343fe94f998", size = 38824 },
+    { url = "https://files.pythonhosted.org/packages/36/89/0aae34c10fe524cce30fe5fc433210376bce94cf74d05b0d68344c8ba46e/wrapt-1.17.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a604bf7a053f8362d27eb9fefd2097f82600b856d5abe996d623babd067b1ab5", size = 38920 },
+    { url = "https://files.pythonhosted.org/packages/3b/24/11c4510de906d77e0cfb5197f1b1445d4fec42c9a39ea853d482698ac681/wrapt-1.17.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cbabee4f083b6b4cd282f5b817a867cf0b1028c54d445b7ec7cfe6505057cf8", size = 88690 },
+    { url = "https://files.pythonhosted.org/packages/71/d7/cfcf842291267bf455b3e266c0c29dcb675b5540ee8b50ba1699abf3af45/wrapt-1.17.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:49703ce2ddc220df165bd2962f8e03b84c89fee2d65e1c24a7defff6f988f4d6", size = 80861 },
+    { url = "https://files.pythonhosted.org/packages/d5/66/5d973e9f3e7370fd686fb47a9af3319418ed925c27d72ce16b791231576d/wrapt-1.17.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8112e52c5822fc4253f3901b676c55ddf288614dc7011634e2719718eaa187dc", size = 89174 },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/8e17bb70f6ae25dabc1aaf990f86824e4fd98ee9cadf197054e068500d27/wrapt-1.17.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fee687dce376205d9a494e9c121e27183b2a3df18037f89d69bd7b35bcf59e2", size = 86721 },
+    { url = "https://files.pythonhosted.org/packages/6f/54/f170dfb278fe1c30d0ff864513cff526d624ab8de3254b20abb9cffedc24/wrapt-1.17.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:18983c537e04d11cf027fbb60a1e8dfd5190e2b60cc27bc0808e653e7b218d1b", size = 79763 },
+    { url = "https://files.pythonhosted.org/packages/4a/98/de07243751f1c4a9b15c76019250210dd3486ce098c3d80d5f729cba029c/wrapt-1.17.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:703919b1633412ab54bcf920ab388735832fdcb9f9a00ae49387f0fe67dad504", size = 87585 },
+    { url = "https://files.pythonhosted.org/packages/f9/f0/13925f4bd6548013038cdeb11ee2cbd4e37c30f8bfd5db9e5a2a370d6e20/wrapt-1.17.2-cp313-cp313-win32.whl", hash = "sha256:abbb9e76177c35d4e8568e58650aa6926040d6a9f6f03435b7a522bf1c487f9a", size = 36676 },
+    { url = "https://files.pythonhosted.org/packages/bf/ae/743f16ef8c2e3628df3ddfd652b7d4c555d12c84b53f3d8218498f4ade9b/wrapt-1.17.2-cp313-cp313-win_amd64.whl", hash = "sha256:69606d7bb691b50a4240ce6b22ebb319c1cfb164e5f6569835058196e0f3a845", size = 38871 },
+    { url = "https://files.pythonhosted.org/packages/3d/bc/30f903f891a82d402ffb5fda27ec1d621cc97cb74c16fea0b6141f1d4e87/wrapt-1.17.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:4a721d3c943dae44f8e243b380cb645a709ba5bd35d3ad27bc2ed947e9c68192", size = 56312 },
+    { url = "https://files.pythonhosted.org/packages/8a/04/c97273eb491b5f1c918857cd26f314b74fc9b29224521f5b83f872253725/wrapt-1.17.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:766d8bbefcb9e00c3ac3b000d9acc51f1b399513f44d77dfe0eb026ad7c9a19b", size = 40062 },
+    { url = "https://files.pythonhosted.org/packages/4e/ca/3b7afa1eae3a9e7fefe499db9b96813f41828b9fdb016ee836c4c379dadb/wrapt-1.17.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e496a8ce2c256da1eb98bd15803a79bee00fc351f5dfb9ea82594a3f058309e0", size = 40155 },
+    { url = "https://files.pythonhosted.org/packages/89/be/7c1baed43290775cb9030c774bc53c860db140397047cc49aedaf0a15477/wrapt-1.17.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40d615e4fe22f4ad3528448c193b218e077656ca9ccb22ce2cb20db730f8d306", size = 113471 },
+    { url = "https://files.pythonhosted.org/packages/32/98/4ed894cf012b6d6aae5f5cc974006bdeb92f0241775addad3f8cd6ab71c8/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5aaeff38654462bc4b09023918b7f21790efb807f54c000a39d41d69cf552cb", size = 101208 },
+    { url = "https://files.pythonhosted.org/packages/ea/fd/0c30f2301ca94e655e5e057012e83284ce8c545df7661a78d8bfca2fac7a/wrapt-1.17.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a7d15bbd2bc99e92e39f49a04653062ee6085c0e18b3b7512a4f2fe91f2d681", size = 109339 },
+    { url = "https://files.pythonhosted.org/packages/75/56/05d000de894c4cfcb84bcd6b1df6214297b8089a7bd324c21a4765e49b14/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e3890b508a23299083e065f435a492b5435eba6e304a7114d2f919d400888cc6", size = 110232 },
+    { url = "https://files.pythonhosted.org/packages/53/f8/c3f6b2cf9b9277fb0813418e1503e68414cd036b3b099c823379c9575e6d/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8c8b293cd65ad716d13d8dd3624e42e5a19cc2a2f1acc74b30c2c13f15cb61a6", size = 100476 },
+    { url = "https://files.pythonhosted.org/packages/a7/b1/0bb11e29aa5139d90b770ebbfa167267b1fc548d2302c30c8f7572851738/wrapt-1.17.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c82b8785d98cdd9fed4cac84d765d234ed3251bd6afe34cb7ac523cb93e8b4f", size = 106377 },
+    { url = "https://files.pythonhosted.org/packages/6a/e1/0122853035b40b3f333bbb25f1939fc1045e21dd518f7f0922b60c156f7c/wrapt-1.17.2-cp313-cp313t-win32.whl", hash = "sha256:13e6afb7fe71fe7485a4550a8844cc9ffbe263c0f1a1eea569bc7091d4898555", size = 37986 },
+    { url = "https://files.pythonhosted.org/packages/09/5e/1655cf481e079c1f22d0cabdd4e51733679932718dc23bf2db175f329b76/wrapt-1.17.2-cp313-cp313t-win_amd64.whl", hash = "sha256:eaf675418ed6b3b31c7a989fd007fa7c3be66ce14e5c3b27336383604c9da85c", size = 40750 },
+    { url = "https://files.pythonhosted.org/packages/2d/82/f56956041adef78f849db6b289b282e72b55ab8045a75abad81898c28d19/wrapt-1.17.2-py3-none-any.whl", hash = "sha256:b18f2d1533a71f069c7f82d524a52599053d4c7166e9dd374ae2136b7f40f7c8", size = 23594 },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Set up data model and fixed window chunker to chunk output text from extractions

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a modular text chunking framework with base and fixed window chunkers.
  * Added configuration options for chunk size and overlap with validation and default values.
  * Enabled management of chunker configurations within projects.
  * Added data models and APIs for chunked documents and their relationships to extractions and projects.
  * Provided a registry to instantiate chunkers by type.

* **Bug Fixes**
  * Enforced validation rules ensuring chunk overlap does not exceed chunk size and values are positive integers.

* **Tests**
  * Added comprehensive unit and integration tests covering chunking logic, configurations, data models, and parent-child relationships.

* **Chores**
  * Added a new dependency: `llama-index-core>=0.12.42`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->