### PR TITLE
Kill the "RunConfig" class as it had many problems, leading to ugly code

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/base_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/base_eval.py
@@ -7,7 +7,7 @@ from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig
 from kiln_ai.datamodel.eval import Eval, EvalConfig, EvalScores
 from kiln_ai.datamodel.json_schema import validate_schema_with_value_error
-from kiln_ai.datamodel.task import RunConfig, TaskOutputRatingType, TaskRun
+from kiln_ai.datamodel.task import RunConfigProperties, TaskOutputRatingType, TaskRun
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 
 
@@ -18,7 +18,7 @@ class BaseEval:
     Should be subclassed, and the run_eval method implemented.
     """
 
-    def __init__(self, eval_config: EvalConfig, run_config: RunConfig | None):
+    def __init__(self, eval_config: EvalConfig, run_config: RunConfigProperties | None):
         self.eval_config = eval_config
         eval = eval_config.parent_eval()
         if not eval:

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -169,7 +169,9 @@ class EvalRunner:
             # Create the evaluator for this eval config/run config pair
             evaluator = eval_adapter_from_type(job.eval_config.config_type)(
                 job.eval_config,
-                job.task_run_config.run_config() if job.task_run_config else None,
+                job.task_run_config.run_config_properties
+                if job.task_run_config
+                else None,
             )
             if not isinstance(evaluator, BaseEval):
                 raise ValueError("Not able to create evaluator from eval config")

--- a/libs/core/kiln_ai/adapters/eval/g_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/g_eval.py
@@ -12,7 +12,7 @@ from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig, RunOutpu
 from kiln_ai.adapters.prompt_builders import PromptGenerators
 from kiln_ai.datamodel import Project, Task, TaskRun
 from kiln_ai.datamodel.eval import EvalConfig, EvalConfigType, EvalScores
-from kiln_ai.datamodel.task import RunConfig, RunConfigProperties, StructuredOutputMode
+from kiln_ai.datamodel.task import RunConfigProperties, StructuredOutputMode
 
 # all the tokens we score for, and their float scores.
 TOKEN_TO_SCORE_MAP: Dict[str, float] = {
@@ -89,7 +89,7 @@ class GEval(BaseEval):
     }
     """
 
