### PR TITLE
chore: better logging config

### DIFF
--- a/app/desktop/dev_server.py
+++ b/app/desktop/dev_server.py
@@ -6,6 +6,7 @@ import os
 import uvicorn
 
 from app.desktop.desktop_server import make_app
+from app.desktop.log_config import log_config
 
 # Skip remote model loading when running the dev server (unless explicitly set)
 os.environ.setdefault("KILN_SKIP_REMOTE_MODEL_LIST", "true")
@@ -24,4 +25,6 @@ if __name__ == "__main__":
         reload=True,
         # Debounce when changing many files (changing branch)
         reload_delay=0.1,
+        use_colors=True,
+        log_config=log_config(),
     )


### PR DESCRIPTION
## What does this PR do?

Currently, the logger in dev server is hardcoded to log only `warning` and up - `logger.info` is not shown.

#### 1. Fix coloring of log prefix (e.g. `DEBUG`, `INFO`, etc.) when using the app logger within context of dev server.

#### 2. Allow setting log level via env var when running dev server:
```sh
# use INFO level
KILN_LOG_LEVEL=INFO uv run python -m app.desktop.dev_server
```

#### 3. Add convenience to dump formatted objects to logs:
```sh
some_dict =  {"name": "Bob", "city": "London" }
logger.info("some message", extra={"dict": some_dict})
```

Resulting log is:
```
INFO:     some message
{
  "name": "Bob",
  "city": "London"
}
```

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib
