### PR TITLE
feat: add qwen 3 32B, remove deprecated model, fix reasoning

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -198,7 +198,7 @@ class KilnModelProvider(BaseModel):
     require_openrouter_reasoning: bool = False
     logprobs_openrouter_options: bool = False
     openrouter_skip_required_parameters: bool = False
-    thinking_level: Literal["low", "medium", "high"] | None = None
+    thinking_level: Literal["low", "medium", "high", "none"] | None = None
     ollama_model_aliases: List[str] | None = None
     anthropic_extended_thinking: bool = False
 
@@ -1636,13 +1636,6 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
             ),
             KilnModelProvider(
-                name=ModelProviderName.groq,
-                model_id="qwen-qwq-32b",
-                reasoning_capable=True,
-                parser=ModelParserID.r1_thinking,
-                structured_output_mode=StructuredOutputMode.json_instructions,
-            ),
-            KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="Qwen/QwQ-32B",
                 structured_output_mode=StructuredOutputMode.json_instructions,
@@ -2402,6 +2395,14 @@ built_in_models: List[KilnModel] = [
                 reasoning_capable=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
             ),
+            KilnModelProvider(
+                name=ModelProviderName.groq,
+                model_id="Qwen/Qwen3-32B",
+                supports_data_gen=True,
+                reasoning_capable=True,
+                structured_output_mode=StructuredOutputMode.json_instructions,
+                parser=ModelParserID.r1_thinking,
+            ),
         ],
     ),
     # Qwen 3 32B No Thinking
@@ -2424,6 +2425,13 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 formatter=ModelFormatterID.qwen3_style_no_think,
                 supports_data_gen=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.groq,
+                model_id="Qwen/Qwen3-32B",
+                supports_data_gen=True,
+                structured_output_mode=StructuredOutputMode.json_schema,
+                thinking_level="none",
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -373,6 +373,9 @@ class LiteLlmAdapter(BaseAdapter):
             # Better to ignore them than to fail the model call.
             # https://docs.litellm.ai/docs/completion/input
             "drop_params": True,
+            # This overrides the drop_params setting above for specific parameters that we know should not be dropped
+            # but litellm drops because it is not aware that the model supports them.
+            "allowed_openai_params": ["reasoning_effort"],
             **extra_body,
             **self._additional_body_options,
         }

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -7,9 +7,7 @@ import pytest
 from kiln_ai.adapters.ml_model_list import ModelProviderName, StructuredOutputMode
 from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig
 from kiln_ai.adapters.model_adapters.litellm_adapter import LiteLlmAdapter
-from kiln_ai.adapters.model_adapters.litellm_config import (
-    LiteLlmConfig,
-)
+from kiln_ai.adapters.model_adapters.litellm_config import LiteLlmConfig
 from kiln_ai.datamodel import Project, Task, Usage
 from kiln_ai.datamodel.task import RunConfigProperties
 
@@ -462,6 +460,12 @@ async def test_build_completion_kwargs(
 
     # Verify drop_params is set correctly
     assert kwargs["drop_params"] is True
+
+    # Verify allowed_openai_params is set correctly
+    if extra_body.get("reasoning_effort", None) is not None:
+        assert kwargs["allowed_openai_params"] == ["reasoning_effort"]
+    else:
+        assert kwargs["allowed_openai_params"] == []
 
     # Verify optional parameters
     if top_logprobs is not None:


### PR DESCRIPTION
What does this PR do?

- Add support for `Qwen/Qwen3-32B` on Groq, both non-thinking and thinking (ref: https://groq.com/pricing)
- Remove `qwen-qwq-32b`, which has been decommissioned on Groq
- Add `none` value for `thinking_level` because this is how Groq supports disabling thinking for Qwen3 models (ref: https://console.groq.com/docs/reasoning#options-for-reasoning-effort)
- Add `reasoning_effort` in `allowed_openai_params` we pass on to LiteLLM to override the `drop_params=True` for this particular field, because it drops it incorrectly (ref: https://docs.litellm.ai/docs/completion/drop_params#specify-allowed-openai-params-in-a-request)

Also noticed a lot of the smaller Qwen3 models no longer have any active provider on OpenRouter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a "none" thinking level in model provider options.
  * Introduced new model entries for the latest Qwen 32B models with distinct reasoning capabilities.

* **Bug Fixes**
  * Ensured supported parameters like "reasoning_effort" are retained and not dropped during model completion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->