### PR TITLE
Fix tool calling + reasoning models

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -868,6 +868,8 @@ built_in_models: List[KilnModel] = [
                 # For reasoning models, we need to use json_instructions with OpenRouter
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 require_openrouter_reasoning=True,
+                # Note: this model doesn't return thinking content after a tool call so disabling tool calls. Just use non-thinking version.
+                supports_function_calling=False,
             ),
             KilnModelProvider(
                 name=ModelProviderName.anthropic,
@@ -875,6 +877,9 @@ built_in_models: List[KilnModel] = [
                 model_id="claude-3-7-sonnet-20250219",
                 anthropic_extended_thinking=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
+                # Note: Anthropic expects a specific message format with tool calls and thinking. Would require extra work, and non standard trace generation so not supporting tool calls.
+                # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#extended-thinking-with-tool-use
+                supports_function_calling=False,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -868,8 +868,6 @@ built_in_models: List[KilnModel] = [
                 # For reasoning models, we need to use json_instructions with OpenRouter
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 require_openrouter_reasoning=True,
-                # Note: this model doesn't return thinking content after a tool call so disabling tool calls. Just use non-thinking version.
-                supports_function_calling=False,
             ),
             KilnModelProvider(
                 name=ModelProviderName.anthropic,
@@ -877,9 +875,6 @@ built_in_models: List[KilnModel] = [
                 model_id="claude-3-7-sonnet-20250219",
                 anthropic_extended_thinking=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
-                # Note: Anthropic expects a specific message format with tool calls and thinking. Would require extra work, and non standard trace generation so not supporting tool calls.
-                # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#extended-thinking-with-tool-use
-                supports_function_calling=False,
             ),
         ],
     ),
@@ -2915,7 +2910,8 @@ built_in_models: List[KilnModel] = [
                 supports_data_gen=True,
                 reasoning_capable=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
-                parser=ModelParserID.r1_thinking,
+                # This model doesn't return reasoning content after a tool call so we need to allow optional reasoning.
+                parser=ModelParserID.optional_r1_thinking,
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
@@ -2926,6 +2922,8 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 parser=ModelParserID.r1_thinking,
                 supports_data_gen=True,
+                # Not reliable, even for simple functions
+                supports_function_calling=False,
             ),
             KilnModelProvider(
                 name=ModelProviderName.ollama,
@@ -2948,7 +2946,8 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_data_gen=True,
                 reasoning_capable=True,
-                parser=ModelParserID.r1_thinking,
+                # This model doesn't return reasoning content after a tool call so we need to allow optional reasoning.
+                parser=ModelParserID.optional_r1_thinking,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -670,11 +670,14 @@ class LiteLlmAdapter(BaseAdapter):
         Extract the message from the model with type safety and validation.
         """
         content: str | None = None
+        reasoning_content: str | None = None
         tool_calls: List[ChatCompletionMessageToolCall] | None = None
         tool_calls_param: List[ChatCompletionMessageToolCallParam] = []
         if hasattr(response_choice, "message"):
             if hasattr(response_choice.message, "content"):
                 content = response_choice.message.content
+            if hasattr(response_choice.message, "reasoning_content"):
+                reasoning_content = response_choice.message.reasoning_content
             if hasattr(response_choice.message, "tool_calls"):
                 tool_calls = response_choice.message.tool_calls
 
@@ -707,5 +710,7 @@ class LiteLlmAdapter(BaseAdapter):
             message["content"] = content
         if tool_calls_param:
             message["tool_calls"] = tool_calls_param
+        if reasoning_content:
+            message["reasoning_content"] = reasoning_content
 
         return content, message, tool_calls

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -1,7 +1,8 @@
+import copy
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, TypeAlias, Union
 
 import litellm
 from litellm.types.utils import (
@@ -9,6 +10,9 @@ from litellm.types.utils import (
     ChoiceLogprobs,
     Choices,
     ModelResponse,
+)
+from litellm.types.utils import (
+    Message as LiteLLMMessage,
 )
 from litellm.types.utils import Usage as LiteLlmUsage
 from openai.types.chat import (
@@ -44,11 +48,15 @@ MAX_TOOL_CALLS_PER_TURN = 30
 
 logger = logging.getLogger(__name__)
 
+ChatCompletionMessageIncludingLiteLLM: TypeAlias = Union[
+    ChatCompletionMessageParam, LiteLLMMessage
+]
+
 
 @dataclass
 class ModelTurnResult:
     assistant_message: str
-    all_messages: list[ChatCompletionMessageParam]
+    all_messages: list[ChatCompletionMessageIncludingLiteLLM]
     model_response: ModelResponse | None
     model_choice: Choices | None
     usage: Usage
@@ -77,7 +85,7 @@ class LiteLlmAdapter(BaseAdapter):
     async def _run_model_turn(
         self,
         provider: KilnModelProvider,
-        prior_messages: list[ChatCompletionMessageParam],
+        prior_messages: list[ChatCompletionMessageIncludingLiteLLM],
         top_logprobs: int | None,
         skip_response_format: bool,
     ) -> ModelTurnResult:
@@ -95,7 +103,8 @@ class LiteLlmAdapter(BaseAdapter):
             # Build completion kwargs for tool calls
             completion_kwargs = await self.build_completion_kwargs(
                 provider,
-                messages,
+                # Pass a copy, as acompletion mutates objects and breaks types.
+                copy.deepcopy(messages),
                 top_logprobs,
                 skip_response_format,
             )
@@ -108,11 +117,18 @@ class LiteLlmAdapter(BaseAdapter):
             # count the usage
             usage += self.usage_from_response(model_response)
 
-            # Extract content and tool_calls safely
-            content, assistant_message, tool_calls = self.extract_assistant_response(
-                response_choice
-            )
-            messages.append(assistant_message)
+            # Extract content and tool calls
+            if not hasattr(response_choice, "message"):
+                raise ValueError("Response choice has no message")
+            content = response_choice.message.content
+            tool_calls = response_choice.message.tool_calls
+            if not content and not tool_calls:
+                raise ValueError(
+                    "Model returned an assistant message, but no content or tool calls. This is not supported."
+                )
+
+            # Add message to messages, so it can be used in the next turn
+            messages.append(response_choice.message)
 
             # Process tool calls if any
             if tool_calls and len(tool_calls) > 0:
@@ -166,7 +182,7 @@ class LiteLlmAdapter(BaseAdapter):
             raise ValueError("Model ID is required for OpenAI compatible models")
 
         chat_formatter = self.build_chat_formatter(input)
-        messages: list[ChatCompletionMessageParam] = []
+        messages: list[ChatCompletionMessageIncludingLiteLLM] = []
 
         prior_output: str | None = None
         final_choice: Choices | None = None
@@ -219,11 +235,12 @@ class LiteLlmAdapter(BaseAdapter):
         if not isinstance(prior_output, str):
             raise RuntimeError(f"assistant message is not a string: {prior_output}")
 
+        trace = self.all_messages_to_trace(messages)
         output = RunOutput(
             output=prior_output,
             intermediate_outputs=intermediate_outputs,
             output_logprobs=logprobs,
-            trace=messages,
+            trace=trace,
         )
 
         return output, usage
@@ -504,7 +521,7 @@ class LiteLlmAdapter(BaseAdapter):
     async def build_completion_kwargs(
         self,
         provider: KilnModelProvider,
-        messages: list[ChatCompletionMessageParam],
+        messages: list[ChatCompletionMessageIncludingLiteLLM],
         top_logprobs: int | None,
         skip_response_format: bool = False,
     ) -> dict[str, Any]:
@@ -659,58 +676,63 @@ class LiteLlmAdapter(BaseAdapter):
 
         return assistant_output_from_toolcall, tool_call_response_messages
 
-    def extract_assistant_response(
-        self, response_choice: Choices
-    ) -> tuple[
-        str | None,
-        ChatCompletionAssistantMessageParamWrapper,
-        List[ChatCompletionMessageToolCall] | None,
-    ]:
+    def litellm_message_to_trace_message(
+        self, raw_message: LiteLLMMessage
+    ) -> ChatCompletionAssistantMessageParamWrapper:
         """
-        Extract the message from the model with type safety and validation.
+        Convert a LiteLLM Message object to an OpenAI compatible message, our ChatCompletionAssistantMessageParamWrapper
         """
-        content: str | None = None
-        reasoning_content: str | None = None
-        tool_calls: List[ChatCompletionMessageToolCall] | None = None
-        tool_calls_param: List[ChatCompletionMessageToolCallParam] = []
-        if hasattr(response_choice, "message"):
-            if hasattr(response_choice.message, "content"):
-                content = response_choice.message.content
-            if hasattr(response_choice.message, "reasoning_content"):
-                reasoning_content = response_choice.message.reasoning_content
-            if hasattr(response_choice.message, "tool_calls"):
-                tool_calls = response_choice.message.tool_calls
-
-                # ChatCompletionMessageToolCallParam != ChatCompletionMessageToolCall, obviously
-                for tool_call in tool_calls or []:
-                    # Optional in the SDK for streaming responses, but should never be None by now
-                    if tool_call.function.name is None:
-                        raise ValueError(
-                            "The model requested a tool call, without providing a function name (required)."
-                        )
-                    tool_calls_param.append(
-                        ChatCompletionMessageToolCallParam(
-                            id=tool_call.id,
-                            type="function",
-                            function={
-                                "name": tool_call.function.name,
-                                "arguments": tool_call.function.arguments,
-                            },
-                        )
-                    )
-
-        if not content and not tool_calls_param:
-            raise ValueError(
-                "Model returned an assistant message, but no content or tool calls. This is not supported."
-            )
         message: ChatCompletionAssistantMessageParamWrapper = {
             "role": "assistant",
         }
-        if content:
-            message["content"] = content
-        if tool_calls_param:
-            message["tool_calls"] = tool_calls_param
-        if reasoning_content:
-            message["reasoning_content"] = reasoning_content
+        if raw_message.role != "assistant":
+            raise ValueError(
+                "Model returned a message with a role other than assistant. This is not supported."
+            )
 
-        return content, message, tool_calls
+        if hasattr(raw_message, "content"):
+            message["content"] = raw_message.content
+        if hasattr(raw_message, "reasoning_content"):
+            message["reasoning_content"] = raw_message.reasoning_content
+        if hasattr(raw_message, "tool_calls"):
+            # Convert ChatCompletionMessageToolCall to ChatCompletionMessageToolCallParam
+            open_ai_tool_calls: List[ChatCompletionMessageToolCallParam] = []
+            for litellm_tool_call in raw_message.tool_calls or []:
+                # Optional in the SDK for streaming responses, but should never be None at this point.
+                if litellm_tool_call.function.name is None:
+                    raise ValueError(
+                        "The model requested a tool call, without providing a function name (required)."
+                    )
+                open_ai_tool_calls.append(
+                    ChatCompletionMessageToolCallParam(
+                        id=litellm_tool_call.id,
+                        type="function",
+                        function={
+                            "name": litellm_tool_call.function.name,
+                            "arguments": litellm_tool_call.function.arguments,
+                        },
+                    )
+                )
+            if len(open_ai_tool_calls) > 0:
+                message["tool_calls"] = open_ai_tool_calls
+
+        if not message.get("content") and not message.get("tool_calls"):
+            raise ValueError(
+                "Model returned an assistant message, but no content or tool calls. This is not supported."
+            )
+
+        return message
+
+    def all_messages_to_trace(
+        self, messages: list[ChatCompletionMessageIncludingLiteLLM]
+    ) -> list[ChatCompletionMessageParam]:
+        """
+        Internally we allow LiteLLM Message objects, but for trace we need OpenAI compatible types. Replace LiteLLM Message objects with OpenAI compatible types.
+        """
+        trace: list[ChatCompletionMessageParam] = []
+        for message in messages:
+            if isinstance(message, LiteLLMMessage):
+                trace.append(self.litellm_message_to_trace_message(message))
+            else:
+                trace.append(message)
+        return trace

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter_tools.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter_tools.py
@@ -262,7 +262,15 @@ async def test_tools_simplied_mocked(tmp_path):
     # Second response: final answer
     mock_response_2 = ModelResponse(
         model="gpt-4o-mini",
-        choices=[{"message": {"content": "The answer is [4]", "tool_calls": None}}],
+        choices=[
+            {
+                "message": {
+                    "content": "The answer is [4]",
+                    "tool_calls": None,
+                    "reasoning_content": "I used a tool",
+                }
+            }
+        ],
         usage=usage,
     )
 
@@ -286,6 +294,12 @@ async def test_tools_simplied_mocked(tmp_path):
         assert task_run.usage.output_tokens == 40
         assert task_run.usage.total_tokens == 60
         assert task_run.usage.cost == 1.0
+
+        # Check reasoning content in the trace
+        trace = task_run.trace
+        assert trace is not None
+        assert len(trace) == 5
+        assert trace[4].get("reasoning_content") == "I used a tool"
 
 
 async def test_tools_mocked(tmp_path):

--- a/libs/core/kiln_ai/utils/open_ai_types.py
+++ b/libs/core/kiln_ai/utils/open_ai_types.py
@@ -34,8 +34,12 @@ from typing_extensions import Required, TypedDict
 
 class ChatCompletionAssistantMessageParamWrapper(TypedDict, total=False):
     """
-    Almost exact copy of ChatCompletionAssistantMessageParam, but with List[T] instead of Iterable[T] for tool_calls.
+    Almost exact copy of ChatCompletionAssistantMessageParam, but two changes.
+
+    First change: List[T] instead of Iterable[T] for tool_calls. Addresses pydantic issue.
     https://github.com/pydantic/pydantic/issues/9541
+
+    Second change: Add reasoning_content to the message. A LiteLLM property for reasoning data.
     """
 
     role: Required[Literal["assistant"]]
@@ -51,6 +55,12 @@ class ChatCompletionAssistantMessageParamWrapper(TypedDict, total=False):
     """The contents of the assistant message.
 
     Required unless `tool_calls` or `function_call` is specified.
+    """
+
+    reasoning_content: Optional[str]
+    """The reasoning content of the assistant message. 
+    
+    A LiteLLM property for reasoning data: https://docs.litellm.ai/docs/reasoning_content
     """
 
     function_call: Optional[FunctionCall]

--- a/libs/core/kiln_ai/utils/test_open_ai_types.py
+++ b/libs/core/kiln_ai/utils/test_open_ai_types.py
@@ -32,6 +32,10 @@ def test_assistant_message_param_properties_match():
     openai_properties = set(openai_annotations.keys())
     kiln_properties = set(kiln_annotations.keys())
 
+    # Reasoning content is an added property. Confirm it's there and remove it from the comparison.
+    assert "reasoning_content" in kiln_properties, "Kiln should have reasoning_content"
+    kiln_properties.remove("reasoning_content")
+
     assert openai_properties == kiln_properties, (
         f"Property names don't match. "
         f"OpenAI has: {openai_properties}, "


### PR DESCRIPTION
Fix several issues with tool calling, traces, and reasoning when combined with tools. See commit messages for detailed breakdowns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Manage external tools: add, view, and remove Remote/Local MCP tool servers per project; enable/disable demo tools; detailed server pages with available tools.
  - Tool-calling runs: select multiple tools per task; tools included in run requests; model dropdown warns/filters when tool support is required.
  - Per-project available tools store and per-task tool selection persistence.
- Improvements
  - Multi-select Fancy Select, collapse header badges, empty-state messaging, reusable settings components.
  - Models now display tool-calling support.
- Bug Fixes
  - Show “Output Model” only when model_id is a string.
- Chores
  - Added MCP CLI dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->