### PR TITLE
Check against null instead of on the double var itself

### DIFF
--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
@@ -672,7 +672,7 @@
                         {:else if score_type === "norm_mae"}
                           {scores.mean_normalized_absolute_error.toFixed(3)}
                         {:else if score_type === "spearman"}
-                          {#if scores.spearman_correlation}
+                          {#if scores.spearman_correlation != null}
                             {scores.spearman_correlation.toFixed(3)}
                           {:else}
                             N/A <InfoTooltip
@@ -681,7 +681,7 @@
                             />
                           {/if}
                         {:else if score_type === "pearson"}
-                          {#if scores.pearson_correlation}
+                          {#if scores.pearson_correlation != null}
                             {scores.pearson_correlation.toFixed(3)}
                           {:else}
                             N/A <InfoTooltip
@@ -690,7 +690,7 @@
                             />
                           {/if}
                         {:else if score_type === "kendalltau"}
-                          {#if scores.kendalltau_correlation}
+                          {#if scores.kendalltau_correlation != null}
                             {scores.kendalltau_correlation.toFixed(3)}
                           {:else}
                             N/A <InfoTooltip


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected display of correlation metrics (Spearman, Pearson, Kendall Tau) so scores of 0.000 are shown instead of N/A.
  * Ensures consistent rendering in both the header and per-eval score cells; null/undefined still appear as N/A with an info tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->