### PR TITLE
Fix ruff command and lint issues

### DIFF
--- a/app/desktop/desktop.py
+++ b/app/desktop/desktop.py
@@ -1,5 +1,7 @@
-from app.desktop.studio_server.setup_certs import setup_certs
+# ruff: noqa: E402
+from app.desktop.studio_server.setup_certs import setup_certs  # isort:skip
 
+# setup_certs must run before imports to register root certs
 setup_certs()
 
 import contextlib

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -1242,10 +1242,6 @@ def test_openai_compatible_providers():
             "api_key": "test_key",
         }
     ]
-    mock_models = [
-        {"id": "model1", "name": "Model 1"},
-        {"id": "model2", "name": "Model 2"},
-    ]
 
     with (
         patch("app.desktop.studio_server.provider_api.Config.shared") as mock_config,

--- a/checks.sh
+++ b/checks.sh
@@ -15,7 +15,7 @@ headerEnd=" ===\033[0m\n"
 
 echo "${headerStart}Checking Python: Ruff, format, check${headerEnd}"
 # I is import sorting, F401 is unused imports
-uvx  ruff check --select I,F401
+uvx  ruff check --extend-select I,F401
 uvx ruff format --check .
 
 echo "${headerStart}Checking for Misspellings${headerEnd}"

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -485,18 +485,17 @@ async def test_run_job_success_task_run_eval(
     )
 
     # Mock the evaluator
-    mock_result_run = TaskRun(
-        input="test input",
-        input_source=data_source,
-        output=TaskOutput(output="evaluated output"),
-        intermediate_outputs={"intermediate_output": "intermediate output"},
-    )
     mock_scores = {"accuracy": 0.95}
 
     class MockEvaluator(BaseEval):
         async def run_task_and_eval(self, input_text):
             return (
-                mock_result_run,
+                TaskRun(
+                    input="test input",
+                    input_source=data_source,
+                    output=TaskOutput(output="evaluated output"),
+                    intermediate_outputs={"intermediate_output": "intermediate output"},
+                ),
                 mock_scores,
                 {"intermediate_output": "intermediate output"},
             )
@@ -546,11 +545,6 @@ async def test_run_job_success_eval_config_eval(
     )
 
     # Mock the evaluator
-    mock_result_run = TaskRun(
-        input="test input",
-        input_source=data_source,
-        output=TaskOutput(output="evaluated output"),
-    )
     mock_scores: EvalScores = {"accuracy": 0.95}
 
     class MockEvaluator(BaseEval):

--- a/libs/core/kiln_ai/adapters/fine_tune/test_fireworks_tinetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/test_fireworks_tinetune.py
@@ -817,11 +817,6 @@ async def test_deploy_server_success(fireworks_finetune, mock_api_key):
     success_response.status_code = 200
     success_response.json.return_value = {"baseModel": "model-123"}
 
-    status_response = (
-        FineTuneStatus(status=FineTuneStatusType.completed, message=""),
-        "model-123",
-    )
-
     with (
         patch("httpx.AsyncClient") as mock_client_class,
         patch.object(

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -102,7 +102,7 @@ async def test_model_provider_invalid_provider_model_name(base_task):
     """Test error when model or provider name is missing"""
     # Test with missing model name
     with pytest.raises(ValueError, match="Input should be"):
-        adapter = MockAdapter(
+        MockAdapter(
             run_config=RunConfig(
                 task=base_task,
                 model_name="test_model",

--- a/libs/core/kiln_ai/adapters/parsers/test_r1_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/test_r1_parser.py
@@ -46,7 +46,7 @@ def test_response_with_whitespace(parser):
     assert parsed.output.strip() == "This is the result"
 
 
-def test_empty_thinking_content(parser):
+def test_empty_thinking_content_multiline(parser):
     response = RunOutput(
         output="""
         <think>

--- a/libs/core/kiln_ai/adapters/test_provider_tools.py
+++ b/libs/core/kiln_ai/adapters/test_provider_tools.py
@@ -461,7 +461,7 @@ def test_finetune_provider_model_success(mock_project, mock_task, mock_finetune)
     assert provider.model_id == "ft:gpt-3.5-turbo:custom:model-123"
     assert provider.structured_output_mode == StructuredOutputMode.json_schema
     assert provider.reasoning_capable is False
-    assert provider.parser == None
+    assert provider.parser is None
 
 
 def test_finetune_provider_model_success_final_and_intermediate(
@@ -476,7 +476,7 @@ def test_finetune_provider_model_success_final_and_intermediate(
     assert provider.model_id == "ft:gpt-3.5-turbo:custom:model-123"
     assert provider.structured_output_mode == StructuredOutputMode.json_schema
     assert provider.reasoning_capable is False
-    assert provider.parser == None
+    assert provider.parser is None
 
 
 def test_finetune_provider_model_success_r1_compatible(
@@ -590,7 +590,7 @@ def test_finetune_provider_model_structured_mode(
     assert provider.model_id == "fireworks-model-123"
     assert provider.structured_output_mode == expected_mode
     assert provider.reasoning_capable is False
-    assert provider.parser == None
+    assert provider.parser is None
 
 
 def test_openai_compatible_provider_config(mock_shared_config):

--- a/libs/core/kiln_ai/datamodel/task_output.py
+++ b/libs/core/kiln_ai/datamodel/task_output.py
@@ -307,7 +307,7 @@ class TaskOutput(KilnBaseModel):
         if task.output_json_schema is not None:
             try:
                 output_parsed = json.loads(self.output)
-            except json.JSONDecodeError as e:
+            except json.JSONDecodeError:
                 raise ValueError("Output is not a valid JSON object")
 
             validate_schema_with_value_error(

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -517,13 +517,13 @@ def test_eval_run_score_keys_must_match(valid_eval_config, valid_eval_run_data):
     valid_eval_config.parent = eval
 
     # Correct
-    run = EvalRun(
+    EvalRun(
         parent=valid_eval_config,
         **{**valid_eval_run_data, "scores": {"accuracy": 4.5, "critical": 1.0}},
     )
 
     # Correct but wrong order still okay
-    run = EvalRun(
+    EvalRun(
         parent=valid_eval_config,
         **{**valid_eval_run_data, "scores": {"critical": 1.0, "accuracy": 4.5}},
     )
@@ -533,7 +533,7 @@ def test_eval_run_score_keys_must_match(valid_eval_config, valid_eval_run_data):
         ValueError,
         match="The scores produced by the evaluator must match the scores expected by the eval",
     ):
-        run = EvalRun(
+        EvalRun(
             parent=valid_eval_config,
             **{**valid_eval_run_data, "scores": {"accuracy": 4.5}},
         )
@@ -543,7 +543,7 @@ def test_eval_run_score_keys_must_match(valid_eval_config, valid_eval_run_data):
         ValueError,
         match="The scores produced by the evaluator must match the scores expected by the eval",
     ):
-        run = EvalRun(
+        EvalRun(
             parent=valid_eval_config,
             **{
                 **valid_eval_run_data,
@@ -556,7 +556,7 @@ def test_eval_run_score_keys_must_match(valid_eval_config, valid_eval_run_data):
         ValueError,
         match="The scores produced by the evaluator must match the scores expected by the eval",
     ):
-        run = EvalRun(
+        EvalRun(
             parent=valid_eval_config,
             **{**valid_eval_run_data, "scores": {"accuracy": 4.5, "wrong": 1.0}},
         )
@@ -566,7 +566,7 @@ def test_eval_run_custom_scores_not_allowed(valid_eval_config, valid_eval_run_da
     with pytest.raises(
         ValueError, match="Custom scores are not supported in evaluators"
     ):
-        eval = Eval(
+        Eval(
             name="Test Eval",
             eval_set_filter_id="tag::tag1",
             eval_configs_filter_id="tag::tag2",


### PR DESCRIPTION
Fix how we call ruff in checks.sh. Extend adds rules. Select was just running the specific rules, skipping defaults. Codex cleaned up some test issues and other missing concerns.

## Testing
- `uvx ruff check --extend-select I,F401`
- `uvx ruff format --check .`
- `uv run pyright .`
- `uv run python3 -m pytest --benchmark-quiet -q .`
- `uv run bash ./checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_688920a2530c8332a24476d216d9ca2e