### PR TITLE
Don't require built in model names to be in the enum, since we now push new models OTA

### DIFF
--- a/libs/core/kiln_ai/adapters/provider_tools.py
+++ b/libs/core/kiln_ai/adapters/provider_tools.py
@@ -74,21 +74,21 @@ def builtin_model_from(
     name: str, provider_name: str | None = None
 ) -> KilnModelProvider | None:
     """
-    Gets a model and provider from the built-in list of models.
+    Gets a model provider from the built-in list of models.
 
     Args:
         name: The name of the model to get
         provider_name: Optional specific provider to use (defaults to first available)
 
     Returns:
-        A tuple of (provider, model), if the model is found and has a provider
+        A KilnModelProvider, or None if not found
     """
     # Select the model from built_in_models using the name
     model = next(filter(lambda m: m.name == name, built_in_models), None)
     if model is None:
         return None
 
-    # If a provider is provided, select the provider from the model's provider_config
+    # If a provider is provided, select the appropriate provider. Otherwise, use the first available.
     provider: KilnModelProvider | None = None
     if model.providers is None or len(model.providers) == 0:
         return None

--- a/libs/core/kiln_ai/adapters/provider_tools.py
+++ b/libs/core/kiln_ai/adapters/provider_tools.py
@@ -5,7 +5,6 @@ from typing import Dict, List
 from kiln_ai.adapters.ml_model_list import (
     KilnModel,
     KilnModelProvider,
-    ModelName,
     ModelParserID,
     ModelProviderName,
     StructuredOutputMode,
@@ -82,23 +81,17 @@ def builtin_model_from(
         provider_name: Optional specific provider to use (defaults to first available)
 
     Returns:
-        A tuple of (provider, model)
-
-    Raises:
-        ValueError: If the model or provider is not found, or if the provider is misconfigured
+        A tuple of (provider, model), if the model is found and has a provider
     """
-    if name not in ModelName.__members__:
-        return None
-
     # Select the model from built_in_models using the name
-    model = next(filter(lambda m: m.name == name, built_in_models))
+    model = next(filter(lambda m: m.name == name, built_in_models), None)
     if model is None:
-        raise ValueError(f"Model {name} not found")
+        return None
 
     # If a provider is provided, select the provider from the model's provider_config
     provider: KilnModelProvider | None = None
     if model.providers is None or len(model.providers) == 0:
-        raise ValueError(f"Model {name} has no providers")
+        return None
     elif provider_name is None:
         provider = model.providers[0]
     else:

--- a/libs/core/kiln_ai/adapters/test_provider_tools.py
+++ b/libs/core/kiln_ai/adapters/test_provider_tools.py
@@ -421,6 +421,17 @@ async def test_builtin_model_from_invalid_provider(mock_config):
 
 
 @pytest.mark.asyncio
+async def test_builtin_model_future_proof():
+    """Test handling of a model that doesn't exist yet but could be added over the air"""
+    with patch("kiln_ai.adapters.provider_tools.built_in_models") as mock_models:
+        mock_models.__iter__.return_value = []
+
+        # should not find it, but should not raise an error
+        result = builtin_model_from("gpt_99")
+        assert result is None
+
+
+@pytest.mark.asyncio
 async def test_builtin_model_from_model_no_providers():
     """Test handling of a model with no providers"""
     with patch("kiln_ai.adapters.provider_tools.built_in_models") as mock_models:
@@ -433,10 +444,8 @@ async def test_builtin_model_from_model_no_providers():
         )
         mock_models.__iter__.return_value = [mock_model]
 
-        with pytest.raises(ValueError) as exc_info:
-            await builtin_model_from(ModelName.phi_3_5)
-
-        assert str(exc_info.value) == f"Model {ModelName.phi_3_5} has no providers"
+        result = builtin_model_from(ModelName.phi_3_5)
+        assert result is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when selecting unavailable models or providers, ensuring the system returns no result instead of raising errors.

* **Tests**
  * Added and updated tests to verify that missing or misconfigured models and providers now result in a safe return value rather than an exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->