### PR TITLE
For Pass/Fail evals - All Fails (0.0) show up as the fallback of "N/A" in UI

### DIFF
--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/[eval_config_id]/[run_config_id]/run_result/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/[eval_config_id]/[run_config_id]/run_result/+page.svelte
@@ -239,7 +239,7 @@
                 {@const score_value =
                   result.scores[string_to_json_key(score.name)]}
                 <td class="text-center">
-                  {score_value ? score_value.toFixed(2) : "N/A"}
+                  {score_value != null ? score_value.toFixed(2) : "N/A"}
                 </td>
               {/each}
             </tr>


### PR DESCRIPTION
## What does this PR do?
Was testing the new Issue Eval flow and was wondering why I wasn't seeing any failing examples (scores of 0.0). they show up as N/A in UI. I did confirm it's a pure UI issue. Cursor helped me with the one-liner here.

## Checklists

- [X] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib

`main`
<img width="510" height="401" alt="Screenshot 2025-07-10 at 11 14 34 AM" src="https://github.com/user-attachments/assets/7f297700-2667-459a-a90f-f6840e932138" />

`this branch`
<img width="520" height="461" alt="Screenshot 2025-07-10 at 11 14 20 AM" src="https://github.com/user-attachments/assets/e739de8f-dff4-4678-a067-0a7c980c0a99" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display of score values in tables so that zero and other falsy numeric scores are now shown with two decimal places instead of displaying "N/A".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->