### PR TITLE
chore: new cursor rule format

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -11,6 +11,7 @@ alwaysApply: true
   2.  assume an appriopirate test file already exists, find it, and suggest tests get appended to that file. If no such file exists, ask me before assuming a new test file is the correct route.
   3.  Test brevity is important. Use approaches for re-use and brevity including using fixtures for repeated code, and using pytest parameterize for similar tests
   4.  After writing a new test, run it and ensure it works. Fix any issues you find.
+- To run backend / Python tests, run `uv run python3 -m pytest . -s -v` or a variant of it to run individual tests
 - To run web tests `cd app/web_ui` then `npm run test_run` (not `npm run test` which won't return)
 - Don't include comments in code explaining changes, explain changes in chat instead.
 - If a python API's interface changes (or a new one is added), generate new bindings by running `cd app/web_ui/src/lib/ && ./generate.sh`

--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -1,3 +1,7 @@
+---
+alwaysApply: true
+---
+
 - call me "boss"
 - We always use typescript, not javascript
 - Always assume pydantic 2 (not pydantic 1)


### PR DESCRIPTION
## What does this PR do?

Cursor has changed the format of Cursor rules. Rules are apparently supposed to be in `.mdc` files inside `.cursor/rules/`; ref:
- https://docs.cursor.com/context/rules#cursorrules-legacy

This PR moves the rules according to the new structure; and adds a rule on how to run backend tests (it usually tries to run the wrong command, which fails):
```
- To run backend / Python tests, run `uv run python3 -m pytest . -s -v` or a variant of it to run individual tests
```

Tested and it also figures out how to run individual tests with this.

We could further split up the rules into backend / frontend as the docs says we can have multiple `.cursor/rules/` in different directories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to include instructions for running backend Python tests.
  * Added configuration details to ensure consistent application of these rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->