### PR TITLE
Save the tools selected per task, so it's not constantly resetting.

### DIFF
--- a/app/web_ui/src/lib/stores/tools_store.ts
+++ b/app/web_ui/src/lib/stores/tools_store.ts
@@ -1,0 +1,11 @@
+import { indexedDBStore } from "./index_db_store"
+
+type ToolsStore = {
+  selected_tool_ids_by_task_id: Record<string, string[]>
+}
+
+const tools_store_key = "tools_store"
+export const { store: tools_store, initialized: tools_store_initialized } =
+  indexedDBStore<ToolsStore>(tools_store_key, {
+    selected_tool_ids_by_task_id: {},
+  })

--- a/app/web_ui/src/lib/ui/collapse.svelte
+++ b/app/web_ui/src/lib/ui/collapse.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   export let title: string
   export let small: boolean = true
+  export let badge: string | null = null
 </script>
 
 <div
@@ -14,6 +15,11 @@
       ? 'text-sm'
       : ''} min-h-[24px]"
   >
+    {#if badge}
+      <span class="badge badge-outline mr-2 px-1 text-xs min-w-[20px]"
+        >{badge}</span
+      >
+    {/if}
     {title}
   </div>
   <div class="collapse-content flex flex-col gap-4" style="min-width: 0">

--- a/app/web_ui/src/lib/ui/fancy_select.svelte
+++ b/app/web_ui/src/lib/ui/fancy_select.svelte
@@ -103,6 +103,11 @@
     }, 0)
   }
 
+  // Make it reactive, when selected changes, update the selected_values
+  $: if (multi_select && selected instanceof Array) {
+    selected_values = selected
+  }
+
   // Function to check if menu is scrollable
   function checkIfScrollable() {
     if (menuElement) {

--- a/app/web_ui/src/lib/ui/run_options.svelte
+++ b/app/web_ui/src/lib/ui/run_options.svelte
@@ -6,26 +6,46 @@
   import { available_tools, load_available_tools } from "$lib/stores"
   import { onMount } from "svelte"
   import type { ToolSetApiDescription } from "$lib/types"
+  import { tools_store, tools_store_initialized } from "$lib/stores/tools_store"
 
   // These defaults are used by every provider I checked (OpenRouter, Fireworks, Together, etc)
   export let temperature: number = 1.0
   export let top_p: number = 1.0
   export let structured_output_mode: StructuredOutputMode = "default"
   export let has_structured_output: boolean = false
-  export let tools: string[] = []
   export let project_id: string
+  export let task_id: string
+  export let tools: string[] = []
 
   onMount(async () => {
-    load_tools(project_id)
+    await load_tools(project_id, task_id)
   })
 
-  function load_tools(project_id: string) {
+  let tools_store_loaded_task_id: string | null = null
+  async function load_tools(project_id: string, task_id: string) {
     if (project_id) {
       load_available_tools(project_id)
     }
+
+    if (task_id !== tools_store_loaded_task_id) {
+      await tools_store_initialized
+      tools = $tools_store.selected_tool_ids_by_task_id[task_id] || []
+      tools_store_loaded_task_id = task_id
+    }
   }
-  // Update if project_id changes
-  $: load_tools(project_id)
+  // Load tools if project_id or task_id changes
+  $: load_tools(project_id, task_id)
+
+  // Update tools_store when tools changes, only after initial load so we don't update it with the empty initial value
+  $: if (task_id && tools && tools_store_loaded_task_id === task_id) {
+    tools_store.update((state) => ({
+      ...state,
+      selected_tool_ids_by_task_id: {
+        ...state.selected_tool_ids_by_task_id,
+        [task_id]: tools,
+      },
+    }))
+  }
 
   export let validate_temperature: (value: unknown) => string | null = (
     value: unknown,

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/add_run_method.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/add_run_method.svelte
@@ -166,6 +166,7 @@
         bind:structured_output_mode={task_run_config_structured_output_mode}
         has_structured_output={!!$current_task?.output_json_schema}
         {project_id}
+        {task_id}
       />
     </Collapse>
     {#if add_task_config_error}

--- a/app/web_ui/src/routes/(app)/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/run/+page.svelte
@@ -172,7 +172,10 @@
           bind:this={model_dropdown}
         />
         {#if $current_project?.id}
-          <Collapse title="Advanced Options">
+          <Collapse
+            title="Advanced Options"
+            badge={tools.length > 0 ? "" + tools.length : null}
+          >
             <RunOptions
               bind:tools
               bind:temperature
@@ -180,6 +183,7 @@
               bind:structured_output_mode
               has_structured_output={requires_structured_output}
               project_id={$current_project?.id}
+              task_id={$current_task?.id || ""}
             />
           </Collapse>
         {/if}


### PR DESCRIPTION
also add a nice little badge to collapse, so we can indicate some tools are selected

<img width="322" height="75" alt="Screenshot 2025-08-28 at 5 49 15 PM" src="https://github.com/user-attachments/assets/a1a7ea3c-76d9-4019-ba62-893412965479" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool selections are now saved per task and persist across sessions.
  * Advanced Options shows a badge indicating the number of selected tools.
  * Run and Compare pages pass task context to options, enabling per-task configurations.
* **Bug Fixes**
  * Multi-select dropdown stays in sync when the selection is updated externally, preventing stale or mismatched selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->