### PR TITLE
Add GPT 5 mini/nano on openrouter (full not supported)

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -289,6 +289,13 @@ built_in_models: List[KilnModel] = [
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
             ),
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="openai/gpt-5-mini",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                suggested_for_evals=True,
+                suggested_for_data_gen=True,
+            ),
         ],
     ),
     # GPT 5 Nano
@@ -300,6 +307,11 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openai,
                 model_id="gpt-5-nano",
+                structured_output_mode=StructuredOutputMode.json_schema,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="openai/gpt-5-nano",
                 structured_output_mode=StructuredOutputMode.json_schema,
             ),
         ],
@@ -331,6 +343,7 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_logprobs=True,
                 suggested_for_evals=True,
+                suggested_for_data_gen=True,
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
@@ -338,11 +351,13 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_logprobs=True,
                 suggested_for_evals=True,
+                suggested_for_data_gen=True,
             ),
             KilnModelProvider(
                 name=ModelProviderName.azure_openai,
                 model_id="gpt-4.1",
                 suggested_for_evals=True,
+                suggested_for_data_gen=True,
             ),
         ],
     ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter options for GPT-5 Mini and GPT-5 Nano to the model catalog, enabling selection directly in the app.
* **Chores**
  * Updated model recommendations to better highlight options suited for data generation and evaluations across GPT-4.1 and OpenRouter variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->