### PR TITLE
Toggle and list item for demo tools

### DIFF
--- a/app/desktop/studio_server/test_tool_api.py
+++ b/app/desktop/studio_server/test_tool_api.py
@@ -2878,3 +2878,56 @@ async def test_validate_tool_server_connectivity_local_mcp_failed():
         # Should raise the raw exception
         with pytest.raises(Exception, match="Local MCP server failed"):
             await validate_tool_server_connectivity(tool_server)
+
+
+# Tests for demo tools API endpoints
+def test_get_demo_tools_enabled(client):
+    """Test GET /api/demo_tools returns True when demo tools are enabled"""
+    with patch("app.desktop.studio_server.tool_api.Config.shared") as mock_config:
+        mock_config_instance = mock_config.return_value
+        mock_config_instance.enable_demo_tools = True
+
+        response = client.get("/api/demo_tools")
+
+        assert response.status_code == 200
+        assert response.json() is True
+
+
+def test_get_demo_tools_disabled(client):
+    """Test GET /api/demo_tools returns False when demo tools are disabled"""
+    with patch("app.desktop.studio_server.tool_api.Config.shared") as mock_config:
+        mock_config_instance = mock_config.return_value
+        mock_config_instance.enable_demo_tools = False
+
+        response = client.get("/api/demo_tools")
+
+        assert response.status_code == 200
+        assert response.json() is False
+
+
+def test_set_demo_tools_enable(client):
+    """Test POST /api/demo_tools enables demo tools"""
+    with patch("app.desktop.studio_server.tool_api.Config.shared") as mock_config:
+        mock_config_instance = mock_config.return_value
+        mock_config_instance.enable_demo_tools = False  # Initially disabled
+
+        response = client.post("/api/demo_tools?enable_demo_tools=true")
+
+        assert response.status_code == 200
+        assert response.json() is True
+        # Verify the config was updated
+        assert mock_config_instance.enable_demo_tools is True
+
+
+def test_set_demo_tools_disable(client):
+    """Test POST /api/demo_tools disables demo tools"""
+    with patch("app.desktop.studio_server.tool_api.Config.shared") as mock_config:
+        mock_config_instance = mock_config.return_value
+        mock_config_instance.enable_demo_tools = True  # Initially enabled
+
+        response = client.post("/api/demo_tools?enable_demo_tools=false")
+
+        assert response.status_code == 200
+        assert response.json() is False
+        # Verify the config was updated
+        assert mock_config_instance.enable_demo_tools is False

--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -388,3 +388,12 @@ def connect_tool_servers_api(app: FastAPI):
         tool_server.save_to_file()
 
         return tool_server
+
+    @app.get("/api/demo_tools")
+    async def get_demo_tools() -> bool:
+        return Config.shared().enable_demo_tools
+
+    @app.post("/api/demo_tools")
+    async def set_demo_tools(enable_demo_tools: bool) -> bool:
+        Config.shared().enable_demo_tools = enable_demo_tools
+        return Config.shared().enable_demo_tools

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1158,6 +1158,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/demo_tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Demo Tools */
+        get: operations["get_demo_tools_api_demo_tools_get"];
+        put?: never;
+        /** Set Demo Tools */
+        post: operations["set_demo_tools_api_demo_tools_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -6026,6 +6044,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ExternalToolServer"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_demo_tools_api_demo_tools_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": boolean;
+                };
+            };
+        };
+    };
+    set_demo_tools_api_demo_tools_post: {
+        parameters: {
+            query: {
+                enable_demo_tools: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": boolean;
                 };
             };
             /** @description Validation Error */

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/+page.svelte
@@ -3,6 +3,7 @@
   import AppPage from "../../../../app_page.svelte"
   import { page } from "$app/stores"
   import SettingsSection from "$lib/ui/settings_section.svelte"
+  import { client } from "$lib/api_client"
 
   $: project_id = $page.params.project_id
 
@@ -125,6 +126,25 @@
       installation_instruction: "",
     },
   ]
+
+  async function enable_demo_tools() {
+    try {
+      const { error } = await client.POST("/api/demo_tools", {
+        params: {
+          query: {
+            enable_demo_tools: true,
+          },
+        },
+      })
+      if (error) {
+        throw error
+      }
+      goto(`/settings/manage_tools/${project_id}`)
+    } catch (error) {
+      console.error(error)
+      alert("Error enabling demo tools.")
+    }
+  }
 </script>
 
 <AppPage title="Add Tools">
@@ -132,6 +152,13 @@
     <SettingsSection
       title="Sample Tools"
       items={[
+        {
+          name: "Math Demo Tools",
+          description:
+            "Enable with one click to try out tool calling. Simple math tools: add, subtract, multiply, divide.",
+          button_text: "Enable",
+          on_click: () => enable_demo_tools(),
+        },
         ...sampleRemoteMcpServers.map((item) => ({
           name: item.name,
           description: item.description,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Math Demo Tools” as a sample tool you can enable from the Add Tools page.
  - Manage Tools now displays the Math Demo Tools when enabled and provides a Disable button.
  - The page automatically loads and reflects the current demo tools status.
  - Demo tools can be toggled on/off instantly from the UI without restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->