### PR TITLE
Bring back the demo tools, if a config value is set

### DIFF
--- a/app/desktop/studio_server/test_tool_api.py
+++ b/app/desktop/studio_server/test_tool_api.py
@@ -419,7 +419,10 @@ def test_get_available_tools_success(client, test_project):
             response = client.get(f"/api/projects/{test_project.id}/available_tools")
 
             assert response.status_code == 200
-            result = response.json()
+            set_result = response.json()
+            assert len(set_result) == 1
+            assert set_result[0]["set_name"] == "MCP Server: test_available_tools"
+            result = set_result[0]["tools"]
             assert len(result) == 3
 
             # Verify tool details
@@ -514,20 +517,25 @@ def test_get_available_tools_multiple_servers(client, test_project):
             response = client.get(f"/api/projects/{test_project.id}/available_tools")
 
             assert response.status_code == 200
-            result = response.json()
-            assert len(result) == 3  # 2 from server1 + 1 from server2
+            set_result = response.json()
+            assert len(set_result) == 2
+            first_set = set_result[0]
+            assert first_set["set_name"] == "MCP Server: mcp_server_1"
+            assert len(first_set["tools"]) == 2  # 2 from server1
+            second_set = set_result[1]
+            assert second_set["set_name"] == "MCP Server: mcp_server_2"
+            assert len(second_set["tools"]) == 1  # 1 from server2
+            for tool in first_set["tools"]:
+                assert tool["id"].startswith(f"mcp::remote::{server1_id}::")
+            for tool in second_set["tools"]:
+                assert tool["id"].startswith(f"mcp::remote::{server2_id}::")
 
             # Verify tools from both servers are present
-            tool_names = [tool["name"] for tool in result]
+            tool_names = [tool["name"] for tool in first_set["tools"]]
             assert "tool_a" in tool_names
             assert "tool_b" in tool_names
+            tool_names = [tool["name"] for tool in second_set["tools"]]
             assert "tool_x" in tool_names
-
-            # Verify tool IDs contain correct server IDs
-            server1_tools = [t for t in result if server1_id in t["id"]]
-            server2_tools = [t for t in result if server2_id in t["id"]]
-            assert len(server1_tools) == 2
-            assert len(server2_tools) == 1
 
 
 def test_get_available_tools_mcp_error_handling(client, test_project):
@@ -571,3 +579,80 @@ def test_get_available_tools_mcp_error_handling(client, test_project):
             # In a real implementation, you might want to handle this more gracefully
             with pytest.raises(Exception, match="MCP connection failed"):
                 client.get(f"/api/projects/{test_project.id}/available_tools")
+
+
+def test_get_available_tools_demo_tools_enabled(client, test_project):
+    """Test get_available_tools includes demo tools when enabled"""
+    with (
+        patch(
+            "app.desktop.studio_server.tool_api.project_from_id"
+        ) as mock_project_from_id,
+        patch("app.desktop.studio_server.tool_api.Config.shared") as mock_config,
+    ):
+        mock_project_from_id.return_value = test_project
+
+        # Mock config to enable demo tools
+        mock_config_instance = AsyncMock()
+        mock_config_instance.enable_demo_tools = True
+        mock_config.return_value = mock_config_instance
+
+        response = client.get(f"/api/projects/{test_project.id}/available_tools")
+
+        assert response.status_code == 200
+        result = response.json()
+
+        # Should have one tool set for demo tools
+        assert len(result) == 1
+        demo_set = result[0]
+        assert demo_set["set_name"] == "Kiln Demo Tools"
+        assert len(demo_set["tools"]) == 4
+
+        # Verify all demo tools are present with correct IDs and names
+        tool_names = [tool["name"] for tool in demo_set["tools"]]
+        tool_ids = [tool["id"] for tool in demo_set["tools"]]
+
+        assert "Addition" in tool_names
+        assert "Subtraction" in tool_names
+        assert "Multiplication" in tool_names
+        assert "Division" in tool_names
+
+        assert "kiln_tool::add_numbers" in tool_ids
+        assert "kiln_tool::subtract_numbers" in tool_ids
+        assert "kiln_tool::multiply_numbers" in tool_ids
+        assert "kiln_tool::divide_numbers" in tool_ids
+
+        # Verify descriptions
+        for tool in demo_set["tools"]:
+            assert tool["description"] is not None
+            if tool["name"] == "Addition":
+                assert tool["description"] == "Add two numbers together"
+            elif tool["name"] == "Subtraction":
+                assert tool["description"] == "Subtract two numbers"
+            elif tool["name"] == "Multiplication":
+                assert tool["description"] == "Multiply two numbers"
+            elif tool["name"] == "Division":
+                assert tool["description"] == "Divide two numbers"
+
+
+def test_get_available_tools_demo_tools_disabled(client, test_project):
+    """Test get_available_tools excludes demo tools when disabled"""
+    with (
+        patch(
+            "app.desktop.studio_server.tool_api.project_from_id"
+        ) as mock_project_from_id,
+        patch("app.desktop.studio_server.tool_api.Config.shared") as mock_config,
+    ):
+        mock_project_from_id.return_value = test_project
+
+        # Mock config to disable demo tools (default behavior)
+        mock_config_instance = AsyncMock()
+        mock_config_instance.enable_demo_tools = False
+        mock_config.return_value = mock_config_instance
+
+        response = client.get(f"/api/projects/{test_project.id}/available_tools")
+
+        assert response.status_code == 200
+        result = response.json()
+
+        # Should have no tool sets when demo tools are disabled and no MCP servers
+        assert len(result) == 0

