### PR TITLE
Use str instead of enum when loading remote config provider models

### DIFF
--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -16,7 +16,6 @@ from kiln_ai.adapters.docker_model_runner_tools import (
 from kiln_ai.adapters.ml_model_list import (
     KilnModel,
     KilnModelProvider,
-    ModelName,
     ModelProviderName,
     StructuredOutputMode,
     built_in_models,
@@ -157,7 +156,7 @@ class ProviderModel(BaseModel):
 
 
 class ProviderModels(BaseModel):
-    models: Dict[ModelName, ProviderModel]
+    models: Dict[str, ProviderModel]
 
 
 def connect_provider_api(app: FastAPI):

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -16,6 +16,7 @@ from kiln_ai.adapters.ml_model_list import (
     ModelProviderName,
     StructuredOutputMode,
     built_in_models,
+    default_structured_output_mode_for_model_provider,
 )
 from kiln_ai.utils.config import Config
 
@@ -2893,3 +2894,48 @@ async def test_connect_wandb_request_exception(mock_config_shared, mock_requests
         not hasattr(mock_config, "wandb_api_key")
         or mock_config.wandb_api_key != "test-api-key"
     )
+
+
+def test_remote_model_name_not_in_enum_handled_gracefully():
+    # Test with a model name that definitely doesn't exist in the ModelName enum
+    remote_model_name = "remote-model-abc"
+
+    # This should not raise an exception even though the model name is not in the enum
+    result = default_structured_output_mode_for_model_provider(
+        model_name=remote_model_name,
+        provider=ModelProviderName.openai,
+        default=StructuredOutputMode.json_schema,
+    )
+
+    # Should return the default mode since the model is not found
+    assert result == StructuredOutputMode.json_schema
+
+
+def test_get_providers_models_handles_remote_models(client):
+    # Mock built_in_models to include models with names that are not in the enum
+    mock_model1 = MagicMock()
+    mock_model1.name = "remote-model-abc"
+    mock_model1.friendly_name = "Remote Model ABC"
+
+    mock_model2 = MagicMock()
+    mock_model2.name = "remote-model-xyz"
+    mock_model2.friendly_name = "Remote Model XYZ"
+
+    mock_built_in_models = [mock_model1, mock_model2]
+
+    with patch(
+        "app.desktop.studio_server.provider_api.built_in_models", mock_built_in_models
+    ):
+        response = client.get("/api/providers/models")
+
+        # Should handle the remote model names without failing
+        assert response.status_code == 200
+        data = response.json()
+
+        assert "remote-model-abc" in data["models"]
+        assert "remote-model-xyz" in data["models"]
+
+        assert data["models"]["remote-model-abc"]["id"] == "remote-model-abc"
+        assert data["models"]["remote-model-abc"]["name"] == "Remote Model ABC"
+        assert data["models"]["remote-model-xyz"]["id"] == "remote-model-xyz"
+        assert data["models"]["remote-model-xyz"]["name"] == "Remote Model XYZ"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility with remote/unknown model names across providers.
  * Provider model listings now include remote models with correct identifiers.
  * Applies a sensible default structured output mode per provider when a model is unrecognized.

* **Bug Fixes**
  * Prevents errors when encountering model names not in the built-in list.

* **Tests**
  * Added coverage to verify graceful handling and correct exposure of remote models in provider listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->