### PR TITLE
Updated judge default score type value

### DIFF
--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
@@ -75,12 +75,7 @@
         )))
   )
 
-  // Update sorting when score_type or score_summary changes
-  $: if (eval_configs && score_summary && evaluator) {
-    sortEvalConfigs()
-  }
-
-  // Sort eval_configs whenever score_type changes
+  // Sort eval_configs whenever score_type or score_summary changes
   $: if (score_type && eval_configs && score_summary && evaluator) {
     sortEvalConfigs()
   }
@@ -212,6 +207,15 @@
         throw error
       }
       evaluator = data
+      // Override default score_type to "mse" when eval rating type is pass_fail or pass_fail_critical
+      // We have different scores to compare human preference to LLM-as-Judge in evals. Kendall Tau (the current default) is a great score for comparing ranked data, but kinda lousy for pass/fail data
+      const hasPassFailRating = evaluator.output_scores.some(
+        (score) =>
+          score.type === "pass_fail" || score.type === "pass_fail_critical",
+      )
+      if (hasPassFailRating) {
+        score_type = "mse"
+      }
     } catch (error) {
       eval_error = createKilnError(error)
     } finally {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatically picks an appropriate score metric when pass/fail-style outputs are present (defaults to MSE); otherwise uses Kendall Tau.
  * Defers sorting and score display until a score type is determined to ensure consistent ordering.

* **Bug Fixes**
  * Prevents premature rendering and sorting of score headers/cells while scoring data isn’t ready.

* **UX**
  * Shows "None" with a tooltip for missing scores to clarify unavailable data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->