### PR TITLE
Skip create task on import

### DIFF
--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_project/edit_project.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_project/edit_project.svelte
@@ -165,11 +165,11 @@
 
       if (redirect_on_created && data?.id) {
         // Check if the imported project has tasks to decide where to redirect
-        const should_skip_task_creation = await check_project_has_tasks(data.id)
+        const should_skip_task_creation = await project_has_tasks(data.id)
 
         if (should_skip_task_creation) {
           // Project has tasks, go directly to main app
-          goto("/")
+          goto("/run")
         } else {
           // Project has no tasks, go to task creation
           redirect_to_project(data.id)
@@ -184,7 +184,7 @@
   }
 
   // Check if an imported project has existing tasks
-  async function check_project_has_tasks(project_id: string): Promise<boolean> {
+  async function project_has_tasks(project_id: string): Promise<boolean> {
     try {
       const { data: tasks_data, error: tasks_error } = await client.GET(
         "/api/projects/{project_id}/tasks",

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_project/edit_project.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_project/edit_project.svelte
@@ -162,14 +162,51 @@
       saved = true
       // Wait for saved to propagate to warn_before_unload
       await tick()
+
       if (redirect_on_created && data?.id) {
-        redirect_to_project(data.id)
+        // Check if the imported project has tasks to decide where to redirect
+        const should_skip_task_creation = await check_project_has_tasks(data.id)
+
+        if (should_skip_task_creation) {
+          // Project has tasks, go directly to main app
+          goto("/")
+        } else {
+          // Project has no tasks, go to task creation
+          redirect_to_project(data.id)
+        }
         return
       }
     } catch (e) {
       error = createKilnError(e)
     } finally {
       submitting = false
+    }
+  }
+
+  // Check if an imported project has existing tasks
+  async function check_project_has_tasks(project_id: string): Promise<boolean> {
+    try {
+      const { data: tasks_data, error: tasks_error } = await client.GET(
+        "/api/projects/{project_id}/tasks",
+        {
+          params: {
+            path: {
+              project_id,
+            },
+          },
+        },
+      )
+
+      if (tasks_error) {
+        // If we can't fetch tasks, assume we need to create one
+        return false
+      }
+
+      // Return true if project has at least one task
+      return tasks_data && tasks_data.length > 0
+    } catch (e) {
+      // If error checking tasks, default to going to task creation
+      return false
     }
   }
 </script>

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_project/edit_project.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_project/edit_project.svelte
@@ -168,10 +168,10 @@
         const should_skip_task_creation = await project_has_tasks(data.id)
 
         if (should_skip_task_creation) {
-          // Project has tasks, go directly to main app
-          goto("/run")
+          // Project has tasks, go to select task page
+          goto("/setup/select_task")
         } else {
-          // Project has no tasks, go to task creation
+          // Project has no tasks, go to task creation page
           redirect_to_project(data.id)
         }
         return


### PR DESCRIPTION
## What does this PR do?

When importing an existing Kiln project that already contains tasks, users were being redirected through the "Create a Task" setup flow. 

This PR adds routing logic that checks whether an imported project already has existing tasks. If the project has existing tasks it would now skip the task creation step and go to Select Task. If the project has no tasks, the flow remained the same as before. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved post-import navigation: After importing a project, users are redirected based on whether the project contains tasks. If tasks exist, users are taken to task selection; otherwise, they are guided to the project page to create tasks.

* **Bug Fixes**
  * Enhanced error handling during project import to ensure users are redirected appropriately even if there is an issue fetching project tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->