### PR TITLE
docs: update lib docs

### DIFF
--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -153,7 +153,10 @@ item = kiln_ai.datamodel.TaskRun(
             type=kiln_ai.datamodel.DataSourceType.human,
             properties={"created_by": "Jane Doe"},
         ),
-        rating=kiln_ai.datamodel.TaskOutputRating(score=5,type="five_star"),
+        rating=kiln_ai.datamodel.TaskOutputRating(
+            value=5,
+            type=kiln_ai.datamodel.datamodel_enums.five_star,
+        ),
     ),
 )
 item.save_to_file()

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -247,6 +247,25 @@ for run in task.runs():
 
 ```
 
+## Tagging Task Runs programmatically
+
+You can also tag your Kiln Task runs programmatically:
+
+```py
+# Load your Kiln Task from disk
+task_path = "/Users/youruser/Kiln Projects/test project/tasks/632780983478 - Joke Generator/task.kiln"
+task = kiln_ai.datamodel.Task.load_from_file(task_path)
+
+for run in task.runs():
+    # Parse the task output from JSON
+    output = json.loads(run.output.output)
+
+    # Add a tag if the punchline is unusually short
+    if len(output["punchline"]) < 100:
+        run.tags.append("very_short")
+        run.save_to_file()  # Persist the updated tags
+```
+
 ### Adding Custom Model or AI Provider from Code
 
 You can add additional AI models and providers to Kiln.

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -41,6 +41,7 @@ The library has a [comprehensive set of docs](https://kiln-ai.github.io/Kiln/kil
   - [Using your Kiln Dataset in a Notebook or Project](#using-your-kiln-dataset-in-a-notebook-or-project)
   - [Using Kiln Dataset in Pandas](#using-kiln-dataset-in-pandas)
   - [Building and Running a Kiln Task from Code](#building-and-running-a-kiln-task-from-code)
+  - [Tagging Task Runs Programmatically](#tagging-task-runs-programmatically)
   - [Adding Custom Model or AI Provider from Code](#adding-custom-model-or-ai-provider-from-code)
 - [Full API Reference](#full-api-reference)
 
@@ -247,7 +248,7 @@ for run in task.runs():
 
 ```
 
-## Tagging Task Runs programmatically
+## Tagging Task Runs Programmatically
 
 You can also tag your Kiln Task runs programmatically:
 


### PR DESCRIPTION
## What does this PR do?

Update lib documentation.

Changes:
- fix: `TaskOutputRating` expects `value=int` (not `score=int`) and an enum for `type="five_star"`)
- docs: add example about tagging Task runs programmatically


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the example for creating a TaskOutputRating to use named parameters and enum constants.
  * Added a new section demonstrating how to programmatically tag Kiln Task runs based on output content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->