-    def __init__(self, eval_config: EvalConfig, run_config: RunConfig | None):
+    def __init__(self, eval_config: EvalConfig, run_config: RunConfigProperties | None):
         if (
             eval_config.config_type != EvalConfigType.g_eval
             and eval_config.config_type != EvalConfigType.llm_as_judge

--- a/libs/core/kiln_ai/adapters/eval/test_base_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/test_base_eval.py
@@ -380,7 +380,7 @@ async def test_run_task_and_eval():
         async def run_eval(self, task_run):
             return {"overall_rating": 5, "quality": 4}, {"thinking": "test thinking"}
 
-    evaluator = MockEval(eval_config, run_config.run_config())
+    evaluator = MockEval(eval_config, run_config.run_config_properties)
 
     # Mock dependencies
     mock_adapter = AsyncMock()

--- a/libs/core/kiln_ai/adapters/eval/test_g_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/test_g_eval.py
@@ -19,7 +19,7 @@ from kiln_ai.datamodel import (
     TaskRun,
 )
 from kiln_ai.datamodel.eval import Eval, EvalConfig, EvalConfigType, EvalOutputScore
-from kiln_ai.datamodel.task import RunConfig
+from kiln_ai.datamodel.task import RunConfigProperties
 
 
 @pytest.fixture
@@ -93,11 +93,10 @@ def test_eval_config(test_task):
 
 
 @pytest.fixture
-def test_run_config(test_task):
-    return RunConfig(
+def test_run_config():
+    return RunConfigProperties(
         model_name="llama_3_1_8b",
         model_provider_name="groq",
-        task=test_task,
         prompt_id="simple_prompt_builder",
         structured_output_mode="json_schema",
     )

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -26,7 +26,6 @@ from kiln_ai.adapters.model_adapters.base_adapter import (
 )
 from kiln_ai.adapters.model_adapters.litellm_config import LiteLlmConfig
 from kiln_ai.datamodel.json_schema import validate_schema_with_value_error
-from kiln_ai.datamodel.task import run_config_from_run_config_properties
 from kiln_ai.tools.base_tool import KilnToolInterface
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 
@@ -59,14 +58,9 @@ class LiteLlmAdapter(BaseAdapter):
         self._litellm_model_id: str | None = None
         self._cached_available_tools: list[KilnToolInterface] | None = None
 
-        # Create a RunConfig, adding the task to the RunConfigProperties
-        run_config = run_config_from_run_config_properties(
-            task=kiln_task,
-            run_config_properties=config.run_config_properties,
-        )
-
         super().__init__(
-            run_config=run_config,
+            task=kiln_task,
+            run_config=config.run_config_properties,
             config=base_adapter_config,
         )
 
@@ -337,7 +331,7 @@ class LiteLlmAdapter(BaseAdapter):
                 raise_exhaustive_enum_error(structured_output_mode)
 
     def json_schema_response_format(self) -> dict[str, Any]:
-        output_schema = self.task().output_schema()
+        output_schema = self.task.output_schema()
         return {
             "response_format": {
                 "type": "json_schema",
@@ -350,7 +344,7 @@ class LiteLlmAdapter(BaseAdapter):
 
     def tool_call_params(self, strict: bool) -> dict[str, Any]:
         # Add additional_properties: false to the schema (OpenAI requires this for some models)
-        output_schema = self.task().output_schema()
+        output_schema = self.task.output_schema()
         if not isinstance(output_schema, dict):
             raise ValueError(
                 "Invalid output schema for this task. Can not use tool calls."

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -7,7 +7,7 @@ from kiln_ai.adapters.model_adapters.base_adapter import BaseAdapter, RunOutput
 from kiln_ai.datamodel import Task
 from kiln_ai.datamodel.datamodel_enums import ChatStrategy
 from kiln_ai.datamodel.run_config import ToolsRunConfig
-from kiln_ai.datamodel.task import RunConfig, RunConfigProperties
+from kiln_ai.datamodel.task import RunConfigProperties
 from kiln_ai.tools.base_tool import KilnToolInterface
 from kiln_ai.tools.tool_id import KilnBuiltInToolId
 
@@ -37,8 +37,8 @@ def base_task():
 @pytest.fixture
 def adapter(base_task):
     return MockAdapter(
-        run_config=RunConfig(
-            task=base_task,
+        task=base_task,
+        run_config=RunConfigProperties(
             model_name="test_model",
             model_provider_name="openai",
             prompt_id="simple_prompt_builder",
@@ -106,8 +106,8 @@ async def test_model_provider_invalid_provider_model_name(base_task):
     # Test with missing model name
     with pytest.raises(ValueError, match="Input should be"):
         MockAdapter(
-            run_config=RunConfig(
-                task=base_task,
+            task=base_task,
+            run_config=RunConfigProperties(
                 model_name="test_model",
                 model_provider_name="invalid",
                 prompt_id="simple_prompt_builder",
@@ -119,8 +119,8 @@ async def test_model_provider_missing_model_names(base_task):
     """Test error when model or provider name is missing"""
     # Test with missing model name
     adapter = MockAdapter(
-        run_config=RunConfig(
-            task=base_task,
+        task=base_task,
+        run_config=RunConfigProperties(
             model_name="",
             model_provider_name="openai",
             prompt_id="simple_prompt_builder",
@@ -417,8 +417,7 @@ async def test_update_run_config_unknown_structured_output_mode(
 ):
     """Test that unknown structured output mode is updated to the default for the model provider"""
     # Create a run config with the initial mode
-    run_config = RunConfig(
-        task=base_task,
+    run_config = RunConfigProperties(
         model_name="test_model",
         model_provider_name="openai",
         prompt_id="simple_prompt_builder",
@@ -434,7 +433,7 @@ async def test_update_run_config_unknown_structured_output_mode(
         mock_default.return_value = StructuredOutputMode.json_mode
 
         # Create the adapter
-        adapter = MockAdapter(run_config=run_config)
+        adapter = MockAdapter(task=base_task, run_config=run_config)
 
         # Verify the mode was updated correctly
         assert adapter.run_config.structured_output_mode == expected_mode
@@ -497,8 +496,8 @@ def test_available_tools(
 
     # Create adapter with tools config
     adapter = MockAdapter(
-        run_config=RunConfig(
-            task=base_task,
+        task=base_task,
+        run_config=RunConfigProperties(
             model_name="test_model",
             model_provider_name="openai",
             prompt_id="simple_prompt_builder",
@@ -530,8 +529,8 @@ def test_available_tools_with_invalid_tool_id(base_task):
 
     # Create adapter
     adapter = MockAdapter(
-        run_config=RunConfig(
-            task=base_task,
+        task=base_task,
+        run_config=RunConfigProperties(
             model_name="test_model",
             model_provider_name="openai",
             prompt_id="simple_prompt_builder",

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -66,7 +66,7 @@ def test_initialization(config, mock_task):
     )
 
     assert adapter.config == config
-    assert adapter.run_config.task == mock_task
+    assert adapter.task == mock_task
     assert adapter.run_config.prompt_id == "simple_prompt_builder"
     assert adapter.base_adapter_config.default_tags == ["test-tag"]
     assert adapter.run_config.model_name == config.run_config_properties.model_name

--- a/libs/core/kiln_ai/adapters/model_adapters/test_saving_adapter_results.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_saving_adapter_results.py
@@ -13,7 +13,7 @@ from kiln_ai.datamodel import (
     Task,
     Usage,
 )
-from kiln_ai.datamodel.task import RunConfig
+from kiln_ai.datamodel.task import RunConfigProperties
 from kiln_ai.utils.config import Config
 
 
@@ -41,8 +41,8 @@ def test_task(tmp_path):
 @pytest.fixture
 def adapter(test_task):
     return MockAdapter(
-        run_config=RunConfig(
-            task=test_task,
+        task=test_task,
+        run_config=RunConfigProperties(
             model_name="phi_3_5",
             model_provider_name="ollama",
             prompt_id="simple_chain_of_thought_prompt_builder",
@@ -240,8 +240,8 @@ async def test_autosave_true(test_task, adapter):
 def test_properties_for_task_output_custom_values(test_task):
     """Test that _properties_for_task_output includes custom temperature, top_p, and structured_output_mode"""
     adapter = MockAdapter(
-        run_config=RunConfig(
-            task=test_task,
+        task=test_task,
+        run_config=RunConfigProperties(
             model_name="gpt-4",
             model_provider_name="openai",
             prompt_id="simple_prompt_builder",

--- a/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
@@ -11,7 +11,7 @@ from kiln_ai.adapters.model_adapters.base_adapter import BaseAdapter, RunOutput,
 from kiln_ai.adapters.ollama_tools import ollama_online
 from kiln_ai.adapters.test_prompt_adaptors import get_all_models_and_providers
 from kiln_ai.datamodel import PromptId
-from kiln_ai.datamodel.task import RunConfig, RunConfigProperties
+from kiln_ai.datamodel.task import RunConfigProperties
 from kiln_ai.datamodel.test_json_schema import json_joke_schema, json_triangle_schema
 
 
@@ -40,8 +40,8 @@ async def test_structured_output_ollama(tmp_path, model_name):
 class MockAdapter(BaseAdapter):
     def __init__(self, kiln_task: datamodel.Task, response: Dict | str | None):
         super().__init__(
-            run_config=RunConfig(
-                task=kiln_task,
+            task=kiln_task,
+            run_config=RunConfigProperties(
                 model_name="phi_3_5",
                 model_provider_name="ollama",
                 prompt_id="simple_chain_of_thought_prompt_builder",

--- a/libs/core/kiln_ai/datamodel/task.py
+++ b/libs/core/kiln_ai/datamodel/task.py
@@ -43,18 +43,6 @@ class TaskRequirement(BaseModel):
     type: TaskOutputRatingType = Field(default=TaskOutputRatingType.five_star)
 
 
-class RunConfig(RunConfigProperties):
-    """
-    A configuration for running a task.
-
-    This includes everything needed to run a task, except the input. Running the same RunConfig with the same input should make identical calls to the model (output may vary as models are non-deterministic).
-
-    For example: task, model, provider, prompt, etc.
-    """
-
-    task: "Task" = Field(description="The task to run.")
-
-
 class TaskRunConfig(KilnParentedModel):
     """
     A Kiln model for persisting a run config in a Kiln Project, nested under a task.
@@ -85,15 +73,6 @@ class TaskRunConfig(KilnParentedModel):
             return None
         return self.parent  # type: ignore
 
-    def run_config(self) -> RunConfig:
-        parent_task = self.parent_task()
-        if parent_task is None:
-            raise ValueError("Run config must be parented to a task")
-        return run_config_from_run_config_properties(
-            task=parent_task,
-            run_config_properties=self.run_config_properties,
-        )
-
     # Previously we didn't store structured_output_mode in the run_config_properties. Updgrade old models when loading from file.
     @model_validator(mode="before")
     def upgrade_old_entries(cls, data: dict, info: ValidationInfo) -> dict:
@@ -114,22 +93,6 @@ class TaskRunConfig(KilnParentedModel):
             )
 
         return data
-
-
-def run_config_from_run_config_properties(
-    task: "Task",
-    run_config_properties: RunConfigProperties,
-) -> RunConfig:
-    return RunConfig(
-        task=task,
-        model_name=run_config_properties.model_name,
-        model_provider_name=run_config_properties.model_provider_name,
-        prompt_id=run_config_properties.prompt_id,
-        top_p=run_config_properties.top_p,
-        temperature=run_config_properties.temperature,
-        structured_output_mode=run_config_properties.structured_output_mode,
-        tools_config=run_config_properties.tools_config,
-    )
 
 
 class Task(

--- a/libs/core/kiln_ai/datamodel/test_basemodel.py
+++ b/libs/core/kiln_ai/datamodel/test_basemodel.py
@@ -17,7 +17,7 @@ from kiln_ai.datamodel.basemodel import (
     string_to_valid_name,
 )
 from kiln_ai.datamodel.model_cache import ModelCache
-from kiln_ai.datamodel.task import RunConfig
+from kiln_ai.datamodel.task import RunConfigProperties
 
 
 @pytest.fixture
@@ -552,8 +552,8 @@ def base_task():
 @pytest.fixture
 def adapter(base_task):
     return MockAdapter(
-        run_config=RunConfig(
-            task=base_task,
+        task=base_task,
+        run_config=RunConfigProperties(
             model_name="test_model",
             model_provider_name="openai",
             prompt_id="simple_prompt_builder",

--- a/libs/core/kiln_ai/datamodel/test_task.py
+++ b/libs/core/kiln_ai/datamodel/test_task.py
@@ -3,22 +3,18 @@ from pydantic import ValidationError
 
 from kiln_ai.datamodel.datamodel_enums import StructuredOutputMode, TaskOutputRatingType
 from kiln_ai.datamodel.prompt_id import PromptGenerators
-from kiln_ai.datamodel.task import RunConfig, RunConfigProperties, Task, TaskRunConfig
+from kiln_ai.datamodel.task import RunConfigProperties, Task, TaskRunConfig
 from kiln_ai.datamodel.task_output import normalize_rating
 
 
 def test_runconfig_valid_creation():
-    task = Task(id="task1", name="Test Task", instruction="Do something")
-
-    config = RunConfig(
-        task=task,
+    config = RunConfigProperties(
         model_name="gpt-4",
         model_provider_name="openai",
         prompt_id=PromptGenerators.SIMPLE,
         structured_output_mode="json_schema",
     )
 
-    assert config.task == task
     assert config.model_name == "gpt-4"
     assert config.model_provider_name == "openai"
     assert config.prompt_id == PromptGenerators.SIMPLE  # Check default value
@@ -26,13 +22,12 @@ def test_runconfig_valid_creation():
 
 def test_runconfig_missing_required_fields():
     with pytest.raises(ValidationError) as exc_info:
-        RunConfig()
+        RunConfigProperties()  # type: ignore
 
     errors = exc_info.value.errors()
     assert (
-        len(errors) == 5
+        len(errors) == 4
     )  # task, model_name, model_provider_name, and prompt_id are required
-    assert any(error["loc"][0] == "task" for error in errors)
     assert any(error["loc"][0] == "model_name" for error in errors)
     assert any(error["loc"][0] == "model_provider_name" for error in errors)
     assert any(error["loc"][0] == "prompt_id" for error in errors)
@@ -40,10 +35,7 @@ def test_runconfig_missing_required_fields():
 
 
 def test_runconfig_custom_prompt_id():
-    task = Task(id="task1", name="Test Task", instruction="Do something")
-
-    config = RunConfig(
-        task=task,
+    config = RunConfigProperties(
         model_name="gpt-4",
         model_provider_name="openai",
         prompt_id=PromptGenerators.SIMPLE_CHAIN_OF_THOUGHT,
@@ -100,28 +92,16 @@ def test_task_run_config_missing_required_fields(sample_task):
     with pytest.raises(ValidationError) as exc_info:
         TaskRunConfig(
             run_config_properties=RunConfigProperties(
-                task=sample_task, model_name="gpt-4", model_provider_name="openai"
-            ),
+                model_name="gpt-4", model_provider_name="openai"
+            ),  # type: ignore
             parent=sample_task,
-        )
+        )  # type: ignore
     assert "Field required" in str(exc_info.value)
 
     # Test missing run_config
     with pytest.raises(ValidationError) as exc_info:
-        TaskRunConfig(name="Test Config", parent=sample_task)
+        TaskRunConfig(name="Test Config", parent=sample_task)  # type: ignore
     assert "Field required" in str(exc_info.value)
-
-
-def test_task_run_config_missing_task_in_run_config(sample_task):
-    with pytest.raises(
-        ValidationError, match="Input should be a valid dictionary or instance of Task"
-    ):
-        # Create a run config without a task
-        RunConfig(
-            model_name="gpt-4",
-            model_provider_name="openai",
-            task=None,  # type: ignore
-        )
 
 
 @pytest.mark.parametrize(
@@ -165,10 +145,8 @@ def test_normalize_rating_errors(rating_type, rating):
 
 def test_run_config_defaults():
     """RunConfig should require top_p, temperature, and structured_output_mode to be set."""
-    task = Task(id="task1", name="Test Task", instruction="Do something")
 
-    config = RunConfig(
-        task=task,
+    config = RunConfigProperties(
         model_name="gpt-4",
         model_provider_name="openai",
         prompt_id=PromptGenerators.SIMPLE,
@@ -180,11 +158,9 @@ def test_run_config_defaults():
 
 def test_run_config_valid_ranges():
     """RunConfig should accept valid ranges for top_p and temperature."""
-    task = Task(id="task1", name="Test Task", instruction="Do something")
 
     # Test valid values
-    config = RunConfig(
-        task=task,
+    config = RunConfigProperties(
         model_name="gpt-4",
         model_provider_name="openai",
         prompt_id=PromptGenerators.SIMPLE,
@@ -201,10 +177,8 @@ def test_run_config_valid_ranges():
 @pytest.mark.parametrize("top_p", [0.0, 0.5, 1.0])
 def test_run_config_valid_top_p(top_p):
     """Test that RunConfig accepts valid top_p values (0-1)."""
-    task = Task(id="task1", name="Test Task", instruction="Do something")
 
-    config = RunConfig(
-        task=task,
+    config = RunConfigProperties(
         model_name="gpt-4",
         model_provider_name="openai",
         prompt_id=PromptGenerators.SIMPLE,
@@ -219,11 +193,9 @@ def test_run_config_valid_top_p(top_p):
 @pytest.mark.parametrize("top_p", [-0.1, 1.1, 2.0])
 def test_run_config_invalid_top_p(top_p):
     """Test that RunConfig rejects invalid top_p values."""
-    task = Task(id="task1", name="Test Task", instruction="Do something")
 
     with pytest.raises(ValueError, match="top_p must be between 0 and 1"):
-        RunConfig(
-            task=task,
+        RunConfigProperties(
             model_name="gpt-4",
             model_provider_name="openai",
             prompt_id=PromptGenerators.SIMPLE,
@@ -236,10 +208,8 @@ def test_run_config_invalid_top_p(top_p):
 @pytest.mark.parametrize("temperature", [0.0, 1.0, 2.0])
 def test_run_config_valid_temperature(temperature):
     """Test that RunConfig accepts valid temperature values (0-2)."""
-    task = Task(id="task1", name="Test Task", instruction="Do something")
 
-    config = RunConfig(
-        task=task,
+    config = RunConfigProperties(
         model_name="gpt-4",
         model_provider_name="openai",
         prompt_id=PromptGenerators.SIMPLE,
@@ -254,11 +224,9 @@ def test_run_config_valid_temperature(temperature):
 @pytest.mark.parametrize("temperature", [-0.1, 2.1, 3.0])
 def test_run_config_invalid_temperature(temperature):
     """Test that RunConfig rejects invalid temperature values."""
-    task = Task(id="task1", name="Test Task", instruction="Do something")
 
     with pytest.raises(ValueError, match="temperature must be between 0 and 2"):
-        RunConfig(
-            task=task,
+        RunConfigProperties(
             model_name="gpt-4",
             model_provider_name="openai",
             prompt_id=PromptGenerators.SIMPLE,


### PR DESCRIPTION
Issues:
 - We refer to run configs all the time, but we use the term for RunConfigProperties, not run config
 - It was a base model, despite us never wanting to perist it
 - It tied together two separate concepts: a task, and model running parameters
 - Converting between RunConfig and RunConfigProperties was very ugly

Now it's simple: just pass the task separately. Ends up it was only needed about 2 places.