--- a/app/desktop/studio_server/test_tool_api.py
+++ b/app/desktop/studio_server/test_tool_api.py
@@ -519,22 +519,37 @@ def test_get_available_tools_multiple_servers(client, test_project):
             assert response.status_code == 200
             set_result = response.json()
             assert len(set_result) == 2
-            first_set = set_result[0]
-            assert first_set["set_name"] == "MCP Server: mcp_server_1"
-            assert len(first_set["tools"]) == 2  # 2 from server1
-            second_set = set_result[1]
-            assert second_set["set_name"] == "MCP Server: mcp_server_2"
-            assert len(second_set["tools"]) == 1  # 1 from server2
-            for tool in first_set["tools"]:
+
+            # Find sets by name instead of assuming order
+            server1_set = next(
+                (s for s in set_result if s["set_name"] == "MCP Server: mcp_server_1"),
+                None,
+            )
+            server2_set = next(
+                (s for s in set_result if s["set_name"] == "MCP Server: mcp_server_2"),
+                None,
+            )
+
+            assert server1_set is not None, (
+                "Could not find MCP Server: mcp_server_1 in results"
+            )
+            assert server2_set is not None, (
+                "Could not find MCP Server: mcp_server_2 in results"
+            )
+
+            assert len(server1_set["tools"]) == 2  # 2 from server1
+            assert len(server2_set["tools"]) == 1  # 1 from server2
+
+            for tool in server1_set["tools"]:
                 assert tool["id"].startswith(f"mcp::remote::{server1_id}::")
-            for tool in second_set["tools"]:
+            for tool in server2_set["tools"]:
                 assert tool["id"].startswith(f"mcp::remote::{server2_id}::")
 
             # Verify tools from both servers are present
-            tool_names = [tool["name"] for tool in first_set["tools"]]
+            tool_names = [tool["name"] for tool in server1_set["tools"]]
             assert "tool_a" in tool_names
             assert "tool_b" in tool_names
-            tool_names = [tool["name"] for tool in second_set["tools"]]
+            tool_names = [tool["name"] for tool in server2_set["tools"]]
             assert "tool_x" in tool_names
 
 

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1179,6 +1179,11 @@ export interface components {
             /** Created By */
             created_by?: string | null;
         };
