### PR TITLE
Add ExternalTool model

### DIFF
--- a/libs/core/kiln_ai/datamodel/__init__.py
+++ b/libs/core/kiln_ai/datamodel/__init__.py
@@ -22,6 +22,7 @@ from kiln_ai.datamodel.dataset_split import (
     DatasetSplit,
     DatasetSplitDefinition,
 )
+from kiln_ai.datamodel.external_tool import ExternalTool
 from kiln_ai.datamodel.finetune import (
     Finetune,
 )
@@ -58,6 +59,7 @@ __all__ = [
     "DataSource",
     "DataSourceType",
     "DataSourceProperty",
+    "ExternalTool",
     "Finetune",
     "FineTuneStatusType",
     "TaskOutputRatingType",

--- a/libs/core/kiln_ai/datamodel/external_tool.py
+++ b/libs/core/kiln_ai/datamodel/external_tool.py
@@ -28,10 +28,17 @@ class ExternalTool(KilnParentedModel):
         description="The URL of the remote MCP server.",
         min_length=1,
     )
+    headers: dict[str, str] | None = Field(
+        default=None,
+        description="HTTP headers to use when calling the server_url.",
+    )
 
     @model_validator(mode="after")
     def validate_remote_mcp_config(self) -> "ExternalTool":
-        """Validate that remote_mcp type has server_url configured."""
-        if self.type == "remote_mcp" and not self.server_url:
-            raise ValueError("server_url must be set when type is 'remote_mcp'")
+        """Validate that remote_mcp type has server_url and headers configured."""
+        if self.type == "remote_mcp":
+            if not self.server_url:
+                raise ValueError("server_url must be set when type is 'remote_mcp'")
+            if not self.headers:
+                raise ValueError("headers must be set when type is 'remote_mcp'")
         return self

--- a/libs/core/kiln_ai/datamodel/external_tool.py
+++ b/libs/core/kiln_ai/datamodel/external_tool.py
@@ -39,8 +39,6 @@ class ExternalTool(KilnParentedModel):
         if self.type == "remote_mcp":
             if not self.server_url:
                 raise ValueError("server_url must be set when type is 'remote_mcp'")
-            if self.headers is None or self.headers == {}:
-                raise ValueError(
-                    "headers must be a non-empty dictionary when type is 'remote_mcp'"
-                )
+            if not self.headers:
+                raise ValueError("headers must be set when type is 'remote_mcp'")
         return self

