### PR TITLE
Allow selecting a project.kiln file for import using native tkinter file picker

### DIFF
--- a/app/desktop/desktop_server.py
+++ b/app/desktop/desktop_server.py
@@ -3,6 +3,7 @@ import contextlib
 import os
 import threading
 import time
+import tkinter as tk
 from contextlib import asynccontextmanager
 
 import kiln_ai.datamodel.strict_mode as datamodel_strict_mode
@@ -16,6 +17,7 @@ from app.desktop.log_config import log_config
 from app.desktop.studio_server.data_gen_api import connect_data_gen_api
 from app.desktop.studio_server.eval_api import connect_evals_api
 from app.desktop.studio_server.finetune_api import connect_fine_tune_api
+from app.desktop.studio_server.import_api import connect_import_api
 from app.desktop.studio_server.prompt_api import connect_prompt_api
 from app.desktop.studio_server.provider_api import connect_provider_api
 from app.desktop.studio_server.repair_api import connect_repair_api
@@ -44,7 +46,7 @@ async def lifespan(app: FastAPI):
     datamodel_strict_mode.set_strict_mode(original_strict_mode)
 
 
-def make_app():
+def make_app(tk_root: tk.Tk | None = None):
     setup_litellm_logging()
 
     load_remote_models(REMOTE_MODEL_LIST_URL)
@@ -57,15 +59,16 @@ def make_app():
     connect_data_gen_api(app)
     connect_fine_tune_api(app)
     connect_evals_api(app)
+    connect_import_api(app, tk_root=tk_root)
 
     # Important: webhost must be last, it handles all other URLs
     connect_webhost(app)
     return app
 
 
-def server_config(port=8757):
+def server_config(port=8757, tk_root: tk.Tk | None = None):
     return uvicorn.Config(
-        make_app(),
+        make_app(tk_root=tk_root),
         host="127.0.0.1",
         port=port,
         use_colors=False,

--- a/app/desktop/studio_server/import_api.py
+++ b/app/desktop/studio_server/import_api.py
@@ -1,0 +1,45 @@
+import asyncio
+import tkinter as tk
+from tkinter import filedialog
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+
+class KilnFileResponse(BaseModel):
+    file_path: str | None
+
+
+def connect_import_api(app: FastAPI, tk_root: tk.Tk | None = None):
+    @app.get("/api/select_kiln_file")
+    async def select_kiln_file(title: str = "Select Kiln File") -> KilnFileResponse:
+        if tk_root is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Not running in app mode. Enter the Kiln file path manually.",
+            )
+
+        # Run the blocking file dialog in a thread pool to not block FastAPI
+        file_path = await asyncio.to_thread(_show_file_dialog, tk_root, title)
+        return KilnFileResponse(file_path=file_path)
+
+
+def _show_file_dialog(tk_root: tk.Tk, title: str) -> str | None:
+    """Run the blocking tkinter operations in a separate thread"""
+    # In order for the dialog to appear on top we: restore app window, bring to front, hide again
+    tk_root.deiconify()
+    tk_root.lift()
+    tk_root.attributes("-topmost", True)
+    tk_root.update_idletasks()
+    tk_root.focus_force()
+    tk_root.withdraw()
+    # Allow other windows to be on top again in 10ms
+    tk_root.after(10, lambda: tk_root.attributes("-topmost", False))
+
+    file_path = filedialog.askopenfilename(
+        title=title,
+        filetypes=[("Kiln files", "*.kiln"), ("All files", "*.*")],
+    )
+    if file_path == "":
+        return None
+    return file_path

