### PR TITLE
Fix connect provider not centered in initial setup screen

### DIFF
--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/+page.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/+page.svelte
@@ -4,7 +4,7 @@
   let has_connected_providers = false
   let intermediate_step = false
   let next_visible = false
-  let is_initial_setup_page = true
+  let centered = true
   $: next_visible = !intermediate_step && has_connected_providers
 </script>
 
@@ -25,7 +25,7 @@
   <ConnectProviders
     bind:has_connected_providers
     bind:intermediate_step
-    bind:is_initial_setup_page
+    bind:centered
   />
 </div>
 

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/+page.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/+page.svelte
@@ -4,6 +4,7 @@
   let has_connected_providers = false
   let intermediate_step = false
   let next_visible = false
+  let is_initial_setup_page = true
   $: next_visible = !intermediate_step && has_connected_providers
 </script>
 
@@ -21,7 +22,11 @@
 <div
   class="flex-none min-h-[50vh] py-8 px-4 h-full flex flex-col py-18 w-full mx-auto"
 >
-  <ConnectProviders bind:has_connected_providers bind:intermediate_step />
+  <ConnectProviders
+    bind:has_connected_providers
+    bind:intermediate_step
+    bind:is_initial_setup_page
+  />
 </div>
 
 <div

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
@@ -301,6 +301,7 @@
     (provider) => provider.connected,
   )
   export let intermediate_step = false
+  export let is_initial_setup_page = false
   let api_key_provider: Provider | null = null
   $: {
     intermediate_step = api_key_provider != null
@@ -690,7 +691,7 @@
   }
 </script>
 
-<div class="w-full">
+<div class="w-full {is_initial_setup_page && 'flex flex-col items-center'}">
   {#if api_key_provider}
     <div class="grow h-full max-w-[400px] flex flex-col place-content-center">
       <div class="grow"></div>

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
@@ -301,7 +301,7 @@
     (provider) => provider.connected,
   )
   export let intermediate_step = false
-  export let is_initial_setup_page = false
+  export let centered = false
   let api_key_provider: Provider | null = null
   $: {
     intermediate_step = api_key_provider != null
@@ -691,7 +691,7 @@
   }
 </script>
 
-<div class="w-full {is_initial_setup_page && 'flex flex-col items-center'}">
+<div class="w-full {centered && 'flex flex-col items-center'}">
   {#if api_key_provider}
     <div class="grow h-full max-w-[400px] flex flex-col place-content-center">
       <div class="grow"></div>


### PR DESCRIPTION
## What does this PR do?

The connect provider interface was not properly centered during the initial setup flow, leading to poor visual alignment and user experience issues.

This PR fixes the centering issue by:
1. Added setup context awareness: Introduced an is_initial_setup_page prop to distinguish between the initial setup flow and other provider connection scenarios.
2. Applied conditional centering: Used Flexbox utilities (flex flex-col items-center) to center the provider connection interface when accessed during initial setup.
3. Maintained existing behavior: Other provider connection screens (outside of initial setup) remain unchanged

Before: 
<img width="1044" height="559" alt="image" src="https://github.com/user-attachments/assets/12be3a74-163e-4914-8e84-42dea82d4f2d" />

After:
<img width="836" height="559" alt="image" src="https://github.com/user-attachments/assets/d507575e-2681-4800-bf39-1bc6de84a7a5" />

Connect Provider screen under `/settings/providers` remained unchanged. 
<img width="494" height="522" alt="image" src="https://github.com/user-attachments/assets/21c95713-6084-4a78-a792-8dec4406999f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved layout styling for the provider connection page during initial setup, enhancing the visual alignment and user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->