### PR TITLE
fix: store not updating after requirements changed

### DIFF
--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -582,7 +582,14 @@
             >
           </div>
         {/if}
+        <p class="text-xs text-gray-500 mt-1 text-light">
+          The rating criteria are defined in the <a
+            href={`/settings/edit_task/${project_id}/${task.id}`}
+            class="link">task</a
+          > settings.
+        </p>
       </div>
+
       <div class="grid grid-cols-[auto,1fr] gap-4 text-sm 2xl:text-base">
         {#if rating_requirements}
           {#each rating_requirements as requirement, index}

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -5,7 +5,12 @@
   import FormList from "$lib/utils/form_list.svelte"
   import FormContainer from "$lib/utils/form_container.svelte"
   import SchemaSection from "./schema_section.svelte"
-  import { current_project } from "$lib/stores"
+  import {
+    current_project,
+    current_task_rating_options,
+    load_current_task,
+    load_rating_options,
+  } from "$lib/stores"
   import { goto } from "$app/navigation"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
   import { ui_state, projects } from "$lib/stores"
@@ -36,7 +41,6 @@
   let error: KilnError | null = null
   let submitting = false
   export let saved: boolean = false
-
   // Warn before unload if there's any user input
   $: warn_before_unload =
     !saved &&
@@ -128,8 +132,15 @@
         ...get(ui_state),
         current_task_id: data.id,
         current_project_id: target_project_id,
+        current_task_rating_options: null,
       })
       saved = true
+
+      // reload the current task to make sure changes propagate throughout the UI
+      // e.g. the rating options
+      await load_current_task(get(current_project))
+      await load_rating_options()
+
       // Wait for the saved change to propagate to the warn_before_unload
       await tick()
       if (redirect_on_created) {

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -7,7 +7,6 @@
   import SchemaSection from "./schema_section.svelte"
   import {
     current_project,
-    current_task_rating_options,
     load_current_task,
     load_rating_options,
   } from "$lib/stores"


### PR DESCRIPTION
## What does this PR do?

Changes:
- fix: bug where the requirements under `Output Rating` in the judging UI do not update after editing the Task in `Settings > Edit Task`
- ui: add small text linking to where the Task requirements can be updated;
  - reason: the Task creation page no longer seems to let users define requirements, so users now need to add/edit requirements after creating the Task, but it is not obvious where to do this (or that they can even edit the requirements)

How to reproduce the bug:
1. go into `Settings > Edit Task`
2. add a requirement / delete a requirement
3. click `Save`
4. go to `Dataset` by clicking the link in the sidebar
5. click on a Sample
6. observe that the requirements listed under `Output Rating` in the right sidebar are outdated (they update if you hard refresh the browser)

UI change:
<img width="469" height="343" alt="image" src="https://github.com/user-attachments/assets/9d01fffc-436b-4cf0-bb18-8b94f68f9daf" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational message below the "Output Rating" section, including a link to task settings for rating criteria details.

* **Bug Fixes**
  * Ensured that updated rating options are properly refreshed and displayed throughout the UI after creating or editing a task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->