### PR TITLE
Revert "feat: add qwen 3 32B, remove deprecated model, fix reasoning"

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -198,7 +198,7 @@ class KilnModelProvider(BaseModel):
     require_openrouter_reasoning: bool = False
     logprobs_openrouter_options: bool = False
     openrouter_skip_required_parameters: bool = False
-    thinking_level: Literal["low", "medium", "high", "none"] | None = None
+    thinking_level: Literal["low", "medium", "high"] | None = None
     ollama_model_aliases: List[str] | None = None
     anthropic_extended_thinking: bool = False
     gemini_reasoning_enabled: bool = False
@@ -1640,6 +1640,13 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
             ),
             KilnModelProvider(
+                name=ModelProviderName.groq,
+                model_id="qwen-qwq-32b",
+                reasoning_capable=True,
+                parser=ModelParserID.r1_thinking,
+                structured_output_mode=StructuredOutputMode.json_instructions,
+            ),
+            KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="Qwen/QwQ-32B",
                 structured_output_mode=StructuredOutputMode.json_instructions,
@@ -2399,14 +2406,6 @@ built_in_models: List[KilnModel] = [
                 reasoning_capable=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
             ),
-            KilnModelProvider(
-                name=ModelProviderName.groq,
-                model_id="Qwen/Qwen3-32B",
-                supports_data_gen=True,
-                reasoning_capable=True,
-                structured_output_mode=StructuredOutputMode.json_instructions,
-                parser=ModelParserID.r1_thinking,
-            ),
         ],
     ),
     # Qwen 3 32B No Thinking
@@ -2429,13 +2428,6 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 formatter=ModelFormatterID.qwen3_style_no_think,
                 supports_data_gen=True,
-            ),
-            KilnModelProvider(
-                name=ModelProviderName.groq,
-                model_id="Qwen/Qwen3-32B",
-                supports_data_gen=True,
-                structured_output_mode=StructuredOutputMode.json_schema,
-                thinking_level="none",
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -378,17 +378,9 @@ class LiteLlmAdapter(BaseAdapter):
             # Better to ignore them than to fail the model call.
             # https://docs.litellm.ai/docs/completion/input
             "drop_params": True,
-            # LiteLLM drops params that it believes are not supported by the model, but sometimes it does that incorrectly
-            # adding a property name from extra_body to this list will override the drop_params setting for that param.
-            "allowed_openai_params": [],
             **extra_body,
             **self._additional_body_options,
         }
-
-        # We only whitelist it if we are sending it, otherwise the outgoing request will go out with reasoning_effort=None
-        # so it is better to not send it at all than to send it with a value of None
-        if extra_body.get("reasoning_effort", None) is not None:
-            completion_kwargs["allowed_openai_params"].append("reasoning_effort")
 
         if not skip_response_format:
             # Response format: json_schema, json_instructions, json_mode, function_calling, etc

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -7,7 +7,9 @@ import pytest
 from kiln_ai.adapters.ml_model_list import ModelProviderName, StructuredOutputMode
 from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig
 from kiln_ai.adapters.model_adapters.litellm_adapter import LiteLlmAdapter
-from kiln_ai.adapters.model_adapters.litellm_config import LiteLlmConfig
+from kiln_ai.adapters.model_adapters.litellm_config import (
+    LiteLlmConfig,
+)
 from kiln_ai.datamodel import Project, Task, Usage
 from kiln_ai.datamodel.task import RunConfigProperties
 
@@ -460,12 +462,6 @@ async def test_build_completion_kwargs(
 
     # Verify drop_params is set correctly
     assert kwargs["drop_params"] is True
-
-    # Verify allowed_openai_params is set correctly
-    if extra_body.get("reasoning_effort", None) is not None:
-        assert kwargs["allowed_openai_params"] == ["reasoning_effort"]
-    else:
-        assert kwargs["allowed_openai_params"] == []
 
     # Verify optional parameters
     if top_logprobs is not None:


### PR DESCRIPTION
Reverts Kiln-AI/Kiln#446

Introducing a new enum value broke the config for old clients! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the QwQ 32B (Qwen Reasoning) model from Groq, with enhanced reasoning capabilities.

* **Bug Fixes**
  * Updated supported thinking levels for models, removing the "none" option to ensure consistency.
  * Refined model-provider mappings for Groq-related Qwen 32B models.

* **Tests**
  * Updated tests to reflect changes in allowed parameters for model completion requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->