### PR TITLE
Update docs link to new domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,9 +11,9 @@ Insert a clear and concise description of what the bug is.
 
 **Checks**
 
-- [ ] I've read the [troubleshooting guide](https://docs.getkiln.ai/docs/troubleshooting-and-logs)
+- [ ] I've read the [troubleshooting guide](https://docs.kiln.tech/docs/troubleshooting-and-logs)
 - [ ] I've tried to reproduce the problem using another model, and confirmed it's not an issue specific to the model I've chosen.
-- [ ] I've searched [the docs](https://docs.getkiln.ai) for a solution
+- [ ] I've searched [the docs](https://docs.kiln.tech) for a solution
 - [ ] I've searched for existing Github issues/discussions
 
 **To Reproduce**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,7 +12,7 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 
 **Checks**
 
-- [ ] I've searched [the docs](https://docs.getkiln.ai) for a solution
+- [ ] I've searched [the docs](https://docs.kiln.tech) for a solution
 - [ ] I've searched for existing Github issues
 
 **Describe the solution you'd like**

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 </h3>
 
 <p align="center">
-  <a href="https://docs.getkiln.ai/docs/fine-tuning-guide"><strong>Fine Tuning</strong></a> •
-  <a href="https://docs.getkiln.ai/docs/synthetic-data-generation"><strong>Synthetic Data Generation</strong></a> • 
-  <a href="https://docs.getkiln.ai/docs/evaluations"><strong>Evals</strong></a> • 
-  <a href="https://docs.getkiln.ai/docs/collaboration"><strong>Collaboration</strong></a> • 
-  <a href="https://docs.getkiln.ai"><strong>Docs</strong></a>
+  <a href="https://docs.kiln.tech/docs/fine-tuning-guide"><strong>Fine Tuning</strong></a> •
+  <a href="https://docs.kiln.tech/docs/synthetic-data-generation"><strong>Synthetic Data Generation</strong></a> • 
+  <a href="https://docs.kiln.tech/docs/evaluations"><strong>Evals</strong></a> • 
+  <a href="https://docs.kiln.tech/docs/collaboration"><strong>Collaboration</strong></a> • 
+  <a href="https://docs.kiln.tech"><strong>Docs</strong></a>
 </p>
 
 |         |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -26,7 +26,7 @@
 | Apps    | [![MacOS](https://img.shields.io/badge/MacOS-black?logo=apple)](https://kiln.tech/download) [![Windows](https://img.shields.io/badge/Windows-0067b8.svg?logo=data:image/svg%2bxml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyBmaWxsPSIjZmZmIiB2aWV3Qm94PSIwIDAgMzIgMzIiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE2Ljc0MiAxNi43NDJ2MTQuMjUzaDE0LjI1M3YtMTQuMjUzek0xLjAwNCAxNi43NDJ2MTQuMjUzaDE0LjI1NnYtMTQuMjUzek0xNi43NDIgMS4wMDR2MTQuMjU2aDE0LjI1M3YtMTQuMjU2ek0xLjAwNCAxLjAwNHYxNC4yNTZoMTQuMjU2di0xNC4yNTZ6Ij48L3BhdGg+Cjwvc3ZnPg==)](https://kiln.tech/download) [![Linux](https://img.shields.io/badge/Linux-444444?logo=linux&logoColor=ffffff)](https://kiln.tech/download) ![Github Downsloads](https://img.shields.io/github/downloads/kiln-ai/kiln/total)                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | Connect | [![Discord](https://img.shields.io/badge/Discord-Kiln_AI-blue?logo=Discord&logoColor=white)](https://kiln.tech/discord) [![Newsletter](https://img.shields.io/badge/Newsletter-subscribe-blue?logo=mailboxdotorg&logoColor=white)](https://kiln.tech/blog)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 
-[<img width="220" alt="Download button" src="https://github.com/user-attachments/assets/a5d51b8b-b30a-4a16-a902-ab6ef1d58dc0">](https://kiln.tech/download) [<img width="220" alt="Quick start button" src="https://github.com/user-attachments/assets/aff1b35f-72c0-4286-9b28-40a415558359">](https://docs.getkiln.ai/getting-started/quickstart)
+[<img width="220" alt="Download button" src="https://github.com/user-attachments/assets/a5d51b8b-b30a-4a16-a902-ab6ef1d58dc0">](https://kiln.tech/download) [<img width="220" alt="Quick start button" src="https://github.com/user-attachments/assets/aff1b35f-72c0-4286-9b28-40a415558359">](https://docs.kiln.tech/getting-started/quickstart)
 
 ## Key Features
 
@@ -61,29 +61,29 @@ The Kiln desktop app is completely free. Available on MacOS, Windows and Linux.
 
 ## Docs & Guides
 
-Kiln is quite intuitive, so we suggest launching the desktop app and diving in. However if you have any questions or want to learn more, our [docs are here to help](https://docs.getkiln.ai).
+Kiln is quite intuitive, so we suggest launching the desktop app and diving in. However if you have any questions or want to learn more, our [docs are here to help](https://docs.kiln.tech).
 
 ### Video Guides
 
-- [Fine Tuning LLM Models](https://docs.getkiln.ai/docs/fine-tuning-guide)
-- [Guide: Train a Reasoning Model](https://docs.getkiln.ai/docs/guide-train-a-reasoning-model)
-- [LLM Evaluators](https://docs.getkiln.ai/docs/evaluators)
+- [Fine Tuning LLM Models](https://docs.kiln.tech/docs/fine-tuning-guide)
+- [Guide: Train a Reasoning Model](https://docs.kiln.tech/docs/guide-train-a-reasoning-model)
+- [LLM Evaluators](https://docs.kiln.tech/docs/evaluators)
 
 ### All Docs
 
-- [Quick Start](https://docs.getkiln.ai/getting-started/quickstart)
-- [How to use any AI model or provider in Kiln](https://docs.getkiln.ai/docs/models-and-ai-providers)
-- [Reasoning & Chain of Thought](https://docs.getkiln.ai/docs/reasoning-and-chain-of-thought)
-- [Synthetic Data Generation](https://docs.getkiln.ai/docs/synthetic-data-generation)
-- [Collaborating with Kiln](https://docs.getkiln.ai/docs/collaboration)
-- [Rating and Labeling Data](https://docs.getkiln.ai/docs/reviewing-and-rating)
-- [Prompt Styles](https://docs.getkiln.ai/docs/prompts)
-- [Structure Data / JSON](https://docs.getkiln.ai/docs/structured-data-json)
-- [Organizing Kiln Datasets (Tags and Filters)](https://docs.getkiln.ai/docs/organizing-datasets)
-- [Our Data Model](https://docs.getkiln.ai/docs/kiln-datamodel)
-- [Repairing Responses](https://docs.getkiln.ai/docs/repairing-responses)
-- [Keyboard Shortcuts](https://docs.getkiln.ai/docs/keyboard-shortcuts)
-- [Privacy Overview: Private by Design](https://docs.getkiln.ai/docs/privacy)
+- [Quick Start](https://docs.kiln.tech/getting-started/quickstart)
+- [How to use any AI model or provider in Kiln](https://docs.kiln.tech/docs/models-and-ai-providers)
+- [Reasoning & Chain of Thought](https://docs.kiln.tech/docs/reasoning-and-chain-of-thought)
+- [Synthetic Data Generation](https://docs.kiln.tech/docs/synthetic-data-generation)
+- [Collaborating with Kiln](https://docs.kiln.tech/docs/collaboration)
+- [Rating and Labeling Data](https://docs.kiln.tech/docs/reviewing-and-rating)
+- [Prompt Styles](https://docs.kiln.tech/docs/prompts)
+- [Structure Data / JSON](https://docs.kiln.tech/docs/structured-data-json)
+- [Organizing Kiln Datasets (Tags and Filters)](https://docs.kiln.tech/docs/organizing-datasets)
+- [Our Data Model](https://docs.kiln.tech/docs/kiln-datamodel)
+- [Repairing Responses](https://docs.kiln.tech/docs/repairing-responses)
+- [Keyboard Shortcuts](https://docs.kiln.tech/docs/keyboard-shortcuts)
+- [Privacy Overview: Private by Design](https://docs.kiln.tech/docs/privacy)
 
 For developers, see our [Kiln Python Library Docs](https://kiln-ai.github.io/Kiln/kiln_core_docs/kiln_ai.html). These include how to load datasets into Kiln, or using Kiln datasets in your own code-base/notebooks.
 

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
@@ -481,7 +481,7 @@
 <AppPage
   title="Dataset"
   sub_subtitle="Read the Docs"
-  sub_subtitle_link="https://docs.getkiln.ai/docs/organizing-datasets"
+  sub_subtitle_link="https://docs.kiln.tech/docs/organizing-datasets"
   no_y_padding
   action_buttons={[
     {

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/upload_dataset_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/upload_dataset_dialog.svelte
@@ -90,7 +90,7 @@
         <p>
           Upload a CSV to add each row to your dataset. The CSV must have a
           header row (<a
-            href="https://docs.getkiln.ai/docs/organizing-datasets"
+            href="https://docs.kiln.tech/docs/organizing-datasets"
             target="_blank"
             class="link">see docs</a
           >). The following columns are supported:

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/+page.svelte
@@ -136,7 +136,7 @@
   title="Evals"
   subtitle="Evaluate the quality of your prompts, models and tunes"
   sub_subtitle={is_empty ? undefined : "Read the Docs"}
-  sub_subtitle_link="https://docs.getkiln.ai/docs/evaluations"
+  sub_subtitle_link="https://docs.kiln.tech/docs/evaluations"
   action_buttons={is_empty
     ? []
     : [

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
@@ -389,7 +389,7 @@
     title="Eval: {evaluator?.name || ''}"
     subtitle="Follow these steps to find the best way to evaluate and run your task"
     sub_subtitle="Read the Docs"
-    sub_subtitle_link="https://docs.getkiln.ai/docs/evaluations"
+    sub_subtitle_link="https://docs.kiln.tech/docs/evaluations"
     action_buttons={[
       {
         label: "Edit",

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -410,7 +410,7 @@
   title="Compare Run Methods"
   subtitle="Find the best method of running your task."
   sub_subtitle="Read the Docs"
-  sub_subtitle_link="https://docs.getkiln.ai/docs/evaluations#finding-the-ideal-run-method"
+  sub_subtitle_link="https://docs.kiln.tech/docs/evaluations#finding-the-ideal-run-method"
   action_buttons={[
     {
       label: "Compare Judges",

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/create_eval_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/create_eval_config/+page.svelte
@@ -312,7 +312,7 @@
     title="Add a Judge"
     subtitle="A judge evaluates task outputs with a model, evaluation prompt, and algorithm."
     sub_subtitle="Read the Docs"
-    sub_subtitle_link="https://docs.getkiln.ai/docs/evaluations#finding-the-ideal-eval-method"
+    sub_subtitle_link="https://docs.kiln.tech/docs/evaluations#finding-the-ideal-eval-method"
   >
     {#if loading}
       <div class="w-full min-h-[50vh] flex justify-center items-center">

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
@@ -416,7 +416,7 @@
   title="Compare Judges"
   subtitle="Find the judge that best matches human preferences"
   sub_subtitle="Read the docs"
-  sub_subtitle_link="https://docs.getkiln.ai/docs/evaluations#finding-the-ideal-eval-method"
+  sub_subtitle_link="https://docs.kiln.tech/docs/evaluations#finding-the-ideal-eval-method"
   action_buttons={eval_configs?.length
     ? [
         {
@@ -778,7 +778,7 @@
     <div class="font-bold text-xl mt-6">Detailed Instructions</div>
     <div>
       <a
-        href="https://docs.getkiln.ai/docs/evaluations#finding-the-ideal-eval-method"
+        href="https://docs.kiln.tech/docs/evaluations#finding-the-ideal-eval-method"
         target="_blank"
         class="link">Read the docs</a
       > for more information, a detailed walkthrough, and technical details about

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/run_eval.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/run_eval.svelte
@@ -212,7 +212,7 @@
         <div>
           If you want to add more data to your eval,
           <a
-            href="https://docs.getkiln.ai/docs/evaluations#create-your-eval-datasets"
+            href="https://docs.kiln.tech/docs/evaluations#create-your-eval-datasets"
             target="_blank"
             class="link">read the docs</a
           > for instructions.

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/empty_eval.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/empty_eval.svelte
@@ -64,7 +64,7 @@
       Create an Evaluator
     </a>
     <a
-      href="https://docs.getkiln.ai/docs/evaluations"
+      href="https://docs.kiln.tech/docs/evaluations"
       class="btn"
       target="_blank"
     >

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/+page.svelte
@@ -84,7 +84,7 @@
   title="Fine Tune"
   subtitle="Fine-tune models for the current task."
   sub_subtitle="Read the Docs"
-  sub_subtitle_link="https://docs.getkiln.ai/docs/fine-tuning-guide"
+  sub_subtitle_link="https://docs.kiln.tech/docs/fine-tuning-guide"
   action_buttons={is_empty
     ? []
     : [

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/empty_finetune.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/empty_finetune.svelte
@@ -89,7 +89,7 @@
       Create a Fine-Tune
     </a>
     <a
-      href="https://docs.getkiln.ai/docs/fine-tuning-guide"
+      href="https://docs.kiln.tech/docs/fine-tuning-guide"
       class="btn"
       target="_blank"
     >

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
@@ -511,7 +511,7 @@
         : []),
       {
         label: "Docs & Guide",
-        href: "https://docs.getkiln.ai/docs/synthetic-data-generation",
+        href: "https://docs.kiln.tech/docs/synthetic-data-generation",
       },
     ]}
   >

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/data_gen_intro.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/data_gen_intro.svelte
@@ -182,7 +182,7 @@
       <div slot="description">
         Adding topics will help generate diverse data. They can be nested,
         forming a topic tree. <a
-          href="https://docs.getkiln.ai/docs/synthetic-data-generation#topic-tree-data-generation"
+          href="https://docs.kiln.tech/docs/synthetic-data-generation#topic-tree-data-generation"
           target="_blank"
           class="link">Guide</a
         >.

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth_data_guidance.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth_data_guidance.svelte
@@ -107,7 +107,7 @@
       Add guidance to improve or steer the AI-generated {description_plural()}.
       Learn more and see examples
       <a
-        href="https://docs.getkiln.ai/docs/synthetic-data-generation#human-guidance"
+        href="https://docs.kiln.tech/docs/synthetic-data-generation#human-guidance"
         target="_blank"
         class="link">in the docs</a
       >.

--- a/app/web_ui/src/routes/(app)/models/+page.svelte
+++ b/app/web_ui/src/routes/(app)/models/+page.svelte
@@ -424,7 +424,7 @@
     title="Model Library"
     subtitle="Browse available models"
     sub_subtitle="Read the Docs"
-    sub_subtitle_link="https://docs.getkiln.ai/docs/models-and-ai-providers"
+    sub_subtitle_link="https://docs.kiln.tech/docs/models-and-ai-providers"
     action_buttons={[
       {
         label: "Manage Providers",

--- a/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/+page.svelte
@@ -13,7 +13,7 @@
     title="Prompts"
     subtitle={`Prompts for the task "${$current_task?.name}"`}
     sub_subtitle="Read the Docs"
-    sub_subtitle_link="https://docs.getkiln.ai/docs/prompts"
+    sub_subtitle_link="https://docs.kiln.tech/docs/prompts"
     action_buttons={[
       {
         label: "Create Prompt",

--- a/app/web_ui/src/routes/(app)/settings/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/+page.svelte
@@ -91,7 +91,7 @@
           name: "Docs & Getting Started",
           description:
             "Read the docs, including our getting started guide and video tutorials.",
-          href: "https://docs.getkiln.ai",
+          href: "https://docs.kiln.tech",
           button_text: "Docs & Guides",
           is_external: true,
         },

--- a/app/web_ui/src/routes/(app)/settings/providers/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/providers/+page.svelte
@@ -7,7 +7,7 @@
 <AppPage
   title="AI Providers"
   sub_subtitle="Read the Docs"
-  sub_subtitle_link="https://docs.getkiln.ai/docs/models-and-ai-providers"
+  sub_subtitle_link="https://docs.kiln.tech/docs/models-and-ai-providers"
   action_buttons={[
     {
       label: "Custom Models",

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
@@ -128,7 +128,7 @@
       ],
       api_key_fields: ["API Key", "Endpoint URL"],
       api_key_warning:
-        "With Azure OpenAI, you must deploy each model manually.\nSee our docs for details: https://docs.getkiln.ai/docs/models-and-ai-providers#azure-openai-api",
+        "With Azure OpenAI, you must deploy each model manually.\nSee our docs for details: https://docs.kiln.tech/docs/models-and-ai-providers#azure-openai-api",
     },
     {
       name: "Hugging Face",
@@ -159,7 +159,7 @@
       ],
       api_key_fields: ["Project ID", "Project Location"],
       api_key_warning:
-        "With Vertex AI, you must deploy some models manually.\nSee our docs for details: https://docs.getkiln.ai/docs/models-and-ai-providers#google-vertex-ai",
+        "With Vertex AI, you must deploy some models manually.\nSee our docs for details: https://docs.kiln.tech/docs/models-and-ai-providers#google-vertex-ai",
     },
     {
       name: "Together.ai",

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -301,7 +301,7 @@
           Define requirements you can use to rate the results of the model.
           These are used in the prompt, ratings, evals and training.
           <a
-            href="https://docs.getkiln.ai/docs/reviewing-and-rating"
+            href="https://docs.kiln.tech/docs/reviewing-and-rating"
             target="_blank"
             class="link">Learn more</a
           >.

--- a/guides/Collaborating with Kiln.md
+++ b/guides/Collaborating with Kiln.md
@@ -2,7 +2,7 @@
 
 ---
 
-# This guide as moved to [our docs](https://docs.kiln.tech/docs/collaboration). This page may be out of date.
+# This guide has moved to [our docs](https://docs.kiln.tech/docs/collaboration)
 
 We suggest reading the [latest version](https://docs.kiln.tech/docs/collaboration).
 

--- a/guides/Collaborating with Kiln.md
+++ b/guides/Collaborating with Kiln.md
@@ -2,9 +2,9 @@
 
 ---
 
-# This guide as moved to [our docs](https://docs.getkiln.ai/docs/collaboration). This page may be out of date.
+# This guide as moved to [our docs](https://docs.kiln.tech/docs/collaboration). This page may be out of date.
 
-We suggest reading the [latest version](https://docs.getkiln.ai/docs/collaboration).
+We suggest reading the [latest version](https://docs.kiln.tech/docs/collaboration).
 
 ---
 

--- a/guides/Fine Tuning LLM Models Guide.md
+++ b/guides/Fine Tuning LLM Models Guide.md
@@ -3,9 +3,9 @@
 
 ---
 
-# This guide has moved to [our docs](https://docs.getkiln.ai/docs/fine-tuning-guide). This page may be out of date.
+# This guide has moved to [our docs](https://docs.kiln.tech/docs/fine-tuning-guide). This page may be out of date.
 
-We suggest reading the [latest version](https://docs.getkiln.ai/docs/fine-tuning-guide).
+We suggest reading the [latest version](https://docs.kiln.tech/docs/fine-tuning-guide).
 
 ---
 

--- a/guides/Model Support.md
+++ b/guides/Model Support.md
@@ -3,9 +3,9 @@
 
 ---
 
-# This guide as moved to [our docs](https://docs.getkiln.ai/docs/models-and-ai-providers). This page may be out of date.
+# This guide as moved to [our docs](https://docs.kiln.tech/docs/models-and-ai-providers). This page may be out of date.
 
-We suggest reading the [latest version](https://docs.getkiln.ai/docs/models-and-ai-providers).
+We suggest reading the [latest version](https://docs.kiln.tech/docs/models-and-ai-providers).
 
 ---
 

--- a/guides/Model Support.md
+++ b/guides/Model Support.md
@@ -3,7 +3,7 @@
 
 ---
 
-# This guide as moved to [our docs](https://docs.kiln.tech/docs/models-and-ai-providers). This page may be out of date.
+# This guide has moved to [our docs](https://docs.kiln.tech/docs/models-and-ai-providers)
 
 We suggest reading the [latest version](https://docs.kiln.tech/docs/models-and-ai-providers).
 

--- a/guides/Synthetic Data Generation.md
+++ b/guides/Synthetic Data Generation.md
@@ -1,19 +1,16 @@
-# Synthetic Data Generation - Kiln AI 
-
+# Synthetic Data Generation - Kiln AI
 
 ---
 
-# This guide as moved to [our docs](https://docs.kiln.tech/docs/synthetic-data-generation). This page may be out of date.
+# This guide has moved to [our docs](https://docs.kiln.tech/docs/synthetic-data-generation)
 
-We suggest reading the [latest version](https://docs.kiln.tech/docs/synthetic-data-generation).
+This page may be out of date. We suggest reading the [latest version](https://docs.kiln.tech/docs/synthetic-data-generation).
 
 ---
 
 ## Original Content
 
-
-[Kiln](https://kiln.tech) can generate synthetic data for your tasks. 
-
+[Kiln](https://kiln.tech) can generate synthetic data for your tasks.
 
 ## Video Walkthrough
 
@@ -84,21 +81,21 @@ You can use synthetic data generation as many times as you'd like. Data will be 
 
 Synthetic data can help resolve issues in your LLM systems.
 
-As an example, let's assume your model is often generating text using the wrong tone. For this example: too formal when the use case calls for more causal tone. 
+As an example, let's assume your model is often generating text using the wrong tone. For this example: too formal when the use case calls for more causal tone.
 
 Synthetic data can help resolve this issue, and ensure it doesn't regress.
 
-1) Open the synthetic dataset tab.
-2) Select a high quality model - even if it's not one that's fast or cheap enough for production.
-3) Start generating data which shows the issue, but use the human guidance feature and better model to ensure the outputs are high quality.
-4) Manually delete examples that don't have the correct style.
-5) Once the synthetic data tool is reliably generating correct data (with this model and guidance pair), scale up your generation to hundreds of samples.
-6) Save your new synthetic dataset
+1. Open the synthetic dataset tab.
+2. Select a high quality model - even if it's not one that's fast or cheap enough for production.
+3. Start generating data which shows the issue, but use the human guidance feature and better model to ensure the outputs are high quality.
+4. Manually delete examples that don't have the correct style.
+5. Once the synthetic data tool is reliably generating correct data (with this model and guidance pair), scale up your generation to hundreds of samples.
+6. Save your new synthetic dataset
 
 The new examples will be saved to your dataset, and will include a unique tag to idenity them (e.g. `synthetic_session_12345`). With this new dataset in hand you can resolve the issue:
 
-1) Simple: Fix the root prompt, and use this new dataset subset in your evaluations to ensure it works (and doesn't regress in the future)
-2) Advanced: [Fine-tune a model](Fine%20Tuning%20LLM%20Models%20Guide.md) with this data, so smaller and faster models learn to emulate your desired styles. Withhold a test set to ensure it worked.
+1. Simple: Fix the root prompt, and use this new dataset subset in your evaluations to ensure it works (and doesn't regress in the future)
+2. Advanced: [Fine-tune a model](Fine%20Tuning%20LLM%20Models%20Guide.md) with this data, so smaller and faster models learn to emulate your desired styles. Withhold a test set to ensure it worked.
 
 ## Collaboration
 
@@ -113,7 +110,6 @@ Kiln includes a rating interface for rating dataset entries. This can be used to
 Only highly rated data will be used for features like multi-shot prompting.
 
 <img width="337" alt="rating UI" src="https://github.com/user-attachments/assets/6872d5ad-18ad-46f3-9091-2e26741cb852">
-
 
 ## Consuming Your Dataset
 

--- a/guides/Synthetic Data Generation.md
+++ b/guides/Synthetic Data Generation.md
@@ -3,9 +3,9 @@
 
 ---
 
-# This guide as moved to [our docs](https://docs.getkiln.ai/docs/synthetic-data-generation). This page may be out of date.
+# This guide as moved to [our docs](https://docs.kiln.tech/docs/synthetic-data-generation). This page may be out of date.
 
-We suggest reading the [latest version](https://docs.getkiln.ai/docs/synthetic-data-generation).
+We suggest reading the [latest version](https://docs.kiln.tech/docs/synthetic-data-generation).
 
 ---
 

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -273,8 +273,8 @@ You can add additional AI models and providers to Kiln.
 
 See our docs for more information, including how to add these from the UI:
 
-- [Custom Models From Existing Providers](https://docs.getkiln.ai/docs/models-and-ai-providers#custom-models-from-existing-providers)
-- [Custom OpenAI Compatible Servers](https://docs.getkiln.ai/docs/models-and-ai-providers#custom-openai-compatible-servers)
+- [Custom Models From Existing Providers](https://docs.kiln.tech/docs/models-and-ai-providers#custom-models-from-existing-providers)
+- [Custom OpenAI Compatible Servers](https://docs.kiln.tech/docs/models-and-ai-providers#custom-openai-compatible-servers)
 
 You can also add these from code. The kiln_ai.utils.Config class helps you manage the Kiln config file (stored at `~/.kiln_settings/config.yaml`):
 

--- a/libs/core/kiln_ai/datamodel/__init__.py
+++ b/libs/core/kiln_ai/datamodel/__init__.py
@@ -3,7 +3,7 @@ See our docs for details about our datamodel classes and hierarchy:
 
 Developer docs: https://kiln-ai.github.io/Kiln/kiln_core_docs/kiln_ai.html
 
-User docs: https://docs.getkiln.ai/developers/kiln-datamodel
+User docs: https://docs.kiln.tech/developers/kiln-datamodel
 """
 
 # This component uses "flat" imports so we don't have too much internal structure exposed in the API.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated all documentation and help links across the app, README, guides, and issue templates to docs.kiln.tech; preserved content and navigation labels.
  - Minor wording/formatting tweak in Key Features.

- Chores
  - Standardized in-app subtitles, dialogs, guidance links, and “Read the docs”/“Learn more” anchors to the new docs domain for consistent navigation.
  - No functional, behavioral, or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->