+        /** Audio */
+        Audio: {
+            /** Id */
+            id: string;
+        };
         /** AvailableModels */
         AvailableModels: {
             /** Provider Name */
@@ -1248,6 +1253,171 @@ export interface components {
             filename: string;
             /** Imported Count */
             imported_count: number;
+        };
+        /**
+         * ChatCompletionAssistantMessageParamWrapper
+         * @description Almost exact copy of ChatCompletionAssistantMessageParam, but with List[T] instead of Iterable[T] for tool_calls.
+         *     https://github.com/pydantic/pydantic/issues/9541
+         */
+        "ChatCompletionAssistantMessageParamWrapper-Input": {
+            /**
+             * Role
+             * @constant
+             */
+            role: "assistant";
+            audio?: components["schemas"]["Audio"] | null;
+            /** Content */
+            content?: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartRefusalParam"])[] | null;
+            function_call?: components["schemas"]["FunctionCall"] | null;
+            /** Name */
+            name?: string;
+            /** Refusal */
+            refusal?: string | null;
+            /** Tool Calls */
+            tool_calls?: components["schemas"]["ChatCompletionMessageToolCallParam"][];
+        };
+        /**
+         * ChatCompletionAssistantMessageParamWrapper
+         * @description Almost exact copy of ChatCompletionAssistantMessageParam, but with List[T] instead of Iterable[T] for tool_calls.
+         *     https://github.com/pydantic/pydantic/issues/9541
+         */
+        "ChatCompletionAssistantMessageParamWrapper-Output": {
+            /**
+             * Role
+             * @constant
+             */
+            role: "assistant";
+            audio?: components["schemas"]["Audio"] | null;
+            /** Content */
+            content?: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartRefusalParam"])[] | null;
+            function_call?: components["schemas"]["FunctionCall"] | null;
+            /** Name */
+            name?: string;
+            /** Refusal */
+            refusal?: string | null;
+            /** Tool Calls */
+            tool_calls?: components["schemas"]["ChatCompletionMessageToolCallParam"][];
+        };
+        /** ChatCompletionContentPartImageParam */
+        ChatCompletionContentPartImageParam: {
+            image_url: components["schemas"]["ImageURL"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "image_url";
+        };
+        /** ChatCompletionContentPartInputAudioParam */
+        ChatCompletionContentPartInputAudioParam: {
+            input_audio: components["schemas"]["InputAudio"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "input_audio";
+        };
+        /** ChatCompletionContentPartRefusalParam */
+        ChatCompletionContentPartRefusalParam: {
+            /** Refusal */
+            refusal: string;
+            /**
+             * Type
+             * @constant
+             */
+            type: "refusal";
+        };
+        /** ChatCompletionContentPartTextParam */
+        ChatCompletionContentPartTextParam: {
+            /** Text */
+            text: string;
+            /**
+             * Type
+             * @constant
+             */
+            type: "text";
+        };
+        /** ChatCompletionDeveloperMessageParam */
+        ChatCompletionDeveloperMessageParam: {
+            /** Content */
+            content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
+            /**
+             * Role
+             * @constant
+             */
+            role: "developer";
+            /** Name */
+            name?: string;
+        };
+        /** ChatCompletionFunctionMessageParam */
+        ChatCompletionFunctionMessageParam: {
+            /** Content */
+            content: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Role
+             * @constant
+             */
+            role: "function";
+        };
+        /** ChatCompletionMessageToolCallParam */
+        ChatCompletionMessageToolCallParam: {
+            /** Id */
+            id: string;
+            function: components["schemas"]["Function"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "function";
+        };
+        /** ChatCompletionSystemMessageParam */
+        ChatCompletionSystemMessageParam: {
+            /** Content */
+            content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
+            /**
+             * Role
+             * @constant
+             */
+            role: "system";
+            /** Name */
+            name?: string;
+        };
+        /** ChatCompletionToolMessageParam */
+        ChatCompletionToolMessageParam: {
+            /** Content */
+            content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
+            /**
+             * Role
+             * @constant
+             */
+            role: "tool";
+            /** Tool Call Id */
+            tool_call_id: string;
+        };
+        /** ChatCompletionUserMessageParam */
+        "ChatCompletionUserMessageParam-Input": {
+            /** Content */
+            content: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartImageParam"] | components["schemas"]["ChatCompletionContentPartInputAudioParam"] | components["schemas"]["File"])[];
+            /**
+             * Role
+             * @constant
+             */
+            role: "user";
+            /** Name */
+            name?: string;
+        };
+        /** ChatCompletionUserMessageParam */
+        "ChatCompletionUserMessageParam-Output": {
+            /** Content */
+            content: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartImageParam"] | components["schemas"]["ChatCompletionContentPartInputAudioParam"] | components["schemas"]["File"])[];
+            /**
+             * Role
+             * @constant
+             */
+            role: "user";
+            /** Name */
+            name?: string;
         };
         /**
          * ChatStrategy
@@ -1908,7 +2078,10 @@ export interface components {
          * @enum {string}
          */
         EvalTemplateId: "kiln_requirements" | "kiln_issue" | "toxicity" | "bias" | "maliciousness" | "factual_correctness" | "jailbreak";
-        /** ExternalToolApiDescription */
+        /**
+         * ExternalToolApiDescription
+         * @description This class is a wrapper of MCP's Tool object to be displayed in the UI under tool_server/[tool_server_id].
+         */
         ExternalToolApiDescription: {
             /** Name */
             name: string;
@@ -1962,7 +2135,10 @@ export interface components {
             /** Model Type */
             readonly model_type: string;
         };
-        /** ExternalToolServerApiDescription */
+        /**
+         * ExternalToolServerApiDescription
+         * @description This class is used to describe the external tool server under tool_servers/[tool_server_id] UI. It is based of ExternalToolServer.
+         */
         ExternalToolServerApiDescription: {
             /** Id */
             id: string | null;
@@ -1992,6 +2168,24 @@ export interface components {
             };
             /** Description */
             description?: string | null;
+        };
+        /** File */
+        File: {
+            file: components["schemas"]["FileFile"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "file";
+        };
+        /** FileFile */
+        FileFile: {
+            /** File Data */
+            file_data?: string;
+            /** File Id */
+            file_id?: string;
+            /** Filename */
+            filename?: string;
         };
         /**
          * FineTuneParameter
@@ -2202,10 +2396,44 @@ export interface components {
             finetune: components["schemas"]["Finetune"];
             status: components["schemas"]["FineTuneStatus"];
         };
+        /** Function */
+        Function: {
+            /** Arguments */
+            arguments: string;
+            /** Name */
+            name: string;
+        };
+        /** FunctionCall */
+        FunctionCall: {
+            /** Arguments */
+            arguments: string;
+            /** Name */
+            name: string;
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
+        };
+        /** ImageURL */
+        ImageURL: {
+            /** Url */
+            url: string;
+            /**
+             * Detail
+             * @enum {string}
+             */
+            detail?: "auto" | "low" | "high";
+        };
+        /** InputAudio */
+        InputAudio: {
+            /** Data */
+            data: string;
+            /**
+             * Format
+             * @enum {string}
+             */
+            format: "wav" | "mp3";
         };
         /**
          * KilnBaseModel
@@ -2272,7 +2500,10 @@ export interface components {
             /** File Path */
             file_path: string | null;
         };
-        /** KilnToolServerDescription */
+        /**
+         * KilnToolServerDescription
+         * @description This class is used to describe the external tool server under Settings -> Manage Tools UI.
+         */
         KilnToolServerDescription: {
             /** Name */
             name: string;
@@ -2988,6 +3219,11 @@ export interface components {
             tags: string[];
             /** @description Usage information for the task run. This includes the number of input tokens, output tokens, and total tokens used. */
             usage?: components["schemas"]["Usage"] | null;
+            /**
+             * Trace
+             * @description The trace of the task run in OpenAI format. This is the list of messages that were sent to/from the model.
+             */
+            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParam"] | components["schemas"]["ChatCompletionSystemMessageParam"] | components["schemas"]["ChatCompletionUserMessageParam-Input"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper-Input"] | components["schemas"]["ChatCompletionToolMessageParam"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
         };
         /**
          * TaskRun
@@ -3044,6 +3280,11 @@ export interface components {
             tags: string[];
             /** @description Usage information for the task run. This includes the number of input tokens, output tokens, and total tokens used. */
             usage?: components["schemas"]["Usage"] | null;
+            /**
+             * Trace
+             * @description The trace of the task run in OpenAI format. This is the list of messages that were sent to/from the model.
+             */
+            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParam"] | components["schemas"]["ChatCompletionSystemMessageParam"] | components["schemas"]["ChatCompletionUserMessageParam-Output"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper-Output"] | components["schemas"]["ChatCompletionToolMessageParam"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
             /** Model Type */
             readonly model_type: string;
         };
@@ -3104,6 +3345,13 @@ export interface components {
          * @enum {string}
          */
         ToolServerType: "remote_mcp";
+        /** ToolSetApiDescription */
+        ToolSetApiDescription: {
+            /** Set Name */
+            set_name: string;
+            /** Tools */
+            tools: components["schemas"]["ToolApiDescription"][];
+        };
         /**
          * ToolsRunConfig
          * @description A config describing which tools are available to a task.
@@ -5612,7 +5860,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ToolApiDescription"][];
+                    "application/json": components["schemas"]["ToolSetApiDescription"][];
                 };
             };
             /** @description Validation Error */

--- a/app/web_ui/src/lib/stores.ts
+++ b/app/web_ui/src/lib/stores.ts
@@ -9,7 +9,7 @@ import type {
   RatingOptionResponse,
   TaskRequirement,
   ModelDetails,
-  ToolApiDescription,
+  ToolSetApiDescription,
 } from "./types"
 import { client } from "./api_client"
 import { createKilnError } from "$lib/utils/error_handlers"
@@ -200,9 +200,9 @@ export async function load_current_task(project: Project | null) {
 }
 
 // Available tools, by project ID
-export const available_tools = writable<Record<string, ToolApiDescription[]>>(
-  {},
-)
+export const available_tools = writable<
+  Record<string, ToolSetApiDescription[]>
+>({})
 let loading_project_tools: string[] = []
 
 export async function load_available_tools(

--- a/app/web_ui/src/lib/types.ts
+++ b/app/web_ui/src/lib/types.ts
@@ -46,3 +46,5 @@ export type ExternalToolServerApiDescription =
   components["schemas"]["ExternalToolServerApiDescription"]
 export type ToolServerType = components["schemas"]["ToolServerType"]
 export type ToolApiDescription = components["schemas"]["ToolApiDescription"]
+export type ToolSetApiDescription =
+  components["schemas"]["ToolSetApiDescription"]

--- a/app/web_ui/src/lib/ui/run_options.svelte
+++ b/app/web_ui/src/lib/ui/run_options.svelte
@@ -5,7 +5,7 @@
   import { structuredOutputModeToString } from "$lib/utils/formatters"
   import { available_tools, load_available_tools } from "$lib/stores"
   import { onMount } from "svelte"
-  import type { ToolApiDescription } from "$lib/types"
+  import type { ToolSetApiDescription } from "$lib/types"
 
   // These defaults are used by every provider I checked (OpenRouter, Fireworks, Together, etc)
   export let temperature: number = 1.0
@@ -131,17 +131,21 @@
   ]
 
   function get_tool_options(
-    available_tools: ToolApiDescription[],
+    available_tools: ToolSetApiDescription[],
   ): OptionGroup[] {
-    return [
-      {
-        options: available_tools?.map((tool) => ({
+    let option_groups: OptionGroup[] = []
+
+    available_tools?.forEach((tool_set) => {
+      option_groups.push({
+        label: tool_set.set_name,
+        options: tool_set.tools.map((tool) => ({
           value: tool.id,
           label: tool.name,
           description: tool.description || undefined,
         })),
-      },
-    ]
+      })
+    })
+    return option_groups
   }
 </script>
 

--- a/libs/core/kiln_ai/utils/config.py
+++ b/libs/core/kiln_ai/utils/config.py
@@ -147,6 +147,11 @@ class Config:
                 env_var="CEREBRAS_API_KEY",
                 sensitive=True,
             ),
+            "enable_demo_tools": ConfigProperty(
+                bool,
+                env_var="ENABLE_DEMO_TOOLS",
+                default=False,
+            ),
         }
         self._lock = threading.Lock()
         self._settings = self.load_settings()


### PR DESCRIPTION
Also: organize the available_tool list into sets. One set for demo tools, one for each MCP server, and ready for RAG.

<img width="336" height="501" alt="Screenshot 2025-08-21 at 5 42 30 PM" src="https://github.com/user-attachments/assets/168225d9-4639-48ed-ab63-e86013690536" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Available tools are now grouped into named sets (e.g., per server) instead of a single flat list; the UI shows grouped tool options.
  - Optional demo tools set (Addition, Subtraction, Multiplication, Division) can be enabled via an environment flag.
  - Expanded public API schema: adds audio, image, file, and function/tool-call message types.
  - Task run payloads can include rich, chat-style traces.
- Tests
  - Updated to validate grouped tool sets, demo tools flag behavior, and multi-server scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->