### PR TITLE
fix: svelte-check warnings about unused ts annotations

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1240,7 +1240,9 @@ export interface components {
             name?: string | null;
             type: components["schemas"]["EvalConfigType"];
             /** Properties */
-            properties: Record<string, never>;
+            properties: {
+                [key: string]: unknown;
+            };
             /** Model Name */
             model_name: string;
             provider: components["schemas"]["ModelProviderName"];
@@ -1385,7 +1387,9 @@ export interface components {
              * Input
              * @description Input for this sample
              */
-            input: string | Record<string, never>;
+            input: string | {
+                [key: string]: unknown;
+            };
             /**
              * Topic Path
              * @description The path to the topic for this sample. Empty is the root topic.
@@ -1669,7 +1673,9 @@ export interface components {
              * @description Properties to be used to execute the eval config. This is config_type specific and should serialize to a json dict.
              * @default {}
              */
-            properties: Record<string, never>;
+            properties: {
+                [key: string]: unknown;
+            };
             /** Model Type */
             readonly model_type: string;
         };
@@ -2071,7 +2077,7 @@ export interface components {
          *         created_at (datetime): Timestamp when the model was created
          *         created_by (str): User ID of the creator
          */
-        "KilnBaseModel-Input": {
+        KilnBaseModel: {
             /**
              * V
              * @default 1
@@ -2088,37 +2094,6 @@ export interface components {
             created_at?: string;
             /** Created By */
             created_by?: string;
-        };
-        /**
-         * KilnBaseModel
-         * @description Base model for all Kiln data models with common functionality for persistence and versioning.
-         *
-         *     Attributes:
-         *         v (int): Schema version number for migration support
-         *         id (str): Unique identifier for the model instance
-         *         path (Path): File system path where the model is stored
-         *         created_at (datetime): Timestamp when the model was created
-         *         created_by (str): User ID of the creator
-         */
-        "KilnBaseModel-Output": {
-            /**
-             * V
-             * @default 1
-             */
-            v: number;
-            /** Id */
-            id?: string | null;
-            /** Path */
-            path?: string | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at?: string;
-            /** Created By */
-            created_by?: string;
-            /** Model Type */
-            readonly model_type: string;
         };
         /** KilnFileResponse */
         KilnFileResponse: {
@@ -2165,13 +2140,6 @@ export interface components {
             /** Task Filter */
             task_filter?: string[] | null;
         };
-        /**
-         * ModelName
-         * @description Enumeration of specific model versions supported by the system.
-         *     Where models have instruct and raw versions, instruct is default and raw is specified.
-         * @enum {string}
-         */
-        ModelName: "llama_3_1_8b" | "llama_3_1_70b" | "llama_3_1_405b" | "llama_3_2_1b" | "llama_3_2_3b" | "llama_3_2_11b" | "llama_3_2_90b" | "llama_3_3_70b" | "llama_4_maverick" | "llama_4_scout" | "gpt_5" | "gpt_5_chat" | "gpt_5_mini" | "gpt_5_nano" | "gpt_4o_mini" | "gpt_4o" | "gpt_4_1" | "gpt_4_1_mini" | "gpt_4_1_nano" | "gpt_o3_low" | "gpt_o3_medium" | "gpt_o3_high" | "gpt_oss_20b" | "gpt_oss_120b" | "gpt_o1_low" | "gpt_o1_medium" | "gpt_o1_high" | "gpt_o4_mini_low" | "gpt_o4_mini_medium" | "gpt_o4_mini_high" | "gpt_o3_mini_low" | "gpt_o3_mini_medium" | "gpt_o3_mini_high" | "phi_3_5" | "phi_4" | "phi_4_5p6b" | "phi_4_mini" | "mistral_large" | "mistral_nemo" | "mistral_small_3" | "magistral_medium" | "magistral_medium_thinking" | "gemma_2_2b" | "gemma_2_9b" | "gemma_2_27b" | "gemma_3_1b" | "gemma_3_4b" | "gemma_3_12b" | "gemma_3_27b" | "gemma_3n_2b" | "gemma_3n_4b" | "claude_3_5_haiku" | "claude_3_5_sonnet" | "claude_3_7_sonnet" | "claude_3_7_sonnet_thinking" | "claude_sonnet_4" | "claude_opus_4" | "gemini_1_5_flash" | "gemini_1_5_flash_8b" | "gemini_1_5_pro" | "gemini_2_0_flash" | "gemini_2_0_flash_lite" | "gemini_2_5_pro" | "gemini_2_5_flash" | "gemini_2_5_flash_lite" | "nemotron_70b" | "mixtral_8x7b" | "qwen_2p5_7b" | "qwen_2p5_14b" | "qwen_2p5_72b" | "qwq_32b" | "deepseek_3" | "deepseek_r1" | "deepseek_r1_0528" | "deepseek_r1_0528_distill_qwen3_8b" | "deepseek_r1_distill_qwen_32b" | "deepseek_r1_distill_llama_70b" | "deepseek_r1_distill_qwen_14b" | "deepseek_r1_distill_qwen_1p5b" | "deepseek_r1_distill_qwen_7b" | "deepseek_r1_distill_llama_8b" | "dolphin_2_9_8x22b" | "grok_2" | "grok_3" | "grok_3_mini" | "grok_4" | "qwen_3_0p6b" | "qwen_3_0p6b_no_thinking" | "qwen_3_1p7b" | "qwen_3_1p7b_no_thinking" | "qwen_3_4b" | "qwen_3_4b_no_thinking" | "qwen_3_8b" | "qwen_3_8b_no_thinking" | "qwen_3_14b" | "qwen_3_14b_no_thinking" | "qwen_3_30b_a3b_2507" | "qwen_3_30b_a3b" | "qwen_3_30b_a3b_2507_no_thinking" | "qwen_3_30b_a3b_no_thinking" | "qwen_3_32b" | "qwen_3_32b_no_thinking" | "qwen_3_235b_a22b_2507" | "qwen_3_235b_a22b" | "qwen_3_235b_a22b_2507_no_thinking" | "qwen_3_235b_a22b_no_thinking" | "qwen_long_l1_32b" | "kimi_k2" | "kimi_dev_72b" | "glm_4_1v_9b_thinking" | "glm_z1_32b_0414" | "glm_z1_9b_0414" | "ernie_4_5_300b_a47b" | "hunyuan_a13b" | "hunyuan_a13b_no_thinking" | "minimax_m1_80k" | "pangu_pro_moe_72b_a16b";
         /**
          * ModelProviderName
          * @description Enumeration of supported AI model providers.
@@ -2499,7 +2467,9 @@ export interface components {
             /** Plaintext Input */
             plaintext_input?: string | null;
             /** Structured Input */
-            structured_input?: Record<string, never> | null;
+            structured_input?: {
+                [key: string]: unknown;
+            } | null;
             /** Tags */
             tags?: string[] | null;
         };
@@ -2795,7 +2765,7 @@ export interface components {
             created_at?: string;
             /** Created By */
             created_by?: string;
-            parent?: components["schemas"]["KilnBaseModel-Input"] | null;
+            parent?: components["schemas"]["KilnBaseModel"] | null;
             /**
              * Input
              * @description The inputs to the task. JSON formatted for structured input, plaintext for unstructured input.
@@ -3055,7 +3025,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -3147,7 +3119,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -3203,7 +3177,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -3271,7 +3247,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -3607,7 +3585,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -4014,7 +3994,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": Record<string, never>;
+                "application/json": {
+                    [key: string]: unknown;
+                };
             };
         };
         responses: {
@@ -4191,7 +4173,9 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/create_eval_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/create_eval_config/+page.svelte
@@ -165,9 +165,7 @@
             // @ts-expect-error provider is not typed, but server will validate
             provider: provider_name,
             properties: {
-              // @ts-expect-error properties are not typed, but server will validate
               eval_steps: eval_steps,
-              // @ts-expect-error properties are not typed, but server will validate
               task_description: task_description,
             },
           },

--- a/app/web_ui/src/routes/(app)/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/run/+page.svelte
@@ -136,7 +136,6 @@
             structured_output_mode: structured_output_mode,
           },
           plaintext_input: input_form.get_plaintext_input_data(),
-          // @ts-expect-error openapi-fetch generates the wrong type for this: Record<string, never>
           structured_input: input_form.get_structured_input_data(),
           tags: ["manual_run"],
         },

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -135,7 +135,6 @@
             run_id: run?.id || "",
           },
         },
-        // @ts-expect-error type checking and PATCH don't mix
         body: patch_body,
       },
     )

--- a/app/web_ui/src/routes/(app)/settings/providers/add_models/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/providers/add_models/+page.svelte
@@ -26,7 +26,16 @@
       if (!settings) {
         throw new KilnError("Settings not found", null)
       }
-      custom_models = settings["custom_models"] || []
+      const incoming_settings_custom_models = settings["custom_models"]
+      if (
+        !Array.isArray(incoming_settings_custom_models) ||
+        incoming_settings_custom_models.some(
+          (model: string) => typeof model !== "string",
+        )
+      ) {
+        throw new KilnError("Custom models must be an array of strings", null)
+      }
+      custom_models = incoming_settings_custom_models || []
       if (settings["open_ai_api_key"]) {
         connected_providers.push(["openai", "OpenAI"])
       }

--- a/app/web_ui/src/routes/(app)/settings/providers/add_models/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/providers/add_models/+page.svelte
@@ -27,15 +27,16 @@
         throw new KilnError("Settings not found", null)
       }
       const incoming_settings_custom_models = settings["custom_models"]
-      if (
+      if (!incoming_settings_custom_models) {
+        custom_models = []
+      } else if (
         !Array.isArray(incoming_settings_custom_models) ||
-        incoming_settings_custom_models.some(
-          (model: string) => typeof model !== "string",
-        )
+        incoming_settings_custom_models.some((m) => typeof m !== "string")
       ) {
         throw new KilnError("Custom models must be an array of strings", null)
+      } else {
+        custom_models = incoming_settings_custom_models
       }
-      custom_models = incoming_settings_custom_models || []
       if (settings["open_ai_api_key"]) {
         connected_providers.push(["openai", "OpenAI"])
       }

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_project/edit_project.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_project/edit_project.svelte
@@ -73,7 +73,6 @@
                 project_id: project.id,
               },
             },
-            // @ts-expect-error Patching only takes some fields
             body,
           },
         )

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -99,7 +99,6 @@
                 project_id,
               },
             },
-            // @ts-expect-error This API is not typed
             body: body,
           },
         )
@@ -118,7 +117,6 @@
                 task_id: task.id || "",
               },
             },
-            // @ts-expect-error This API is not typed
             body: body,
           },
         )


### PR DESCRIPTION
## What does this PR do?

Started getting errors in the svelte-check that runs in `./checks.sh`. This seems to be due to the API schema types having changed slightly such that the TS bypass annotations are no longer needed - which triggers an error.

I do not know why I started getting these errors today - my `openapi-typescript` package seems to be the same version as in `package.json`; and these errors are coming from files that I have not touched. Started getting them on my feature branch, but am also getting them on `main`.

To test if you are getting the same issue on `main`:
1. Edit a Svelte file (for example, `./app/web_ui/src/routes/(app)/settings`) and save
2. `git add . && ./checks.sh`
3. See if you get the svelte-check errors

And:
```sh
pushd app/web_ui/src/lib && ./generate_schema.sh && popd && git add . && ./checks.sh
```

To see if this PR introduces an issue for you:
1. Edit a Svelte file (for example, `./app/web_ui/src/routes/(app)/settings`) and save
2. `git add . && ./checks.sh`
3. See if you get other issues (maybe typecheck errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More flexible API payloads: many endpoints now accept generic key–value data for request and response bodies.
  - Public API surface simplified by removing legacy model metadata and a large model-name enum.

- Bug Fixes
  - Settings > Providers: “Custom models” now validates as an array of strings and raises a clear error if invalid.

- Refactor
  - Removed several TypeScript error-suppression comments so payloads are fully type-checked (no expected runtime changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->