### PR TITLE
ui: add link to the prompt in the eval Compare Run Methods table

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,4 +37,6 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "svelte"],
+  "typescript.preferences.importModuleSpecifier": "shortest",
+  "typescript.suggest.autoImports": true
 }

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -35,6 +35,7 @@
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
   import AddRunMethod from "./add_run_method.svelte"
   import posthog from "posthog-js"
+  import { prompt_link } from "../../../../../../../lib/utils/link_builder"
 
   $: project_id = $page.params.project_id
   $: task_id = $page.params.task_id
@@ -592,10 +593,20 @@
                     </div>
 
                     <div class="text-sm text-gray-500">
-                      Prompt: {getRunConfigPromptDisplayName(
-                        task_run_config,
-                        $current_task_prompts,
-                      )}
+                      Prompt: <a
+                        href={prompt_link(
+                          $page.params.project_id,
+                          $page.params.task_id,
+                          task_run_config.run_config_properties.prompt_id,
+                        )}
+                        class="link"
+                      >
+                        {getRunConfigPromptDisplayName(
+                          task_run_config,
+                          $current_task_prompts,
+                        )}
+                      </a>
+
                       {#if prompt_info_text}
                         <InfoTooltip
                           tooltip_text={prompt_info_text}

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -35,7 +35,7 @@
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
   import AddRunMethod from "./add_run_method.svelte"
   import posthog from "posthog-js"
-  import { prompt_link } from "../../../../../../../lib/utils/link_builder"
+  import { prompt_link } from "$lib/utils/link_builder"
 
   $: project_id = $page.params.project_id
   $: task_id = $page.params.task_id


### PR DESCRIPTION
## What does this PR do?

Add a link to the prompt in the `Compare Run Methods` eval page - makes it easier to know what prompt the run method is for:

<img width="1522" height="1108" alt="image" src="https://github.com/user-attachments/assets/ba827459-5f45-4e27-93cb-6e4da74833ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt names in the run methods table are now clickable links directing users to the prompt's detail page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->