### PR TITLE
Fixed "Fine-Tune Prompt" link not working on "Compare Run Methods" page

### DIFF
--- a/app/web_ui/src/lib/utils/link_builder.test.ts
+++ b/app/web_ui/src/lib/utils/link_builder.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest"
+import { prompt_link } from "./link_builder"
+
+describe("prompt_link", () => {
+  const mockProjectId = "test-project"
+  const mockTaskId = "test-task"
+
+  describe("parameter validation", () => {
+    it("returns undefined when project_id is missing", () => {
+      const result = prompt_link("", mockTaskId, "123456")
+      expect(result).toBeUndefined()
+    })
+
+    it("returns undefined when task_id is missing", () => {
+      const result = prompt_link(mockProjectId, "", "123456")
+      expect(result).toBeUndefined()
+    })
+
+    it("returns undefined when prompt_id is missing", () => {
+      const result = prompt_link(mockProjectId, mockTaskId, "")
+      expect(result).toBeUndefined()
+    })
+
+    it("returns undefined when all parameters are missing", () => {
+      const result = prompt_link("", "", "")
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("fine-tuned prompts", () => {
+    it("handles fine-tuned prompt with simple ID", () => {
+      const promptId = "fine_tune_prompt::123456"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      expect(result).toBe(
+        `/fine_tune/${mockProjectId}/${mockTaskId}/fine_tune/123456`,
+      )
+    })
+
+    it("handles fine-tuned prompt with complex ID containing double colons", () => {
+      const promptId = "fine_tune_prompt::789123::456789::987654"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      // Should extract the last part after the final "::"
+      expect(result).toBe(
+        `/fine_tune/${mockProjectId}/${mockTaskId}/fine_tune/987654`,
+      )
+    })
+
+    it("handles fine-tuned prompt with no additional parts", () => {
+      const promptId = "fine_tune_prompt::"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      expect(result).toBe(
+        `/fine_tune/${mockProjectId}/${mockTaskId}/fine_tune/`,
+      )
+    })
+
+    it("handles fine-tuned prompt with multiple numeric IDs", () => {
+      const promptId =
+        "fine_tune_prompt::306673458440::629828465317::310597603461"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      // Should extract the last numeric ID
+      expect(result).toBe(
+        `/fine_tune/${mockProjectId}/${mockTaskId}/fine_tune/310597603461`,
+      )
+    })
+
+    it("URL encodes fine-tuned prompt IDs with special characters", () => {
+      const promptId = "fine_tune_prompt::123456789"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      expect(result).toBe(
+        `/fine_tune/${mockProjectId}/${mockTaskId}/fine_tune/123456789`,
+      )
+    })
+  })
+
+  describe("generator prompts (non-ID style)", () => {
+    it("links to generator_details for prompts without double colons", () => {
+      const promptId = "987654321"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      expect(result).toBe(
+        `/prompts/${mockProjectId}/${mockTaskId}/generator_details/987654321`,
+      )
+    })
+
+    it("URL encodes generator prompt IDs with special characters", () => {
+      const promptId = "456789123"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      expect(result).toBe(
+        `/prompts/${mockProjectId}/${mockTaskId}/generator_details/456789123`,
+      )
+    })
+  })
+
+  describe("saved prompts (ID style)", () => {
+    it("links to saved prompts for prompts with double colons", () => {
+      const promptId = "111222::333444::555666"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      expect(result).toBe(
+        `/prompts/${mockProjectId}/${mockTaskId}/saved/111222%3A%3A333444%3A%3A555666`,
+      )
+    })
+
+    it("handles saved prompts with single double colon", () => {
+      const promptId = "777888::999000"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      expect(result).toBe(
+        `/prompts/${mockProjectId}/${mockTaskId}/saved/777888%3A%3A999000`,
+      )
+    })
+
+    it("URL encodes saved prompt IDs with special characters", () => {
+      const promptId = "123456::789012"
+      const result = prompt_link(mockProjectId, mockTaskId, promptId)
+
+      expect(result).toBe(
+        `/prompts/${mockProjectId}/${mockTaskId}/saved/123456%3A%3A789012`,
+      )
+    })
+  })
+
+  describe("edge cases", () => {
+    it("handles project and task IDs that need URL encoding", () => {
+      const projectWithSpaces = "project with spaces"
+      const taskWithSymbols = "task&symbols"
+      const promptId = "555777999"
+
+      const result = prompt_link(projectWithSpaces, taskWithSymbols, promptId)
+
+      expect(result).toBe(
+        `/prompts/project with spaces/task&symbols/generator_details/555777999`,
+      )
+    })
+
+    it("distinguishes between fine-tune and regular prompts with similar prefixes", () => {
+      const regularPrompt = "111333555"
+      const result = prompt_link(mockProjectId, mockTaskId, regularPrompt)
+
+      expect(result).toBe(
+        `/prompts/${mockProjectId}/${mockTaskId}/generator_details/111333555`,
+      )
+    })
+  })
+})

--- a/app/web_ui/src/lib/utils/link_builder.ts
+++ b/app/web_ui/src/lib/utils/link_builder.ts
@@ -6,6 +6,13 @@ export function prompt_link(
   if (!project_id || !task_id || !prompt_id) {
     return undefined
   }
+  // Special case for fine-tuned prompts
+  if (prompt_id.startsWith("fine_tune_prompt::")) {
+    const trimmed_prompt_id = prompt_id.replace("fine_tune_prompt::", "")
+    const fine_tune_id =
+      trimmed_prompt_id.split("::").pop() || trimmed_prompt_id
+    return `/fine_tune/${project_id}/${task_id}/fine_tune/${encodeURIComponent(fine_tune_id)}`
+  }
   if (!prompt_id.includes("::")) {
     // not an ID style prompt, link to static
     return `/prompts/${project_id}/${task_id}/generator_details/${encodeURIComponent(prompt_id)}`

--- a/app/web_ui/src/lib/utils/link_builder.ts
+++ b/app/web_ui/src/lib/utils/link_builder.ts
@@ -1,3 +1,5 @@
+const FINE_TUNE_PROMPT_PREFIX = "fine_tune_prompt::"
+
 export function prompt_link(
   project_id: string,
   task_id: string,
@@ -7,8 +9,9 @@ export function prompt_link(
     return undefined
   }
   // Special case for fine-tuned prompts
-  if (prompt_id.startsWith("fine_tune_prompt::")) {
-    const trimmed_prompt_id = prompt_id.replace("fine_tune_prompt::", "")
+  if (prompt_id.startsWith(FINE_TUNE_PROMPT_PREFIX)) {
+    // Get the last component of the prompt ID. fine_tune_prompt::fine_tune_id
+    const trimmed_prompt_id = prompt_id.replace(FINE_TUNE_PROMPT_PREFIX, "")
     const fine_tune_id =
       trimmed_prompt_id.split("::").pop() || trimmed_prompt_id
     return `/fine_tune/${project_id}/${task_id}/fine_tune/${encodeURIComponent(fine_tune_id)}`

--- a/app/web_ui/src/lib/utils/link_builder.ts
+++ b/app/web_ui/src/lib/utils/link_builder.ts
@@ -10,7 +10,7 @@ export function prompt_link(
   }
   // Special case for fine-tuned prompts
   if (prompt_id.startsWith(FINE_TUNE_PROMPT_PREFIX)) {
-    // Get the last component of the prompt ID. fine_tune_prompt::fine_tune_id
+    // Get the last component of the prompt ID. fine_tune_prompt::[project_id]::[task_id]::fine_tune_id
     const trimmed_prompt_id = prompt_id.replace(FINE_TUNE_PROMPT_PREFIX, "")
     const fine_tune_id =
       trimmed_prompt_id.split("::").pop() || trimmed_prompt_id

--- a/libs/core/kiln_ai/datamodel/prompt_id.py
+++ b/libs/core/kiln_ai/datamodel/prompt_id.py
@@ -60,11 +60,11 @@ def _check_prompt_id(id: str) -> str:
         return id
 
     if id.startswith("fine_tune_prompt::"):
-        # check it had a fine_tune_id after the :: -- 'fine_tune_prompt::fine_tune_id'
-        fine_tune_id = id[18:]
-        if len(fine_tune_id) == 0:
+        # check it had a fine_tune_id after the :: -- 'fine_tune_prompt::[project_id]::[task_id]::fine_tune_id'
+        parts = id.split("::")
+        if len(parts) != 4 or len(parts[3]) == 0:
             raise ValueError(
-                f"Invalid fine-tune prompt ID: {id}. Expected format: 'fine_tune_prompt::[fine_tune_id]'."
+                f"Invalid fine-tune prompt ID: {id}. Expected format: 'fine_tune_prompt::[project_id]::[task_id]::[fine_tune_id]'."
             )
         return id
 

--- a/libs/core/kiln_ai/datamodel/test_prompt_id.py
+++ b/libs/core/kiln_ai/datamodel/test_prompt_id.py
@@ -29,7 +29,7 @@ def test_valid_saved_prompt_id():
 
 def test_valid_fine_tune_prompt_id():
     """Test that valid fine-tune prompt IDs are accepted"""
-    valid_id = "fine_tune_prompt::ft_123456"
+    valid_id = "fine_tune_prompt::project_123::task_456::ft_123456"
     model = ModelTester(prompt_id=valid_id)
     assert model.prompt_id == valid_id
 
@@ -53,6 +53,10 @@ def test_invalid_saved_prompt_id_format(invalid_id):
     [
         ("fine_tune_prompt::", "Invalid fine-tune prompt ID: fine_tune_prompt::"),
         ("fine_tune_prompt", "Invalid prompt ID: fine_tune_prompt"),
+        (
+            "fine_tune_prompt::ft_123456",
+            "Invalid fine-tune prompt ID: fine_tune_prompt::ft_123456",
+        ),
     ],
 )
 def test_invalid_fine_tune_prompt_id_format(invalid_id, expected_error):


### PR DESCRIPTION
## What does this PR do?

Previously in "Compare Run Methods" page tapping on "Fine-Tune Prompt" does not navigate to the corresponding Fine Tune run. Added logic to construct url for fine tune prompt ids. 

## Checklists

- [YES] Tests have been run locally and passed
- [YES] New tests have been added to any work in /lib


https://github.com/user-attachments/assets/b45dc179-918b-43b4-ae5e-a5d0b785b632



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of prompt links for fine-tuned prompts, generating more accurate URLs for prompt IDs with the "fine_tune_prompt::" prefix.

* **Tests**
  * Added comprehensive tests to verify correct URL construction for various prompt ID formats and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->