### PR TITLE
chore: flag unused imports

### DIFF
--- a/app/desktop/studio_server/data_gen_api.py
+++ b/app/desktop/studio_server/data_gen_api.py
@@ -10,7 +10,6 @@ from kiln_ai.adapters.data_gen.data_gen_task import (
 from kiln_ai.adapters.ml_model_list import (
     default_structured_output_mode_for_model_provider,
 )
-from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig
 from kiln_ai.datamodel import DataSource, DataSourceType, PromptId, TaskRun
 from kiln_ai.datamodel.prompt_id import PromptGenerators
 from kiln_ai.datamodel.task import RunConfigProperties

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -6,13 +6,7 @@ from fastapi.responses import StreamingResponse
 from kiln_ai.adapters.eval.eval_runner import EvalRunner
 from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.prompt_builders import prompt_builder_from_id
-from kiln_ai.datamodel import (
-    BasePrompt,
-    DataSource,
-    DataSourceType,
-    Task,
-    TaskRun,
-)
+from kiln_ai.datamodel import BasePrompt, Task, TaskRun
 from kiln_ai.datamodel.basemodel import ID_TYPE
 from kiln_ai.datamodel.dataset_filters import DatasetFilterId, dataset_filter_from_id
 from kiln_ai.datamodel.eval import (

--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Dict, List

--- a/app/desktop/studio_server/repair_api.py
+++ b/app/desktop/studio_server/repair_api.py
@@ -1,5 +1,3 @@
-import json
-
 from fastapi import FastAPI, HTTPException
 from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.ml_model_list import (
@@ -8,13 +6,9 @@ from kiln_ai.adapters.ml_model_list import (
 from kiln_ai.adapters.repair.repair_task import RepairTaskRun
 from kiln_ai.datamodel import TaskRun
 from kiln_ai.datamodel.datamodel_enums import StructuredOutputMode
-from kiln_ai.datamodel.json_schema import validate_schema
 from kiln_ai.datamodel.prompt_id import PromptGenerators
 from kiln_ai.datamodel.task import RunConfigProperties
-from kiln_ai.datamodel.task_output import (
-    DataSource,
-    DataSourceType,
-)
+from kiln_ai.datamodel.task_output import DataSource, DataSourceType
 from kiln_ai.utils.config import Config
 from kiln_server.run_api import model_provider_from_string, task_and_run_from_id
 from pydantic import BaseModel, ConfigDict, Field, ValidationError

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -254,7 +254,7 @@ async def test_connect_openrouter():
 
 @pytest.fixture
 def mock_environ():
-    with patch("app.desktop.studio_server.provider_api.os.environ", {}) as mock_env:
+    with patch("os.environ", {}) as mock_env:
         yield mock_env
 
 

--- a/checks.sh
+++ b/checks.sh
@@ -14,8 +14,8 @@ headerStart="\n\033[4;34m=== "
 headerEnd=" ===\033[0m\n"
 
 echo "${headerStart}Checking Python: Ruff, format, check${headerEnd}"
-# I is import sorting
-uvx  ruff check --select I
+# I is import sorting, F401 is unused imports
+uvx  ruff check --select I,F401
 uvx ruff format --check .
 
 echo "${headerStart}Checking for Misspellings${headerEnd}"

--- a/libs/core/kiln_ai/adapters/chat/chat_formatter.py
+++ b/libs/core/kiln_ai/adapters/chat/chat_formatter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from enum import Enum
 from typing import Dict, List, Literal, Optional
 
 from kiln_ai.datamodel.datamodel_enums import ChatStrategy

--- a/libs/core/kiln_ai/adapters/eval/base_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/base_eval.py
@@ -7,12 +7,7 @@ from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig
 from kiln_ai.datamodel.eval import Eval, EvalConfig, EvalScores
 from kiln_ai.datamodel.json_schema import validate_schema_with_value_error
-from kiln_ai.datamodel.task import (
-    RunConfig,
-    RunConfigProperties,
-    TaskOutputRatingType,
-    TaskRun,
-)
+from kiln_ai.datamodel.task import RunConfig, TaskOutputRatingType, TaskRun
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 
 

--- a/libs/core/kiln_ai/adapters/fine_tune/base_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/base_finetune.py
@@ -3,12 +3,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from kiln_ai.adapters.ml_model_list import built_in_models
-from kiln_ai.datamodel import (
-    DatasetSplit,
-    FineTuneStatusType,
-    Task,
-)
+from kiln_ai.datamodel import DatasetSplit, FineTuneStatusType, Task
 from kiln_ai.datamodel import Finetune as FinetuneModel
 from kiln_ai.datamodel.datamodel_enums import ChatStrategy
 from kiln_ai.utils.name_generator import generate_memorable_name

--- a/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
@@ -1,15 +1,11 @@
 import json
 import tempfile
-from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Protocol
 from uuid import uuid4
 
-from kiln_ai.adapters.chat.chat_formatter import (
-    ChatMessage,
-    get_chat_formatter,
-)
+from kiln_ai.adapters.chat.chat_formatter import ChatMessage, get_chat_formatter
 from kiln_ai.datamodel import DatasetSplit, TaskRun
 from kiln_ai.datamodel.datamodel_enums import THINKING_DATA_STRATEGIES, ChatStrategy
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error

--- a/libs/core/kiln_ai/adapters/fine_tune/test_dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/test_dataset_formatter.py
@@ -857,7 +857,7 @@ def test_serialize_r1_style_message_missing_thinking(thinking, final_output):
 
 def test_vertex_gemini_role_map_coverage():
     """Test that VERTEX_GEMINI_ROLE_MAP covers all possible ChatMessage.role values"""
-    from typing import Literal, get_type_hints
+    from typing import get_type_hints
 
     # Get the Literal type from ChatMessage.role
     role_type = get_type_hints(ChatMessage)["role"]

--- a/libs/core/kiln_ai/adapters/fine_tune/test_vertex_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/test_vertex_finetune.py
@@ -1,6 +1,5 @@
-import time
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from google.cloud import storage
@@ -10,11 +9,7 @@ from vertexai.tuning import sft
 from kiln_ai.adapters.fine_tune.base_finetune import FineTuneStatusType
 from kiln_ai.adapters.fine_tune.dataset_formatter import DatasetFormat, DatasetFormatter
 from kiln_ai.adapters.fine_tune.vertex_finetune import VertexFinetune
-from kiln_ai.datamodel import (
-    DatasetSplit,
-    StructuredOutputMode,
-    Task,
-)
+from kiln_ai.datamodel import DatasetSplit, StructuredOutputMode, Task
 from kiln_ai.datamodel import Finetune as FinetuneModel
 from kiln_ai.datamodel.datamodel_enums import ChatStrategy
 from kiln_ai.datamodel.dataset_split import Train80Test20SplitDefinition

--- a/libs/core/kiln_ai/adapters/fine_tune/together_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/together_finetune.py
@@ -1,4 +1,4 @@
-from typing import Literal, Tuple
+from typing import Tuple
 
 from together import Together
 from together.types.files import FilePurpose

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Literal
+from typing import List, Literal
 
 from pydantic import BaseModel
 

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -4,7 +4,6 @@ import pytest
 
 from kiln_ai.adapters.ml_model_list import KilnModelProvider, StructuredOutputMode
 from kiln_ai.adapters.model_adapters.base_adapter import BaseAdapter, RunOutput
-from kiln_ai.adapters.parsers.request_formatters import request_formatter_from_id
 from kiln_ai.datamodel import Task
 from kiln_ai.datamodel.datamodel_enums import ChatStrategy
 from kiln_ai.datamodel.task import RunConfig, RunConfigProperties

--- a/libs/core/kiln_ai/adapters/parsers/parser_registry.py
+++ b/libs/core/kiln_ai/adapters/parsers/parser_registry.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 from kiln_ai.adapters.ml_model_list import ModelParserID
 from kiln_ai.adapters.parsers.base_parser import BaseParser
 from kiln_ai.adapters.parsers.r1_parser import R1ThinkingParser

--- a/libs/core/kiln_ai/adapters/parsers/r1_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/r1_parser.py
@@ -1,5 +1,4 @@
 from kiln_ai.adapters.parsers.base_parser import BaseParser
-from kiln_ai.adapters.parsers.json_parser import parse_json_string
 from kiln_ai.adapters.run_output import RunOutput
 
 

--- a/libs/core/kiln_ai/adapters/remote_config.py
+++ b/libs/core/kiln_ai/adapters/remote_config.py
@@ -1,5 +1,4 @@
 import argparse
-import asyncio
 import json
 import logging
 import os

--- a/libs/core/kiln_ai/adapters/repair/repair_task.py
+++ b/libs/core/kiln_ai/adapters/repair/repair_task.py
@@ -1,13 +1,8 @@
 import json
-from typing import Type
 
 from pydantic import BaseModel, Field
 
-from kiln_ai.adapters.prompt_builders import (
-    BasePromptBuilder,
-    SavedPromptBuilder,
-    prompt_builder_from_id,
-)
+from kiln_ai.adapters.prompt_builders import BasePromptBuilder, prompt_builder_from_id
 from kiln_ai.datamodel import Priority, Project, Task, TaskRequirement, TaskRun
 
 

--- a/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
@@ -13,10 +13,6 @@ from kiln_ai.adapters.model_adapters.litellm_adapter import (
     LiteLlmConfig,
 )
 from kiln_ai.adapters.ollama_tools import ollama_online
-from kiln_ai.adapters.prompt_builders import (
-    BasePromptBuilder,
-    SimpleChainOfThoughtPromptBuilder,
-)
 from kiln_ai.datamodel import PromptId
 from kiln_ai.datamodel.task import RunConfigProperties
 

--- a/libs/core/kiln_ai/datamodel/finetune.py
+++ b/libs/core/kiln_ai/datamodel/finetune.py
@@ -5,7 +5,6 @@ from typing_extensions import Self
 
 from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentedModel
 from kiln_ai.datamodel.datamodel_enums import (
-    THINKING_DATA_STRATEGIES,
     ChatStrategy,
     FineTuneStatusType,
     StructuredOutputMode,

--- a/libs/core/kiln_ai/datamodel/task_output.py
+++ b/libs/core/kiln_ai/datamodel/task_output.py
@@ -2,8 +2,6 @@ import json
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, Type, Union
 
-import jsonschema
-import jsonschema.exceptions
 from pydantic import BaseModel, Field, ValidationInfo, model_validator
 from typing_extensions import Self
 

--- a/libs/core/kiln_ai/datamodel/task_run.py
+++ b/libs/core/kiln_ai/datamodel/task_run.py
@@ -1,8 +1,6 @@
 import json
 from typing import TYPE_CHECKING, Dict, List, Union
 
-import jsonschema
-import jsonschema.exceptions
 from pydantic import BaseModel, Field, ValidationInfo, model_validator
 from typing_extensions import Self
 

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -1,7 +1,6 @@
 import pytest
 from pydantic import ValidationError
 
-from kiln_ai.datamodel import BasePrompt
 from kiln_ai.datamodel.basemodel import KilnParentModel
 from kiln_ai.datamodel.eval import (
     Eval,
@@ -11,9 +10,7 @@ from kiln_ai.datamodel.eval import (
     EvalRun,
 )
 from kiln_ai.datamodel.task import Task
-from kiln_ai.datamodel.task_output import (
-    TaskOutputRatingType,
-)
+from kiln_ai.datamodel.task_output import TaskOutputRatingType
 
 
 @pytest.fixture


### PR DESCRIPTION
## What does this PR do?

- Remove all currently unused imports.
- Add check for rule `F401` in `uvx ruff check` script (in `checks.sh`); ref: https://docs.astral.sh/ruff/rules/unused-import/
- Alter one awkward `test_provider_api` test that was mocking `os` relative to the `provider_api.py` file where it was imported but unused
  - should centralize `os` config somewhere to avoid scattered `os.environ` that are difficult to mock / track down

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up and consolidated import statements across multiple files to remove unused imports and simplify code structure.
  * Enhanced linting checks to detect unused imports in addition to import sorting.
* **Tests**
  * Updated test fixtures to patch environment variables more directly.
  * Removed unused imports and streamlined import statements in test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->