### PR TITLE
fix: allow thinking for final_and_intermediate_r1_compatible

### DIFF
--- a/app/desktop/studio_server/finetune_api.py
+++ b/app/desktop/studio_server/finetune_api.py
@@ -6,10 +6,7 @@ import httpx
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from kiln_ai.adapters.fine_tune.base_finetune import FineTuneParameter, FineTuneStatus
-from kiln_ai.adapters.fine_tune.dataset_formatter import (
-    DatasetFormat,
-    DatasetFormatter,
-)
+from kiln_ai.adapters.fine_tune.dataset_formatter import DatasetFormat, DatasetFormatter
 from kiln_ai.adapters.fine_tune.finetune_registry import finetune_registry
 from kiln_ai.adapters.ml_model_list import (
     KilnModel,
@@ -23,13 +20,11 @@ from kiln_ai.adapters.prompt_builders import (
     prompt_builder_from_id,
 )
 from kiln_ai.adapters.provider_tools import provider_enabled, provider_name_from_id
-from kiln_ai.datamodel import (
-    DatasetSplit,
-    Finetune,
-    FineTuneStatusType,
-    Task,
+from kiln_ai.datamodel import DatasetSplit, Finetune, FineTuneStatusType, Task
+from kiln_ai.datamodel.datamodel_enums import (
+    DATA_STRATEGIES_ALLOWED_THINKING_INSTRUCTIONS,
+    ChatStrategy,
 )
-from kiln_ai.datamodel.datamodel_enums import THINKING_DATA_STRATEGIES, ChatStrategy
 from kiln_ai.datamodel.dataset_filters import (
     DatasetFilterId,
     HighRatingDatasetFilter,
@@ -500,7 +495,7 @@ def thinking_instructions_from_request(
     data_strategy: ChatStrategy,
     custom_thinking_instructions: str | None,
 ) -> str | None:
-    if data_strategy not in THINKING_DATA_STRATEGIES:
+    if data_strategy not in DATA_STRATEGIES_ALLOWED_THINKING_INSTRUCTIONS:
         # Not using COT/Thinking style
         return None
 

--- a/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
@@ -7,7 +7,10 @@ from uuid import uuid4
 
 from kiln_ai.adapters.chat.chat_formatter import ChatMessage, get_chat_formatter
 from kiln_ai.datamodel import DatasetSplit, TaskRun
-from kiln_ai.datamodel.datamodel_enums import THINKING_DATA_STRATEGIES, ChatStrategy
+from kiln_ai.datamodel.datamodel_enums import (
+    DATA_STRATEGIES_ALLOWED_THINKING_INSTRUCTIONS,
+    ChatStrategy,
+)
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 
 
@@ -349,7 +352,7 @@ class DatasetFormatter:
 
         generator = FORMAT_GENERATORS[format_type]
 
-        include_cot = data_strategy in THINKING_DATA_STRATEGIES
+        include_cot = data_strategy in DATA_STRATEGIES_ALLOWED_THINKING_INSTRUCTIONS
 
         # Write to a temp file if no path is provided
         output_path = (

--- a/libs/core/kiln_ai/datamodel/datamodel_enums.py
+++ b/libs/core/kiln_ai/datamodel/datamodel_enums.py
@@ -70,7 +70,8 @@ class ChatStrategy(str, Enum):
     single_turn_r1_thinking = "final_and_intermediate_r1_compatible"
 
 
-THINKING_DATA_STRATEGIES: list[ChatStrategy] = [
+# These are the data strategies that support thinking instructions (but not necessarily required)
+DATA_STRATEGIES_ALLOWED_THINKING_INSTRUCTIONS: list[ChatStrategy] = [
     ChatStrategy.two_message_cot_legacy,
     ChatStrategy.single_turn_r1_thinking,
     ChatStrategy.two_message_cot,

--- a/libs/core/kiln_ai/datamodel/finetune.py
+++ b/libs/core/kiln_ai/datamodel/finetune.py
@@ -5,6 +5,7 @@ from typing_extensions import Self
 
 from kiln_ai.datamodel.basemodel import NAME_FIELD, KilnParentedModel
 from kiln_ai.datamodel.datamodel_enums import (
+    DATA_STRATEGIES_ALLOWED_THINKING_INSTRUCTIONS,
     ChatStrategy,
     FineTuneStatusType,
     StructuredOutputMode,
@@ -13,7 +14,7 @@ from kiln_ai.datamodel.datamodel_enums import (
 if TYPE_CHECKING:
     from kiln_ai.datamodel.task import Task
 
-DATA_STRATIGIES_REQUIRED_THINKING_INSTRUCTIONS = [
+DATA_STRATEGIES_REQUIRED_THINKING_INSTRUCTIONS = [
     ChatStrategy.two_message_cot_legacy,
     ChatStrategy.two_message_cot,
 ]
@@ -95,16 +96,16 @@ class Finetune(KilnParentedModel):
     def validate_thinking_instructions(self) -> Self:
         if (
             self.thinking_instructions is not None
-            and self.data_strategy not in DATA_STRATIGIES_REQUIRED_THINKING_INSTRUCTIONS
+            and self.data_strategy not in DATA_STRATEGIES_ALLOWED_THINKING_INSTRUCTIONS
         ):
             raise ValueError(
-                f"Thinking instructions can only be used when data_strategy is one of the following: {DATA_STRATIGIES_REQUIRED_THINKING_INSTRUCTIONS}"
+                f"Thinking instructions can only be used when data_strategy is one of the following: {DATA_STRATEGIES_ALLOWED_THINKING_INSTRUCTIONS}"
             )
         if (
             self.thinking_instructions is None
-            and self.data_strategy in DATA_STRATIGIES_REQUIRED_THINKING_INSTRUCTIONS
+            and self.data_strategy in DATA_STRATEGIES_REQUIRED_THINKING_INSTRUCTIONS
         ):
             raise ValueError(
-                f"Thinking instructions are required when data_strategy is one of the following: {DATA_STRATIGIES_REQUIRED_THINKING_INSTRUCTIONS}"
+                f"Thinking instructions are required when data_strategy is one of the following: {DATA_STRATEGIES_REQUIRED_THINKING_INSTRUCTIONS}"
             )
         return self

--- a/libs/core/kiln_ai/datamodel/test_models.py
+++ b/libs/core/kiln_ai/datamodel/test_models.py
@@ -554,26 +554,26 @@ def test_prompt_parent_task():
             False,
             None,
         ),
-        # Test 4: Invalid case - thinking instructions with final_only
+        # Test 4: Valid case - thinking instructions with final_and_intermediate_r1_compatible
+        (
+            "Think step by step",
+            ChatStrategy.single_turn_r1_thinking,
+            False,
+            None,
+        ),
+        # Test 5: Invalid case - thinking instructions with final_only
         (
             "Think step by step",
             ChatStrategy.single_turn,
             True,
             "Thinking instructions can only be used when data_strategy is",
         ),
-        # Test 5: Invalid case - no thinking instructions with final_and_intermediate
+        # Test 6: Invalid case - no thinking instructions with final_and_intermediate
         (
             None,
             ChatStrategy.two_message_cot_legacy,
             True,
             "Thinking instructions are required when data_strategy is",
-        ),
-        # Test 6: Invalid case - thinking instructions with final_and_intermediate_r1_compatible
-        (
-            "Think step by step",
-            ChatStrategy.single_turn_r1_thinking,
-            True,
-            "Thinking instructions can only be used when data_strategy is",
         ),
         # Test 7: new COT format
         (
@@ -645,6 +645,70 @@ def test_task_run_has_thinking_training_data(intermediate_outputs, expected):
         intermediate_outputs=intermediate_outputs,
     )
     assert task_run.has_thinking_training_data() == expected
+
+
+@pytest.mark.parametrize(
+    "finetune_data_serialized",
+    [
+        json.dumps(
+            {
+                "v": 1,
+                "id": "259677640827",
+                "created_at": "2025-05-01T03:31:21.395639",
+                "created_by": "xxxx",
+                "name": "Harmonious River",
+                "description": None,
+                "structured_output_mode": "json_mode",
+                "provider": "fireworks_ai",
+                "base_model_id": "accounts/fireworks/models/deepseek-r1-distill-qwen-14b",
+                "provider_id": "accounts/xxx/supervisedFineTuningJobs/xxx",
+                "fine_tune_model_id": "accounts/xxx/models/xxx",
+                "dataset_split_id": "123456789",
+                "train_split_name": "all",
+                "validation_split_name": None,
+                "parameters": {},
+                "system_message": "task instruct\n\nYour response should respect the following requirements:\n1) must be funny\n",
+                "thinking_instructions": "think",
+                "latest_status": "completed",
+                "properties": {"endpoint_version": "v2"},
+                "data_strategy": "final_and_intermediate_r1_compatible",
+                "model_type": "finetune",
+            }
+        ),
+        json.dumps(
+            {
+                "v": 1,
+                "id": "168185977261",
+                "created_at": "2025-05-01T04:13:50.389753",
+                "created_by": "leonardmarcq",
+                "name": "Zealous Falcon",
+                "description": None,
+                "structured_output_mode": "json_mode",
+                "provider": "fireworks_ai",
+                "base_model_id": "accounts/fireworks/models/deepseek-r1-distill-qwen-14b",
+                "provider_id": "accounts/xxx/supervisedFineTuningJobs/xxx",
+                "fine_tune_model_id": "accounts/xxx/models/xxx",
+                "dataset_split_id": "123456789",
+                "train_split_name": "all",
+                "validation_split_name": None,
+                "parameters": {},
+                "system_message": "task instruct\n\nYour response should respect the following requirements:\n1) must be funny\n",
+                "thinking_instructions": None,
+                "latest_status": "running",
+                "properties": {"endpoint_version": "v2"},
+                "data_strategy": "final_and_intermediate_r1_compatible",
+                "model_type": "finetune",
+            }
+        ),
+    ],
+)
+def test_finetune_backwards_compat(finetune_data_serialized, tmp_path):
+    finetune_file = tmp_path / "finetune.kiln"
+    with open(finetune_file, "w") as file:
+        file.write(finetune_data_serialized)
+
+    # should not raise an error
+    Finetune.load_from_file(finetune_file)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Bug: an old finetune with `data_strategy = final_and_intermediate_r1_compatible` and `thinking_instructions != null` fails to deserialize from file, which breaks the `available_models` endpoint for the entire dashboard. The issue is coming out of the `validate_thinking_instructions` model_validator. 

Changes:
- fix: allow (but not require) `thinking_instructions` for `final_and_intermediate_r1_compatible`
- chore: fix typo in `DATA_STRATIGIES_REQUIRED_THINKING_INSTRUCTIONS` -> `DATA_STRATEGIES_REQUIRED_THINKING_INSTRUCTIONS`
- chore: rename `THINKING_DATA_STRATEGIES` -> `DATA_STRATEGIES_ALLOWED_THINKING_INSTRUCTIONS` for consistency
- test: 
  - update existing test that checked `thinking_instructions` was not allowed for `final_and_intermediate_r1_compatible`
  - add a backward compatibility test that checks that the two tasks examples below can be deserialized from file without throwing

### Example files of possible finetunes for final_and_intermediate_r1_compatible

**This one  has `thinking_instructions`**
```json
{
  "v": 1,
  "id": "259677640827",
  "created_at": "2025-05-01T03:31:21.395639",
  "created_by": "xxxx",
  "name": "Harmonious River",
  "description": null,
  "structured_output_mode": "json_mode",
  "provider": "fireworks_ai",
  "base_model_id": "accounts/fireworks/models/deepseek-r1-distill-qwen-14b",
  "provider_id": "accounts/xxx/supervisedFineTuningJobs/xxx",
  "fine_tune_model_id": "accounts/xxx/models/xxx",
  "dataset_split_id": "123456789",
  "train_split_name": "all",
  "validation_split_name": null,
  "parameters": {},
  "system_message": "task instruct\n\nYour response should respect the following requirements:\n1) must be funny\n",
  "thinking_instructions": "think",
  "latest_status": "completed",
  "properties": {
    "endpoint_version": "v2"
  },
  "data_strategy": "final_and_intermediate_r1_compatible",
  "model_type": "finetune"
}
```

**This one does not have `thinking_instructions`**:
```json
{
  "v": 1,
  "id": "168185977261",
  "created_at": "2025-05-01T04:13:50.389753",
  "created_by": "leonardmarcq",
  "name": "Zealous Falcon",
  "description": null,
  "structured_output_mode": "json_mode",
  "provider": "fireworks_ai",
  "base_model_id": "accounts/fireworks/models/deepseek-r1-distill-qwen-14b",
  "provider_id": "accounts/xxx/supervisedFineTuningJobs/xxx",
  "fine_tune_model_id": "accounts/xxx/models/xxx",
  "dataset_split_id": "123456789",
  "train_split_name": "all",
  "validation_split_name": null,
  "parameters": {},
  "system_message": "task instruct\n\nYour response should respect the following requirements:\n1) must be funny\n",
  "thinking_instructions": null,
  "latest_status": "running",
  "properties": {
    "endpoint_version": "v2"
  },
  "data_strategy": "final_and_intermediate_r1_compatible",
  "model_type": "finetune"
}
```

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation logic for compatibility between thinking instructions and data strategies.
  * Fixed a typographical error in a constant name related to data strategies.

* **Tests**
  * Updated and expanded test cases to improve validation of thinking instruction compatibility.
  * Added new tests to ensure backward compatibility when loading finetune configurations.

* **Chores**
  * Updated imports and internal references to reflect renamed constants for data strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->