### PR TITLE
Fix our bootloader

### DIFF
--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -1,8 +1,7 @@
 name: Build Signed Windows Release
 
 on:
-  release:
-    types: [created]
+  push:
 
 jobs:
   build:

--- a/.github/workflows/windows_release_build.yml
+++ b/.github/workflows/windows_release_build.yml
@@ -1,7 +1,8 @@
 name: Build Signed Windows Release
 
 on:
-  push:
+  release:
+    types: [created]
 
 jobs:
   build:

--- a/app/desktop/build_desktop_app.sh
+++ b/app/desktop/build_desktop_app.sh
@@ -26,8 +26,8 @@ if [[ $* == *--build-bootloader* ]]; then
   echo "Downloading pyinstaller"
   curl -L https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v6.11.1.tar.gz -o pyinstaller.tar.gz
   tar -xzf pyinstaller.tar.gz
-  # Remove the old pyinstaller
-  rm -r pyinstaller
+  # Remove the old pyinstaller if it exists
+  rm -rf pyinstaller
   mv pyinstaller-6.11.1 pyinstaller
   cd pyinstaller/bootloader
 

--- a/app/desktop/build_desktop_app.sh
+++ b/app/desktop/build_desktop_app.sh
@@ -19,19 +19,25 @@ fi
 # Building the bootloader ourselves helps not be falsely detected as malware by antivirus software on windows.
 # We clone pyinstaller, build the bootloader, and install it into the pyproject desktop pyproject.
 if [[ $* == *--build-bootloader* ]]; then
-  echo "Building pyinstaller inlucding bootloader"
-
+  echo "Building pyinstaller including bootloader"
   mkdir -p desktop/build/bootloader
   cd desktop/build/bootloader
+
+  echo "Downloading pyinstaller"
   curl -L https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v6.11.1.tar.gz -o pyinstaller.tar.gz
   tar -xzf pyinstaller.tar.gz
+  # Remove the old pyinstaller
+  rm -r pyinstaller
   mv pyinstaller-6.11.1 pyinstaller
   cd pyinstaller/bootloader
+
+  echo "Building bootloader"
   python ./waf all
 
   # install the pyinstaller we just built into the desktop pyproject
+  echo "Adding pyinstaller to desktop pyproject"
   cd $APP_DIR/desktop
-  uv add build/bootloader/pyinstaller
+  uv pip install build/bootloader/pyinstaller
 
   # return to the /app directory of the project
   cd $APP_DIR


### PR DESCRIPTION
Fix our bootloader build script to be compatible with newer uv versions. Using `pip install` resolves the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows release build workflow to run on every push instead of only on new releases.
  * Improved build script logging and corrected a typo for clearer progress updates.
  * Enhanced build script to ensure a clean environment by removing existing directories before renaming.
  * Changed the installation method for PyInstaller in the build script for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->