### PR TITLE
fix: model logs escapes unicode in prompts and responses

### DIFF
--- a/libs/core/kiln_ai/utils/logging.py
+++ b/libs/core/kiln_ai/utils/logging.py
@@ -63,14 +63,14 @@ class CustomLiteLLMLogger(CustomLogger):
         # Print the formatted input data for the request in API format, pretty print
         try:
             self.logger.info(
-                f"Formatted Input Data (API):\n{json.dumps(data, indent=2)}"
+                f"Formatted Input Data (API):\n{json.dumps(data, indent=2, ensure_ascii=False)}"
             )
         except Exception as e:
             self.logger.info(f"Formatted Input Data (API): Could not print {e}")
 
         # Print the messages for the request in LiteLLM Message list, pretty print
         try:
-            json_messages = json.dumps(messages, indent=2)
+            json_messages = json.dumps(messages, indent=2, ensure_ascii=False)
             self.logger.info(f"Messages:\n{json_messages}")
         except Exception as e:
             self.logger.info(f"Messages: Could not print {e}")
@@ -115,7 +115,7 @@ class CustomLiteLLMLogger(CustomLogger):
                         # JSON format logs if possible
                         json_content = json.loads(content)
                         self.logger.info(
-                            f"Model Response Content:\n{json.dumps(json_content, indent=2)}"
+                            f"Model Response Content:\n{json.dumps(json_content, indent=2, ensure_ascii=False)}"
                         )
                     except Exception:
                         self.logger.info(f"Model Response Content:\n{content}")

--- a/libs/core/kiln_ai/utils/logging.py
+++ b/libs/core/kiln_ai/utils/logging.py
@@ -149,6 +149,7 @@ def setup_litellm_logging(filename: str = "model_calls.log"):
         get_log_file_path(filename),
         maxBytes=5 * 1024 * 1024,  # 5MB
         backupCount=3,
+        encoding="utf-8",
     )
 
     # Set formatter to match the default formatting


### PR DESCRIPTION
## What does this PR do?

The model logs are escaped, which causes unreadable logs when dealing with non-ascii languages; for example:

```json
2025-07-12 20:33:34,927.927 - INFO - ModelCalls - Model Response Content:
{
  "generated_samples": [
    "\u5929\u6c14, \u670b\u53cb, \u5b66\u6821, \u751f\u65e5, \u770b\u7535\u5f71, \u4e70\u4e1c\u897f, \u4e2d\u56fd\u83dc, \u661f\u671f, \u989c\u8272, \u4ea4\u901a\u5de5\u5177"
  ]
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging to correctly display non-ASCII characters in JSON output, ensuring all characters are shown as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->