### PR TITLE
Make the prompt taller

### DIFF
--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -269,6 +269,7 @@
       label="Prompt / Task Instructions"
       inputType="textarea"
       id="task_instructions"
+      tall="medium"
       description={prompt_description()}
       bind:value={task.instruction}
     />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The Prompt/Task Instructions field in the task creation/editing screen is now taller (medium height), showing more lines by default for easier reading and editing with less scrolling.
  * Applies to the fullscreen setup flow; no user action or settings change required.
  * Visual-only update; all behaviors (validation, saving, error messages) remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->