### PR TITLE
fix: wrong filename in sdk codegen command in cursor rule

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -14,5 +14,5 @@ alwaysApply: true
 - To run backend / Python tests, run `uv run python3 -m pytest . -s -v` or a variant of it to run individual tests
 - To run web tests `cd app/web_ui` then `npm run test_run` (not `npm run test` which won't return)
 - Don't include comments in code explaining changes, explain changes in chat instead.
-- If a python API's interface changes (or a new one is added), generate new bindings by running `cd app/web_ui/src/lib/ && ./generate.sh`
+- If a python API's interface changes (or a new one is added), generate new bindings by running `cd app/web_ui/src/lib/ && ./generate_schema.sh`
 - Our web UI component framework is DaisyUI v4 (based on tailwind). Be sure to use v4 docs and features, not v5


### PR DESCRIPTION
## What does this PR do?

Fix the API client codegen script filename in Cursor rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor instructions for regenerating bindings after Python API changes to reference the correct schema generation script.
  * Clarifies the regeneration process, replacing outdated guidance to reduce confusion and build hiccups during API updates.
  * No impact on application behavior; end users are unaffected.
  * Release artifacts and interfaces remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->