### PR TITLE
Add ability to delete Tool Servers

### DIFF
--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -169,6 +169,15 @@ class ToolSetApiDescription(BaseModel):
     tools: list[ToolApiDescription]
 
 
+def tool_server_from_id(project_id: str, tool_server_id: str) -> ExternalToolServer:
+    project = project_from_id(project_id)
+    for tool_server in project.external_tool_servers(readonly=True):
+        if tool_server.id == tool_server_id:
+            return tool_server
+
+    raise HTTPException(status_code=404, detail="Tool server not found")
+
+
 async def available_mcp_tools(
     server: ExternalToolServer,
 ) -> list[ToolApiDescription]:
@@ -293,17 +302,7 @@ def connect_tool_servers_api(app: FastAPI):
     async def get_tool_server(
         project_id: str, tool_server_id: str
     ) -> ExternalToolServerApiDescription:
-        project = project_from_id(project_id)
-        tool_server = next(
-            (
-                t
-                for t in project.external_tool_servers(readonly=True)
-                if t.id == tool_server_id
-            ),
-            None,
-        )
-        if not tool_server:
-            raise HTTPException(status_code=404, detail="Tool not found")
+        tool_server = tool_server_from_id(project_id, tool_server_id)
 
         # Get available tools based on server type
         available_tools = []
@@ -388,3 +387,8 @@ def connect_tool_servers_api(app: FastAPI):
         tool_server.save_to_file()
 
         return tool_server
+
+    @app.delete("/api/projects/{project_id}/tool_servers/{tool_server_id}")
+    async def delete_tool_server(project_id: str, tool_server_id: str):
+        tool_server = tool_server_from_id(project_id, tool_server_id)
+        tool_server.delete()

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1118,7 +1118,8 @@ export interface paths {
         get: operations["get_tool_server_api_projects__project_id__tool_servers__tool_server_id__get"];
         put?: never;
         post?: never;
-        delete?: never;
+        /** Delete Tool Server */
+        delete: operations["delete_tool_server_api_projects__project_id__tool_servers__tool_server_id__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -5956,6 +5957,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ExternalToolServerApiDescription"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_tool_server_api_projects__project_id__tool_servers__tool_server_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                tool_server_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
@@ -18,9 +18,6 @@
   let error: KilnError | null = null
   let delete_dialog: DeleteDialog | null = null
   $: delete_url = `/api/projects/${project_id}/tool_servers/${tool_server_id}`
-  let after_delete = () => {
-    goto(`/settings/manage_tools/${project_id}`)
-  }
 
   onMount(async () => {
     await fetch_tool_server()
@@ -342,5 +339,7 @@
   name="Tool Server"
   bind:this={delete_dialog}
   {delete_url}
-  {after_delete}
+  after_delete={() => {
+    goto(`/settings/manage_tools/${project_id}`)
+  }}
 />

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
@@ -8,6 +8,7 @@
   import { goto } from "$app/navigation"
   import type { ExternalToolServerApiDescription } from "$lib/types"
   import { toolServerTypeToString } from "$lib/utils/formatters"
+  import DeleteDialog from "$lib/ui/delete_dialog.svelte"
 
   $: project_id = $page.params.project_id
   $: tool_server_id = $page.params.tool_server_id
@@ -15,6 +16,11 @@
   let tool_server: ExternalToolServerApiDescription | null = null
   let loading = true
   let error: KilnError | null = null
+  let delete_dialog: DeleteDialog | null = null
+  $: delete_url = `/api/projects/${project_id}/tool_servers/${tool_server_id}`
+  let after_delete = () => {
+    goto(`/settings/manage_tools/${project_id}`)
+  }
 
   onMount(async () => {
     await fetch_tool_server()
@@ -184,7 +190,22 @@
 </script>
 
 <div class="max-w-[1400px]">
-  <AppPage title={"Tool Server"} subtitle={`Name: ${tool_server?.name || ""}`}>
+  <AppPage
+    title={"Tool Server"}
+    subtitle={`Name: ${tool_server?.name || ""}`}
+    action_buttons={[
+      {
+        icon: "/images/delete.svg",
+        handler: () => delete_dialog?.show(),
+      },
+      {
+        label: "Edit",
+        handler: () => {
+          goto(`/settings/edit_tool_server/${project_id}/${tool_server_id}`)
+        },
+      },
+    ]}
+  >
     {#if loading}
       <div class="w-full min-h-[50vh] flex justify-center items-center">
         <div class="loading loading-spinner loading-lg"></div>
@@ -322,3 +343,10 @@
     {/if}
   </AppPage>
 </div>
+
+<DeleteDialog
+  name="Tool Server"
+  bind:this={delete_dialog}
+  {delete_url}
+  {after_delete}
+/>

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
@@ -198,12 +198,6 @@
         icon: "/images/delete.svg",
         handler: () => delete_dialog?.show(),
       },
-      {
-        label: "Edit",
-        handler: () => {
-          goto(`/settings/edit_tool_server/${project_id}/${tool_server_id}`)
-        },
-      },
     ]}
   >
     {#if loading}

--- a/libs/core/kiln_ai/datamodel/test_exteral_tool_server.py
+++ b/libs/core/kiln_ai/datamodel/test_exteral_tool_server.py
@@ -562,7 +562,7 @@ def test_local_mcp_invalid_args_type():
 
 
 def test_local_mcp_empty_args():
-    """Test that empty args list is now allowed for local MCP (arguments no longer required)."""
+    """Test that empty args list is now allowed for local MCP."""
     # Should not raise any exception - empty args are now allowed
     tool_server = ExternalToolServer(
         name="empty_args_tool",


### PR DESCRIPTION
## What does this PR do?

Add new delete API for tool server.
Add delete button under Tool Server page.

<img width="2494" height="1175" alt="image" src="https://github.com/user-attachments/assets/8c532368-6117-40cf-b9d3-2c0b85fa11b6" />


## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete a Tool Server directly from its page with a confirmation dialog; successful deletion returns to the Tools list.
  * Backend supports deleting a Tool Server via the project/tool-server endpoint.

* **Improvements**
  * Clearer "Tool server not found" and "Project not found" error messages.
  * Tool Servers and Available Tools lists update immediately after deletions.
  * Better handling of diverse tool-server configurations (long names, Unicode, complex headers, query params, whitespace).

* **Tests**
  * Expanded coverage for create/update/retrieve/delete flows, multi-server scenarios, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->