### PR TITLE
feat: RAG pipeline datamodel

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -611,6 +611,108 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/projects/{project_id}/chunker_configs/{chunker_config_id}/create_chunker_config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Chunker Config */
+        post: operations["create_chunker_config_api_projects__project_id__chunker_configs__chunker_config_id__create_chunker_config_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/chunker_configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Chunker Configs */
+        get: operations["get_chunker_configs_api_projects__project_id__chunker_configs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/embedding_configs/{embedding_config_id}/create_embedding_config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Embedding Config */
+        post: operations["create_embedding_config_api_projects__project_id__embedding_configs__embedding_config_id__create_embedding_config_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/embedding_configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Embedding Configs */
+        get: operations["get_embedding_configs_api_projects__project_id__embedding_configs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/rag_pipelines/create_rag_pipeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Rag Pipeline */
+        post: operations["create_rag_pipeline_api_projects__project_id__rag_pipelines_create_rag_pipeline_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/rag_pipelines": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Rag Pipelines */
+        get: operations["get_rag_pipelines_api_projects__project_id__rag_pipelines_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/providers/models": {
         parameters: {
             query?: never;
@@ -1482,6 +1584,51 @@ export interface components {
          * @enum {string}
          */
         ChatStrategy: "final_only" | "final_and_intermediate" | "two_message_cot" | "final_and_intermediate_r1_compatible";
+        /** ChunkerConfig */
+        ChunkerConfig: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description A name for this entity.
+             */
+            name: string;
+            /**
+             * Description
+             * @description The description of the chunker config
+             */
+            description?: string | null;
+            /** @description This is used to determine the type of chunker to use. */
+            chunker_type: components["schemas"]["ChunkerType"];
+            /**
+             * Properties
+             * @description Properties to be used to execute the chunker config. This is chunker_type specific and should serialize to a json dict.
+             */
+            properties: {
+                [key: string]: string | number | boolean;
+            };
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * ChunkerType
+         * @enum {string}
+         */
+        ChunkerType: "fixed_window";
         /** CorrelationResult */
         CorrelationResult: {
             /** Mean Absolute Error */
@@ -1499,6 +1646,23 @@ export interface components {
             /** Kendalltau Correlation */
             kendalltau_correlation: number | null;
         };
+        /** CreateChunkerConfigRequest */
+        CreateChunkerConfigRequest: {
+            /**
+             * Name
+             * @description A name for this entity.
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description The description of the chunker config
+             */
+            description?: string | null;
+            /** Properties */
+            properties?: {
+                [key: string]: string | number | boolean;
+            };
+        };
         /**
          * CreateDatasetSplitRequest
          * @description Request to create a dataset split
@@ -1511,6 +1675,23 @@ export interface components {
             name?: string | null;
             /** Description */
             description?: string | null;
+        };
+        /** CreateEmbeddingConfigRequest */
+        CreateEmbeddingConfigRequest: {
+            /**
+             * Name
+             * @description A name for this entity.
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description The description of the embedding config
+             */
+            description?: string | null;
+            /** Properties */
+            properties?: {
+                [key: string]: string | number | boolean;
+            };
         };
         /** CreateEvalConfigRequest */
         CreateEvalConfigRequest: {
@@ -1595,6 +1776,34 @@ export interface components {
             /** Custom Thinking Instructions */
             custom_thinking_instructions?: string | null;
             data_strategy: components["schemas"]["ChatStrategy"];
+        };
+        /** CreateRAGPipelineRequest */
+        CreateRAGPipelineRequest: {
+            /**
+             * Name
+             * @description A name for this entity.
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description The description of the document pipeline
+             */
+            description?: string | null;
+            /**
+             * Extractor Config Id
+             * @description The extractor config to use for the document pipeline
+             */
+            extractor_config_id: string | null;
+            /**
+             * Chunker Config Id
+             * @description The chunker config to use for the document pipeline
+             */
+            chunker_config_id: string | null;
+            /**
+             * Embedding Config Id
+             * @description The embedding config to use for the document pipeline
+             */
+            embedding_config_id: string | null;
         };
         /** CreateTaskRunConfigRequest */
         CreateTaskRunConfigRequest: {
@@ -1865,6 +2074,51 @@ export interface components {
              * @description Tags for the document. Tags are used to categorize documents for filtering and reporting.
              */
             tags?: string[];
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /** EmbeddingConfig */
+        EmbeddingConfig: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description A name for this entity.
+             */
+            name: string;
+            /**
+             * Description
+             * @description The description of the embedding config
+             */
+            description?: string | null;
+            /** @description The provider to use to generate embeddings. */
+            model_provider_name: components["schemas"]["ModelProviderName"];
+            /**
+             * Model Name
+             * @description The model to use to generate embeddings.
+             */
+            model_name: string;
+            /**
+             * Properties
+             * @description Properties to be used to execute the embedding config.
+             */
+            properties: {
+                [key: string]: string | number | boolean;
+            };
             /** Model Type */
             readonly model_type: string;
         };
@@ -2857,6 +3111,52 @@ export interface components {
             models: {
                 [key: string]: components["schemas"]["ProviderModel"];
             };
+        };
+        /** RAGPipeline */
+        RAGPipeline: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description A name for this entity.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A description of the RAG pipeline for you and your team. Will not be used in prompts/training/validation.
+             */
+            description?: string | null;
+            /**
+             * Extractor Config Id
+             * @description The ID of the extractor config that was used to extract the documents.
+             */
+            extractor_config_id: string | null;
+            /**
+             * Chunker Config Id
+             * @description The ID of the chunker config that was used to chunk the documents.
+             */
+            chunker_config_id: string | null;
+            /**
+             * Embedding Config Id
+             * @description The ID of the embedding config that was used to embed the documents.
+             */
+            embedding_config_id: string | null;
+            /** Model Type */
+            readonly model_type: string;
         };
         /** RatingOption */
         RatingOption: {
@@ -4907,6 +5207,204 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_chunker_config_api_projects__project_id__chunker_configs__chunker_config_id__create_chunker_config_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateChunkerConfigRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChunkerConfig"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_chunker_configs_api_projects__project_id__chunker_configs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChunkerConfig"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_embedding_config_api_projects__project_id__embedding_configs__embedding_config_id__create_embedding_config_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateEmbeddingConfigRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EmbeddingConfig"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_embedding_configs_api_projects__project_id__embedding_configs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EmbeddingConfig"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_rag_pipeline_api_projects__project_id__rag_pipelines_create_rag_pipeline_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateRAGPipelineRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RAGPipeline"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_rag_pipelines_api_projects__project_id__rag_pipelines_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RAGPipeline"][];
                 };
             };
             /** @description Validation Error */

--- a/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, Field
 
+from kiln_ai.datamodel.basemodel import ID_TYPE
 from kiln_ai.datamodel.chunk import ChunkerConfig
 
 logger = logging.getLogger(__name__)
@@ -35,3 +36,6 @@ class BaseChunker(ABC):
     @abstractmethod
     async def _chunk(self, text: str) -> ChunkingResult:
         pass
+
+    def chunker_config_id(self) -> ID_TYPE:
+        return self.chunker_config.id

--- a/libs/core/kiln_ai/adapters/embedding/base_embedding_adapter.py
+++ b/libs/core/kiln_ai/adapters/embedding/base_embedding_adapter.py
@@ -5,6 +5,7 @@ from typing import List
 from litellm import Usage
 from pydantic import BaseModel, Field
 
+from kiln_ai.datamodel.basemodel import ID_TYPE
 from kiln_ai.datamodel.embedding import EmbeddingConfig
 
 logger = logging.getLogger(__name__)
@@ -44,3 +45,6 @@ class BaseEmbeddingAdapter(ABC):
     @abstractmethod
     async def _embed(self, text: List[str]) -> EmbeddingResult:
         pass
+
+    def embedding_config_id(self) -> ID_TYPE:
+        return self.embedding_config.id

--- a/libs/core/kiln_ai/adapters/extractors/base_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/base_extractor.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from kiln_ai.datamodel.basemodel import ID_TYPE
 from kiln_ai.datamodel.extraction import ExtractorConfig, OutputFormat
 
 logger = logging.getLogger(__name__)
@@ -63,3 +64,9 @@ class BaseExtractor(ABC):
         return mime_type.lower() in {
             mt.lower() for mt in self.extractor_config.passthrough_mimetypes
         }
+
+    def extractor_config_id(self) -> ID_TYPE:
+        return self.extractor_config.id
+
+    def output_format(self) -> OutputFormat:
+        return self.extractor_config.output_format

--- a/libs/core/kiln_ai/datamodel/__init__.py
+++ b/libs/core/kiln_ai/datamodel/__init__.py
@@ -11,7 +11,7 @@ User docs: https://docs.getkiln.ai/developers/kiln-datamodel
 
 from __future__ import annotations
 
-from kiln_ai.datamodel import chunk, dataset_split, eval, extraction, strict_mode
+from kiln_ai.datamodel import chunk, dataset_split, eval, extraction, rag, strict_mode
 from kiln_ai.datamodel.datamodel_enums import (
     FineTuneStatusType,
     Priority,
@@ -44,6 +44,7 @@ __all__ = [
     "chunk",
     "eval",
     "extraction",
+    "rag",
     "Task",
     "Project",
     "TaskRun",

--- a/libs/core/kiln_ai/datamodel/project.py
+++ b/libs/core/kiln_ai/datamodel/project.py
@@ -4,6 +4,7 @@ from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentModel
 from kiln_ai.datamodel.chunk import ChunkerConfig
 from kiln_ai.datamodel.embedding import EmbeddingConfig
 from kiln_ai.datamodel.extraction import Document, ExtractorConfig
+from kiln_ai.datamodel.rag import RAGPipeline
 from kiln_ai.datamodel.task import Task
 
 
@@ -15,6 +16,7 @@ class Project(
         "extractor_configs": ExtractorConfig,
         "chunker_configs": ChunkerConfig,
         "embedding_configs": EmbeddingConfig,
+        "rag_pipelines": RAGPipeline,
     },
 ):
     """
@@ -45,3 +47,6 @@ class Project(
 
     def embedding_configs(self, readonly: bool = False) -> list[EmbeddingConfig]:
         return super().embedding_configs(readonly=readonly)  # type: ignore
+
+    def rag_pipelines(self, readonly: bool = False) -> list[RAGPipeline]:
+        return super().rag_pipelines(readonly=readonly)  # type: ignore

--- a/libs/core/kiln_ai/datamodel/rag.py
+++ b/libs/core/kiln_ai/datamodel/rag.py
@@ -1,0 +1,24 @@
+from pydantic import Field
+
+from kiln_ai.datamodel.basemodel import ID_TYPE, NAME_FIELD, KilnParentedModel
+
+
+class RAGPipeline(KilnParentedModel):
+    name: str = NAME_FIELD
+
+    description: str | None = Field(
+        default=None,
+        description="A description of the RAG pipeline for you and your team. Will not be used in prompts/training/validation.",
+    )
+
+    extractor_config_id: ID_TYPE = Field(
+        description="The ID of the extractor config that was used to extract the documents.",
+    )
+
+    chunker_config_id: ID_TYPE = Field(
+        description="The ID of the chunker config that was used to chunk the documents.",
+    )
+
+    embedding_config_id: ID_TYPE = Field(
+        description="The ID of the embedding config that was used to embed the documents.",
+    )

--- a/libs/core/kiln_ai/datamodel/test_rag.py
+++ b/libs/core/kiln_ai/datamodel/test_rag.py
@@ -1,0 +1,339 @@
+import pytest
+from pydantic import ValidationError
+
+from kiln_ai.datamodel.project import Project
+from kiln_ai.datamodel.rag import RAGPipeline
+
+
+@pytest.fixture
+def mock_project(tmp_path):
+    project_path = tmp_path / "test_project" / "project.kiln"
+    project_path.parent.mkdir()
+
+    project = Project(name="Test Project", path=str(project_path))
+    project.save_to_file()
+
+    return project
+
+
+@pytest.fixture
+def sample_rag_pipeline_data():
+    """Sample data for creating a RAGPipeline instance."""
+    return {
+        "name": "Test RAG Pipeline",
+        "description": "A test RAG pipeline for testing purposes",
+        "extractor_config_id": "extractor123",
+        "chunker_config_id": "chunker456",
+        "embedding_config_id": "embedding789",
+    }
+
+
+def test_rag_pipeline_valid_creation(sample_rag_pipeline_data):
+    """Test creating a RAGPipeline with all required fields."""
+    rag_pipeline = RAGPipeline(**sample_rag_pipeline_data)
+
+    assert rag_pipeline.name == "Test RAG Pipeline"
+    assert rag_pipeline.description == "A test RAG pipeline for testing purposes"
+    assert rag_pipeline.extractor_config_id == "extractor123"
+    assert rag_pipeline.chunker_config_id == "chunker456"
+    assert rag_pipeline.embedding_config_id == "embedding789"
+
+
+def test_rag_pipeline_minimal_creation():
+    """Test creating a RAGPipeline with only required fields."""
+    rag_pipeline = RAGPipeline(
+        name="Minimal RAG Pipeline",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    assert rag_pipeline.name == "Minimal RAG Pipeline"
+    assert rag_pipeline.description is None
+    assert rag_pipeline.extractor_config_id == "extractor123"
+    assert rag_pipeline.chunker_config_id == "chunker456"
+    assert rag_pipeline.embedding_config_id == "embedding789"
+
+
+def test_rag_pipeline_missing_required_fields():
+    """Test that missing required fields raise ValidationError."""
+    # Test missing name
+    with pytest.raises(ValidationError) as exc_info:
+        RAGPipeline(
+            extractor_config_id="extractor123",
+            chunker_config_id="chunker456",
+            embedding_config_id="embedding789",
+        )
+    errors = exc_info.value.errors()
+    assert any(error["loc"][0] == "name" for error in errors)
+
+    # Test missing extractor_config_id
+    with pytest.raises(ValidationError) as exc_info:
+        RAGPipeline(
+            name="Test Pipeline",
+            chunker_config_id="chunker456",
+            embedding_config_id="embedding789",
+        )
+    errors = exc_info.value.errors()
+    assert any(error["loc"][0] == "extractor_config_id" for error in errors)
+
+    # Test missing chunker_config_id
+    with pytest.raises(ValidationError) as exc_info:
+        RAGPipeline(
+            name="Test Pipeline",
+            extractor_config_id="extractor123",
+            embedding_config_id="embedding789",
+        )
+    errors = exc_info.value.errors()
+    assert any(error["loc"][0] == "chunker_config_id" for error in errors)
+
+    # Test missing embedding_config_id
+    with pytest.raises(ValidationError) as exc_info:
+        RAGPipeline(
+            name="Test Pipeline",
+            extractor_config_id="extractor123",
+            chunker_config_id="chunker456",
+        )
+    errors = exc_info.value.errors()
+    assert any(error["loc"][0] == "embedding_config_id" for error in errors)
+
+
+def test_rag_pipeline_name_validation():
+    """Test name field validation according to NAME_FIELD constraints."""
+    # Valid names
+    RAGPipeline(
+        name="Valid Name",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    RAGPipeline(
+        name="Valid_Name-With_123",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    RAGPipeline(
+        name="a",  # Minimum length
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    RAGPipeline(
+        name="a" * 120,  # Maximum length
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    # Invalid names
+    with pytest.raises(ValidationError):
+        RAGPipeline(
+            name="",  # Empty string
+            extractor_config_id="extractor123",
+            chunker_config_id="chunker456",
+            embedding_config_id="embedding789",
+        )
+
+    with pytest.raises(ValidationError):
+        RAGPipeline(
+            name="a" * 121,  # Too long
+            extractor_config_id="extractor123",
+            chunker_config_id="chunker456",
+            embedding_config_id="embedding789",
+        )
+
+    with pytest.raises(ValidationError):
+        RAGPipeline(
+            name="Invalid!Name",
+            extractor_config_id="extractor123",
+            chunker_config_id="chunker456",
+            embedding_config_id="embedding789",
+        )
+
+    with pytest.raises(ValidationError):
+        RAGPipeline(
+            name="Invalid.Name",
+            extractor_config_id="extractor123",
+            chunker_config_id="chunker456",
+            embedding_config_id="embedding789",
+        )
+
+
+def test_rag_pipeline_description_optional():
+    """Test that description field is optional and can be None."""
+    rag_pipeline = RAGPipeline(
+        name="Test Pipeline",
+        description=None,
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    assert rag_pipeline.description is None
+
+
+def test_rag_pipeline_description_string():
+    """Test that description field accepts string values."""
+    rag_pipeline = RAGPipeline(
+        name="Test Pipeline",
+        description="A detailed description of the RAG pipeline",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    assert rag_pipeline.description == "A detailed description of the RAG pipeline"
+
+
+def test_rag_pipeline_id_generation():
+    """Test that RAGPipeline generates an ID automatically."""
+    rag_pipeline = RAGPipeline(
+        name="Test Pipeline",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    assert rag_pipeline.id is not None
+    assert isinstance(rag_pipeline.id, str)
+    assert len(rag_pipeline.id) == 12  # ID should be 12 digits
+
+
+def test_rag_pipeline_inheritance():
+    """Test that RAGPipeline inherits from KilnParentedModel."""
+    rag_pipeline = RAGPipeline(
+        name="Test Pipeline",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    # Test that it has the expected base class attributes
+    assert hasattr(rag_pipeline, "v")  # schema version
+    assert hasattr(rag_pipeline, "id")  # unique identifier
+    assert hasattr(rag_pipeline, "path")  # file system path
+    assert hasattr(rag_pipeline, "created_at")  # creation timestamp
+    assert hasattr(rag_pipeline, "created_by")  # creator user ID
+    assert hasattr(rag_pipeline, "parent")  # parent reference
+
+
+def test_rag_pipeline_model_type():
+    """Test that RAGPipeline has the correct model type."""
+    rag_pipeline = RAGPipeline(
+        name="Test Pipeline",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    assert rag_pipeline.model_type == "r_a_g_pipeline"
+
+
+def test_rag_pipeline_config_id_types():
+    """Test that config IDs can be various string formats."""
+    # Test with numeric strings
+    rag_pipeline = RAGPipeline(
+        name="Test Pipeline",
+        extractor_config_id="123",
+        chunker_config_id="456",
+        embedding_config_id="789",
+    )
+
+    assert rag_pipeline.extractor_config_id == "123"
+    assert rag_pipeline.chunker_config_id == "456"
+    assert rag_pipeline.embedding_config_id == "789"
+
+    # Test with UUID-like strings
+    rag_pipeline = RAGPipeline(
+        name="Test Pipeline",
+        extractor_config_id="extractor-123-456-789",
+        chunker_config_id="chunker-abc-def-ghi",
+        embedding_config_id="embedding-xyz-uvw-rst",
+    )
+
+    assert rag_pipeline.extractor_config_id == "extractor-123-456-789"
+    assert rag_pipeline.chunker_config_id == "chunker-abc-def-ghi"
+    assert rag_pipeline.embedding_config_id == "embedding-xyz-uvw-rst"
+
+
+def test_rag_pipeline_serialization():
+    """Test that RAGPipeline can be serialized and deserialized."""
+    original_pipeline = RAGPipeline(
+        name="Test Pipeline",
+        description="A test pipeline",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    # Serialize to dict
+    pipeline_dict = original_pipeline.model_dump()
+
+    # Deserialize back to object
+    deserialized_pipeline = RAGPipeline(**pipeline_dict)
+
+    assert deserialized_pipeline.name == original_pipeline.name
+    assert deserialized_pipeline.description == original_pipeline.description
+    assert (
+        deserialized_pipeline.extractor_config_id
+        == original_pipeline.extractor_config_id
+    )
+    assert (
+        deserialized_pipeline.chunker_config_id == original_pipeline.chunker_config_id
+    )
+    assert (
+        deserialized_pipeline.embedding_config_id
+        == original_pipeline.embedding_config_id
+    )
+
+
+def test_rag_pipeline_default_values():
+    """Test that RAGPipeline has appropriate default values."""
+    rag_pipeline = RAGPipeline(
+        name="Test Pipeline",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    # Test default values
+    assert rag_pipeline.description is None
+    assert rag_pipeline.v == 1  # schema version default
+    assert rag_pipeline.id is not None  # auto-generated ID
+    assert rag_pipeline.path is None  # no path by default
+    assert rag_pipeline.parent is None  # no parent by default
+
+
+def test_project_has_rag_pipelines(mock_project):
+    """Test relationship between project and RAGPipeline."""
+    # create 2 rag pipelines
+    rag_pipeline_1 = RAGPipeline(
+        parent=mock_project,
+        name="Test Pipeline 1",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    rag_pipeline_2 = RAGPipeline(
+        parent=mock_project,
+        name="Test Pipeline 2",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+    )
+
+    # save the rag pipelines
+    rag_pipeline_1.save_to_file()
+    rag_pipeline_2.save_to_file()
+
+    # check that the project has the rag pipelines
+    child_rag_pipelines = mock_project.rag_pipelines()
+    assert len(child_rag_pipelines) == 2
+
+    for rag_pipeline in child_rag_pipelines:
+        assert rag_pipeline.id in [rag_pipeline_1.id, rag_pipeline_2.id]

--- a/libs/core/kiln_ai/utils/rag_pipeline.py
+++ b/libs/core/kiln_ai/utils/rag_pipeline.py
@@ -1,0 +1,394 @@
+import logging
+from abc import ABC
+from enum import Enum
+from typing import Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from kiln_ai.adapters.chunkers.base_chunker import BaseChunker
+from kiln_ai.adapters.embedding.base_embedding_adapter import BaseEmbeddingAdapter
+from kiln_ai.adapters.extractors.base_extractor import BaseExtractor
+from kiln_ai.datamodel import Project
+from kiln_ai.datamodel.basemodel import KilnAttachmentModel
+from kiln_ai.datamodel.chunk import Chunk, ChunkedDocument
+from kiln_ai.datamodel.embedding import ChunkEmbeddings, Embedding
+from kiln_ai.datamodel.extraction import Document, Extraction, ExtractionSource
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentPipelineProgress(BaseModel):
+    total_count: int = Field(
+        description="The total number of items to process",
+        default=0,
+    )
+
+    completed_count: int = Field(
+        description="The number of items that have been processed",
+        default=0,
+    )
+
+    error_count: int = Field(
+        description="The number of items that have errored",
+        default=0,
+    )
+
+    message: str | None = Field(
+        description="An arbitrary message to display to the user. For example, 'Extracting documents...', 'Chunking documents...', 'Saving embeddings...'",
+        default=None,
+    )
+
+
+class DocumentPipelineStage(str, Enum):
+    EXTRACTING = "extracting"
+    CHUNKING = "chunking"
+    EMBEDDING = "embedding"
+
+
+class AbstractPipelineObserver(ABC):
+    """
+    An observer for a document pipeline events; the implementation should override the event handlers.
+    """
+
+    async def on_start(self):
+        """
+        Called when the pipeline starts.
+        """
+        pass
+
+    async def on_progress(self, progress: DocumentPipelineProgress):
+        """
+        Called when the pipeline makes progress.
+        """
+        pass
+
+    async def on_end(self):
+        """
+        Called when the pipeline ends.
+        """
+        pass
+
+    async def on_error(self, error: Exception):
+        """
+        Called when the pipeline encounters an error.
+        """
+        pass
+
+
+class DocumentPipelineConfiguration(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    stages: Mapping[DocumentPipelineStage, bool] = Field(
+        description="The stages to run in the pipeline, ordered by the order in which they should be run",
+        default={
+            DocumentPipelineStage.EXTRACTING: True,
+            DocumentPipelineStage.CHUNKING: True,
+            DocumentPipelineStage.EMBEDDING: True,
+        },
+    )
+
+    extractor: BaseExtractor = Field(
+        description="The extractor to use for the pipeline",
+    )
+
+    chunker: BaseChunker = Field(
+        description="The chunker to use for the pipeline",
+    )
+
+    embedding_adapter: BaseEmbeddingAdapter = Field(
+        description="The embedding adapter to use for the pipeline",
+    )
+
+
+class DocumentPipeline:
+    progress_message: str = "Initializing..."
+
+    def __init__(self, project: Project, configuration: DocumentPipelineConfiguration):
+        if not any(configuration.stages.values()):
+            raise ValueError("At least one stage must be enabled")
+
+        self.project = project
+        self.configuration = configuration
+        self.observers: list[AbstractPipelineObserver] = []
+
+    def register_observers(self, observers: list[AbstractPipelineObserver]):
+        for observer in observers:
+            self.observers.append(observer)
+
+    async def _notify_progress(self, progress: DocumentPipelineProgress):
+        try:
+            for observer in self.observers:
+                await observer.on_progress(progress)
+        except Exception as e:
+            logger.error(f"Error notifying observers of progress: {e}", exc_info=True)
+
+    async def _notify_start(self):
+        try:
+            for observer in self.observers:
+                await observer.on_start()
+        except Exception as e:
+            logger.error(f"Error notifying observers of start: {e}", exc_info=True)
+
+    async def _notify_end(self):
+        try:
+            for observer in self.observers:
+                await observer.on_end()
+        except Exception as e:
+            logger.error(f"Error notifying observers of end: {e}", exc_info=True)
+
+    async def _notify_error(self, error: Exception):
+        try:
+            for observer in self.observers:
+                await observer.on_error(error)
+        except Exception as e:
+            logger.error(f"Error notifying observers of error: {e}", exc_info=True)
+
+    def is_same_extractor(self, extraction: Extraction) -> bool:
+        return (
+            extraction.extractor_config_id
+            == self.configuration.extractor.extractor_config_id()
+        )
+
+    def is_same_chunker(self, chunked_document: ChunkedDocument) -> bool:
+        return (
+            chunked_document.chunker_config_id
+            == self.configuration.chunker.chunker_config_id()
+        )
+
+    def is_same_embedding_adapter(self, chunk_embeddings: ChunkEmbeddings) -> bool:
+        return (
+            chunk_embeddings.embedding_config_id
+            == self.configuration.embedding_adapter.embedding_config_id()
+        )
+
+    async def _collect_documents_to_extract(self):
+        await self._notify_progress(
+            DocumentPipelineProgress(
+                message="Preparing to extract documents...",
+            )
+        )
+
+        documents_to_extract: list[Document] = []
+        for document in self.project.documents(readonly=True):
+            already_extracted = any(
+                self.is_same_extractor(extraction)
+                for extraction in document.extractions(readonly=True)
+            )
+            if not already_extracted:
+                documents_to_extract.append(document)
+
+        return documents_to_extract
+
+    async def _collect_extractions_to_chunk(self):
+        await self._notify_progress(
+            DocumentPipelineProgress(
+                message="Preparing to chunk extractions...",
+            )
+        )
+
+        extractions_to_chunk: list[Extraction] = []
+        for document in self.project.documents(readonly=True):
+            extractions = document.extractions(readonly=True)
+            for extraction in extractions:
+                if self.is_same_extractor(extraction):
+                    already_chunked = any(
+                        self.is_same_chunker(chunked_document)
+                        for chunked_document in extraction.chunked_documents(
+                            readonly=True
+                        )
+                    )
+                    if not already_chunked:
+                        extractions_to_chunk.append(extraction)
+
+        return extractions_to_chunk
+
+    async def _collect_chunked_documents_to_embed(self):
+        await self._notify_progress(
+            DocumentPipelineProgress(
+                message="Preparing to embed chunked documents...",
+            )
+        )
+
+        chunked_documents_to_embed: list[ChunkedDocument] = []
+        for document in self.project.documents(readonly=True):
+            extractions = document.extractions(readonly=True)
+            for extraction in extractions:
+                if self.is_same_extractor(extraction):
+                    for chunked_document in extraction.chunked_documents(readonly=True):
+                        if self.is_same_chunker(chunked_document):
+                            already_embedded = any(
+                                self.is_same_embedding_adapter(chunk_embeddings)
+                                for chunk_embeddings in chunked_document.chunk_embeddings(
+                                    readonly=True
+                                )
+                            )
+                            if not already_embedded:
+                                chunked_documents_to_embed.append(chunked_document)
+
+        return chunked_documents_to_embed
+
+    async def _run_extracting_stage(self, documents: list[Document]):
+        total_count = len(documents)
+        error_count = 0
+        completed_count = 0
+
+        async def notify_progress():
+            await self._notify_progress(
+                DocumentPipelineProgress(
+                    message="Extracting documents...",
+                    total_count=total_count,
+                    completed_count=completed_count,
+                    error_count=error_count,
+                )
+            )
+
+        await notify_progress()
+
+        for document in documents:
+            if document.path is None:
+                raise ValueError("Document path is not set")
+
+            output = await self.configuration.extractor.extract(
+                path=document.original_file.attachment.resolve_path(
+                    document.path.parent
+                ),
+                mime_type=document.original_file.mime_type,
+            )
+
+            extraction = Extraction(
+                parent=document,
+                extractor_config_id=self.configuration.extractor.extractor_config_id(),
+                output=KilnAttachmentModel.from_data(
+                    data=output.content,
+                    mime_type=output.content_format,
+                ),
+                source=ExtractionSource.PASSTHROUGH
+                if output.is_passthrough
+                else ExtractionSource.PROCESSED,
+            )
+
+            extraction.save_to_file()
+
+            completed_count += 1
+            await notify_progress()
+
+    async def _run_chunking_stage(self, extractions: list[Extraction]):
+        total_count = len(extractions)
+        error_count = 0
+        completed_count = 0
+
+        async def notify_progress():
+            await self._notify_progress(
+                DocumentPipelineProgress(
+                    message="Chunking extractions...",
+                    total_count=total_count,
+                    completed_count=completed_count,
+                    error_count=error_count,
+                )
+            )
+
+        await notify_progress()
+
+        for extraction in extractions:
+            chunker = self.configuration.chunker
+            if chunker is None:
+                raise ValueError("Chunker is not set")
+
+            extraction_output_content = await extraction.output_content()
+            if extraction_output_content is None:
+                raise ValueError("Extraction output content is not set")
+
+            chunking_result = await chunker.chunk(extraction_output_content)
+            if chunking_result is None:
+                raise ValueError("Chunking result is not set")
+
+            chunked_document = ChunkedDocument(
+                parent=extraction,
+                chunker_config_id=self.configuration.chunker.chunker_config_id(),
+                chunks=[
+                    Chunk(
+                        content=KilnAttachmentModel.from_data(
+                            data=chunk.text,
+                            mime_type=self.configuration.extractor.output_format(),
+                        ),
+                    )
+                    for chunk in chunking_result.chunks
+                ],
+            )
+
+            chunked_document.save_to_file()
+
+            completed_count += 1
+            await notify_progress()
+
+    async def _run_embedding_stage(self, chunked_documents: list[ChunkedDocument]):
+        total_count = len(chunked_documents)
+        error_count = 0
+        completed_count = 0
+
+        async def notify_progress():
+            await self._notify_progress(
+                DocumentPipelineProgress(
+                    message="Embedding chunked documents...",
+                    total_count=total_count,
+                    completed_count=completed_count,
+                    error_count=error_count,
+                )
+            )
+
+        await notify_progress()
+
+        for chunked_document in chunked_documents:
+            embedding_adapter = self.configuration.embedding_adapter
+            if embedding_adapter is None:
+                raise ValueError("Embedding adapter is not set")
+
+            chunks_text = await chunked_document.load_chunks_text()
+            if chunks_text is None or len(chunks_text) == 0:
+                raise ValueError("No chunks text found")
+
+            chunk_embedding_result = await embedding_adapter.embed(text=chunks_text)
+            if chunk_embedding_result is None:
+                raise ValueError("Chunk embedding result is not set")
+
+            chunk_embeddings = ChunkEmbeddings(
+                parent=chunked_document,
+                embedding_config_id=self.configuration.embedding_adapter.embedding_config_id(),
+                embeddings=[
+                    Embedding(
+                        vector=embedding.vector,
+                    )
+                    for embedding in chunk_embedding_result.embeddings
+                ],
+            )
+
+            chunk_embeddings.save_to_file()
+
+            completed_count += 1
+            await notify_progress()
+
+    async def run(self):
+        await self._notify_start()
+
+        for stage in [
+            DocumentPipelineStage.EXTRACTING,
+            DocumentPipelineStage.CHUNKING,
+            DocumentPipelineStage.EMBEDDING,
+        ]:
+            stage_enabled = self.configuration.stages.get(stage, False)
+            if not stage_enabled:
+                continue
+
+            if stage == DocumentPipelineStage.EXTRACTING:
+                docs = await self._collect_documents_to_extract()
+                await self._run_extracting_stage(docs)
+            elif stage == DocumentPipelineStage.CHUNKING:
+                extractions = await self._collect_extractions_to_chunk()
+                await self._run_chunking_stage(extractions)
+            elif stage == DocumentPipelineStage.EMBEDDING:
+                chunked_documents = await self._collect_chunked_documents_to_embed()
+                await self._run_embedding_stage(chunked_documents)
+            else:
+                raise ValueError(f"Unknown stage: {stage}")
+
+        await self._notify_end()


### PR DESCRIPTION
## What does this PR do?

Changes:
- add `RAGPipeline` datamodel to store the combination of `ExtractorConfig`, `ChunkerConfig`, `EmbeddingConfig`
- add endpoints to create / list `ChunkerConfig` and `EmbeddingConfig`
- add `RAGPipeline` orchestrator class to run a full RAG pipeline; to replace the `run_extractor_runner_with_status` which is too light for a whole pipeline run, client can subscribe to progress updates (and convert to SSE in the API layer)

The idea is to then use these in the UI and recenter the `Extractor` page around a higher level concept of `RAG Pipeline`, if we do E2E eval, users do not necessarily need separate views of each part of the pipeline. The main UI then would be a form that lets the user create a full pipeline:
- extractor: show the existing ones in a dropdown; or create one if you want a new one
- chunker config: show the existing ones in a dropdown (currently, the only difference between chunker configs is the `chunk_overlap` and `chunk_size` properties; as we only support one type (`fixed_window`))
- embedding config: can abstract this away and simply let the users pick an embedding model in the dropdown (under the hood, those will map to different embedding configs, but no need to expose that immediately)

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