--- a/app/desktop/studio_server/test_import_api.py
+++ b/app/desktop/studio_server/test_import_api.py
@@ -1,0 +1,123 @@
+import tkinter as tk
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.desktop.studio_server.import_api import _show_file_dialog, connect_import_api
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    return app
+
+
+@pytest.fixture
+def client_no_tk(app):
+    connect_import_api(app, tk_root=None)
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_tk_root():
+    mock_root = MagicMock(spec=tk.Tk)
+    return mock_root
+
+
+@pytest.fixture
+def client_with_tk(app, mock_tk_root):
+    connect_import_api(app, tk_root=mock_tk_root)
+    return TestClient(app)
+
+
+def test_select_kiln_file_no_tk_root(client_no_tk):
+    """Test that the endpoint raises HTTPException when tk_root is None"""
+    response = client_no_tk.get("/api/select_kiln_file")
+    assert response.status_code == 400
+    assert "Not running in app mode" in response.json()["detail"]
+
+
+def test_select_kiln_file_with_custom_title(client_no_tk):
+    """Test that custom title parameter is handled when tk_root is None"""
+    response = client_no_tk.get("/api/select_kiln_file?title=Custom Title")
+    assert response.status_code == 400
+    assert "Not running in app mode" in response.json()["detail"]
+
+
+@patch("app.desktop.studio_server.import_api.filedialog.askopenfilename")
+def test_select_kiln_file_success(mock_filedialog, client_with_tk, mock_tk_root):
+    """Test successful file selection"""
+    mock_filedialog.return_value = "/path/to/test.kiln"
+
+    response = client_with_tk.get("/api/select_kiln_file")
+
+    assert response.status_code == 200
+    assert response.json() == {"file_path": "/path/to/test.kiln"}
+
+    # Verify dialog was called with correct parameters
+    mock_filedialog.assert_called_once_with(
+        title="Select Kiln File",
+        filetypes=[("Kiln files", "*.kiln"), ("All files", "*.*")],
+    )
+
+
+@patch("app.desktop.studio_server.import_api.filedialog.askopenfilename")
+def test_select_kiln_file_with_custom_title_success(mock_filedialog, client_with_tk):
+    """Test successful file selection with custom title"""
+    mock_filedialog.return_value = "/path/to/custom.kiln"
+
+    response = client_with_tk.get("/api/select_kiln_file?title=Choose Your File")
+
+    assert response.status_code == 200
+    assert response.json() == {"file_path": "/path/to/custom.kiln"}
+
+    # Verify dialog was called with custom title
+    mock_filedialog.assert_called_once_with(
+        title="Choose Your File",
+        filetypes=[("Kiln files", "*.kiln"), ("All files", "*.*")],
+    )
+
+
+@patch("app.desktop.studio_server.import_api.filedialog.askopenfilename")
+def test_select_kiln_file_cancelled(mock_filedialog, client_with_tk):
+    """Test when user cancels file selection (returns empty string)"""
+    mock_filedialog.return_value = ""
+
+    response = client_with_tk.get("/api/select_kiln_file")
+
+    assert response.status_code == 200
+    assert response.json() == {"file_path": None}
+
+
+@patch("app.desktop.studio_server.import_api.filedialog.askopenfilename")
+def test_show_file_dialog_window_manipulation(mock_filedialog):
+    """Test that _show_file_dialog properly manipulates the tkinter window"""
+    mock_root = MagicMock(spec=tk.Tk)
+    mock_filedialog.return_value = "/test/path.kiln"
+
+    result = _show_file_dialog(mock_root, "Test Title")
+
+    # Verify window manipulation calls
+    mock_root.deiconify.assert_called_once()
+    mock_root.lift.assert_called_once()
+    mock_root.attributes.assert_any_call("-topmost", True)
+    mock_root.update_idletasks.assert_called_once()
+    mock_root.focus_force.assert_called_once()
+    mock_root.withdraw.assert_called_once()
+    mock_root.after.assert_called_once()
+
+    # Check the after callback disables topmost
+    after_args = mock_root.after.call_args
+    assert after_args[0][0] == 10  # 10ms delay
+    callback = after_args[0][1]
+    callback()  # Execute the lambda
+    mock_root.attributes.assert_any_call("-topmost", False)
+
+    # Verify filedialog was called correctly
+    mock_filedialog.assert_called_once_with(
+        title="Test Title", filetypes=[("Kiln files", "*.kiln"), ("All files", "*.*")]
+    )
+
+    assert result == "/test/path.kiln"

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1056,6 +1056,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/select_kiln_file": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Select Kiln File */
+        get: operations["select_kiln_file_api_select_kiln_file_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2074,6 +2091,11 @@ export interface components {
             created_by?: string;
             /** Model Type */
             readonly model_type: string;
+        };
+        /** KilnFileResponse */
+        KilnFileResponse: {
+            /** File Path */
+            file_path: string | null;
         };
         /** MeanUsage */
         MeanUsage: {
@@ -5314,6 +5336,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RunConfigEvalScoresSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    select_kiln_file_api_select_kiln_file_get: {
+        parameters: {
+            query?: {
+                title?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KilnFileResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
Adds and endpoint which shows a native file picker using our tk app window.

Needs testing on windows and linux, working on Mac.

https://github.com/user-attachments/assets/204da3c7-3b8a-4b9b-96ba-bffd626b00c5