--- a/libs/core/kiln_ai/datamodel/external_tool.py
+++ b/libs/core/kiln_ai/datamodel/external_tool.py
@@ -1,4 +1,6 @@
-from pydantic import Field
+from typing import Literal
+
+from pydantic import Field, model_validator
 
 from kiln_ai.datamodel.basemodel import (
     FilenameString,
@@ -8,13 +10,16 @@ from kiln_ai.datamodel.basemodel import (
 
 class ExternalTool(KilnParentedModel):
     """
-    Configuration for communicating with a remote MCP (Model Context Protocol) Server for LLM tool calls.
+    Configuration for communicating with a external MCP (Model Context Protocol) Server for LLM tool calls. External tools can be remote or local.
 
     This model stores the necessary configuration to connect to and authenticate with
     external MCP servers that provide tools for LLM interactions.
     """
 
     name: FilenameString = Field(description="The name of the external tool.")
+    type: Literal["remote_mcp"] = Field(
+        description="The type of external tool. Remote tools are hosted on a remote server",
+    )
     description: str | None = Field(
         default=None,
         description="A description of the external tool for you and your team. Will not be used in prompts/training/validation.",
@@ -23,7 +28,10 @@ class ExternalTool(KilnParentedModel):
         description="The URL of the remote MCP server.",
         min_length=1,
     )
-    api_key: str = Field(
-        description="API key for authenticating with the MCP server.",
-        min_length=1,
-    )
+
+    @model_validator(mode="after")
+    def validate_remote_mcp_config(self) -> "ExternalTool":
+        """Validate that remote_mcp type has server_url configured."""
+        if self.type == "remote_mcp" and not self.server_url:
+            raise ValueError("server_url must be set when type is 'remote_mcp'")
+        return self

--- a/libs/core/kiln_ai/datamodel/external_tool.py
+++ b/libs/core/kiln_ai/datamodel/external_tool.py
@@ -1,0 +1,29 @@
+from pydantic import Field
+
+from kiln_ai.datamodel.basemodel import (
+    FilenameString,
+    KilnParentedModel,
+)
+
+
+class ExternalTool(KilnParentedModel):
+    """
+    Configuration for communicating with a remote MCP (Model Context Protocol) Server for LLM tool calls.
+
+    This model stores the necessary configuration to connect to and authenticate with
+    external MCP servers that provide tools for LLM interactions.
+    """
+
+    name: FilenameString = Field(description="The name of the external tool.")
+    description: str | None = Field(
+        default=None,
+        description="A description of the external tool for you and your team. Will not be used in prompts/training/validation.",
+    )
+    server_url: str = Field(
+        description="The URL of the remote MCP server.",
+        min_length=1,
+    )
+    api_key: str = Field(
+        description="API key for authenticating with the MCP server.",
+        min_length=1,
+    )

--- a/libs/core/kiln_ai/datamodel/external_tool.py
+++ b/libs/core/kiln_ai/datamodel/external_tool.py
@@ -39,6 +39,8 @@ class ExternalTool(KilnParentedModel):
         if self.type == "remote_mcp":
             if not self.server_url:
                 raise ValueError("server_url must be set when type is 'remote_mcp'")
-            if not self.headers:
-                raise ValueError("headers must be set when type is 'remote_mcp'")
+            if self.headers is None or self.headers == {}:
+                raise ValueError(
+                    "headers must be a non-empty dictionary when type is 'remote_mcp'"
+                )
         return self

--- a/libs/core/kiln_ai/datamodel/project.py
+++ b/libs/core/kiln_ai/datamodel/project.py
@@ -1,10 +1,13 @@
 from pydantic import Field
 
 from kiln_ai.datamodel.basemodel import FilenameString, KilnParentModel
+from kiln_ai.datamodel.external_tool import ExternalTool
 from kiln_ai.datamodel.task import Task
 
 
-class Project(KilnParentModel, parent_of={"tasks": Task}):
+class Project(
+    KilnParentModel, parent_of={"tasks": Task, "external_tools": ExternalTool}
+):
     """
     A collection of related tasks.
 
@@ -21,3 +24,6 @@ class Project(KilnParentModel, parent_of={"tasks": Task}):
     # Needed for typechecking. We should fix this in KilnParentModel
     def tasks(self) -> list[Task]:
         return super().tasks()  # type: ignore
+
+    def external_tools(self) -> list[ExternalTool]:
+        return super().external_tools()  # type: ignore

--- a/libs/core/kiln_ai/datamodel/test_exteral_tool.py
+++ b/libs/core/kiln_ai/datamodel/test_exteral_tool.py
@@ -10,17 +10,19 @@ def test_external_tool_creation():
         name="test_tool",
         type=ToolType.remote_mcp,
         description="A test external tool",
-        server_url="https://api.example.com",
-        headers={
-            "Authorization": "Bearer token123",
-            "Content-Type": "application/json",
+        properties={
+            "server_url": "https://api.example.com",
+            "headers": {
+                "Authorization": "Bearer token123",
+                "Content-Type": "application/json",
+            },
         },
     )
 
     assert tool.name == "test_tool"
     assert tool.description == "A test external tool"
-    assert tool.server_url == "https://api.example.com"
-    assert tool.headers == {
+    assert tool.properties["server_url"] == "https://api.example.com"
+    assert tool.properties["headers"] == {
         "Authorization": "Bearer token123",
         "Content-Type": "application/json",
     }
@@ -32,14 +34,16 @@ def test_external_tool_creation_minimal():
     tool = ExternalTool(
         name="minimal_tool",
         type=ToolType.remote_mcp,
-        server_url="https://api.example.com",
-        headers={"Authorization": "Bearer token"},
+        properties={
+            "server_url": "https://api.example.com",
+            "headers": {"Authorization": "Bearer token"},
+        },
     )
 
     assert tool.name == "minimal_tool"
     assert tool.description is None
-    assert tool.server_url == "https://api.example.com"
-    assert tool.headers == {"Authorization": "Bearer token"}
+    assert tool.properties["server_url"] == "https://api.example.com"
+    assert tool.properties["headers"] == {"Authorization": "Bearer token"}
 
 
 def test_external_tool_name_validation():
@@ -50,8 +54,10 @@ def test_external_tool_name_validation():
         tool = ExternalTool(
             name=name,
             type=ToolType.remote_mcp,
-            server_url="https://api.example.com",
-            headers={"Authorization": "Bearer token"},
+            properties={
+                "server_url": "https://api.example.com",
+                "headers": {"Authorization": "Bearer token"},
+            },
         )
         assert tool.name == name
 
@@ -76,8 +82,10 @@ def test_external_tool_name_validation():
             ExternalTool(
                 name=invalid_name,
                 type=ToolType.remote_mcp,
-                server_url="https://api.example.com",
-                headers={"Authorization": "Bearer token"},
+                properties={
+                    "server_url": "https://api.example.com",
+                    "headers": {"Authorization": "Bearer token"},
+                },
             )
 
 
@@ -88,8 +96,10 @@ def test_external_tool_name_length_constraints():
         ExternalTool(
             name="",
             type=ToolType.remote_mcp,
-            server_url="https://api.example.com",
-            headers={"Authorization": "Bearer token"},
+            properties={
+                "server_url": "https://api.example.com",
+                "headers": {"Authorization": "Bearer token"},
+            },
         )
 
     # Test name that's too long (> 120 chars)
@@ -98,8 +108,10 @@ def test_external_tool_name_length_constraints():
         ExternalTool(
             name=long_name,
             type=ToolType.remote_mcp,
-            server_url="https://api.example.com",
-            headers={"Authorization": "Bearer token"},
+            properties={
+                "server_url": "https://api.example.com",
+                "headers": {"Authorization": "Bearer token"},
+            },
         )
 
     # Test maximum valid length (120 chars)
@@ -107,8 +119,10 @@ def test_external_tool_name_length_constraints():
     tool = ExternalTool(
         name=max_name,
         type=ToolType.remote_mcp,
-        server_url="https://api.example.com",
-        headers={"Authorization": "Bearer token"},
+        properties={
+            "server_url": "https://api.example.com",
+            "headers": {"Authorization": "Bearer token"},
+        },
     )
     assert tool.name == max_name
 
@@ -119,8 +133,10 @@ def test_external_tool_required_fields():
     with pytest.raises(ValidationError):
         ExternalTool(
             type=ToolType.remote_mcp,
-            server_url="https://api.example.com",
-            headers={"Authorization": "Bearer token"},
+            properties={
+                "server_url": "https://api.example.com",
+                "headers": {"Authorization": "Bearer token"},
+            },
         )  # type: ignore
 
     # Missing server_url
@@ -128,15 +144,19 @@ def test_external_tool_required_fields():
         ExternalTool(
             name="test_tool",
             type=ToolType.remote_mcp,
-            headers={"Authorization": "Bearer token"},
-        )  # type: ignore
+            properties={
+                "headers": {"Authorization": "Bearer token"},
+            },
+        )
 
     # Missing type
     with pytest.raises(ValidationError):
         ExternalTool(
             name="test_tool",
-            server_url="https://api.example.com",
-            headers={"Authorization": "Bearer token"},
+            properties={
+                "server_url": "https://api.example.com",
+                "headers": {"Authorization": "Bearer token"},
+            },
         )  # type: ignore
 
     # Missing headers
@@ -144,7 +164,9 @@ def test_external_tool_required_fields():
         ExternalTool(
             name="test_tool",
             type=ToolType.remote_mcp,
-            server_url="https://api.example.com",
+            properties={
+                "server_url": "https://api.example.com",
+            },
         )
 
 
@@ -155,8 +177,10 @@ def test_external_tool_empty_string_validation():
         ExternalTool(
             name="test_tool",
             type=ToolType.remote_mcp,
-            server_url="",
-            headers={"Authorization": "Bearer token"},
+            properties={
+                "server_url": "",
+                "headers": {"Authorization": "Bearer token"},
+            },
         )
 
 
@@ -174,10 +198,12 @@ def test_external_tool_headers_validation():
         tool = ExternalTool(
             name="test_tool",
             type=ToolType.remote_mcp,
-            server_url="https://api.example.com",
-            headers=headers,
+            properties={
+                "server_url": "https://api.example.com",
+                "headers": headers,
+            },
         )
-        assert tool.headers == headers
+        assert tool.properties["headers"] == headers
 
     # Test that None headers are rejected for remote_mcp type
     with pytest.raises(
@@ -186,8 +212,10 @@ def test_external_tool_headers_validation():
         ExternalTool(
             name="test_tool",
             type=ToolType.remote_mcp,
-            server_url="https://api.example.com",
-            headers=None,
+            properties={
+                "server_url": "https://api.example.com",
+                "headers": None,
+            },
         )
 
     # Test that empty headers dict is rejected
@@ -197,8 +225,10 @@ def test_external_tool_headers_validation():
         ExternalTool(
             name="test_tool",
             type=ToolType.remote_mcp,
-            server_url="https://api.example.com",
-            headers={},
+            properties={
+                "server_url": "https://api.example.com",
+                "headers": {},
+            },
         )
 
 
@@ -217,10 +247,12 @@ def test_external_tool_server_url_validation():
         tool = ExternalTool(
             name="test_tool",
             type=ToolType.remote_mcp,
-            server_url=url,
-            headers={"Authorization": "Bearer token"},
+            properties={
+                "server_url": url,
+                "headers": {"Authorization": "Bearer token"},
+            },
         )
-        assert tool.server_url == url
+        assert tool.properties["server_url"] == url
 
 
 def test_external_tool_description_optional():
@@ -230,8 +262,10 @@ def test_external_tool_description_optional():
         name="test_tool",
         type=ToolType.remote_mcp,
         description="A test tool",
-        server_url="https://api.example.com",
-        headers={"Authorization": "Bearer token"},
+        properties={
+            "server_url": "https://api.example.com",
+            "headers": {"Authorization": "Bearer token"},
+        },
     )
     assert tool_with_desc.description == "A test tool"
 
@@ -239,8 +273,10 @@ def test_external_tool_description_optional():
     tool_without_desc = ExternalTool(
         name="test_tool",
         type=ToolType.remote_mcp,
-        server_url="https://api.example.com",
-        headers={"Authorization": "Bearer token"},
+        properties={
+            "server_url": "https://api.example.com",
+            "headers": {"Authorization": "Bearer token"},
+        },
     )
     assert tool_without_desc.description is None
 
@@ -249,8 +285,10 @@ def test_external_tool_description_optional():
         name="test_tool",
         type=ToolType.remote_mcp,
         description=None,
-        server_url="https://api.example.com",
-        headers={"Authorization": "Bearer token"},
+        properties={
+            "server_url": "https://api.example.com",
+            "headers": {"Authorization": "Bearer token"},
+        },
     )
     assert tool_none_desc.description is None
 
@@ -260,8 +298,10 @@ def test_external_tool_inheritance():
     tool = ExternalTool(
         name="test_tool",
         type=ToolType.remote_mcp,
-        server_url="https://api.example.com",
-        headers={"Authorization": "Bearer token"},
+        properties={
+            "server_url": "https://api.example.com",
+            "headers": {"Authorization": "Bearer token"},
+        },
     )
 
     # Should have inherited fields from KilnBaseModel
@@ -283,8 +323,10 @@ def test_external_tool_model_validation_assignment():
     tool = ExternalTool(
         name="test_tool",
         type=ToolType.remote_mcp,
-        server_url="https://api.example.com",
-        headers={"Authorization": "Bearer token"},
+        properties={
+            "server_url": "https://api.example.com",
+            "headers": {"Authorization": "Bearer token"},
+        },
     )
 
     # Valid assignment should work
@@ -292,20 +334,26 @@ def test_external_tool_model_validation_assignment():
     assert tool.name == "new_name"
 
     # Valid headers assignment should work
-    tool.headers = {"X-API-Key": "new-key"}
-    assert tool.headers == {"X-API-Key": "new-key"}
+    tool.properties["headers"] = {"X-API-Key": "new-key"}
+    assert tool.properties["headers"] == {"X-API-Key": "new-key"}
 
     # Invalid assignment should raise ValidationError
     with pytest.raises(ValidationError):
         tool.name = "invalid/name/with/slashes"
 
     with pytest.raises(ValidationError):
-        tool.server_url = ""
+        tool.properties["server_url"] = ""
+        # Trigger validation by reassigning the properties dict
+        tool.properties = tool.properties
 
     # Invalid headers assignment (None) should raise ValidationError
     with pytest.raises(ValidationError):
-        tool.headers = None
+        tool.properties["headers"] = None
+        # Trigger validation by reassigning the properties dict
+        tool.properties = tool.properties
 
     # Invalid headers assignment (empty dict) should raise ValidationError
     with pytest.raises(ValidationError):
-        tool.headers = {}
+        tool.properties["headers"] = {}
+        # Trigger validation by reassigning the properties dict
+        tool.properties = tool.properties

--- a/libs/core/kiln_ai/datamodel/test_exteral_tool.py
+++ b/libs/core/kiln_ai/datamodel/test_exteral_tool.py
@@ -8,28 +8,26 @@ def test_external_tool_creation():
     """Test successful creation of ExternalTool with valid data."""
     tool = ExternalTool(
         name="test_tool",
+        type="remote_mcp",
         description="A test external tool",
         server_url="https://api.example.com",
-        api_key="test_api_key_123",
     )
 
     assert tool.name == "test_tool"
     assert tool.description == "A test external tool"
     assert tool.server_url == "https://api.example.com"
-    assert tool.api_key == "test_api_key_123"
     assert tool.id is not None  # Should have auto-generated ID
 
 
 def test_external_tool_creation_minimal():
     """Test creation of ExternalTool with minimal required fields."""
     tool = ExternalTool(
-        name="minimal_tool", server_url="https://api.example.com", api_key="test_key"
+        name="minimal_tool", type="remote_mcp", server_url="https://api.example.com"
     )
 
     assert tool.name == "minimal_tool"
     assert tool.description is None
     assert tool.server_url == "https://api.example.com"
-    assert tool.api_key == "test_key"
 
 
 def test_external_tool_name_validation():
@@ -38,7 +36,7 @@ def test_external_tool_name_validation():
     valid_names = ["test_tool", "Tool123", "my-tool", "Tool_Name_v2"]
     for name in valid_names:
         tool = ExternalTool(
-            name=name, server_url="https://api.example.com", api_key="test_key"
+            name=name, type="remote_mcp", server_url="https://api.example.com"
         )
         assert tool.name == name
 
@@ -62,8 +60,8 @@ def test_external_tool_name_validation():
         with pytest.raises(ValidationError):
             ExternalTool(
                 name=invalid_name,
+                type="remote_mcp",
                 server_url="https://api.example.com",
-                api_key="test_key",
             )
 
 
@@ -71,19 +69,19 @@ def test_external_tool_name_length_constraints():
     """Test name length constraints (FilenameString: 1-120 chars)."""
     # Test empty name
     with pytest.raises(ValidationError):
-        ExternalTool(name="", server_url="https://api.example.com", api_key="test_key")
+        ExternalTool(name="", type="remote_mcp", server_url="https://api.example.com")
 
     # Test name that's too long (> 120 chars)
     long_name = "a" * 121
     with pytest.raises(ValidationError):
         ExternalTool(
-            name=long_name, server_url="https://api.example.com", api_key="test_key"
+            name=long_name, type="remote_mcp", server_url="https://api.example.com"
         )
 
     # Test maximum valid length (120 chars)
     max_name = "a" * 120
     tool = ExternalTool(
-        name=max_name, server_url="https://api.example.com", api_key="test_key"
+        name=max_name, type="remote_mcp", server_url="https://api.example.com"
     )
     assert tool.name == max_name
 
@@ -92,26 +90,22 @@ def test_external_tool_required_fields():
     """Test that missing required fields raise ValidationError."""
     # Missing name
     with pytest.raises(ValidationError):
-        ExternalTool(server_url="https://api.example.com", api_key="test_key")
+        ExternalTool(type="remote_mcp", server_url="https://api.example.com")  # type: ignore
 
     # Missing server_url
     with pytest.raises(ValidationError):
-        ExternalTool(name="test_tool", api_key="test_key")
+        ExternalTool(name="test_tool", type="remote_mcp")  # type: ignore
 
-    # Missing api_key
+    # Missing type
     with pytest.raises(ValidationError):
-        ExternalTool(name="test_tool", server_url="https://api.example.com")
+        ExternalTool(name="test_tool", server_url="https://api.example.com")  # type: ignore
 
 
 def test_external_tool_empty_string_validation():
     """Test that empty strings for required fields raise ValidationError."""
     # Empty server_url
     with pytest.raises(ValidationError):
-        ExternalTool(name="test_tool", server_url="", api_key="test_key")
-
-    # Empty api_key
-    with pytest.raises(ValidationError):
-        ExternalTool(name="test_tool", server_url="https://api.example.com", api_key="")
+        ExternalTool(name="test_tool", type="remote_mcp", server_url="")
 
 
 def test_external_tool_server_url_validation():
@@ -126,28 +120,8 @@ def test_external_tool_server_url_validation():
     ]
 
     for url in valid_urls:
-        tool = ExternalTool(name="test_tool", server_url=url, api_key="test_key")
+        tool = ExternalTool(name="test_tool", type="remote_mcp", server_url=url)
         assert tool.server_url == url
-
-
-def test_external_tool_api_key_validation():
-    """Test api_key field validation."""
-    # Valid API keys
-    valid_keys = [
-        "simple_key",
-        "key-with-dashes",
-        "key_with_underscores",
-        "KeyWithMixedCase123",
-        "very-long-api-key-with-many-characters-1234567890",
-        "sk-1234567890abcdef",  # OpenAI-style key
-        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",  # JWT-style
-    ]
-
-    for key in valid_keys:
-        tool = ExternalTool(
-            name="test_tool", server_url="https://api.example.com", api_key=key
-        )
-        assert tool.api_key == key
 
 
 def test_external_tool_description_optional():
@@ -155,24 +129,24 @@ def test_external_tool_description_optional():
     # With description
     tool_with_desc = ExternalTool(
         name="test_tool",
+        type="remote_mcp",
         description="A test tool",
         server_url="https://api.example.com",
-        api_key="test_key",
     )
     assert tool_with_desc.description == "A test tool"
 
     # Without description (should be None)
     tool_without_desc = ExternalTool(
-        name="test_tool", server_url="https://api.example.com", api_key="test_key"
+        name="test_tool", type="remote_mcp", server_url="https://api.example.com"
     )
     assert tool_without_desc.description is None
 
     # Explicitly set to None
     tool_none_desc = ExternalTool(
         name="test_tool",
+        type="remote_mcp",
         description=None,
         server_url="https://api.example.com",
-        api_key="test_key",
     )
     assert tool_none_desc.description is None
 
@@ -180,7 +154,7 @@ def test_external_tool_description_optional():
 def test_external_tool_inheritance():
     """Test that ExternalTool properly inherits from KilnParentedModel."""
     tool = ExternalTool(
-        name="test_tool", server_url="https://api.example.com", api_key="test_key"
+        name="test_tool", type="remote_mcp", server_url="https://api.example.com"
     )
 
     # Should have inherited fields from KilnBaseModel
@@ -200,7 +174,7 @@ def test_external_tool_inheritance():
 def test_external_tool_model_validation_assignment():
     """Test that model validation works on assignment."""
     tool = ExternalTool(
-        name="test_tool", server_url="https://api.example.com", api_key="test_key"
+        name="test_tool", type="remote_mcp", server_url="https://api.example.com"
     )
 
     # Valid assignment should work
@@ -213,6 +187,3 @@ def test_external_tool_model_validation_assignment():
 
     with pytest.raises(ValidationError):
         tool.server_url = ""
-
-    with pytest.raises(ValidationError):
-        tool.api_key = ""

--- a/libs/core/kiln_ai/datamodel/test_exteral_tool.py
+++ b/libs/core/kiln_ai/datamodel/test_exteral_tool.py
@@ -179,8 +179,7 @@ def test_external_tool_headers_validation():
 
     # Test that None headers are rejected for remote_mcp type
     with pytest.raises(
-        ValidationError,
-        match="headers must be a non-empty dictionary when type is 'remote_mcp'",
+        ValidationError, match="headers must be set when type is 'remote_mcp'"
     ):
         ExternalTool(
             name="test_tool",
@@ -191,8 +190,7 @@ def test_external_tool_headers_validation():
 
     # Test that empty headers dict is rejected
     with pytest.raises(
-        ValidationError,
-        match="headers must be a non-empty dictionary when type is 'remote_mcp'",
+        ValidationError, match="headers must be set when type is 'remote_mcp'"
     ):
         ExternalTool(
             name="test_tool",

--- a/libs/core/kiln_ai/datamodel/test_exteral_tool.py
+++ b/libs/core/kiln_ai/datamodel/test_exteral_tool.py
@@ -179,7 +179,8 @@ def test_external_tool_headers_validation():
 
     # Test that None headers are rejected for remote_mcp type
     with pytest.raises(
-        ValidationError, match="headers must be set when type is 'remote_mcp'"
+        ValidationError,
+        match="headers must be a non-empty dictionary when type is 'remote_mcp'",
     ):
         ExternalTool(
             name="test_tool",
@@ -190,7 +191,8 @@ def test_external_tool_headers_validation():
 
     # Test that empty headers dict is rejected
     with pytest.raises(
-        ValidationError, match="headers must be set when type is 'remote_mcp'"
+        ValidationError,
+        match="headers must be a non-empty dictionary when type is 'remote_mcp'",
     ):
         ExternalTool(
             name="test_tool",

--- a/libs/core/kiln_ai/datamodel/test_exteral_tool.py
+++ b/libs/core/kiln_ai/datamodel/test_exteral_tool.py
@@ -1,14 +1,14 @@
 import pytest
 from pydantic import ValidationError
 
-from kiln_ai.datamodel.external_tool import ExternalTool
+from kiln_ai.datamodel.external_tool import ExternalTool, ToolType
 
 
 def test_external_tool_creation():
     """Test successful creation of ExternalTool with valid data."""
     tool = ExternalTool(
         name="test_tool",
-        type="remote_mcp",
+        type=ToolType.remote_mcp,
         description="A test external tool",
         server_url="https://api.example.com",
         headers={
@@ -31,7 +31,7 @@ def test_external_tool_creation_minimal():
     """Test creation of ExternalTool with minimal required fields."""
     tool = ExternalTool(
         name="minimal_tool",
-        type="remote_mcp",
+        type=ToolType.remote_mcp,
         server_url="https://api.example.com",
         headers={"Authorization": "Bearer token"},
     )
@@ -49,7 +49,7 @@ def test_external_tool_name_validation():
     for name in valid_names:
         tool = ExternalTool(
             name=name,
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             server_url="https://api.example.com",
             headers={"Authorization": "Bearer token"},
         )
@@ -75,7 +75,7 @@ def test_external_tool_name_validation():
         with pytest.raises(ValidationError):
             ExternalTool(
                 name=invalid_name,
-                type="remote_mcp",
+                type=ToolType.remote_mcp,
                 server_url="https://api.example.com",
                 headers={"Authorization": "Bearer token"},
             )
@@ -87,7 +87,7 @@ def test_external_tool_name_length_constraints():
     with pytest.raises(ValidationError):
         ExternalTool(
             name="",
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             server_url="https://api.example.com",
             headers={"Authorization": "Bearer token"},
         )
@@ -97,7 +97,7 @@ def test_external_tool_name_length_constraints():
     with pytest.raises(ValidationError):
         ExternalTool(
             name=long_name,
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             server_url="https://api.example.com",
             headers={"Authorization": "Bearer token"},
         )
@@ -106,7 +106,7 @@ def test_external_tool_name_length_constraints():
     max_name = "a" * 120
     tool = ExternalTool(
         name=max_name,
-        type="remote_mcp",
+        type=ToolType.remote_mcp,
         server_url="https://api.example.com",
         headers={"Authorization": "Bearer token"},
     )
@@ -118,7 +118,7 @@ def test_external_tool_required_fields():
     # Missing name
     with pytest.raises(ValidationError):
         ExternalTool(
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             server_url="https://api.example.com",
             headers={"Authorization": "Bearer token"},
         )  # type: ignore
@@ -127,7 +127,7 @@ def test_external_tool_required_fields():
     with pytest.raises(ValidationError):
         ExternalTool(
             name="test_tool",
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             headers={"Authorization": "Bearer token"},
         )  # type: ignore
 
@@ -142,7 +142,9 @@ def test_external_tool_required_fields():
     # Missing headers
     with pytest.raises(ValidationError):
         ExternalTool(
-            name="test_tool", type="remote_mcp", server_url="https://api.example.com"
+            name="test_tool",
+            type=ToolType.remote_mcp,
+            server_url="https://api.example.com",
         )
 
 
@@ -152,7 +154,7 @@ def test_external_tool_empty_string_validation():
     with pytest.raises(ValidationError):
         ExternalTool(
             name="test_tool",
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             server_url="",
             headers={"Authorization": "Bearer token"},
         )
@@ -171,7 +173,7 @@ def test_external_tool_headers_validation():
     for headers in valid_headers:
         tool = ExternalTool(
             name="test_tool",
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             server_url="https://api.example.com",
             headers=headers,
         )
@@ -183,7 +185,7 @@ def test_external_tool_headers_validation():
     ):
         ExternalTool(
             name="test_tool",
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             server_url="https://api.example.com",
             headers=None,
         )
@@ -194,7 +196,7 @@ def test_external_tool_headers_validation():
     ):
         ExternalTool(
             name="test_tool",
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             server_url="https://api.example.com",
             headers={},
         )
@@ -214,7 +216,7 @@ def test_external_tool_server_url_validation():
     for url in valid_urls:
         tool = ExternalTool(
             name="test_tool",
-            type="remote_mcp",
+            type=ToolType.remote_mcp,
             server_url=url,
             headers={"Authorization": "Bearer token"},
         )
@@ -226,7 +228,7 @@ def test_external_tool_description_optional():
     # With description
     tool_with_desc = ExternalTool(
         name="test_tool",
-        type="remote_mcp",
+        type=ToolType.remote_mcp,
         description="A test tool",
         server_url="https://api.example.com",
         headers={"Authorization": "Bearer token"},
@@ -236,7 +238,7 @@ def test_external_tool_description_optional():
     # Without description (should be None)
     tool_without_desc = ExternalTool(
         name="test_tool",
-        type="remote_mcp",
+        type=ToolType.remote_mcp,
         server_url="https://api.example.com",
         headers={"Authorization": "Bearer token"},
     )
@@ -245,7 +247,7 @@ def test_external_tool_description_optional():
     # Explicitly set to None
     tool_none_desc = ExternalTool(
         name="test_tool",
-        type="remote_mcp",
+        type=ToolType.remote_mcp,
         description=None,
         server_url="https://api.example.com",
         headers={"Authorization": "Bearer token"},
@@ -257,7 +259,7 @@ def test_external_tool_inheritance():
     """Test that ExternalTool properly inherits from KilnParentedModel."""
     tool = ExternalTool(
         name="test_tool",
-        type="remote_mcp",
+        type=ToolType.remote_mcp,
         server_url="https://api.example.com",
         headers={"Authorization": "Bearer token"},
     )
@@ -280,7 +282,7 @@ def test_external_tool_model_validation_assignment():
     """Test that model validation works on assignment."""
     tool = ExternalTool(
         name="test_tool",
-        type="remote_mcp",
+        type=ToolType.remote_mcp,
         server_url="https://api.example.com",
         headers={"Authorization": "Bearer token"},
     )


### PR DESCRIPTION
## What does this PR do?

Add a new `ExternalTool` data model to model configurations to make an external MCP server call. Starts with remote_mcp server for now. 

* Add new model for remote_mcp
* Add necessary fields to perform basic remote mcp call. 

## Checklists

- [Yes] Tests have been run locally and passed
- [Yes] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring external tools, allowing users to define connections to external servers for tool calls within projects.
  * Projects can now include and manage external tools alongside existing tasks.

* **Bug Fixes**
  * Improved validation for external tool configuration, ensuring required fields are present and correctly formatted.

* **Tests**
  * Introduced comprehensive tests to verify the creation, validation, and behavior of external tool configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->