### PR TITLE
fix: better attachment file extension handling

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -110,7 +110,7 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_ollama)
 
 
-class MockFileFactoryMimeType(Enum):
+class MockFileFactoryMimeType(str, Enum):
     # documents
     PDF = "application/pdf"
     CSV = "text/csv"

--- a/libs/core/kiln_ai/adapters/extractors/test_extractor_runner.py
+++ b/libs/core/kiln_ai/adapters/extractors/test_extractor_runner.py
@@ -118,9 +118,7 @@ def test_collect_jobs_excludes_already_run_extraction(
         parent=mock_document,
         source=ExtractionSource.PROCESSED,
         extractor_config_id="other-extractor-config-id",
-        output=KilnAttachmentModel.from_data(
-            "test extraction output", "text/plain", ".txt"
-        ),
+        output=KilnAttachmentModel.from_data("test extraction output", "text/plain"),
     ).save_to_file()
 
     # should get the one job, since the document was not already extracted with this extractor config
@@ -134,9 +132,7 @@ def test_collect_jobs_excludes_already_run_extraction(
         parent=mock_document,
         source=ExtractionSource.PROCESSED,
         extractor_config_id=mock_extractor_config.id,
-        output=KilnAttachmentModel.from_data(
-            "test extraction output", "text/plain", ".txt"
-        ),
+        output=KilnAttachmentModel.from_data("test extraction output", "text/plain"),
     ).save_to_file()
 
     jobs = mock_extractor_runner.collect_jobs()

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -28,6 +28,7 @@ from typing_extensions import Self
 from kiln_ai.datamodel.model_cache import ModelCache
 from kiln_ai.utils.config import Config
 from kiln_ai.utils.formatting import snake_case
+from kiln_ai.utils.mime_type import guess_extension
 
 # ID is a 12 digit random integer string.
 # Should be unique per item, at least inside the context of a parent/child relationship.
@@ -179,13 +180,11 @@ class KilnAttachmentModel(BaseModel):
         return target_path
 
     @classmethod
-    def from_data(
-        cls, data: str | bytes, mime_type: str, suffix: str | None = None
-    ) -> Self:
+    def from_data(cls, data: str | bytes, mime_type: str) -> Self:
         """Create an attachment from str or byte data, in a temp file. The attachment is persisted to
         its permanent location when the model is saved.
         """
-        extension = suffix or mimetypes.guess_extension(mime_type) or ".unknown"
+        extension = guess_extension(mime_type) or ".unknown"
         temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=extension)
         if isinstance(data, str):
             temp_file.write(data.encode("utf-8"))

--- a/libs/core/kiln_ai/utils/mime_type.py
+++ b/libs/core/kiln_ai/utils/mime_type.py
@@ -17,3 +17,22 @@ def guess_mime_type(filename: str) -> str | None:
 
     mime_type, _ = mimetypes.guess_type(filename_normalized)
     return mime_type
+
+
+def guess_extension(mime_type: str) -> str | None:
+    mapping = {
+        "application/pdf": ".pdf",
+        "image/png": ".png",
+        "video/mp4": ".mp4",
+        "audio/ogg": ".ogg",
+        "text/markdown": ".md",
+        "text/plain": ".txt",
+        "text/html": ".html",
+        "text/csv": ".csv",
+        "image/jpeg": ".jpeg",
+        "image/jpg": ".jpeg",
+        "audio/mpeg": ".mp3",
+        "audio/wav": ".wav",
+        "video/quicktime": ".mov",
+    }
+    return mapping.get(mime_type)


### PR DESCRIPTION
## What does this PR do?

Fix a bug where for some file types (`.mov` / `video/quicktime`), we fail to infer the `extension` of the attachment (after loading it from bytes) and the resulting attachment file gets written with an `.unknown` file extension.

Changes:
- add mapping to resolve `mimetype -> extension`; keeping fallback to `.unknown` if not found
- remove optional `suffix` (was not used and was confusing; could reintroduce as an `extension_override` in the future, should we need to)

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved attachment handling to automatically assign correct file extensions based on MIME type when creating attachments from raw data.
  * Added support for unknown or generic MIME types, defaulting to a ".unknown" file extension.

* **Bug Fixes**
  * Enhanced file extension detection for a wider range of MIME types.

* **Tests**
  * Added comprehensive tests to verify correct file extension assignment for various MIME types and unknown types during attachment creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->