### PR TITLE
Check if input is an array

### DIFF
--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -1,0 +1,97 @@
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+from mcp import StdioServerParameters
+from mcp.client.session import ClientSession
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
+
+from kiln_ai.datamodel.external_tool_server import ExternalToolServer, ToolServerType
+from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
+
+
+class MCPSessionManager:
+    """
+    This class is a singleton that manages MCP sessions for remote MCP servers.
+    """
+
+    _shared_instance = None
+
+    @classmethod
+    def shared(cls):
+        if cls._shared_instance is None:
+            cls._shared_instance = cls()
+        return cls._shared_instance
+
+    @asynccontextmanager
+    async def mcp_client(
+        self,
+        tool_server: ExternalToolServer,
+    ) -> AsyncGenerator[
+        ClientSession,
+        None,
+    ]:
+        match tool_server.type:
+            case ToolServerType.remote_mcp:
+                async with self._create_remote_mcp_session(tool_server) as session:
+                    yield session
+            case ToolServerType.local_mcp:
+                async with self._create_local_mcp_session(tool_server) as session:
+                    yield session
+            case _:
+                raise_exhaustive_enum_error(tool_server.type)
+
+    @asynccontextmanager
+    async def _create_remote_mcp_session(
+        self,
+        tool_server: ExternalToolServer,
+    ) -> AsyncGenerator[ClientSession, None]:
+        """
+        Create a session for a remote MCP server.
+        """
+        # Make sure the server_url is set
+        server_url = tool_server.properties.get("server_url")
+        if not server_url:
+            raise ValueError("server_url is required")
+
+        headers = tool_server.properties.get("headers", {})
+
+        async with streamablehttp_client(server_url, headers=headers) as (
+            read_stream,
+            write_stream,
+            _,
+        ):
+            # Create a session using the client streams
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
+
+    @asynccontextmanager
+    async def _create_local_mcp_session(
+        self,
+        tool_server: ExternalToolServer,
+    ) -> AsyncGenerator[ClientSession, None]:
+        """
+        Create a session for a local MCP server.
+        """
+        command = tool_server.properties.get("command")
+        if not command:
+            raise ValueError("command is required")
+
+        args = tool_server.properties.get("args", [])
+        if not isinstance(args, list):
+            raise ValueError("args must be an array")
+
+        env_vars = tool_server.properties.get("env_vars", {})
+
+        # Set the server parameters
+        server_params = StdioServerParameters(
+            command=command,
+            args=args,
+            env=env_vars,
+        )
+
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session


### PR DESCRIPTION
## What does this PR do?

Updates the validation logic for the `args` parameter within the `_create_local_mcp_session` function in `mcp_session_manager.py`. The previous check `if not args:` incorrectly raised a `ValueError` for an empty list `[]`. This PR changes the validation to `if not isinstance(args, list):` to correctly ensure `args` is an array type, allowing valid empty arrays to pass.

## Related Issues

<!--- Link to related issues. For example: "Fixes: https://github.com/Kiln-AI/Kiln/issues/12345" -->

## Contributor License Agreement

I, @<your-github-username>, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib

---
<a href="https://cursor.com/background-agent?bcId=bc-25cb34a5-9f9f-4d4f-b31b-d1eb0dfc1800">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25cb34a5-9f9f-4d4f-b31b-d1eb0dfc1800">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

