### PR TITLE
chore: add config for official Cursor Python (without pylance)

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,3 +1,6 @@
 {
-  "exclude": ["**/test_*.py", "app/desktop/build/**", "app/web_ui/**", "**/.venv"]
+  "exclude": ["**/test_*.py", "app/desktop/build/**", "app/web_ui/**", "**/.venv"],
+  "typeCheckingMode": "basic",
+  "autoImportCompletions": true,
+  "extraPaths": ["./"]
 }


### PR DESCRIPTION
## What does this PR do?

Copied the `pyright` config from `.vscode/settings.json` into `pyright.json`. This ensures typechecking works correctly with the official `Python` extension in Cursor (`anysphere.cursorpyright`).

I have kept the `python.analysis.XXX` in the `.vscode/settings.json` because that would still be needed by the official VS Code setup.

### TL;DR

- If you still have `pylance` installed, typechecking works via `.vscode/settings.json`, and this PR has no effect.
- If you are using Cursor’s official Python extension and **don’t** have `pylance` (which can no longer be installed), typechecking is broken without a `pyright.json` file - you get squiggles everywhere.

### Background

- `pylance` (Microsoft’s official extension) is no longer supported on Cursor. It may still work if previously installed, but it can no longer be installed via the Cursor extension marketplace if you don't already have it.
- `basedpyright` is a community fork of `pyright` with some `pylance`-like features, but it is unofficial.
- `anysphere.cursorpyright` (published as `Python` in the Cursor marketplace) is Cursor’s official fork of `basedpyright`. However, it does not read settings from `.vscode/settings.json`; it only uses `pyright.json`.

This is the official extension:
<img width="1124" height="940" alt="image" src="https://github.com/user-attachments/assets/267c13c3-5cd7-47c9-8880-8bad556ad324" />

Pylance no longer showing up in the extension marketplace:
<img width="702" height="614" alt="image" src="https://github.com/user-attachments/assets/cec26f67-9559-41f1-abf9-a34d55c69b94" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated type checking and import completion settings for improved development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->