### PR TITLE
Store MCP Server Secrets in Settings

### DIFF
--- a/app/desktop/studio_server/test_tool_api.py
+++ b/app/desktop/studio_server/test_tool_api.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from kiln_ai.datamodel.external_tool_server import ExternalToolServer, ToolServerType
 from kiln_ai.datamodel.project import Project
+from kiln_ai.utils.config import MCP_SECRETS_KEY
 from kiln_ai.utils.dataset_import import format_validation_error
 from mcp.types import ListToolsResult, Tool
 from pydantic import ValidationError
@@ -3537,7 +3538,7 @@ async def test_delete_tool_server_with_secret_headers(client, test_project):
                 expected_remaining_secrets = {
                     "other_server::some_header": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 async def test_delete_tool_server_no_secret_headers(client, test_project):
@@ -3593,7 +3594,7 @@ async def test_delete_tool_server_no_secret_headers(client, test_project):
                 expected_remaining_secrets = {
                     "other_server::some_header": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 async def test_delete_tool_server_missing_secret_header_keys_property(
@@ -3654,7 +3655,7 @@ async def test_delete_tool_server_missing_secret_header_keys_property(
                 expected_remaining_secrets = {
                     "other_server::some_header": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 async def test_delete_tool_server_secret_key_not_in_config(client, test_project):
@@ -3712,7 +3713,7 @@ async def test_delete_tool_server_secret_key_not_in_config(client, test_project)
                 expected_remaining_secrets = {
                     "other_server::some_header": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 async def test_delete_tool_server_local_mcp_no_secret_headers(client, test_project):
@@ -3768,7 +3769,7 @@ async def test_delete_tool_server_local_mcp_no_secret_headers(client, test_proje
                 expected_remaining_secrets = {
                     "other_server::some_header": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 # Tests for demo tools API endpoints
@@ -3880,10 +3881,10 @@ async def test_connect_remote_mcp_with_secret_headers(client, test_project):
         # Verify config.update_settings was called to store secrets
         mock_config_instance.update_settings.assert_called_once()
         call_args = mock_config_instance.update_settings.call_args[0][0]
-        assert "mcp_secrets" in call_args
+        assert MCP_SECRETS_KEY in call_args
 
         # Verify secret values were stored with correct keys
-        mcp_secrets = call_args["mcp_secrets"]
+        mcp_secrets = call_args[MCP_SECRETS_KEY]
         server_id = result["id"]
         assert f"{server_id}::Authorization" in mcp_secrets
         assert f"{server_id}::X-API-Key" in mcp_secrets
@@ -3976,7 +3977,7 @@ async def test_connect_remote_mcp_existing_mcp_secrets(client, test_project):
         call_args = mock_config_instance.update_settings.call_args[0][0]
 
         # Verify existing secrets are preserved and new ones added
-        mcp_secrets = call_args["mcp_secrets"]
+        mcp_secrets = call_args[MCP_SECRETS_KEY]
         server_id = result["id"]
 
         # Existing secrets should still be there
@@ -4074,7 +4075,7 @@ async def test_delete_tool_server_config_update_fixed(client, test_project):
                 expected_remaining_secrets = {
                     "other_server::some_header": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 async def test_delete_tool_server_missing_secret_key_in_config(client, test_project):
@@ -4131,7 +4132,7 @@ async def test_delete_tool_server_missing_secret_key_in_config(client, test_proj
                 expected_remaining_secrets = {
                     "other_server::some_header": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 # Tests for local MCP secret environment variables functionality
@@ -4195,10 +4196,10 @@ async def test_connect_local_mcp_with_secret_env_vars(client, test_project):
         # Verify config.update_settings was called to store secrets
         mock_config_instance.update_settings.assert_called_once()
         call_args = mock_config_instance.update_settings.call_args[0][0]
-        assert "mcp_secrets" in call_args
+        assert MCP_SECRETS_KEY in call_args
 
         # Verify secret values were stored with correct keys
-        mcp_secrets = call_args["mcp_secrets"]
+        mcp_secrets = call_args[MCP_SECRETS_KEY]
         server_id = result["id"]
         assert f"{server_id}::SECRET_API_KEY" in mcp_secrets
         assert f"{server_id}::ANOTHER_SECRET" in mcp_secrets
@@ -4293,7 +4294,7 @@ async def test_connect_local_mcp_existing_mcp_secrets(client, test_project):
         call_args = mock_config_instance.update_settings.call_args[0][0]
 
         # Verify existing secrets are preserved and new ones added
-        mcp_secrets = call_args["mcp_secrets"]
+        mcp_secrets = call_args[MCP_SECRETS_KEY]
         server_id = result["id"]
 
         # Existing secrets should still be there
@@ -4438,7 +4439,7 @@ async def test_delete_local_mcp_tool_server_with_secret_env_vars(client, test_pr
                 expected_remaining_secrets = {
                     "other_server::some_env_var": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 async def test_delete_local_mcp_tool_server_no_secret_env_vars(client, test_project):
@@ -4495,7 +4496,7 @@ async def test_delete_local_mcp_tool_server_no_secret_env_vars(client, test_proj
                 expected_remaining_secrets = {
                     "other_server::some_env_var": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 async def test_delete_local_mcp_tool_server_secret_key_not_in_config(
@@ -4556,7 +4557,7 @@ async def test_delete_local_mcp_tool_server_secret_key_not_in_config(
                 expected_remaining_secrets = {
                     "other_server::some_env_var": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 async def test_delete_local_mcp_tool_server_missing_secret_env_var_keys_property(
@@ -4618,7 +4619,7 @@ async def test_delete_local_mcp_tool_server_missing_secret_env_var_keys_property
                 expected_remaining_secrets = {
                     "other_server::some_env_var": "other_value"
                 }
-                assert call_args["mcp_secrets"] == expected_remaining_secrets
+                assert call_args[MCP_SECRETS_KEY] == expected_remaining_secrets
 
 
 # Tests for LocalToolServerCreationRequest secret environment variable validation

--- a/app/desktop/studio_server/test_tool_api.py
+++ b/app/desktop/studio_server/test_tool_api.py
@@ -454,10 +454,10 @@ async def test_get_available_tool_servers_with_missing_secrets(client, test_proj
             mock_tool_server.name = "tool_with_missing_secrets"
             mock_tool_server.type = ToolServerType.remote_mcp
             mock_tool_server.description = "Tool with missing secrets"
-            mock_tool_server.missing_secrets.return_value = [
-                "Authorization",
-                "X-API-Key",
-            ]
+            mock_tool_server.retrieve_secrets.return_value = (
+                {},
+                ["Authorization", "X-API-Key"],
+            )
 
             # Mock the project's external_tool_servers method
             mock_project = Mock()
@@ -519,7 +519,7 @@ async def test_get_available_tool_servers_local_mcp_with_missing_secrets(
             mock_tool_server.name = "local_tool_with_missing_secrets"
             mock_tool_server.type = ToolServerType.local_mcp
             mock_tool_server.description = "Local tool with missing secrets"
-            mock_tool_server.missing_secrets.return_value = ["API_KEY"]
+            mock_tool_server.retrieve_secrets.return_value = ({}, ["API_KEY"])
 
             # Mock the project's external_tool_servers method
             mock_project = Mock()
@@ -5056,10 +5056,10 @@ async def test_get_tool_server_with_missing_secrets(client, test_project):
                 "headers": {"Authorization": "Bearer token", "X-API-Key": "key"},
                 "secret_header_keys": ["Authorization", "X-API-Key"],
             }
-            mock_tool_server.missing_secrets.return_value = [
-                "Authorization",
-                "X-API-Key",
-            ]
+            mock_tool_server.retrieve_secrets.return_value = (
+                {},
+                ["Authorization", "X-API-Key"],
+            )
             mock_tool_server_from_id.return_value = mock_tool_server
 
             # Get the tool server - should return with missing_secrets and no available_tools
@@ -5134,9 +5134,10 @@ async def test_get_tool_server_with_some_missing_secrets(client, test_project):
                 },
                 "secret_header_keys": ["Authorization", "X-API-Key"],
             }
-            mock_tool_server.missing_secrets.return_value = [
-                "X-API-Key"
-            ]  # Only one missing
+            mock_tool_server.retrieve_secrets.return_value = (
+                {"Authorization": "Bearer token"},
+                ["X-API-Key"],
+            )  # Only one missing
             mock_tool_server_from_id.return_value = mock_tool_server
 
             # Get the tool server - should return with missing_secrets and no available_tools
@@ -5198,7 +5199,10 @@ async def test_get_tool_server_no_missing_secrets(client, test_project):
                 "headers": {"Authorization": "Bearer token", "X-API-Key": "key"},
                 "secret_header_keys": ["Authorization", "X-API-Key"],
             }
-            mock_tool_server.missing_secrets.return_value = []  # No missing secrets
+            mock_tool_server.retrieve_secrets.return_value = (
+                {"Authorization": "Bearer token", "X-API-Key": "key"},
+                [],
+            )  # No missing secrets
             mock_tool_server_from_id.return_value = mock_tool_server
 
             # Mock successful tool retrieval
@@ -5280,9 +5284,10 @@ async def test_get_tool_server_local_mcp_with_missing_secrets(client, test_proje
                 },
                 "secret_env_var_keys": ["API_KEY", "DATABASE_PASSWORD"],
             }
-            mock_tool_server.missing_secrets.return_value = [
-                "DATABASE_PASSWORD"
-            ]  # Missing secret
+            mock_tool_server.retrieve_secrets.return_value = (
+                {"API_KEY": "secret_key"},
+                ["DATABASE_PASSWORD"],
+            )  # Missing secret
             mock_tool_server_from_id.return_value = mock_tool_server
 
             # Get the tool server - should return with missing_secrets

--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -322,7 +322,6 @@ def connect_tool_servers_api(app: FastAPI):
         project_id: str, tool_server_id: str
     ) -> ExternalToolServerApiDescription:
         tool_server = tool_server_from_id(project_id, tool_server_id)
-        print(f"tool_server: {tool_server}")
 
         # Get available tools based on server type
         available_tools = []

--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -358,7 +358,7 @@ def connect_tool_servers_api(app: FastAPI):
             missing_secrets=[],
         )
 
-        # Check if the tool server has missing secretes (e.g. new user syncing exisitng project)
+        # Check if the tool server has missing secretes (e.g. new user syncing exisiting project)
         # If there are missing secrets, add a requirement to the result and skip getting available tools.
         missing_secrets = tool_server.missing_secrets()
         if missing_secrets and len(missing_secrets) > 0:

--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -29,6 +29,7 @@ class KilnToolServerDescription(BaseModel):
     id: ID_TYPE
     type: ToolServerType
     description: str | None
+    missing_secrets: list[str]
 
 
 class ExternalToolServerCreationRequest(BaseModel):
@@ -333,6 +334,7 @@ def connect_tool_servers_api(app: FastAPI):
                 id=tool.id,
                 type=tool.type,
                 description=tool.description,
+                missing_secrets=tool.missing_secrets(),
             )
             for tool in project.external_tool_servers()
         ]

--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -384,10 +384,7 @@ def connect_tool_servers_api(app: FastAPI):
         # Validate the tool server connectivity
         await validate_tool_server_connectivity(tool_server)
 
-        # Store secret headers in the configuration after validation
-        tool_server.save_secrets()
-
-        # Save the tool to file (save_to_file will automatically strip secrets)
+        # Save the tool to file
         tool_server.save_to_file()
 
         return tool_server
@@ -418,10 +415,7 @@ def connect_tool_servers_api(app: FastAPI):
         MCPSessionManager.shared().clear_shell_path_cache()
         await validate_tool_server_connectivity(tool_server)
 
-        # Store secret env vars in the configuration after validation
-        tool_server.save_secrets()
-
-        # Save the tool to file (save_to_file will automatically strip secrets)
+        # Save the tool to file
         tool_server.save_to_file()
 
         return tool_server

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -4,6421 +4,6195 @@
  */
 
 export interface paths {
-  "/ping": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Ping */
-    get: operations["ping_ping_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/project": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Create Project */
-    post: operations["create_project_api_project_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/project/{project_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    /** Update Project */
-    patch: operations["update_project_api_project__project_id__patch"]
-    trace?: never
-  }
-  "/api/projects": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Projects */
-    get: operations["get_projects_api_projects_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Project */
-    get: operations["get_project_api_projects__project_id__get"]
-    put?: never
-    post?: never
-    /** Delete Project */
-    delete: operations["delete_project_api_projects__project_id__delete"]
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/import_project": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Import Project */
-    post: operations["import_project_api_import_project_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/task": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Create Task */
-    post: operations["create_task_api_projects__project_id__task_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/task/{task_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    /** Delete Task */
-    delete: operations["delete_task_api_projects__project_id__task__task_id__delete"]
-    options?: never
-    head?: never
-    /** Update Task */
-    patch: operations["update_task_api_projects__project_id__task__task_id__patch"]
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Tasks */
-    get: operations["get_tasks_api_projects__project_id__tasks_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Task */
-    get: operations["get_task_api_projects__project_id__tasks__task_id__get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/rating_options": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * Get Rating Options
-     * @description Generates an object which determines which rating options should be shown for a given dataset item.
-     */
-    get: operations["get_rating_options_api_projects__project_id__tasks__task_id__rating_options_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/task/{task_id}/prompt": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Create Prompt */
-    post: operations["create_prompt_api_projects__project_id__task__task_id__prompt_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/task/{task_id}/prompts": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Prompts */
-    get: operations["get_prompts_api_projects__project_id__task__task_id__prompts_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/prompts/{prompt_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    /** Delete Prompt */
-    delete: operations["delete_prompt_api_projects__project_id__tasks__task_id__prompts__prompt_id__delete"]
-    options?: never
-    head?: never
-    /** Update Prompt */
-    patch: operations["update_prompt_api_projects__project_id__tasks__task_id__prompts__prompt_id__patch"]
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Run */
-    get: operations["get_run_api_projects__project_id__tasks__task_id__runs__run_id__get"]
-    put?: never
-    post?: never
-    /** Delete Run */
-    delete: operations["delete_run_api_projects__project_id__tasks__task_id__runs__run_id__delete"]
-    options?: never
-    head?: never
-    /** Update Run */
-    patch: operations["update_run_api_projects__project_id__tasks__task_id__runs__run_id__patch"]
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/runs": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Runs */
-    get: operations["get_runs_api_projects__project_id__tasks__task_id__runs_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/runs_summaries": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Runs Summary */
-    get: operations["get_runs_summary_api_projects__project_id__tasks__task_id__runs_summaries_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/runs/delete": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Delete Runs */
-    post: operations["delete_runs_api_projects__project_id__tasks__task_id__runs_delete_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/run": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Run Task */
-    post: operations["run_task_api_projects__project_id__tasks__task_id__run_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/runs/edit_tags": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Edit Tags */
-    post: operations["edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/runs/bulk_upload": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Bulk Upload */
-    post: operations["bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/providers/models": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Providers Models */
-    get: operations["get_providers_models_api_providers_models_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/available_models": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Available Models */
-    get: operations["get_available_models_api_available_models_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/provider/ollama/connect": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Connect Ollama Api */
-    get: operations["connect_ollama_api_api_provider_ollama_connect_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/provider/docker_model_runner/connect": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Connect Docker Model Runner Api */
-    get: operations["connect_docker_model_runner_api_api_provider_docker_model_runner_connect_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/provider/openai_compatible": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Save Openai Compatible Providers */
-    post: operations["save_openai_compatible_providers_api_provider_openai_compatible_post"]
-    /** Delete Openai Compatible Providers */
-    delete: operations["delete_openai_compatible_providers_api_provider_openai_compatible_delete"]
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/provider/connect_api_key": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Connect Api Key */
-    post: operations["connect_api_key_api_provider_connect_api_key_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/provider/disconnect_api_key": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Disconnect Api Key */
-    post: operations["disconnect_api_key_api_provider_disconnect_api_key_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/task/{task_id}/gen_prompt/{prompt_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Generate Prompt */
-    get: operations["generate_prompt_api_projects__project_id__task__task_id__gen_prompt__prompt_id__get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}/run_repair": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Run Repair */
-    post: operations["run_repair_api_projects__project_id__tasks__task_id__runs__run_id__run_repair_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}/repair": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Post Repair Run */
-    post: operations["post_repair_run_api_projects__project_id__tasks__task_id__runs__run_id__repair_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/settings": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Read Settings */
-    get: operations["read_settings_api_settings_get"]
-    put?: never
-    /** Update Settings */
-    post: operations["update_settings_api_settings_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/settings/{item_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Read Setting Item */
-    get: operations["read_setting_item_api_settings__item_id__get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/open_logs": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Open Logs */
-    post: operations["open_logs_api_open_logs_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/generate_categories": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Generate Categories */
-    post: operations["generate_categories_api_projects__project_id__tasks__task_id__generate_categories_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/generate_inputs": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Generate Samples */
-    post: operations["generate_samples_api_projects__project_id__tasks__task_id__generate_inputs_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/save_sample": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Save Sample */
-    post: operations["save_sample_api_projects__project_id__tasks__task_id__save_sample_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/dataset_splits": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Dataset Splits */
-    get: operations["dataset_splits_api_projects__project_id__tasks__task_id__dataset_splits_get"]
-    put?: never
-    /** Create Dataset Split */
-    post: operations["create_dataset_split_api_projects__project_id__tasks__task_id__dataset_splits_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/finetunes": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Finetunes */
-    get: operations["finetunes_api_projects__project_id__tasks__task_id__finetunes_get"]
-    put?: never
-    /** Create Finetune */
-    post: operations["create_finetune_api_projects__project_id__tasks__task_id__finetunes_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/finetunes/{finetune_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Finetune */
-    get: operations["finetune_api_projects__project_id__tasks__task_id__finetunes__finetune_id__get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    /** Update Finetune */
-    patch: operations["update_finetune_api_projects__project_id__tasks__task_id__finetunes__finetune_id__patch"]
-    trace?: never
-  }
-  "/api/finetune_providers": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Finetune Providers */
-    get: operations["finetune_providers_api_finetune_providers_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/finetune/hyperparameters/{provider_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Finetune Hyperparameters */
-    get: operations["finetune_hyperparameters_api_finetune_hyperparameters__provider_id__get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/finetune_dataset_info": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Finetune Dataset Info */
-    get: operations["finetune_dataset_info_api_projects__project_id__tasks__task_id__finetune_dataset_info_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/download_dataset_jsonl": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Download Dataset Jsonl */
-    get: operations["download_dataset_jsonl_api_download_dataset_jsonl_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/create_evaluator": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Create Evaluator */
-    post: operations["create_evaluator_api_projects__project_id__tasks__task_id__create_evaluator_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/task_run_configs": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Task Run Configs */
-    get: operations["get_task_run_configs_api_projects__project_id__tasks__task_id__task_run_configs_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Eval */
-    get: operations["get_eval_api_projects__project_id__tasks__task_id__eval__eval_id__get"]
-    put?: never
-    post?: never
-    /** Delete Eval */
-    delete: operations["delete_eval_api_projects__project_id__tasks__task_id__eval__eval_id__delete"]
-    options?: never
-    head?: never
-    /** Update Eval */
-    patch: operations["update_eval_api_projects__project_id__tasks__task_id__eval__eval_id__patch"]
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/fav": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    /** Update Eval Favourite */
-    patch: operations["update_eval_favourite_api_projects__project_id__tasks__task_id__eval__eval_id__fav_patch"]
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/evals": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Evals */
-    get: operations["get_evals_api_projects__project_id__tasks__task_id__evals_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_configs": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Eval Configs */
-    get: operations["get_eval_configs_api_projects__project_id__tasks__task_id__eval__eval_id__eval_configs_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_config/{eval_config_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Eval Config */
-    get: operations["get_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/task_run_config": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Create Task Run Config */
-    post: operations["create_task_run_config_api_projects__project_id__tasks__task_id__task_run_config_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/create_eval_config": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Create Eval Config */
-    post: operations["create_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__create_eval_config_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_config/{eval_config_id}/run_task_run_eval": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Run Eval Config */
-    get: operations["run_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__run_task_run_eval_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/set_current_eval_config/{eval_config_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Set Default Eval Config */
-    post: operations["set_default_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__set_current_eval_config__eval_config_id__post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/set_current_run_config/{run_config_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Set Default Run Config */
-    post: operations["set_default_run_config_api_projects__project_id__tasks__task_id__eval__eval_id__set_current_run_config__run_config_id__post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/run_eval_config_eval": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Run Eval Config Eval */
-    get: operations["run_eval_config_eval_api_projects__project_id__tasks__task_id__eval__eval_id__run_eval_config_eval_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_config/{eval_config_id}/run_config/{run_config_id}/results": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Eval Run Results */
-    get: operations["get_eval_run_results_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__run_config__run_config_id__results_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/progress": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Eval Progress */
-    get: operations["get_eval_progress_api_projects__project_id__tasks__task_id__eval__eval_id__progress_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_config/{eval_config_id}/score_summary": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Eval Config Score Summary */
-    get: operations["get_eval_config_score_summary_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__score_summary_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_configs_score_summary": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Eval Configs Score Summary */
-    get: operations["get_eval_configs_score_summary_api_projects__project_id__tasks__task_id__eval__eval_id__eval_configs_score_summary_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tasks/{task_id}/run_config/{run_config_id}/eval_scores": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Run Config Eval Scores */
-    get: operations["get_run_config_eval_scores_api_projects__project_id__tasks__task_id__run_config__run_config_id__eval_scores_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/select_kiln_file": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Select Kiln File */
-    get: operations["select_kiln_file_api_select_kiln_file_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/available_tools": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Available Tools */
-    get: operations["get_available_tools_api_projects__project_id__available_tools_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/available_tool_servers": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Available Tool Servers */
-    get: operations["get_available_tool_servers_api_projects__project_id__available_tool_servers_get"]
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/tool_servers/{tool_server_id}": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Tool Server */
-    get: operations["get_tool_server_api_projects__project_id__tool_servers__tool_server_id__get"]
-    put?: never
-    post?: never
-    /** Delete Tool Server */
-    delete: operations["delete_tool_server_api_projects__project_id__tool_servers__tool_server_id__delete"]
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/connect_remote_mcp": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Connect Remote Mcp */
-    post: operations["connect_remote_mcp_api_projects__project_id__connect_remote_mcp_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/projects/{project_id}/connect_local_mcp": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    get?: never
-    put?: never
-    /** Connect Local Mcp */
-    post: operations["connect_local_mcp_api_projects__project_id__connect_local_mcp_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
-  "/api/demo_tools": {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Get Demo Tools */
-    get: operations["get_demo_tools_api_demo_tools_get"]
-    put?: never
-    /** Set Demo Tools */
-    post: operations["set_demo_tools_api_demo_tools_post"]
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
+    "/ping": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Ping */
+        get: operations["ping_ping_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/project": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Project */
+        post: operations["create_project_api_project_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/project/{project_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Project */
+        patch: operations["update_project_api_project__project_id__patch"];
+        trace?: never;
+    };
+    "/api/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Projects */
+        get: operations["get_projects_api_projects_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Project */
+        get: operations["get_project_api_projects__project_id__get"];
+        put?: never;
+        post?: never;
+        /** Delete Project */
+        delete: operations["delete_project_api_projects__project_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/import_project": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Import Project */
+        post: operations["import_project_api_import_project_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/task": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Task */
+        post: operations["create_task_api_projects__project_id__task_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/task/{task_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Task */
+        delete: operations["delete_task_api_projects__project_id__task__task_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Task */
+        patch: operations["update_task_api_projects__project_id__task__task_id__patch"];
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Tasks */
+        get: operations["get_tasks_api_projects__project_id__tasks_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Task */
+        get: operations["get_task_api_projects__project_id__tasks__task_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/rating_options": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Rating Options
+         * @description Generates an object which determines which rating options should be shown for a given dataset item.
+         */
+        get: operations["get_rating_options_api_projects__project_id__tasks__task_id__rating_options_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/task/{task_id}/prompt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Prompt */
+        post: operations["create_prompt_api_projects__project_id__task__task_id__prompt_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/task/{task_id}/prompts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Prompts */
+        get: operations["get_prompts_api_projects__project_id__task__task_id__prompts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/prompts/{prompt_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Prompt */
+        delete: operations["delete_prompt_api_projects__project_id__tasks__task_id__prompts__prompt_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Prompt */
+        patch: operations["update_prompt_api_projects__project_id__tasks__task_id__prompts__prompt_id__patch"];
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Run */
+        get: operations["get_run_api_projects__project_id__tasks__task_id__runs__run_id__get"];
+        put?: never;
+        post?: never;
+        /** Delete Run */
+        delete: operations["delete_run_api_projects__project_id__tasks__task_id__runs__run_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Run */
+        patch: operations["update_run_api_projects__project_id__tasks__task_id__runs__run_id__patch"];
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Runs */
+        get: operations["get_runs_api_projects__project_id__tasks__task_id__runs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/runs_summaries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Runs Summary */
+        get: operations["get_runs_summary_api_projects__project_id__tasks__task_id__runs_summaries_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/runs/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Delete Runs */
+        post: operations["delete_runs_api_projects__project_id__tasks__task_id__runs_delete_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Run Task */
+        post: operations["run_task_api_projects__project_id__tasks__task_id__run_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/runs/edit_tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Edit Tags */
+        post: operations["edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/runs/bulk_upload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Bulk Upload */
+        post: operations["bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/providers/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Providers Models */
+        get: operations["get_providers_models_api_providers_models_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/available_models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Available Models */
+        get: operations["get_available_models_api_available_models_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider/ollama/connect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Connect Ollama Api */
+        get: operations["connect_ollama_api_api_provider_ollama_connect_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider/docker_model_runner/connect": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Connect Docker Model Runner Api */
+        get: operations["connect_docker_model_runner_api_api_provider_docker_model_runner_connect_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider/openai_compatible": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Save Openai Compatible Providers */
+        post: operations["save_openai_compatible_providers_api_provider_openai_compatible_post"];
+        /** Delete Openai Compatible Providers */
+        delete: operations["delete_openai_compatible_providers_api_provider_openai_compatible_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider/connect_api_key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Connect Api Key */
+        post: operations["connect_api_key_api_provider_connect_api_key_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/provider/disconnect_api_key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Disconnect Api Key */
+        post: operations["disconnect_api_key_api_provider_disconnect_api_key_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/task/{task_id}/gen_prompt/{prompt_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Generate Prompt */
+        get: operations["generate_prompt_api_projects__project_id__task__task_id__gen_prompt__prompt_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}/run_repair": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Run Repair */
+        post: operations["run_repair_api_projects__project_id__tasks__task_id__runs__run_id__run_repair_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}/repair": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Post Repair Run */
+        post: operations["post_repair_run_api_projects__project_id__tasks__task_id__runs__run_id__repair_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read Settings */
+        get: operations["read_settings_api_settings_get"];
+        put?: never;
+        /** Update Settings */
+        post: operations["update_settings_api_settings_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/{item_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read Setting Item */
+        get: operations["read_setting_item_api_settings__item_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/open_logs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Open Logs */
+        post: operations["open_logs_api_open_logs_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/generate_categories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Generate Categories */
+        post: operations["generate_categories_api_projects__project_id__tasks__task_id__generate_categories_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/generate_inputs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Generate Samples */
+        post: operations["generate_samples_api_projects__project_id__tasks__task_id__generate_inputs_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/save_sample": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Save Sample */
+        post: operations["save_sample_api_projects__project_id__tasks__task_id__save_sample_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/dataset_splits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Dataset Splits */
+        get: operations["dataset_splits_api_projects__project_id__tasks__task_id__dataset_splits_get"];
+        put?: never;
+        /** Create Dataset Split */
+        post: operations["create_dataset_split_api_projects__project_id__tasks__task_id__dataset_splits_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/finetunes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Finetunes */
+        get: operations["finetunes_api_projects__project_id__tasks__task_id__finetunes_get"];
+        put?: never;
+        /** Create Finetune */
+        post: operations["create_finetune_api_projects__project_id__tasks__task_id__finetunes_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/finetunes/{finetune_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Finetune */
+        get: operations["finetune_api_projects__project_id__tasks__task_id__finetunes__finetune_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Finetune */
+        patch: operations["update_finetune_api_projects__project_id__tasks__task_id__finetunes__finetune_id__patch"];
+        trace?: never;
+    };
+    "/api/finetune_providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Finetune Providers */
+        get: operations["finetune_providers_api_finetune_providers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/finetune/hyperparameters/{provider_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Finetune Hyperparameters */
+        get: operations["finetune_hyperparameters_api_finetune_hyperparameters__provider_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/finetune_dataset_info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Finetune Dataset Info */
+        get: operations["finetune_dataset_info_api_projects__project_id__tasks__task_id__finetune_dataset_info_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/download_dataset_jsonl": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download Dataset Jsonl */
+        get: operations["download_dataset_jsonl_api_download_dataset_jsonl_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/create_evaluator": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Evaluator */
+        post: operations["create_evaluator_api_projects__project_id__tasks__task_id__create_evaluator_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/task_run_configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Task Run Configs */
+        get: operations["get_task_run_configs_api_projects__project_id__tasks__task_id__task_run_configs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Eval */
+        get: operations["get_eval_api_projects__project_id__tasks__task_id__eval__eval_id__get"];
+        put?: never;
+        post?: never;
+        /** Delete Eval */
+        delete: operations["delete_eval_api_projects__project_id__tasks__task_id__eval__eval_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Eval */
+        patch: operations["update_eval_api_projects__project_id__tasks__task_id__eval__eval_id__patch"];
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/fav": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Eval Favourite */
+        patch: operations["update_eval_favourite_api_projects__project_id__tasks__task_id__eval__eval_id__fav_patch"];
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/evals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Evals */
+        get: operations["get_evals_api_projects__project_id__tasks__task_id__evals_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_configs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Eval Configs */
+        get: operations["get_eval_configs_api_projects__project_id__tasks__task_id__eval__eval_id__eval_configs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_config/{eval_config_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Eval Config */
+        get: operations["get_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/task_run_config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Task Run Config */
+        post: operations["create_task_run_config_api_projects__project_id__tasks__task_id__task_run_config_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/create_eval_config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Eval Config */
+        post: operations["create_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__create_eval_config_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_config/{eval_config_id}/run_task_run_eval": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Run Eval Config */
+        get: operations["run_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__run_task_run_eval_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/set_current_eval_config/{eval_config_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Set Default Eval Config */
+        post: operations["set_default_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__set_current_eval_config__eval_config_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/set_current_run_config/{run_config_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Set Default Run Config */
+        post: operations["set_default_run_config_api_projects__project_id__tasks__task_id__eval__eval_id__set_current_run_config__run_config_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/run_eval_config_eval": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Run Eval Config Eval */
+        get: operations["run_eval_config_eval_api_projects__project_id__tasks__task_id__eval__eval_id__run_eval_config_eval_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_config/{eval_config_id}/run_config/{run_config_id}/results": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Eval Run Results */
+        get: operations["get_eval_run_results_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__run_config__run_config_id__results_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/progress": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Eval Progress */
+        get: operations["get_eval_progress_api_projects__project_id__tasks__task_id__eval__eval_id__progress_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_config/{eval_config_id}/score_summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Eval Config Score Summary */
+        get: operations["get_eval_config_score_summary_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__score_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/eval/{eval_id}/eval_configs_score_summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Eval Configs Score Summary */
+        get: operations["get_eval_configs_score_summary_api_projects__project_id__tasks__task_id__eval__eval_id__eval_configs_score_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tasks/{task_id}/run_config/{run_config_id}/eval_scores": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Run Config Eval Scores */
+        get: operations["get_run_config_eval_scores_api_projects__project_id__tasks__task_id__run_config__run_config_id__eval_scores_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/select_kiln_file": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Select Kiln File */
+        get: operations["select_kiln_file_api_select_kiln_file_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/available_tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Available Tools */
+        get: operations["get_available_tools_api_projects__project_id__available_tools_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/available_tool_servers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Available Tool Servers */
+        get: operations["get_available_tool_servers_api_projects__project_id__available_tool_servers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tool_servers/{tool_server_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Tool Server */
+        get: operations["get_tool_server_api_projects__project_id__tool_servers__tool_server_id__get"];
+        put?: never;
+        post?: never;
+        /** Delete Tool Server */
+        delete: operations["delete_tool_server_api_projects__project_id__tool_servers__tool_server_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/connect_remote_mcp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Connect Remote Mcp */
+        post: operations["connect_remote_mcp_api_projects__project_id__connect_remote_mcp_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/connect_local_mcp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Connect Local Mcp */
+        post: operations["connect_local_mcp_api_projects__project_id__connect_local_mcp_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/demo_tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Demo Tools */
+        get: operations["get_demo_tools_api_demo_tools_get"];
+        put?: never;
+        /** Set Demo Tools */
+        post: operations["set_demo_tools_api_demo_tools_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
-export type webhooks = Record<string, never>
+export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    /** ApiPrompt */
-    ApiPrompt: {
-      /**
-       * Name
-       * @description The name of the prompt.
-       */
-      name: string
-      /**
-       * Description
-       * @description A more detailed description of the prompt.
-       */
-      description?: string | null
-      /**
-       * Generator Id
-       * @description The id of the generator that created this prompt.
-       */
-      generator_id?: string | null
-      /**
-       * Prompt
-       * @description The prompt for the task.
-       */
-      prompt: string
-      /**
-       * Chain Of Thought Instructions
-       * @description Instructions for the model 'thinking' about the requirement prior to answering. Used for chain of thought style prompting. COT will not be used unless this is provided.
-       */
-      chain_of_thought_instructions?: string | null
-      /** Id */
-      id: string
-      /** Created At */
-      created_at?: string | null
-      /** Created By */
-      created_by?: string | null
-    }
-    /** Audio */
-    Audio: {
-      /** Id */
-      id: string
-    }
-    /** AvailableModels */
-    AvailableModels: {
-      /** Provider Name */
-      provider_name: string
-      /** Provider Id */
-      provider_id: string
-      /** Models */
-      models: components["schemas"]["ModelDetails"][]
-    }
-    /**
-     * BasePrompt
-     * @description A prompt for a task. This is the basic data storage format which can be used throughout a project.
-     *
-     *     The "Prompt" model name is reserved for the custom prompts parented by a task.
-     */
-    BasePrompt: {
-      /**
-       * Name
-       * @description The name of the prompt.
-       */
-      name: string
-      /**
-       * Description
-       * @description A more detailed description of the prompt.
-       */
-      description?: string | null
-      /**
-       * Generator Id
-       * @description The id of the generator that created this prompt.
-       */
-      generator_id?: string | null
-      /**
-       * Prompt
-       * @description The prompt for the task.
-       */
-      prompt: string
-      /**
-       * Chain Of Thought Instructions
-       * @description Instructions for the model 'thinking' about the requirement prior to answering. Used for chain of thought style prompting. COT will not be used unless this is provided.
-       */
-      chain_of_thought_instructions?: string | null
-    }
-    /** Body_bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post */
-    Body_bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post: {
-      /**
-       * File
-       * Format: binary
-       */
-      file: string
-      /** Splits */
-      splits?: string | null
-    }
-    /** Body_edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post */
-    Body_edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post: {
-      /** Run Ids */
-      run_ids: string[]
-      /** Add Tags */
-      add_tags?: string[] | null
-      /** Remove Tags */
-      remove_tags?: string[] | null
-    }
-    /** BulkUploadResponse */
-    BulkUploadResponse: {
-      /** Success */
-      success: boolean
-      /** Filename */
-      filename: string
-      /** Imported Count */
-      imported_count: number
-    }
-    /**
-     * ChatCompletionAssistantMessageParamWrapper
-     * @description Almost exact copy of ChatCompletionAssistantMessageParam, but with List[T] instead of Iterable[T] for tool_calls.
-     *     https://github.com/pydantic/pydantic/issues/9541
-     */
-    "ChatCompletionAssistantMessageParamWrapper-Input": {
-      /**
-       * Role
-       * @constant
-       */
-      role: "assistant"
-      audio?: components["schemas"]["Audio"] | null
-      /** Content */
-      content?:
-        | string
-        | (
-            | components["schemas"]["ChatCompletionContentPartTextParam"]
-            | components["schemas"]["ChatCompletionContentPartRefusalParam"]
-          )[]
-        | null
-      function_call?: components["schemas"]["FunctionCall"] | null
-      /** Name */
-      name?: string
-      /** Refusal */
-      refusal?: string | null
-      /** Tool Calls */
-      tool_calls?: components["schemas"]["ChatCompletionMessageToolCallParam"][]
-    }
-    /**
-     * ChatCompletionAssistantMessageParamWrapper
-     * @description Almost exact copy of ChatCompletionAssistantMessageParam, but with List[T] instead of Iterable[T] for tool_calls.
-     *     https://github.com/pydantic/pydantic/issues/9541
-     */
-    "ChatCompletionAssistantMessageParamWrapper-Output": {
-      /**
-       * Role
-       * @constant
-       */
-      role: "assistant"
-      audio?: components["schemas"]["Audio"] | null
-      /** Content */
-      content?:
-        | string
-        | (
-            | components["schemas"]["ChatCompletionContentPartTextParam"]
-            | components["schemas"]["ChatCompletionContentPartRefusalParam"]
-          )[]
-        | null
-      function_call?: components["schemas"]["FunctionCall"] | null
-      /** Name */
-      name?: string
-      /** Refusal */
-      refusal?: string | null
-      /** Tool Calls */
-      tool_calls?: components["schemas"]["ChatCompletionMessageToolCallParam"][]
-    }
-    /** ChatCompletionContentPartImageParam */
-    ChatCompletionContentPartImageParam: {
-      image_url: components["schemas"]["ImageURL"]
-      /**
-       * Type
-       * @constant
-       */
-      type: "image_url"
-    }
-    /** ChatCompletionContentPartInputAudioParam */
-    ChatCompletionContentPartInputAudioParam: {
-      input_audio: components["schemas"]["InputAudio"]
-      /**
-       * Type
-       * @constant
-       */
-      type: "input_audio"
-    }
-    /** ChatCompletionContentPartRefusalParam */
-    ChatCompletionContentPartRefusalParam: {
-      /** Refusal */
-      refusal: string
-      /**
-       * Type
-       * @constant
-       */
-      type: "refusal"
-    }
-    /** ChatCompletionContentPartTextParam */
-    ChatCompletionContentPartTextParam: {
-      /** Text */
-      text: string
-      /**
-       * Type
-       * @constant
-       */
-      type: "text"
-    }
-    /** ChatCompletionDeveloperMessageParam */
-    ChatCompletionDeveloperMessageParam: {
-      /** Content */
-      content:
-        | string
-        | components["schemas"]["ChatCompletionContentPartTextParam"][]
-      /**
-       * Role
-       * @constant
-       */
-      role: "developer"
-      /** Name */
-      name?: string
-    }
-    /** ChatCompletionFunctionMessageParam */
-    ChatCompletionFunctionMessageParam: {
-      /** Content */
-      content: string | null
-      /** Name */
-      name: string
-      /**
-       * Role
-       * @constant
-       */
-      role: "function"
-    }
-    /** ChatCompletionMessageToolCallParam */
-    ChatCompletionMessageToolCallParam: {
-      /** Id */
-      id: string
-      function: components["schemas"]["Function"]
-      /**
-       * Type
-       * @constant
-       */
-      type: "function"
-    }
-    /** ChatCompletionSystemMessageParam */
-    ChatCompletionSystemMessageParam: {
-      /** Content */
-      content:
-        | string
-        | components["schemas"]["ChatCompletionContentPartTextParam"][]
-      /**
-       * Role
-       * @constant
-       */
-      role: "system"
-      /** Name */
-      name?: string
-    }
-    /** ChatCompletionToolMessageParam */
-    ChatCompletionToolMessageParam: {
-      /** Content */
-      content:
-        | string
-        | components["schemas"]["ChatCompletionContentPartTextParam"][]
-      /**
-       * Role
-       * @constant
-       */
-      role: "tool"
-      /** Tool Call Id */
-      tool_call_id: string
-    }
-    /** ChatCompletionUserMessageParam */
-    "ChatCompletionUserMessageParam-Input": {
-      /** Content */
-      content:
-        | string
-        | (
-            | components["schemas"]["ChatCompletionContentPartTextParam"]
-            | components["schemas"]["ChatCompletionContentPartImageParam"]
-            | components["schemas"]["ChatCompletionContentPartInputAudioParam"]
-            | components["schemas"]["File"]
-          )[]
-      /**
-       * Role
-       * @constant
-       */
-      role: "user"
-      /** Name */
-      name?: string
-    }
-    /** ChatCompletionUserMessageParam */
-    "ChatCompletionUserMessageParam-Output": {
-      /** Content */
-      content:
-        | string
-        | (
-            | components["schemas"]["ChatCompletionContentPartTextParam"]
-            | components["schemas"]["ChatCompletionContentPartImageParam"]
-            | components["schemas"]["ChatCompletionContentPartInputAudioParam"]
-            | components["schemas"]["File"]
-          )[]
-      /**
-       * Role
-       * @constant
-       */
-      role: "user"
-      /** Name */
-      name?: string
-    }
-    /**
-     * ChatStrategy
-     * @description Strategy for how a chat is structured.
-     * @enum {string}
-     */
-    ChatStrategy:
-      | "final_only"
-      | "final_and_intermediate"
-      | "two_message_cot"
-      | "final_and_intermediate_r1_compatible"
-    /** CorrelationResult */
-    CorrelationResult: {
-      /** Mean Absolute Error */
-      mean_absolute_error: number
-      /** Mean Normalized Absolute Error */
-      mean_normalized_absolute_error: number
-      /** Mean Squared Error */
-      mean_squared_error: number
-      /** Mean Normalized Squared Error */
-      mean_normalized_squared_error: number
-      /** Spearman Correlation */
-      spearman_correlation: number | null
-      /** Pearson Correlation */
-      pearson_correlation: number | null
-      /** Kendalltau Correlation */
-      kendalltau_correlation: number | null
-    }
-    /**
-     * CreateDatasetSplitRequest
-     * @description Request to create a dataset split
-     */
-    CreateDatasetSplitRequest: {
-      dataset_split_type: components["schemas"]["DatasetSplitType"]
-      /** Filter Id */
-      filter_id: string
-      /** Name */
-      name?: string | null
-      /** Description */
-      description?: string | null
-    }
-    /** CreateEvalConfigRequest */
-    CreateEvalConfigRequest: {
-      /** Name */
-      name?: string | null
-      type: components["schemas"]["EvalConfigType"]
-      /** Properties */
-      properties: Record<string, never>
-      /** Model Name */
-      model_name: string
-      provider: components["schemas"]["ModelProviderName"]
-    }
-    /** CreateEvaluatorRequest */
-    CreateEvaluatorRequest: {
-      /** Name */
-      name: string
-      /** Description */
-      description: string
-      template: components["schemas"]["EvalTemplateId"] | null
-      /** Output Scores */
-      output_scores: components["schemas"]["EvalOutputScore"][]
-      /** Eval Set Filter Id */
-      eval_set_filter_id: string
-      /** Eval Configs Filter Id */
-      eval_configs_filter_id: string
-      /** Template Properties */
-      template_properties: {
-        [key: string]: string | number | boolean
-      }
-    }
-    /**
-     * CreateFinetuneRequest
-     * @description Request to create a finetune
-     */
-    CreateFinetuneRequest: {
-      /** Name */
-      name?: string | null
-      /** Description */
-      description?: string | null
-      /** Dataset Id */
-      dataset_id: string
-      /** Train Split Name */
-      train_split_name: string
-      /** Validation Split Name */
-      validation_split_name?: string | null
-      /** Parameters */
-      parameters: {
-        [key: string]: string | number | boolean
-      }
-      /** Provider */
-      provider: string
-      /** Base Model Id */
-      base_model_id: string
-      /** System Message Generator */
-      system_message_generator?: string | null
-      /** Custom System Message */
-      custom_system_message?: string | null
-      /** Custom Thinking Instructions */
-      custom_thinking_instructions?: string | null
-      data_strategy: components["schemas"]["ChatStrategy"]
-    }
-    /** CreateTaskRunConfigRequest */
-    CreateTaskRunConfigRequest: {
-      /** Name */
-      name?: string | null
-      /** Description */
-      description?: string | null
-      run_config_properties: components["schemas"]["RunConfigProperties"]
-    }
-    /** DataGenCategoriesApiInput */
-    DataGenCategoriesApiInput: {
-      /**
-       * Node Path
-       * @description Path to the node in the category tree
-       * @default []
-       */
-      node_path: string[]
-      /**
-       * Num Subtopics
-       * @description Number of subtopics to generate
-       * @default 6
-       */
-      num_subtopics: number
-      /**
-       * Gen Type
-       * @description The type of task to generate topics for
-       * @enum {string}
-       */
-      gen_type: "eval" | "training"
-      /**
-       * Guidance
-       * @description Optional human guidance for generation
-       */
-      guidance?: string | null
-      /**
-       * Existing Topics
-       * @description Optional list of existing topics to avoid
-       */
-      existing_topics?: string[] | null
-      /**
-       * Model Name
-       * @description The name of the model to use
-       */
-      model_name: string
-      /**
-       * Provider
-       * @description The provider of the model to use
-       */
-      provider: string
-    }
-    /** DataGenSampleApiInput */
-    DataGenSampleApiInput: {
-      /**
-       * Topic
-       * @description Topic path for sample generation
-       * @default []
-       */
-      topic: string[]
-      /**
-       * Num Samples
-       * @description Number of samples to generate
-       * @default 8
-       */
-      num_samples: number
-      /**
-       * Gen Type
-       * @description The type of task to generate topics for
-       * @enum {string}
-       */
-      gen_type: "training" | "eval"
-      /**
-       * Guidance
-       * @description Optional custom guidance for generation
-       */
-      guidance?: string | null
-      /**
-       * Model Name
-       * @description The name of the model to use
-       */
-      model_name: string
-      /**
-       * Provider
-       * @description The provider of the model to use
-       */
-      provider: string
-    }
-    /** DataGenSaveSamplesApiInput */
-    DataGenSaveSamplesApiInput: {
-      /**
-       * Input
-       * @description Input for this sample
-       */
-      input: string | Record<string, never>
-      /**
-       * Topic Path
-       * @description The path to the topic for this sample. Empty is the root topic.
-       */
-      topic_path: string[]
-      /**
-       * Input Model Name
-       * @description The name of the model used to generate the input
-       */
-      input_model_name: string
-      /**
-       * Input Provider
-       * @description The provider of the model used to generate the input
-       */
-      input_provider: string
-      /**
-       * Output Model Name
-       * @description The name of the model to use
-       */
-      output_model_name: string
-      /**
-       * Output Provider
-       * @description The provider of the model to use
-       */
-      output_provider: string
-      /**
-       * Prompt Method
-       * @description The prompt method used to generate the output
-       */
-      prompt_method: string
-      /**
-       * Guidance
-       * @description Optional custom guidance for generation
-       */
-      guidance?: string | null
-      /**
-       * Tags
-       * @description Tags to add to the sample
-       */
-      tags?: string[] | null
-    }
-    /**
-     * DataSource
-     * @description Represents the origin of data, either human or synthetic, with associated properties.
-     *
-     *     Properties vary based on the source type - for synthetic sources this includes
-     *     model information, for human sources this includes creator information.
-     */
-    "DataSource-Input": {
-      type: components["schemas"]["DataSourceType"]
-      /**
-       * Properties
-       * @description Properties describing the data source. For synthetic things like model. For human, the human's name.
-       * @default {}
-       */
-      properties: {
-        [key: string]: string | number
-      }
-      /** @description The run config used to generate the data, if generated by a running a model in Kiln (only true for type=synthetic). */
-      run_config?: components["schemas"]["RunConfigProperties"] | null
-    }
-    /**
-     * DataSource
-     * @description Represents the origin of data, either human or synthetic, with associated properties.
-     *
-     *     Properties vary based on the source type - for synthetic sources this includes
-     *     model information, for human sources this includes creator information.
-     */
-    "DataSource-Output": {
-      type: components["schemas"]["DataSourceType"]
-      /**
-       * Properties
-       * @description Properties describing the data source. For synthetic things like model. For human, the human's name.
-       * @default {}
-       */
-      properties: {
-        [key: string]: string | number
-      }
-      /** @description The run config used to generate the data, if generated by a running a model in Kiln (only true for type=synthetic). */
-      run_config?: components["schemas"]["RunConfigProperties"] | null
-    }
-    /**
-     * DataSourceType
-     * @description The source type of a piece of data.
-     *
-     *     Human: a human created the data
-     *     Synthetic: a model created the data
-     * @enum {string}
-     */
-    DataSourceType: "human" | "synthetic" | "file_import"
-    /**
-     * DatasetSplit
-     * @description A collection of task runs, with optional splits (train, test, validation).
-     *
-     *     Used to freeze a dataset into train/test/validation splits for repeatable fine-tuning or other tasks.
-     *
-     *     Maintains a list of IDs for each split, to avoid data duplication.
-     */
-    DatasetSplit: {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Name
-       * @description The name of the dataset split.
-       */
-      name: string
-      /**
-       * Description
-       * @description A description of the dataset for you and your team. Not used in training.
-       */
-      description?: string | null
-      /**
-       * Splits
-       * @description The splits in the dataset.
-       */
-      splits?: components["schemas"]["DatasetSplitDefinition"][]
-      /**
-       * Split Contents
-       * @description The contents of each split in the dataset. The key is the split name, and the value is a list of task run IDs.
-       */
-      split_contents: {
-        [key: string]: string[]
-      }
-      /**
-       * Filter
-       * @description The filter used to build the dataset.
-       */
-      filter?: string | null
-      /** Model Type */
-      readonly model_type: string
-    }
-    /**
-     * DatasetSplitDefinition
-     * @description A definition of a split in a dataset.
-     *
-     *     Example: name="train", description="The training set", percentage=0.8 (80% of the dataset)
-     */
-    DatasetSplitDefinition: {
-      /**
-       * Name
-       * @description The name of the dataset split definition.
-       */
-      name: string
-      /**
-       * Description
-       * @description A description of the dataset for you and your team. Not used in training.
-       */
-      description?: string | null
-      /**
-       * Percentage
-       * @description The percentage of the dataset that this split represents (between 0 and 1).
-       */
-      percentage: number
-    }
-    /**
-     * DatasetSplitType
-     * @description Dataset split types used in the API. Any split type can be created in code.
-     * @enum {string}
-     */
-    DatasetSplitType:
-      | "train_val"
-      | "train_test"
-      | "train_test_val"
-      | "train_test_val_80"
-      | "all"
-    /** DockerModelRunnerConnection */
-    DockerModelRunnerConnection: {
-      /** Message */
-      message: string
-      /** Version */
-      version?: string | null
-      /** Supported Models */
-      supported_models: string[]
-      /** Untested Models */
-      untested_models?: string[]
-    }
-    /** Eval */
-    Eval: {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Name
-       * @description The name of the eval.
-       */
-      name: string
-      /**
-       * Description
-       * @description The description of the eval
-       */
-      description?: string | null
-      /** @description The template selected when creating this eval. Useful for suggesting eval steps and output scores. */
-      template?: components["schemas"]["EvalTemplateId"] | null
-      /**
-       * Current Config Id
-       * @description The id of the current config to use for this eval. This can be changed over time to run the same eval with different configs.
-       */
-      current_config_id?: string | null
-      /**
-       * Current Run Config Id
-       * @description The id of the a run config which was selected as the best run config for this eval. The run config must belong to the parent Task.
-       */
-      current_run_config_id?: string | null
-      /**
-       * Eval Set Filter Id
-       * @description The id of the dataset filter which defines which dataset items are included when running this eval. Should be mutually exclusive with eval_configs_filter_id.
-       */
-      eval_set_filter_id: string
-      /**
-       * Eval Configs Filter Id
-       * @description The id of the dataset filter which defines which dataset items are included when comparing the quality of the eval configs under this eval. Should consist of dataset items with ratings. Should be mutually exclusive with eval_set_filter_id.
-       */
-      eval_configs_filter_id: string
-      /**
-       * Output Scores
-       * @description The scores this evaluator should produce.
-       */
-      output_scores: components["schemas"]["EvalOutputScore"][]
-      /**
-       * Favourite
-       * @description Whether this eval is a favourite of the user. Rendered as a star icon in the UI.
-       * @default false
-       */
-      favourite: boolean
-      /**
-       * Template Properties
-       * @description Properties to be used to execute the eval. This is template_type specific and should serialize to a json dict.
-       * @default {}
-       */
-      template_properties: {
-        [key: string]: string | number | boolean
-      }
-      /** Model Type */
-      readonly model_type: string
-    }
-    /**
-     * EvalConfig
-     * @description A configuration for running an eval. This includes anything needed to run the eval on a dataset like the prompt, model, thresholds, etc.
-     *
-     *     A eval might have many configs, example running the same eval with 2 different models. Comparing eval results is only valid within the scope of the same config.
-     */
-    EvalConfig: {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Name
-       * @description The name of the eval config.
-       */
-      name: string
-      /**
-       * Model Name
-       * @description The name of the model to use for this eval config.
-       */
-      model_name: string
-      /**
-       * Model Provider
-       * @description The provider of the model to use for this eval config.
-       */
-      model_provider: string
-      /**
-       * @description This is used to determine the type of eval to run.
-       * @default g_eval
-       */
-      config_type: components["schemas"]["EvalConfigType"]
-      /**
-       * Properties
-       * @description Properties to be used to execute the eval config. This is config_type specific and should serialize to a json dict.
-       * @default {}
-       */
-      properties: Record<string, never>
-      /** Model Type */
-      readonly model_type: string
-    }
-    /** EvalConfigCompareSummary */
-    EvalConfigCompareSummary: {
-      /** Results */
-      results: {
-        [key: string]: {
-          [key: string]: components["schemas"]["CorrelationResult"]
-        }
-      }
-      /** Eval Config Percent Complete */
-      eval_config_percent_complete: {
-        [key: string]: number
-      }
-      /** Dataset Size */
-      dataset_size: number
-      /** Fully Rated Count */
-      fully_rated_count: number
-      /** Partially Rated Count */
-      partially_rated_count: number
-      /** Not Rated Count */
-      not_rated_count: number
-    }
-    /** EvalConfigResult */
-    EvalConfigResult: {
-      /** Eval Config Id */
-      eval_config_id: string | null
-      /** Results */
-      results: {
-        [key: string]: components["schemas"]["ScoreSummary"] | null
-      }
-      /** Percent Complete */
-      percent_complete: number
-    }
-    /**
-     * EvalConfigType
-     * @enum {string}
-     */
-    EvalConfigType: "g_eval" | "llm_as_judge"
-    /**
-     * EvalOutputScore
-     * @description A definition of a score that an evaluator will produce.
-     *
-     *     Very similar to TaskRequirement, but conceptually different keeping in a separate models.
-     */
-    EvalOutputScore: {
-      /**
-       * Name
-       * @description The name of the score. Will be provided to the model so use a descriptive name. Should align to the model's TaskRequirement name if you want to use human evals to evaluate the evaluator's performance.
-       */
-      name: string
-      /**
-       * Instruction
-       * @description A description of the score, used to help the model understand the goal of the score. Will be provided to evaluator models, so should be written for the model, not the team/user.
-       */
-      instruction?: string | null
-      /** @description The type of rating to use ('five_star', 'pass_fail', 'pass_fail_critical'). */
-      type: components["schemas"]["TaskOutputRatingType"]
-    }
-    /** EvalProgress */
-    EvalProgress: {
-      /** Dataset Size */
-      dataset_size: number
-      /** Golden Dataset Size */
-      golden_dataset_size: number
-      /** Golden Dataset Not Rated Count */
-      golden_dataset_not_rated_count: number
-      /** Golden Dataset Partially Rated Count */
-      golden_dataset_partially_rated_count: number
-      /** Golden Dataset Fully Rated Count */
-      golden_dataset_fully_rated_count: number
-      current_eval_method: components["schemas"]["EvalConfig"] | null
-      current_run_method: components["schemas"]["TaskRunConfig"] | null
-    }
-    /** EvalResultSummary */
-    EvalResultSummary: {
-      /** Results */
-      results: {
-        [key: string]: {
-          [key: string]: components["schemas"]["ScoreSummary"]
-        }
-      }
-      /** Run Config Percent Complete */
-      run_config_percent_complete: {
-        [key: string]: number
-      }
-      /** Dataset Size */
-      dataset_size: number
-    }
-    /**
-     * EvalRun
-     * @description The results of running an eval on a single dataset item.
-     *
-     *     This is a child of an EvalConfig, which specifies how the scores were generated.
-     *
-     *     Eval runs can be one of 2 types:
-     *     1) eval_config_eval=False: we were evaluating a task run (a method of running the task). We get the task input from the dataset_id.input, run the task with the task_run_config, then ran the evaluator on that output. task_run_config_id must be set. The output saved in this model is the output of the task run.
-     *     2) eval_config_eval=True: we were evaluating an eval config (a method of evaluating the task). We used the existing dataset item input/output, and ran the evaluator on it. task_run_config_id must be None. The input/output saved in this model is the input/output of the dataset item.
-     */
-    EvalRun: {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Dataset Id
-       * @description The ID of the dataset item that was used for this run. Must belong to the same Task as the grand-parent eval of this EvalRun.
-       */
-      dataset_id: string | null
-      /**
-       * Task Run Config Id
-       * @description The ID of the TaskRunConfig that was run, if this eval run was based on a task run. Must belong to the same Task as this eval. Can be None if this eval run is based on an eval config.
-       */
-      task_run_config_id: string | null
-      /**
-       * Eval Config Eval
-       * @description Whether this eval run to evaluate the parent eval config (evaluating the config using an existing dataset item). If true, task_run_config_id must be None, as we're not running the task.
-       * @default false
-       */
-      eval_config_eval: boolean
-      /**
-       * Input
-       * @description The input to the task. JSON formatted for structured input, plaintext for unstructured input.
-       */
-      input: string
-      /**
-       * Output
-       * @description The output of the task. JSON formatted for structured output, plaintext for unstructured output.
-       */
-      output: string
-      /**
-       * Intermediate Outputs
-       * @description The intermediate outputs of the task (example, eval thinking).
-       */
-      intermediate_outputs?: {
-        [key: string]: string
-      } | null
-      /**
-       * Scores
-       * @description The output scores of the evaluator (aligning to those required by the grand-parent Eval this object is a child of).
-       */
-      scores: {
-        [key: string]: number
-      }
-      /** @description The usage of the task run that produced this eval run output (not the usage by the evaluation model). */
-      task_run_usage?: components["schemas"]["Usage"] | null
-      /** Model Type */
-      readonly model_type: string
-    }
-    /** EvalRunResult */
-    EvalRunResult: {
-      /** Results */
-      results: components["schemas"]["EvalRun"][]
-      eval: components["schemas"]["Eval"]
-      eval_config: components["schemas"]["EvalConfig"]
-      run_config: components["schemas"]["TaskRunConfig"]
-    }
-    /**
-     * EvalTemplateId
-     * @description An eval template is a pre-defined eval that can be used as a starting point for a new eval.
-     * @enum {string}
-     */
-    EvalTemplateId:
-      | "kiln_requirements"
-      | "kiln_issue"
-      | "toxicity"
-      | "bias"
-      | "maliciousness"
-      | "factual_correctness"
-      | "jailbreak"
-    /**
-     * ExternalToolApiDescription
-     * @description This class is a wrapper of MCP's Tool object to be displayed in the UI under tool_server/[tool_server_id].
-     */
-    ExternalToolApiDescription: {
-      /** Name */
-      name: string
-      /** Description */
-      description: string | null
-      /** Inputschema */
-      inputSchema?: Record<string, never>
-    }
-    /**
-     * ExternalToolServer
-     * @description Configuration for communicating with a external MCP (Model Context Protocol) Server for LLM tool calls. External tool servers can be remote or local.
-     *
-     *     This model stores the necessary configuration to connect to and authenticate with
-     *     external MCP servers that provide tools for LLM interactions.
-     */
-    ExternalToolServer: {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Name
-       * @description The name of the external tool.
-       */
-      name: string
-      /** @description The type of external tool server. Remote tools are hosted on a remote server */
-      type: components["schemas"]["ToolServerType"]
-      /**
-       * Description
-       * @description A description of the external tool for you and your team. Will not be used in prompts/training/validation.
-       */
-      description?: string | null
-      /**
-       * Properties
-       * @description Configuration properties specific to the tool type.
-       * @default {}
-       */
-      properties: Record<string, never>
-      /** Model Type */
-      readonly model_type: string
-    }
-    /**
-     * ExternalToolServerApiDescription
-     * @description This class is used to describe the external tool server under tool_servers/[tool_server_id] UI. It is based of ExternalToolServer.
-     */
-    ExternalToolServerApiDescription: {
-      /** Id */
-      id: string | null
-      type: components["schemas"]["ToolServerType"]
-      /** Name */
-      name: string
-      /** Description */
-      description: string | null
-      /** Created At */
-      created_at: string | null
-      /** Created By */
-      created_by: string | null
-      /** Properties */
-      properties: Record<string, never>
-      /** Available Tools */
-      available_tools: components["schemas"]["ExternalToolApiDescription"][]
-    }
-    /** ExternalToolServerCreationRequest */
-    ExternalToolServerCreationRequest: {
-      /** Name */
-      name: string
-      /** Description */
-      description?: string | null
-      /** Server Url */
-      server_url: string
-      /** Headers */
-      headers?: {
-        [key: string]: string
-      }
-    }
-    /** File */
-    File: {
-      file: components["schemas"]["FileFile"]
-      /**
-       * Type
-       * @constant
-       */
-      type: "file"
-    }
-    /** FileFile */
-    FileFile: {
-      /** File Data */
-      file_data?: string
-      /** File Id */
-      file_id?: string
-      /** Filename */
-      filename?: string
-    }
-    /**
-     * FineTuneParameter
-     * @description A parameter for a fine-tune. Hyperparameters, etc.
-     */
-    FineTuneParameter: {
-      /** Name */
-      name: string
-      /**
-       * Type
-       * @enum {string}
-       */
-      type: "string" | "int" | "float" | "bool"
-      /** Description */
-      description: string
-      /**
-       * Optional
-       * @default true
-       */
-      optional: boolean
-    }
-    /**
-     * FineTuneStatus
-     * @description The status of a fine-tune, including a user friendly message.
-     */
-    FineTuneStatus: {
-      status: components["schemas"]["FineTuneStatusType"]
-      /** Message */
-      message?: string | null
-      /** Error Details */
-      error_details?: string | null
-    }
-    /**
-     * FineTuneStatusType
-     * @description The status type of a fine-tune (running, completed, failed, etc).
-     * @enum {string}
-     */
-    FineTuneStatusType:
-      | "unknown"
-      | "pending"
-      | "running"
-      | "completed"
-      | "failed"
-    /**
-     * Finetune
-     * @description The Kiln fine-tune datamodel.
-     *
-     *     Initially holds a reference to a training job, with needed identifiers to update the status. When complete, contains the new model ID.
-     */
-    Finetune: {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Name
-       * @description The name of the fine-tune.
-       */
-      name: string
-      /**
-       * Description
-       * @description A description of the fine-tune for you and your team. Not used in training.
-       */
-      description?: string | null
-      /** @description The mode to use to train the model for structured output, if it was trained with structured output. Will determine how we call the tuned model, so we call with the matching mode. */
-      structured_output_mode?:
-        | components["schemas"]["StructuredOutputMode"]
-        | null
-      /**
-       * Provider
-       * @description The provider to use for the fine-tune (e.g. 'openai').
-       */
-      provider: string
-      /**
-       * Base Model Id
-       * @description The id of the base model to use for the fine-tune. This string relates to the provider's IDs for their own models, not Kiln IDs.
-       */
-      base_model_id: string
-      /**
-       * Provider Id
-       * @description The ID of the fine-tune job on the provider's side. May not be the same as the fine_tune_model_id.
-       */
-      provider_id?: string | null
-      /**
-       * Fine Tune Model Id
-       * @description The ID of the fine-tuned model on the provider's side. May not be the same as the provider_id.
-       */
-      fine_tune_model_id?: string | null
-      /**
-       * Dataset Split Id
-       * @description The ID of the dataset split to use for this fine-tune.
-       */
-      dataset_split_id: string
-      /**
-       * Train Split Name
-       * @description The name of the training split to use for this fine-tune.
-       * @default train
-       */
-      train_split_name: string
-      /**
-       * Validation Split Name
-       * @description The name of the validation split to use for this fine-tune. Optional.
-       */
-      validation_split_name?: string | null
-      /**
-       * Parameters
-       * @description The parameters to use for this fine-tune. These are provider-specific.
-       * @default {}
-       */
-      parameters: {
-        [key: string]: string | number | boolean
-      }
-      /**
-       * System Message
-       * @description The system message to use for this fine-tune.
-       */
-      system_message: string
-      /**
-       * Thinking Instructions
-       * @description The thinking instructions to use for this fine-tune. Only used when data_strategy is final_and_intermediate.
-       */
-      thinking_instructions?: string | null
-      /**
-       * @description The latest known status of this fine-tune. Not updated in real time.
-       * @default unknown
-       */
-      latest_status: components["schemas"]["FineTuneStatusType"]
-      /**
-       * Properties
-       * @description Properties of the fine-tune. Different providers may use different properties.
-       * @default {}
-       */
-      properties: {
-        [key: string]: string | number
-      }
-      /**
-       * @description The strategy to use for training the model. 'final_only' will only train on the final response. 'final_and_intermediate' will train on the final response and intermediate outputs (chain of thought or reasoning).
-       * @default final_only
-       */
-      data_strategy: components["schemas"]["ChatStrategy"]
-      /** Model Type */
-      readonly model_type: string
-    }
-    /**
-     * FinetuneDatasetInfo
-     * @description Finetune dataset info
-     */
-    FinetuneDatasetInfo: {
-      /** Existing Datasets */
-      existing_datasets: components["schemas"]["DatasetSplit"][]
-      /** Existing Finetunes */
-      existing_finetunes: components["schemas"]["Finetune"][]
-      /** Finetune Tags */
-      finetune_tags: components["schemas"]["FinetuneDatasetTagInfo"][]
-    }
-    /**
-     * FinetuneDatasetTagInfo
-     * @description Finetune dataset tag info
-     */
-    FinetuneDatasetTagInfo: {
-      /** Tag */
-      tag: string
-      /** Count */
-      count: number
-      /** Reasoning Count */
-      reasoning_count: number
-      /** High Quality Count */
-      high_quality_count: number
-      /** Reasoning And High Quality Count */
-      reasoning_and_high_quality_count: number
-    }
-    /**
-     * FinetuneProvider
-     * @description Finetune provider: list of models a provider supports for fine-tuning
-     */
-    FinetuneProvider: {
-      /** Name */
-      name: string
-      /** Id */
-      id: string
-      /** Enabled */
-      enabled: boolean
-      /** Models */
-      models: components["schemas"]["FinetuneProviderModel"][]
-    }
-    /**
-     * FinetuneProviderModel
-     * @description Finetune provider model: a model a provider supports for fine-tuning
-     */
-    FinetuneProviderModel: {
-      /** Name */
-      name: string
-      /** Id */
-      id: string
-      /** Data Strategies Supported */
-      data_strategies_supported?: components["schemas"]["ChatStrategy"][]
-    }
-    /**
-     * FinetuneWithStatus
-     * @description Finetune with status
-     */
-    FinetuneWithStatus: {
-      finetune: components["schemas"]["Finetune"]
-      status: components["schemas"]["FineTuneStatus"]
-    }
-    /** Function */
-    Function: {
-      /** Arguments */
-      arguments: string
-      /** Name */
-      name: string
-    }
-    /** FunctionCall */
-    FunctionCall: {
-      /** Arguments */
-      arguments: string
-      /** Name */
-      name: string
-    }
-    /** HTTPValidationError */
-    HTTPValidationError: {
-      /** Detail */
-      detail?: components["schemas"]["ValidationError"][]
-    }
-    /** ImageURL */
-    ImageURL: {
-      /** Url */
-      url: string
-      /**
-       * Detail
-       * @enum {string}
-       */
-      detail?: "auto" | "low" | "high"
-    }
-    /** InputAudio */
-    InputAudio: {
-      /** Data */
-      data: string
-      /**
-       * Format
-       * @enum {string}
-       */
-      format: "wav" | "mp3"
-    }
-    /**
-     * KilnBaseModel
-     * @description Base model for all Kiln data models with common functionality for persistence and versioning.
-     *
-     *     Attributes:
-     *         v (int): Schema version number for migration support
-     *         id (str): Unique identifier for the model instance
-     *         path (Path): File system path where the model is stored
-     *         created_at (datetime): Timestamp when the model was created
-     *         created_by (str): User ID of the creator
-     */
-    "KilnBaseModel-Input": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-    }
-    /**
-     * KilnBaseModel
-     * @description Base model for all Kiln data models with common functionality for persistence and versioning.
-     *
-     *     Attributes:
-     *         v (int): Schema version number for migration support
-     *         id (str): Unique identifier for the model instance
-     *         path (Path): File system path where the model is stored
-     *         created_at (datetime): Timestamp when the model was created
-     *         created_by (str): User ID of the creator
-     */
-    "KilnBaseModel-Output": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /** Model Type */
-      readonly model_type: string
-    }
-    /** KilnFileResponse */
-    KilnFileResponse: {
-      /** File Path */
-      file_path: string | null
-    }
-    /**
-     * KilnToolServerDescription
-     * @description This class is used to describe the external tool server under Settings -> Manage Tools UI.
-     */
-    KilnToolServerDescription: {
-      /** Name */
-      name: string
-      /** Id */
-      id: string | null
-      type: components["schemas"]["ToolServerType"]
-      /** Description */
-      description: string | null
-    }
-    /** LocalToolServerCreationRequest */
-    LocalToolServerCreationRequest: {
-      /** Name */
-      name: string
-      /** Description */
-      description?: string | null
-      /** Command */
-      command: string
-      /** Args */
-      args: string[]
-      /** Env Vars */
-      env_vars?: {
-        [key: string]: string
-      }
-    }
-    /** MeanUsage */
-    MeanUsage: {
-      /** Mean Input Tokens */
-      mean_input_tokens?: number | null
-      /** Mean Output Tokens */
-      mean_output_tokens?: number | null
-      /** Mean Total Tokens */
-      mean_total_tokens?: number | null
-      /** Mean Cost */
-      mean_cost?: number | null
-    }
-    /** ModelDetails */
-    ModelDetails: {
-      /** Id */
-      id: string
-      /** Name */
-      name: string
-      /** Supports Structured Output */
-      supports_structured_output: boolean
-      /** Supports Data Gen */
-      supports_data_gen: boolean
-      /** Suggested For Data Gen */
-      suggested_for_data_gen: boolean
-      /** Supports Logprobs */
-      supports_logprobs: boolean
-      /** Suggested For Evals */
-      suggested_for_evals: boolean
-      /** Supports Function Calling */
-      supports_function_calling: boolean
-      /** Uncensored */
-      uncensored: boolean
-      /** Suggested For Uncensored Data Gen */
-      suggested_for_uncensored_data_gen: boolean
-      structured_output_mode: components["schemas"]["StructuredOutputMode"]
-      /**
-       * Untested Model
-       * @default false
-       */
-      untested_model: boolean
-      /** Task Filter */
-      task_filter?: string[] | null
-    }
-    /**
-     * ModelName
-     * @description Enumeration of specific model versions supported by the system.
-     *     Where models have instruct and raw versions, instruct is default and raw is specified.
-     * @enum {string}
-     */
-    ModelName:
-      | "llama_3_1_8b"
-      | "llama_3_1_70b"
-      | "llama_3_1_405b"
-      | "llama_3_2_1b"
-      | "llama_3_2_3b"
-      | "llama_3_2_11b"
-      | "llama_3_2_90b"
-      | "llama_3_3_70b"
-      | "llama_4_maverick"
-      | "llama_4_scout"
-      | "gpt_5"
-      | "gpt_5_chat"
-      | "gpt_5_mini"
-      | "gpt_5_nano"
-      | "gpt_4o_mini"
-      | "gpt_4o"
-      | "gpt_4_1"
-      | "gpt_4_1_mini"
-      | "gpt_4_1_nano"
-      | "gpt_o3_low"
-      | "gpt_o3_medium"
-      | "gpt_o3_high"
-      | "gpt_oss_20b"
-      | "gpt_oss_120b"
-      | "gpt_o1_low"
-      | "gpt_o1_medium"
-      | "gpt_o1_high"
-      | "gpt_o4_mini_low"
-      | "gpt_o4_mini_medium"
-      | "gpt_o4_mini_high"
-      | "gpt_o3_mini_low"
-      | "gpt_o3_mini_medium"
-      | "gpt_o3_mini_high"
-      | "phi_3_5"
-      | "phi_4"
-      | "phi_4_5p6b"
-      | "phi_4_mini"
-      | "mistral_large"
-      | "mistral_nemo"
-      | "mistral_small_3"
-      | "magistral_medium"
-      | "magistral_medium_thinking"
-      | "gemma_2_2b"
-      | "gemma_2_9b"
-      | "gemma_2_27b"
-      | "gemma_3_1b"
-      | "gemma_3_4b"
-      | "gemma_3_12b"
-      | "gemma_3_27b"
-      | "gemma_3n_2b"
-      | "gemma_3n_4b"
-      | "claude_3_5_haiku"
-      | "claude_3_5_sonnet"
-      | "claude_3_7_sonnet"
-      | "claude_3_7_sonnet_thinking"
-      | "claude_sonnet_4"
-      | "claude_opus_4"
-      | "gemini_1_5_flash"
-      | "gemini_1_5_flash_8b"
-      | "gemini_1_5_pro"
-      | "gemini_2_0_flash"
-      | "gemini_2_0_flash_lite"
-      | "gemini_2_5_pro"
-      | "gemini_2_5_flash"
-      | "gemini_2_5_flash_lite"
-      | "nemotron_70b"
-      | "mixtral_8x7b"
-      | "qwen_2p5_7b"
-      | "qwen_2p5_14b"
-      | "qwen_2p5_72b"
-      | "qwq_32b"
-      | "deepseek_3"
-      | "deepseek_r1"
-      | "deepseek_r1_0528"
-      | "deepseek_r1_0528_distill_qwen3_8b"
-      | "deepseek_r1_distill_qwen_32b"
-      | "deepseek_r1_distill_llama_70b"
-      | "deepseek_r1_distill_qwen_14b"
-      | "deepseek_r1_distill_qwen_1p5b"
-      | "deepseek_r1_distill_qwen_7b"
-      | "deepseek_r1_distill_llama_8b"
-      | "dolphin_2_9_8x22b"
-      | "grok_2"
-      | "grok_3"
-      | "grok_3_mini"
-      | "grok_4"
-      | "qwen_3_0p6b"
-      | "qwen_3_0p6b_no_thinking"
-      | "qwen_3_1p7b"
-      | "qwen_3_1p7b_no_thinking"
-      | "qwen_3_4b"
-      | "qwen_3_4b_no_thinking"
-      | "qwen_3_8b"
-      | "qwen_3_8b_no_thinking"
-      | "qwen_3_14b"
-      | "qwen_3_14b_no_thinking"
-      | "qwen_3_30b_a3b_2507"
-      | "qwen_3_30b_a3b"
-      | "qwen_3_30b_a3b_2507_no_thinking"
-      | "qwen_3_30b_a3b_no_thinking"
-      | "qwen_3_32b"
-      | "qwen_3_32b_no_thinking"
-      | "qwen_3_235b_a22b_2507"
-      | "qwen_3_235b_a22b"
-      | "qwen_3_235b_a22b_2507_no_thinking"
-      | "qwen_3_235b_a22b_no_thinking"
-      | "qwen_long_l1_32b"
-      | "kimi_k2"
-      | "kimi_dev_72b"
-      | "glm_4_1v_9b_thinking"
-      | "glm_z1_32b_0414"
-      | "glm_z1_9b_0414"
-      | "ernie_4_5_300b_a47b"
-      | "hunyuan_a13b"
-      | "hunyuan_a13b_no_thinking"
-      | "minimax_m1_80k"
-      | "pangu_pro_moe_72b_a16b"
-    /**
-     * ModelProviderName
-     * @description Enumeration of supported AI model providers.
-     * @enum {string}
-     */
-    ModelProviderName:
-      | "openai"
-      | "groq"
-      | "amazon_bedrock"
-      | "ollama"
-      | "openrouter"
-      | "fireworks_ai"
-      | "kiln_fine_tune"
-      | "kiln_custom_registry"
-      | "openai_compatible"
-      | "anthropic"
-      | "gemini_api"
-      | "azure_openai"
-      | "huggingface"
-      | "vertex"
-      | "together_ai"
-      | "siliconflow_cn"
-      | "cerebras"
-      | "docker_model_runner"
-    /** OllamaConnection */
-    OllamaConnection: {
-      /** Message */
-      message: string
-      /** Version */
-      version?: string | null
-      /** Supported Models */
-      supported_models: string[]
-      /** Untested Models */
-      untested_models?: string[]
-    }
-    /**
-     * Priority
-     * @description Defines priority levels for tasks and requirements, where P0 is highest priority.
-     * @enum {integer}
-     */
-    Priority: 0 | 1 | 2 | 3
-    /**
-     * Project
-     * @description A collection of related tasks.
-     *
-     *     Projects organize tasks into logical groups and provide high-level descriptions
-     *     of the overall goals.
-     */
-    "Project-Input": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Name
-       * @description The name of the project.
-       */
-      name: string
-      /**
-       * Description
-       * @description A description of the project for you and your team. Will not be used in prompts/training/validation.
-       */
-      description?: string | null
-    }
-    /**
-     * Project
-     * @description A collection of related tasks.
-     *
-     *     Projects organize tasks into logical groups and provide high-level descriptions
-     *     of the overall goals.
-     */
-    "Project-Output": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Name
-       * @description The name of the project.
-       */
-      name: string
-      /**
-       * Description
-       * @description A description of the project for you and your team. Will not be used in prompts/training/validation.
-       */
-      description?: string | null
-      /** Model Type */
-      readonly model_type: string
-    }
-    /**
-     * Prompt
-     * @description A prompt for a task. This is the custom prompt parented by a task.
-     */
-    Prompt: {
-      /**
-       * Name
-       * @description The name of the prompt.
-       */
-      name: string
-      /**
-       * Description
-       * @description A more detailed description of the prompt.
-       */
-      description?: string | null
-      /**
-       * Generator Id
-       * @description The id of the generator that created this prompt.
-       */
-      generator_id?: string | null
-      /**
-       * Prompt
-       * @description The prompt for the task.
-       */
-      prompt: string
-      /**
-       * Chain Of Thought Instructions
-       * @description Instructions for the model 'thinking' about the requirement prior to answering. Used for chain of thought style prompting. COT will not be used unless this is provided.
-       */
-      chain_of_thought_instructions?: string | null
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /** Model Type */
-      readonly model_type: string
-    }
-    /** PromptApiResponse */
-    PromptApiResponse: {
-      /** Prompt */
-      prompt: string
-      /** Prompt Id */
-      prompt_id: string
-    }
-    /** PromptCreateRequest */
-    PromptCreateRequest: {
-      /** Name */
-      name: string
-      /** Description */
-      description?: string | null
-      /** Prompt */
-      prompt: string
-      /** Chain Of Thought Instructions */
-      chain_of_thought_instructions?: string | null
-    }
-    /** PromptGenerator */
-    PromptGenerator: {
-      /** Id */
-      id: string
-      /** Short Description */
-      short_description: string
-      /** Description */
-      description: string
-      /** Name */
-      name: string
-      /** Chain Of Thought */
-      chain_of_thought: boolean
-    }
-    /** PromptResponse */
-    PromptResponse: {
-      /** Generators */
-      generators: components["schemas"]["PromptGenerator"][]
-      /** Prompts */
-      prompts: components["schemas"]["ApiPrompt"][]
-    }
-    /** PromptUpdateRequest */
-    PromptUpdateRequest: {
-      /** Name */
-      name: string
-      /** Description */
-      description?: string | null
-    }
-    /** ProviderModel */
-    ProviderModel: {
-      /** Id */
-      id: string
-      /** Name */
-      name: string
-    }
-    /** ProviderModels */
-    ProviderModels: {
-      /** Models */
-      models: {
-        [key: string]: components["schemas"]["ProviderModel"]
-      }
-    }
-    /** RatingOption */
-    RatingOption: {
-      requirement: components["schemas"]["TaskRequirement"]
-      /** Show For All */
-      show_for_all: boolean
-      /** Show For Tags */
-      show_for_tags: string[]
-    }
-    /** RatingOptionResponse */
-    RatingOptionResponse: {
-      /** Options */
-      options: components["schemas"]["RatingOption"][]
-    }
-    /** RepairRunPost */
-    RepairRunPost: {
-      repair_run: components["schemas"]["TaskRun-Input"]
-      /** Evaluator Feedback */
-      evaluator_feedback: string
-    }
-    /** RepairTaskApiInput */
-    RepairTaskApiInput: {
-      /**
-       * Evaluator Feedback
-       * @description Feedback from an evaluator on how to repair the task run.
-       */
-      evaluator_feedback: string
-    }
-    /**
-     * RequirementRating
-     * @description Rating for a specific requirement within a task output.
-     */
-    RequirementRating: {
-      /**
-       * Value
-       * @description The rating value. Interpretation depends on rating type
-       */
-      value: number
-      /** @description The type of rating */
-      type: components["schemas"]["TaskOutputRatingType"]
-    }
-    /** RunConfigEvalResult */
-    RunConfigEvalResult: {
-      /** Eval Id */
-      eval_id: string | null
-      /** Eval Name */
-      eval_name: string
-      /** Dataset Size */
-      dataset_size: number
-      eval_config_result: components["schemas"]["EvalConfigResult"] | null
-      /** Missing Default Eval Config */
-      missing_default_eval_config: boolean
-    }
-    /** RunConfigEvalScoresSummary */
-    RunConfigEvalScoresSummary: {
-      /** Eval Results */
-      eval_results: components["schemas"]["RunConfigEvalResult"][]
-      mean_usage?: components["schemas"]["MeanUsage"] | null
-    }
-    /**
-     * RunConfigProperties
-     * @description A configuration for running a task.
-     *
-     *     This includes everything needed to run a task, except the input and task ID. Running the same RunConfig with the same input should make identical calls to the model (output may vary as models are non-deterministic).
-     */
-    RunConfigProperties: {
-      /**
-       * Model Name
-       * @description The model to use for this run config.
-       */
-      model_name: string
-      /** @description The provider to use for this run config. */
-      model_provider_name: components["schemas"]["ModelProviderName"]
-      /**
-       * Prompt Id
-       * @description The prompt to use for this run config. Defaults to building a simple prompt from the task if not provided.
-       */
-      prompt_id: string
-      /**
-       * Top P
-       * @description The top-p value to use for this run config. Defaults to 1.0.
-       * @default 1
-       */
-      top_p: number
-      /**
-       * Temperature
-       * @description The temperature to use for this run config. Defaults to 1.0.
-       * @default 1
-       */
-      temperature: number
-      /** @description The structured output mode to use for this run config. */
-      structured_output_mode: components["schemas"]["StructuredOutputMode"]
-      /** @description The tools config to use for this run config, defining which tools are available to the model. */
-      tools_config?: components["schemas"]["ToolsRunConfig"] | null
-    }
-    /** RunSummary */
-    RunSummary: {
-      /** Id */
-      id: string | null
-      rating?: components["schemas"]["TaskOutputRating-Output"] | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at: string
-      /** Input Preview */
-      input_preview?: string | null
-      /** Output Preview */
-      output_preview?: string | null
-      /** Repair State */
-      repair_state?: string | null
-      /** Model Name */
-      model_name?: string | null
-      /** Input Source */
-      input_source?: string | null
-      /** Tags */
-      tags?: string[] | null
-    }
-    /**
-     * RunTaskRequest
-     * @description Request model for running a task.
-     */
-    RunTaskRequest: {
-      run_config_properties: components["schemas"]["RunConfigProperties"]
-      /** Plaintext Input */
-      plaintext_input?: string | null
-      /** Structured Input */
-      structured_input?: Record<string, never> | null
-      /** Tags */
-      tags?: string[] | null
-    }
-    /** ScoreSummary */
-    ScoreSummary: {
-      /** Mean Score */
-      mean_score: number
-    }
-    /**
-     * StructuredOutputMode
-     * @description Enumeration of supported structured output modes.
-     *
-     *     - json_schema: request json using API capabilities for json_schema
-     *     - function_calling: request json using API capabilities for function calling
-     *     - json_mode: request json using API's JSON mode, which should return valid JSON, but isn't checking/passing the schema
-     *     - json_instructions: append instructions to the prompt to request json matching the schema. No API capabilities are used. You should have a custom parser on these models as they will be returning strings.
-     *     - json_instruction_and_object: append instructions to the prompt to request json matching the schema. Also request the response as json_mode via API capabilities (returning dictionaries).
-     *     - json_custom_instructions: The model should output JSON, but custom instructions are already included in the system prompt. Don't append additional JSON instructions.
-     *     - default: let the adapter decide (legacy, do not use for new use cases)
-     *     - unknown: used for cases where the structured output mode is not known (on old models where it wasn't saved). Should lookup best option at runtime.
-     * @enum {string}
-     */
-    StructuredOutputMode:
-      | "default"
-      | "json_schema"
-      | "function_calling_weak"
-      | "function_calling"
-      | "json_mode"
-      | "json_instructions"
-      | "json_instruction_and_object"
-      | "json_custom_instructions"
-      | "unknown"
-    /**
-     * Task
-     * @description Represents a specific task to be performed, with associated requirements and validation rules.
-     *
-     *     Contains the task definition, requirements, input/output schemas, and maintains
-     *     a collection of task runs.
-     */
-    Task: {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Name
-       * @description The name of the task.
-       */
-      name: string
-      /**
-       * Description
-       * @description A description of the task for you and your team. Will not be used in prompts/training/validation.
-       */
-      description?: string | null
-      /**
-       * Instruction
-       * @description The instructions for the task. Will be used in prompts/training/validation.
-       */
-      instruction: string
-      /**
-       * Requirements
-       * @default []
-       */
-      requirements: components["schemas"]["TaskRequirement"][]
-      /** Output Json Schema */
-      output_json_schema?: string | null
-      /** Input Json Schema */
-      input_json_schema?: string | null
-      /**
-       * Thinking Instruction
-       * @description Instructions for the model 'thinking' about the requirement prior to answering. Used for chain of thought style prompting.
-       */
-      thinking_instruction?: string | null
-      /** Model Type */
-      readonly model_type: string
-    }
-    /**
-     * TaskOutput
-     * @description An output for a specific task run.
-     *
-     *     Contains the actual output content, its source (human or synthetic),
-     *     and optional rating information.
-     */
-    "TaskOutput-Input": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Output
-       * @description The output of the task. JSON formatted for structured output, plaintext for unstructured output.
-       */
-      output: string
-      /** @description The source of the output: human or synthetic. */
-      source?: components["schemas"]["DataSource-Input"] | null
-      /** @description The rating of the output */
-      rating?: components["schemas"]["TaskOutputRating-Input"] | null
-    }
-    /**
-     * TaskOutput
-     * @description An output for a specific task run.
-     *
-     *     Contains the actual output content, its source (human or synthetic),
-     *     and optional rating information.
-     */
-    "TaskOutput-Output": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Output
-       * @description The output of the task. JSON formatted for structured output, plaintext for unstructured output.
-       */
-      output: string
-      /** @description The source of the output: human or synthetic. */
-      source?: components["schemas"]["DataSource-Output"] | null
-      /** @description The rating of the output */
-      rating?: components["schemas"]["TaskOutputRating-Output"] | null
-      /** Model Type */
-      readonly model_type: string
-    }
-    /**
-     * TaskOutputRating
-     * @description A rating for a task output, including an overall rating and ratings for each requirement.
-     *
-     *     Supports:
-     *     - five_star: 1-5 star ratings
-     *     - pass_fail: boolean pass/fail (1.0 = pass, 0.0 = fail)
-     *     - pass_fail_critical: tri-state (1.0 = pass, 0.0 = fail, -1.0 = critical fail)
-     */
-    "TaskOutputRating-Input": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /** @default five_star */
-      type: components["schemas"]["TaskOutputRatingType"]
-      /**
-       * Value
-       * @description The rating value. Interpretation depends on rating type:
-       *     - five_star: 1-5 stars
-       *     - pass_fail: 1.0 (pass) or 0.0 (fail)
-       *     - pass_fail_critical: 1.0 (pass), 0.0 (fail), or -1.0 (critical fail)
-       */
-      value?: number | null
-      /**
-       * Requirement Ratings
-       * @description The ratings of the requirements of the task. The ID can be either a task_requirement_id or a named rating for an eval_output_score name (in format 'named::<name>').
-       * @default {}
-       */
-      requirement_ratings: {
-        [key: string]: components["schemas"]["RequirementRating"]
-      }
-    }
-    /**
-     * TaskOutputRating
-     * @description A rating for a task output, including an overall rating and ratings for each requirement.
-     *
-     *     Supports:
-     *     - five_star: 1-5 star ratings
-     *     - pass_fail: boolean pass/fail (1.0 = pass, 0.0 = fail)
-     *     - pass_fail_critical: tri-state (1.0 = pass, 0.0 = fail, -1.0 = critical fail)
-     */
-    "TaskOutputRating-Output": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /** @default five_star */
-      type: components["schemas"]["TaskOutputRatingType"]
-      /**
-       * Value
-       * @description The rating value. Interpretation depends on rating type:
-       *     - five_star: 1-5 stars
-       *     - pass_fail: 1.0 (pass) or 0.0 (fail)
-       *     - pass_fail_critical: 1.0 (pass), 0.0 (fail), or -1.0 (critical fail)
-       */
-      value?: number | null
-      /**
-       * Requirement Ratings
-       * @description The ratings of the requirements of the task. The ID can be either a task_requirement_id or a named rating for an eval_output_score name (in format 'named::<name>').
-       * @default {}
-       */
-      requirement_ratings: {
-        [key: string]: components["schemas"]["RequirementRating"]
-      }
-      /** Model Type */
-      readonly model_type: string
-    }
-    /**
-     * TaskOutputRatingType
-     * @description Defines the types of rating systems available for task outputs.
-     * @enum {string}
-     */
-    TaskOutputRatingType:
-      | "five_star"
-      | "pass_fail"
-      | "pass_fail_critical"
-      | "custom"
-    /**
-     * TaskRequirement
-     * @description Defines a specific requirement that should be met by task outputs.
-     *
-     *     Includes an identifier, name, description, instruction for meeting the requirement,
-     *     priority level, and rating type (five_star, pass_fail, pass_fail_critical, custom).
-     */
-    TaskRequirement: {
-      /** Id */
-      id?: string | null
-      /**
-       * Name
-       * @description The name of the task requirement.
-       */
-      name: string
-      /** Description */
-      description?: string | null
-      /** Instruction */
-      instruction: string
-      /** @default 2 */
-      priority: components["schemas"]["Priority"]
-      /** @default five_star */
-      type: components["schemas"]["TaskOutputRatingType"]
-    }
-    /**
-     * TaskRun
-     * @description Represents a single execution of a Task.
-     *
-     *     Contains the input used, its source, the output produced, and optional
-     *     repair information if the output needed correction.
-     */
-    "TaskRun-Input": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      parent?: components["schemas"]["KilnBaseModel-Input"] | null
-      /**
-       * Input
-       * @description The inputs to the task. JSON formatted for structured input, plaintext for unstructured input.
-       */
-      input: string
-      /** @description The source of the input: human or synthetic. */
-      input_source?: components["schemas"]["DataSource-Input"] | null
-      /** @description The output of the task run. */
-      output: components["schemas"]["TaskOutput-Input"]
-      /**
-       * Repair Instructions
-       * @description Instructions for fixing the output. Should define what is wrong, and how to fix it. Will be used by models for both generating a fixed output, and evaluating future models.
-       */
-      repair_instructions?: string | null
-      /** @description An version of the output with issues fixed. This must be a 'fixed' version of the existing output, and not an entirely new output. If you wish to generate an ideal curatorial output for this task unrelated to this output, generate a new TaskOutput with type 'human' instead of using this field. */
-      repaired_output?: components["schemas"]["TaskOutput-Input"] | null
-      /**
-       * Intermediate Outputs
-       * @description Intermediate outputs from the task run. Keys are the names of the intermediate output steps (cot=chain of thought, etc), values are the output data.
-       */
-      intermediate_outputs?: {
-        [key: string]: string
-      } | null
-      /**
-       * Tags
-       * @description Tags for the task run. Tags are used to categorize task runs for filtering and reporting.
-       * @default []
-       */
-      tags: string[]
-      /** @description Usage information for the task run. This includes the number of input tokens, output tokens, and total tokens used. */
-      usage?: components["schemas"]["Usage"] | null
-      /**
-       * Trace
-       * @description The trace of the task run in OpenAI format. This is the list of messages that were sent to/from the model.
-       */
-      trace?:
-        | (
-            | components["schemas"]["ChatCompletionDeveloperMessageParam"]
-            | components["schemas"]["ChatCompletionSystemMessageParam"]
-            | components["schemas"]["ChatCompletionUserMessageParam-Input"]
-            | components["schemas"]["ChatCompletionAssistantMessageParamWrapper-Input"]
-            | components["schemas"]["ChatCompletionToolMessageParam"]
-            | components["schemas"]["ChatCompletionFunctionMessageParam"]
-          )[]
-        | null
-    }
-    /**
-     * TaskRun
-     * @description Represents a single execution of a Task.
-     *
-     *     Contains the input used, its source, the output produced, and optional
-     *     repair information if the output needed correction.
-     */
-    "TaskRun-Output": {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Input
-       * @description The inputs to the task. JSON formatted for structured input, plaintext for unstructured input.
-       */
-      input: string
-      /** @description The source of the input: human or synthetic. */
-      input_source?: components["schemas"]["DataSource-Output"] | null
-      /** @description The output of the task run. */
-      output: components["schemas"]["TaskOutput-Output"]
-      /**
-       * Repair Instructions
-       * @description Instructions for fixing the output. Should define what is wrong, and how to fix it. Will be used by models for both generating a fixed output, and evaluating future models.
-       */
-      repair_instructions?: string | null
-      /** @description An version of the output with issues fixed. This must be a 'fixed' version of the existing output, and not an entirely new output. If you wish to generate an ideal curatorial output for this task unrelated to this output, generate a new TaskOutput with type 'human' instead of using this field. */
-      repaired_output?: components["schemas"]["TaskOutput-Output"] | null
-      /**
-       * Intermediate Outputs
-       * @description Intermediate outputs from the task run. Keys are the names of the intermediate output steps (cot=chain of thought, etc), values are the output data.
-       */
-      intermediate_outputs?: {
-        [key: string]: string
-      } | null
-      /**
-       * Tags
-       * @description Tags for the task run. Tags are used to categorize task runs for filtering and reporting.
-       * @default []
-       */
-      tags: string[]
-      /** @description Usage information for the task run. This includes the number of input tokens, output tokens, and total tokens used. */
-      usage?: components["schemas"]["Usage"] | null
-      /**
-       * Trace
-       * @description The trace of the task run in OpenAI format. This is the list of messages that were sent to/from the model.
-       */
-      trace?:
-        | (
-            | components["schemas"]["ChatCompletionDeveloperMessageParam"]
-            | components["schemas"]["ChatCompletionSystemMessageParam"]
-            | components["schemas"]["ChatCompletionUserMessageParam-Output"]
-            | components["schemas"]["ChatCompletionAssistantMessageParamWrapper-Output"]
-            | components["schemas"]["ChatCompletionToolMessageParam"]
-            | components["schemas"]["ChatCompletionFunctionMessageParam"]
-          )[]
-        | null
-      /** Model Type */
-      readonly model_type: string
-    }
-    /**
-     * TaskRunConfig
-     * @description A Kiln model for persisting a run config in a Kiln Project, nested under a task.
-     *
-     *     Typically used to save a method of running a task for evaluation.
-     *
-     *     A run config includes everything needed to run a task, except the input. Running the same RunConfig with the same input should make identical calls to the model (output may vary as models are non-deterministic).
-     */
-    TaskRunConfig: {
-      /**
-       * V
-       * @default 1
-       */
-      v: number
-      /** Id */
-      id?: string | null
-      /** Path */
-      path?: string | null
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string
-      /** Created By */
-      created_by?: string
-      /**
-       * Name
-       * @description The name of the task run config.
-       */
-      name: string
-      /**
-       * Description
-       * @description The description of the task run config.
-       */
-      description?: string | null
-      /** @description The run config properties to use for this task run. */
-      run_config_properties: components["schemas"]["RunConfigProperties"]
-      /** @description A prompt to use for run config. */
-      prompt?: components["schemas"]["BasePrompt"] | null
-      /** Model Type */
-      readonly model_type: string
-    }
-    /** ToolApiDescription */
-    ToolApiDescription: {
-      /** Id */
-      id: string
-      /** Name */
-      name: string
-      /** Description */
-      description: string | null
-    }
-    /**
-     * ToolServerType
-     * @description Enumeration of supported external tool server types.
-     * @enum {string}
-     */
-    ToolServerType: "remote_mcp" | "local_mcp"
-    /** ToolSetApiDescription */
-    ToolSetApiDescription: {
-      /** Set Name */
-      set_name: string
-      /** Tools */
-      tools: components["schemas"]["ToolApiDescription"][]
-    }
-    /**
-     * ToolsRunConfig
-     * @description A config describing which tools are available to a task.
-     */
-    ToolsRunConfig: {
-      /**
-       * Tools
-       * @description The IDs of the tools available to the task.
-       */
-      tools: string[]
-    }
-    /** UpdateEvalRequest */
-    UpdateEvalRequest: {
-      /** Name */
-      name: string
-      /** Description */
-      description?: string | null
-    }
-    /** UpdateFavouriteRequest */
-    UpdateFavouriteRequest: {
-      /** Favourite */
-      favourite: boolean
-    }
-    /**
-     * UpdateFinetuneRequest
-     * @description Request to update a finetune
-     */
-    UpdateFinetuneRequest: {
-      /** Name */
-      name: string
-      /** Description */
-      description?: string | null
-    }
-    /** Usage */
-    Usage: {
-      /**
-       * Input Tokens
-       * @description The number of input tokens used in the task run.
-       */
-      input_tokens?: number | null
-      /**
-       * Output Tokens
-       * @description The number of output tokens used in the task run.
-       */
-      output_tokens?: number | null
-      /**
-       * Total Tokens
-       * @description The total number of tokens used in the task run.
-       */
-      total_tokens?: number | null
-      /**
-       * Cost
-       * @description The cost of the task run in US dollars, saved at runtime (prices can change over time).
-       */
-      cost?: number | null
-    }
-    /** ValidationError */
-    ValidationError: {
-      /** Location */
-      loc: (string | number)[]
-      /** Message */
-      msg: string
-      /** Error Type */
-      type: string
-    }
-  }
-  responses: never
-  parameters: never
-  requestBodies: never
-  headers: never
-  pathItems: never
+    schemas: {
+        /** ApiPrompt */
+        ApiPrompt: {
+            /**
+             * Name
+             * @description The name of the prompt.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A more detailed description of the prompt.
+             */
+            description?: string | null;
+            /**
+             * Generator Id
+             * @description The id of the generator that created this prompt.
+             */
+            generator_id?: string | null;
+            /**
+             * Prompt
+             * @description The prompt for the task.
+             */
+            prompt: string;
+            /**
+             * Chain Of Thought Instructions
+             * @description Instructions for the model 'thinking' about the requirement prior to answering. Used for chain of thought style prompting. COT will not be used unless this is provided.
+             */
+            chain_of_thought_instructions?: string | null;
+            /** Id */
+            id: string;
+            /** Created At */
+            created_at?: string | null;
+            /** Created By */
+            created_by?: string | null;
+        };
+        /** Audio */
+        Audio: {
+            /** Id */
+            id: string;
+        };
+        /** AvailableModels */
+        AvailableModels: {
+            /** Provider Name */
+            provider_name: string;
+            /** Provider Id */
+            provider_id: string;
+            /** Models */
+            models: components["schemas"]["ModelDetails"][];
+        };
+        /**
+         * BasePrompt
+         * @description A prompt for a task. This is the basic data storage format which can be used throughout a project.
+         *
+         *     The "Prompt" model name is reserved for the custom prompts parented by a task.
+         */
+        BasePrompt: {
+            /**
+             * Name
+             * @description The name of the prompt.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A more detailed description of the prompt.
+             */
+            description?: string | null;
+            /**
+             * Generator Id
+             * @description The id of the generator that created this prompt.
+             */
+            generator_id?: string | null;
+            /**
+             * Prompt
+             * @description The prompt for the task.
+             */
+            prompt: string;
+            /**
+             * Chain Of Thought Instructions
+             * @description Instructions for the model 'thinking' about the requirement prior to answering. Used for chain of thought style prompting. COT will not be used unless this is provided.
+             */
+            chain_of_thought_instructions?: string | null;
+        };
+        /** Body_bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post */
+        Body_bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post: {
+            /**
+             * File
+             * Format: binary
+             */
+            file: string;
+            /** Splits */
+            splits?: string | null;
+        };
+        /** Body_edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post */
+        Body_edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post: {
+            /** Run Ids */
+            run_ids: string[];
+            /** Add Tags */
+            add_tags?: string[] | null;
+            /** Remove Tags */
+            remove_tags?: string[] | null;
+        };
+        /** BulkUploadResponse */
+        BulkUploadResponse: {
+            /** Success */
+            success: boolean;
+            /** Filename */
+            filename: string;
+            /** Imported Count */
+            imported_count: number;
+        };
+        /**
+         * ChatCompletionAssistantMessageParamWrapper
+         * @description Almost exact copy of ChatCompletionAssistantMessageParam, but with List[T] instead of Iterable[T] for tool_calls.
+         *     https://github.com/pydantic/pydantic/issues/9541
+         */
+        "ChatCompletionAssistantMessageParamWrapper-Input": {
+            /**
+             * Role
+             * @constant
+             */
+            role: "assistant";
+            audio?: components["schemas"]["Audio"] | null;
+            /** Content */
+            content?: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartRefusalParam"])[] | null;
+            function_call?: components["schemas"]["FunctionCall"] | null;
+            /** Name */
+            name?: string;
+            /** Refusal */
+            refusal?: string | null;
+            /** Tool Calls */
+            tool_calls?: components["schemas"]["ChatCompletionMessageToolCallParam"][];
+        };
+        /**
+         * ChatCompletionAssistantMessageParamWrapper
+         * @description Almost exact copy of ChatCompletionAssistantMessageParam, but with List[T] instead of Iterable[T] for tool_calls.
+         *     https://github.com/pydantic/pydantic/issues/9541
+         */
+        "ChatCompletionAssistantMessageParamWrapper-Output": {
+            /**
+             * Role
+             * @constant
+             */
+            role: "assistant";
+            audio?: components["schemas"]["Audio"] | null;
+            /** Content */
+            content?: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartRefusalParam"])[] | null;
+            function_call?: components["schemas"]["FunctionCall"] | null;
+            /** Name */
+            name?: string;
+            /** Refusal */
+            refusal?: string | null;
+            /** Tool Calls */
+            tool_calls?: components["schemas"]["ChatCompletionMessageToolCallParam"][];
+        };
+        /** ChatCompletionContentPartImageParam */
+        ChatCompletionContentPartImageParam: {
+            image_url: components["schemas"]["ImageURL"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "image_url";
+        };
+        /** ChatCompletionContentPartInputAudioParam */
+        ChatCompletionContentPartInputAudioParam: {
+            input_audio: components["schemas"]["InputAudio"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "input_audio";
+        };
+        /** ChatCompletionContentPartRefusalParam */
+        ChatCompletionContentPartRefusalParam: {
+            /** Refusal */
+            refusal: string;
+            /**
+             * Type
+             * @constant
+             */
+            type: "refusal";
+        };
+        /** ChatCompletionContentPartTextParam */
+        ChatCompletionContentPartTextParam: {
+            /** Text */
+            text: string;
+            /**
+             * Type
+             * @constant
+             */
+            type: "text";
+        };
+        /** ChatCompletionDeveloperMessageParam */
+        ChatCompletionDeveloperMessageParam: {
+            /** Content */
+            content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
+            /**
+             * Role
+             * @constant
+             */
+            role: "developer";
+            /** Name */
+            name?: string;
+        };
+        /** ChatCompletionFunctionMessageParam */
+        ChatCompletionFunctionMessageParam: {
+            /** Content */
+            content: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Role
+             * @constant
+             */
+            role: "function";
+        };
+        /** ChatCompletionMessageToolCallParam */
+        ChatCompletionMessageToolCallParam: {
+            /** Id */
+            id: string;
+            function: components["schemas"]["Function"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "function";
+        };
+        /** ChatCompletionSystemMessageParam */
+        ChatCompletionSystemMessageParam: {
+            /** Content */
+            content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
+            /**
+             * Role
+             * @constant
+             */
+            role: "system";
+            /** Name */
+            name?: string;
+        };
+        /** ChatCompletionToolMessageParam */
+        ChatCompletionToolMessageParam: {
+            /** Content */
+            content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
+            /**
+             * Role
+             * @constant
+             */
+            role: "tool";
+            /** Tool Call Id */
+            tool_call_id: string;
+        };
+        /** ChatCompletionUserMessageParam */
+        "ChatCompletionUserMessageParam-Input": {
+            /** Content */
+            content: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartImageParam"] | components["schemas"]["ChatCompletionContentPartInputAudioParam"] | components["schemas"]["File"])[];
+            /**
+             * Role
+             * @constant
+             */
+            role: "user";
+            /** Name */
+            name?: string;
+        };
+        /** ChatCompletionUserMessageParam */
+        "ChatCompletionUserMessageParam-Output": {
+            /** Content */
+            content: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartImageParam"] | components["schemas"]["ChatCompletionContentPartInputAudioParam"] | components["schemas"]["File"])[];
+            /**
+             * Role
+             * @constant
+             */
+            role: "user";
+            /** Name */
+            name?: string;
+        };
+        /**
+         * ChatStrategy
+         * @description Strategy for how a chat is structured.
+         * @enum {string}
+         */
+        ChatStrategy: "final_only" | "final_and_intermediate" | "two_message_cot" | "final_and_intermediate_r1_compatible";
+        /** CorrelationResult */
+        CorrelationResult: {
+            /** Mean Absolute Error */
+            mean_absolute_error: number;
+            /** Mean Normalized Absolute Error */
+            mean_normalized_absolute_error: number;
+            /** Mean Squared Error */
+            mean_squared_error: number;
+            /** Mean Normalized Squared Error */
+            mean_normalized_squared_error: number;
+            /** Spearman Correlation */
+            spearman_correlation: number | null;
+            /** Pearson Correlation */
+            pearson_correlation: number | null;
+            /** Kendalltau Correlation */
+            kendalltau_correlation: number | null;
+        };
+        /**
+         * CreateDatasetSplitRequest
+         * @description Request to create a dataset split
+         */
+        CreateDatasetSplitRequest: {
+            dataset_split_type: components["schemas"]["DatasetSplitType"];
+            /** Filter Id */
+            filter_id: string;
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
+        };
+        /** CreateEvalConfigRequest */
+        CreateEvalConfigRequest: {
+            /** Name */
+            name?: string | null;
+            type: components["schemas"]["EvalConfigType"];
+            /** Properties */
+            properties: Record<string, never>;
+            /** Model Name */
+            model_name: string;
+            provider: components["schemas"]["ModelProviderName"];
+        };
+        /** CreateEvaluatorRequest */
+        CreateEvaluatorRequest: {
+            /** Name */
+            name: string;
+            /** Description */
+            description: string;
+            template: components["schemas"]["EvalTemplateId"] | null;
+            /** Output Scores */
+            output_scores: components["schemas"]["EvalOutputScore"][];
+            /** Eval Set Filter Id */
+            eval_set_filter_id: string;
+            /** Eval Configs Filter Id */
+            eval_configs_filter_id: string;
+            /** Template Properties */
+            template_properties: {
+                [key: string]: string | number | boolean;
+            };
+        };
+        /**
+         * CreateFinetuneRequest
+         * @description Request to create a finetune
+         */
+        CreateFinetuneRequest: {
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Dataset Id */
+            dataset_id: string;
+            /** Train Split Name */
+            train_split_name: string;
+            /** Validation Split Name */
+            validation_split_name?: string | null;
+            /** Parameters */
+            parameters: {
+                [key: string]: string | number | boolean;
+            };
+            /** Provider */
+            provider: string;
+            /** Base Model Id */
+            base_model_id: string;
+            /** System Message Generator */
+            system_message_generator?: string | null;
+            /** Custom System Message */
+            custom_system_message?: string | null;
+            /** Custom Thinking Instructions */
+            custom_thinking_instructions?: string | null;
+            data_strategy: components["schemas"]["ChatStrategy"];
+        };
+        /** CreateTaskRunConfigRequest */
+        CreateTaskRunConfigRequest: {
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
+            run_config_properties: components["schemas"]["RunConfigProperties"];
+        };
+        /** DataGenCategoriesApiInput */
+        DataGenCategoriesApiInput: {
+            /**
+             * Node Path
+             * @description Path to the node in the category tree
+             * @default []
+             */
+            node_path: string[];
+            /**
+             * Num Subtopics
+             * @description Number of subtopics to generate
+             * @default 6
+             */
+            num_subtopics: number;
+            /**
+             * Gen Type
+             * @description The type of task to generate topics for
+             * @enum {string}
+             */
+            gen_type: "eval" | "training";
+            /**
+             * Guidance
+             * @description Optional human guidance for generation
+             */
+            guidance?: string | null;
+            /**
+             * Existing Topics
+             * @description Optional list of existing topics to avoid
+             */
+            existing_topics?: string[] | null;
+            /**
+             * Model Name
+             * @description The name of the model to use
+             */
+            model_name: string;
+            /**
+             * Provider
+             * @description The provider of the model to use
+             */
+            provider: string;
+        };
+        /** DataGenSampleApiInput */
+        DataGenSampleApiInput: {
+            /**
+             * Topic
+             * @description Topic path for sample generation
+             * @default []
+             */
+            topic: string[];
+            /**
+             * Num Samples
+             * @description Number of samples to generate
+             * @default 8
+             */
+            num_samples: number;
+            /**
+             * Gen Type
+             * @description The type of task to generate topics for
+             * @enum {string}
+             */
+            gen_type: "training" | "eval";
+            /**
+             * Guidance
+             * @description Optional custom guidance for generation
+             */
+            guidance?: string | null;
+            /**
+             * Model Name
+             * @description The name of the model to use
+             */
+            model_name: string;
+            /**
+             * Provider
+             * @description The provider of the model to use
+             */
+            provider: string;
+        };
+        /** DataGenSaveSamplesApiInput */
+        DataGenSaveSamplesApiInput: {
+            /**
+             * Input
+             * @description Input for this sample
+             */
+            input: string | Record<string, never>;
+            /**
+             * Topic Path
+             * @description The path to the topic for this sample. Empty is the root topic.
+             */
+            topic_path: string[];
+            /**
+             * Input Model Name
+             * @description The name of the model used to generate the input
+             */
+            input_model_name: string;
+            /**
+             * Input Provider
+             * @description The provider of the model used to generate the input
+             */
+            input_provider: string;
+            /**
+             * Output Model Name
+             * @description The name of the model to use
+             */
+            output_model_name: string;
+            /**
+             * Output Provider
+             * @description The provider of the model to use
+             */
+            output_provider: string;
+            /**
+             * Prompt Method
+             * @description The prompt method used to generate the output
+             */
+            prompt_method: string;
+            /**
+             * Guidance
+             * @description Optional custom guidance for generation
+             */
+            guidance?: string | null;
+            /**
+             * Tags
+             * @description Tags to add to the sample
+             */
+            tags?: string[] | null;
+        };
+        /**
+         * DataSource
+         * @description Represents the origin of data, either human or synthetic, with associated properties.
+         *
+         *     Properties vary based on the source type - for synthetic sources this includes
+         *     model information, for human sources this includes creator information.
+         */
+        "DataSource-Input": {
+            type: components["schemas"]["DataSourceType"];
+            /**
+             * Properties
+             * @description Properties describing the data source. For synthetic things like model. For human, the human's name.
+             * @default {}
+             */
+            properties: {
+                [key: string]: string | number;
+            };
+            /** @description The run config used to generate the data, if generated by a running a model in Kiln (only true for type=synthetic). */
+            run_config?: components["schemas"]["RunConfigProperties"] | null;
+        };
+        /**
+         * DataSource
+         * @description Represents the origin of data, either human or synthetic, with associated properties.
+         *
+         *     Properties vary based on the source type - for synthetic sources this includes
+         *     model information, for human sources this includes creator information.
+         */
+        "DataSource-Output": {
+            type: components["schemas"]["DataSourceType"];
+            /**
+             * Properties
+             * @description Properties describing the data source. For synthetic things like model. For human, the human's name.
+             * @default {}
+             */
+            properties: {
+                [key: string]: string | number;
+            };
+            /** @description The run config used to generate the data, if generated by a running a model in Kiln (only true for type=synthetic). */
+            run_config?: components["schemas"]["RunConfigProperties"] | null;
+        };
+        /**
+         * DataSourceType
+         * @description The source type of a piece of data.
+         *
+         *     Human: a human created the data
+         *     Synthetic: a model created the data
+         * @enum {string}
+         */
+        DataSourceType: "human" | "synthetic" | "file_import";
+        /**
+         * DatasetSplit
+         * @description A collection of task runs, with optional splits (train, test, validation).
+         *
+         *     Used to freeze a dataset into train/test/validation splits for repeatable fine-tuning or other tasks.
+         *
+         *     Maintains a list of IDs for each split, to avoid data duplication.
+         */
+        DatasetSplit: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description The name of the dataset split.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A description of the dataset for you and your team. Not used in training.
+             */
+            description?: string | null;
+            /**
+             * Splits
+             * @description The splits in the dataset.
+             */
+            splits?: components["schemas"]["DatasetSplitDefinition"][];
+            /**
+             * Split Contents
+             * @description The contents of each split in the dataset. The key is the split name, and the value is a list of task run IDs.
+             */
+            split_contents: {
+                [key: string]: string[];
+            };
+            /**
+             * Filter
+             * @description The filter used to build the dataset.
+             */
+            filter?: string | null;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * DatasetSplitDefinition
+         * @description A definition of a split in a dataset.
+         *
+         *     Example: name="train", description="The training set", percentage=0.8 (80% of the dataset)
+         */
+        DatasetSplitDefinition: {
+            /**
+             * Name
+             * @description The name of the dataset split definition.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A description of the dataset for you and your team. Not used in training.
+             */
+            description?: string | null;
+            /**
+             * Percentage
+             * @description The percentage of the dataset that this split represents (between 0 and 1).
+             */
+            percentage: number;
+        };
+        /**
+         * DatasetSplitType
+         * @description Dataset split types used in the API. Any split type can be created in code.
+         * @enum {string}
+         */
+        DatasetSplitType: "train_val" | "train_test" | "train_test_val" | "train_test_val_80" | "all";
+        /** DockerModelRunnerConnection */
+        DockerModelRunnerConnection: {
+            /** Message */
+            message: string;
+            /** Version */
+            version?: string | null;
+            /** Supported Models */
+            supported_models: string[];
+            /** Untested Models */
+            untested_models?: string[];
+        };
+        /** Eval */
+        Eval: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description The name of the eval.
+             */
+            name: string;
+            /**
+             * Description
+             * @description The description of the eval
+             */
+            description?: string | null;
+            /** @description The template selected when creating this eval. Useful for suggesting eval steps and output scores. */
+            template?: components["schemas"]["EvalTemplateId"] | null;
+            /**
+             * Current Config Id
+             * @description The id of the current config to use for this eval. This can be changed over time to run the same eval with different configs.
+             */
+            current_config_id?: string | null;
+            /**
+             * Current Run Config Id
+             * @description The id of the a run config which was selected as the best run config for this eval. The run config must belong to the parent Task.
+             */
+            current_run_config_id?: string | null;
+            /**
+             * Eval Set Filter Id
+             * @description The id of the dataset filter which defines which dataset items are included when running this eval. Should be mutually exclusive with eval_configs_filter_id.
+             */
+            eval_set_filter_id: string;
+            /**
+             * Eval Configs Filter Id
+             * @description The id of the dataset filter which defines which dataset items are included when comparing the quality of the eval configs under this eval. Should consist of dataset items with ratings. Should be mutually exclusive with eval_set_filter_id.
+             */
+            eval_configs_filter_id: string;
+            /**
+             * Output Scores
+             * @description The scores this evaluator should produce.
+             */
+            output_scores: components["schemas"]["EvalOutputScore"][];
+            /**
+             * Favourite
+             * @description Whether this eval is a favourite of the user. Rendered as a star icon in the UI.
+             * @default false
+             */
+            favourite: boolean;
+            /**
+             * Template Properties
+             * @description Properties to be used to execute the eval. This is template_type specific and should serialize to a json dict.
+             * @default {}
+             */
+            template_properties: {
+                [key: string]: string | number | boolean;
+            };
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * EvalConfig
+         * @description A configuration for running an eval. This includes anything needed to run the eval on a dataset like the prompt, model, thresholds, etc.
+         *
+         *     A eval might have many configs, example running the same eval with 2 different models. Comparing eval results is only valid within the scope of the same config.
+         */
+        EvalConfig: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description The name of the eval config.
+             */
+            name: string;
+            /**
+             * Model Name
+             * @description The name of the model to use for this eval config.
+             */
+            model_name: string;
+            /**
+             * Model Provider
+             * @description The provider of the model to use for this eval config.
+             */
+            model_provider: string;
+            /**
+             * @description This is used to determine the type of eval to run.
+             * @default g_eval
+             */
+            config_type: components["schemas"]["EvalConfigType"];
+            /**
+             * Properties
+             * @description Properties to be used to execute the eval config. This is config_type specific and should serialize to a json dict.
+             * @default {}
+             */
+            properties: Record<string, never>;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /** EvalConfigCompareSummary */
+        EvalConfigCompareSummary: {
+            /** Results */
+            results: {
+                [key: string]: {
+                    [key: string]: components["schemas"]["CorrelationResult"];
+                };
+            };
+            /** Eval Config Percent Complete */
+            eval_config_percent_complete: {
+                [key: string]: number;
+            };
+            /** Dataset Size */
+            dataset_size: number;
+            /** Fully Rated Count */
+            fully_rated_count: number;
+            /** Partially Rated Count */
+            partially_rated_count: number;
+            /** Not Rated Count */
+            not_rated_count: number;
+        };
+        /** EvalConfigResult */
+        EvalConfigResult: {
+            /** Eval Config Id */
+            eval_config_id: string | null;
+            /** Results */
+            results: {
+                [key: string]: components["schemas"]["ScoreSummary"] | null;
+            };
+            /** Percent Complete */
+            percent_complete: number;
+        };
+        /**
+         * EvalConfigType
+         * @enum {string}
+         */
+        EvalConfigType: "g_eval" | "llm_as_judge";
+        /**
+         * EvalOutputScore
+         * @description A definition of a score that an evaluator will produce.
+         *
+         *     Very similar to TaskRequirement, but conceptually different keeping in a separate models.
+         */
+        EvalOutputScore: {
+            /**
+             * Name
+             * @description The name of the score. Will be provided to the model so use a descriptive name. Should align to the model's TaskRequirement name if you want to use human evals to evaluate the evaluator's performance.
+             */
+            name: string;
+            /**
+             * Instruction
+             * @description A description of the score, used to help the model understand the goal of the score. Will be provided to evaluator models, so should be written for the model, not the team/user.
+             */
+            instruction?: string | null;
+            /** @description The type of rating to use ('five_star', 'pass_fail', 'pass_fail_critical'). */
+            type: components["schemas"]["TaskOutputRatingType"];
+        };
+        /** EvalProgress */
+        EvalProgress: {
+            /** Dataset Size */
+            dataset_size: number;
+            /** Golden Dataset Size */
+            golden_dataset_size: number;
+            /** Golden Dataset Not Rated Count */
+            golden_dataset_not_rated_count: number;
+            /** Golden Dataset Partially Rated Count */
+            golden_dataset_partially_rated_count: number;
+            /** Golden Dataset Fully Rated Count */
+            golden_dataset_fully_rated_count: number;
+            current_eval_method: components["schemas"]["EvalConfig"] | null;
+            current_run_method: components["schemas"]["TaskRunConfig"] | null;
+        };
+        /** EvalResultSummary */
+        EvalResultSummary: {
+            /** Results */
+            results: {
+                [key: string]: {
+                    [key: string]: components["schemas"]["ScoreSummary"];
+                };
+            };
+            /** Run Config Percent Complete */
+            run_config_percent_complete: {
+                [key: string]: number;
+            };
+            /** Dataset Size */
+            dataset_size: number;
+        };
+        /**
+         * EvalRun
+         * @description The results of running an eval on a single dataset item.
+         *
+         *     This is a child of an EvalConfig, which specifies how the scores were generated.
+         *
+         *     Eval runs can be one of 2 types:
+         *     1) eval_config_eval=False: we were evaluating a task run (a method of running the task). We get the task input from the dataset_id.input, run the task with the task_run_config, then ran the evaluator on that output. task_run_config_id must be set. The output saved in this model is the output of the task run.
+         *     2) eval_config_eval=True: we were evaluating an eval config (a method of evaluating the task). We used the existing dataset item input/output, and ran the evaluator on it. task_run_config_id must be None. The input/output saved in this model is the input/output of the dataset item.
+         */
+        EvalRun: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Dataset Id
+             * @description The ID of the dataset item that was used for this run. Must belong to the same Task as the grand-parent eval of this EvalRun.
+             */
+            dataset_id: string | null;
+            /**
+             * Task Run Config Id
+             * @description The ID of the TaskRunConfig that was run, if this eval run was based on a task run. Must belong to the same Task as this eval. Can be None if this eval run is based on an eval config.
+             */
+            task_run_config_id: string | null;
+            /**
+             * Eval Config Eval
+             * @description Whether this eval run to evaluate the parent eval config (evaluating the config using an existing dataset item). If true, task_run_config_id must be None, as we're not running the task.
+             * @default false
+             */
+            eval_config_eval: boolean;
+            /**
+             * Input
+             * @description The input to the task. JSON formatted for structured input, plaintext for unstructured input.
+             */
+            input: string;
+            /**
+             * Output
+             * @description The output of the task. JSON formatted for structured output, plaintext for unstructured output.
+             */
+            output: string;
+            /**
+             * Intermediate Outputs
+             * @description The intermediate outputs of the task (example, eval thinking).
+             */
+            intermediate_outputs?: {
+                [key: string]: string;
+            } | null;
+            /**
+             * Scores
+             * @description The output scores of the evaluator (aligning to those required by the grand-parent Eval this object is a child of).
+             */
+            scores: {
+                [key: string]: number;
+            };
+            /** @description The usage of the task run that produced this eval run output (not the usage by the evaluation model). */
+            task_run_usage?: components["schemas"]["Usage"] | null;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /** EvalRunResult */
+        EvalRunResult: {
+            /** Results */
+            results: components["schemas"]["EvalRun"][];
+            eval: components["schemas"]["Eval"];
+            eval_config: components["schemas"]["EvalConfig"];
+            run_config: components["schemas"]["TaskRunConfig"];
+        };
+        /**
+         * EvalTemplateId
+         * @description An eval template is a pre-defined eval that can be used as a starting point for a new eval.
+         * @enum {string}
+         */
+        EvalTemplateId: "kiln_requirements" | "kiln_issue" | "toxicity" | "bias" | "maliciousness" | "factual_correctness" | "jailbreak";
+        /**
+         * ExternalToolApiDescription
+         * @description This class is a wrapper of MCP's Tool object to be displayed in the UI under tool_server/[tool_server_id].
+         */
+        ExternalToolApiDescription: {
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Inputschema */
+            inputSchema?: Record<string, never>;
+        };
+        /**
+         * ExternalToolServer
+         * @description Configuration for communicating with a external MCP (Model Context Protocol) Server for LLM tool calls. External tool servers can be remote or local.
+         *
+         *     This model stores the necessary configuration to connect to and authenticate with
+         *     external MCP servers that provide tools for LLM interactions.
+         */
+        ExternalToolServer: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description The name of the external tool.
+             */
+            name: string;
+            /** @description The type of external tool server. Remote tools are hosted on a remote server */
+            type: components["schemas"]["ToolServerType"];
+            /**
+             * Description
+             * @description A description of the external tool for you and your team. Will not be used in prompts/training/validation.
+             */
+            description?: string | null;
+            /**
+             * Properties
+             * @description Configuration properties specific to the tool type.
+             * @default {}
+             */
+            properties: Record<string, never>;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * ExternalToolServerApiDescription
+         * @description This class is used to describe the external tool server under tool_servers/[tool_server_id] UI. It is based of ExternalToolServer.
+         */
+        ExternalToolServerApiDescription: {
+            /** Id */
+            id: string | null;
+            type: components["schemas"]["ToolServerType"];
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /** Created At */
+            created_at: string | null;
+            /** Created By */
+            created_by: string | null;
+            /** Properties */
+            properties: Record<string, never>;
+            /** Available Tools */
+            available_tools: components["schemas"]["ExternalToolApiDescription"][];
+        };
+        /** ExternalToolServerCreationRequest */
+        ExternalToolServerCreationRequest: {
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /** Server Url */
+            server_url: string;
+            /** Headers */
+            headers?: {
+                [key: string]: string;
+            };
+            /** Secret Header Keys */
+            secret_header_keys?: string[];
+        };
+        /** File */
+        File: {
+            file: components["schemas"]["FileFile"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "file";
+        };
+        /** FileFile */
+        FileFile: {
+            /** File Data */
+            file_data?: string;
+            /** File Id */
+            file_id?: string;
+            /** Filename */
+            filename?: string;
+        };
+        /**
+         * FineTuneParameter
+         * @description A parameter for a fine-tune. Hyperparameters, etc.
+         */
+        FineTuneParameter: {
+            /** Name */
+            name: string;
+            /**
+             * Type
+             * @enum {string}
+             */
+            type: "string" | "int" | "float" | "bool";
+            /** Description */
+            description: string;
+            /**
+             * Optional
+             * @default true
+             */
+            optional: boolean;
+        };
+        /**
+         * FineTuneStatus
+         * @description The status of a fine-tune, including a user friendly message.
+         */
+        FineTuneStatus: {
+            status: components["schemas"]["FineTuneStatusType"];
+            /** Message */
+            message?: string | null;
+            /** Error Details */
+            error_details?: string | null;
+        };
+        /**
+         * FineTuneStatusType
+         * @description The status type of a fine-tune (running, completed, failed, etc).
+         * @enum {string}
+         */
+        FineTuneStatusType: "unknown" | "pending" | "running" | "completed" | "failed";
+        /**
+         * Finetune
+         * @description The Kiln fine-tune datamodel.
+         *
+         *     Initially holds a reference to a training job, with needed identifiers to update the status. When complete, contains the new model ID.
+         */
+        Finetune: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description The name of the fine-tune.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A description of the fine-tune for you and your team. Not used in training.
+             */
+            description?: string | null;
+            /** @description The mode to use to train the model for structured output, if it was trained with structured output. Will determine how we call the tuned model, so we call with the matching mode. */
+            structured_output_mode?: components["schemas"]["StructuredOutputMode"] | null;
+            /**
+             * Provider
+             * @description The provider to use for the fine-tune (e.g. 'openai').
+             */
+            provider: string;
+            /**
+             * Base Model Id
+             * @description The id of the base model to use for the fine-tune. This string relates to the provider's IDs for their own models, not Kiln IDs.
+             */
+            base_model_id: string;
+            /**
+             * Provider Id
+             * @description The ID of the fine-tune job on the provider's side. May not be the same as the fine_tune_model_id.
+             */
+            provider_id?: string | null;
+            /**
+             * Fine Tune Model Id
+             * @description The ID of the fine-tuned model on the provider's side. May not be the same as the provider_id.
+             */
+            fine_tune_model_id?: string | null;
+            /**
+             * Dataset Split Id
+             * @description The ID of the dataset split to use for this fine-tune.
+             */
+            dataset_split_id: string;
+            /**
+             * Train Split Name
+             * @description The name of the training split to use for this fine-tune.
+             * @default train
+             */
+            train_split_name: string;
+            /**
+             * Validation Split Name
+             * @description The name of the validation split to use for this fine-tune. Optional.
+             */
+            validation_split_name?: string | null;
+            /**
+             * Parameters
+             * @description The parameters to use for this fine-tune. These are provider-specific.
+             * @default {}
+             */
+            parameters: {
+                [key: string]: string | number | boolean;
+            };
+            /**
+             * System Message
+             * @description The system message to use for this fine-tune.
+             */
+            system_message: string;
+            /**
+             * Thinking Instructions
+             * @description The thinking instructions to use for this fine-tune. Only used when data_strategy is final_and_intermediate.
+             */
+            thinking_instructions?: string | null;
+            /**
+             * @description The latest known status of this fine-tune. Not updated in real time.
+             * @default unknown
+             */
+            latest_status: components["schemas"]["FineTuneStatusType"];
+            /**
+             * Properties
+             * @description Properties of the fine-tune. Different providers may use different properties.
+             * @default {}
+             */
+            properties: {
+                [key: string]: string | number;
+            };
+            /**
+             * @description The strategy to use for training the model. 'final_only' will only train on the final response. 'final_and_intermediate' will train on the final response and intermediate outputs (chain of thought or reasoning).
+             * @default final_only
+             */
+            data_strategy: components["schemas"]["ChatStrategy"];
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * FinetuneDatasetInfo
+         * @description Finetune dataset info
+         */
+        FinetuneDatasetInfo: {
+            /** Existing Datasets */
+            existing_datasets: components["schemas"]["DatasetSplit"][];
+            /** Existing Finetunes */
+            existing_finetunes: components["schemas"]["Finetune"][];
+            /** Finetune Tags */
+            finetune_tags: components["schemas"]["FinetuneDatasetTagInfo"][];
+        };
+        /**
+         * FinetuneDatasetTagInfo
+         * @description Finetune dataset tag info
+         */
+        FinetuneDatasetTagInfo: {
+            /** Tag */
+            tag: string;
+            /** Count */
+            count: number;
+            /** Reasoning Count */
+            reasoning_count: number;
+            /** High Quality Count */
+            high_quality_count: number;
+            /** Reasoning And High Quality Count */
+            reasoning_and_high_quality_count: number;
+        };
+        /**
+         * FinetuneProvider
+         * @description Finetune provider: list of models a provider supports for fine-tuning
+         */
+        FinetuneProvider: {
+            /** Name */
+            name: string;
+            /** Id */
+            id: string;
+            /** Enabled */
+            enabled: boolean;
+            /** Models */
+            models: components["schemas"]["FinetuneProviderModel"][];
+        };
+        /**
+         * FinetuneProviderModel
+         * @description Finetune provider model: a model a provider supports for fine-tuning
+         */
+        FinetuneProviderModel: {
+            /** Name */
+            name: string;
+            /** Id */
+            id: string;
+            /** Data Strategies Supported */
+            data_strategies_supported?: components["schemas"]["ChatStrategy"][];
+        };
+        /**
+         * FinetuneWithStatus
+         * @description Finetune with status
+         */
+        FinetuneWithStatus: {
+            finetune: components["schemas"]["Finetune"];
+            status: components["schemas"]["FineTuneStatus"];
+        };
+        /** Function */
+        Function: {
+            /** Arguments */
+            arguments: string;
+            /** Name */
+            name: string;
+        };
+        /** FunctionCall */
+        FunctionCall: {
+            /** Arguments */
+            arguments: string;
+            /** Name */
+            name: string;
+        };
+        /** HTTPValidationError */
+        HTTPValidationError: {
+            /** Detail */
+            detail?: components["schemas"]["ValidationError"][];
+        };
+        /** ImageURL */
+        ImageURL: {
+            /** Url */
+            url: string;
+            /**
+             * Detail
+             * @enum {string}
+             */
+            detail?: "auto" | "low" | "high";
+        };
+        /** InputAudio */
+        InputAudio: {
+            /** Data */
+            data: string;
+            /**
+             * Format
+             * @enum {string}
+             */
+            format: "wav" | "mp3";
+        };
+        /**
+         * KilnBaseModel
+         * @description Base model for all Kiln data models with common functionality for persistence and versioning.
+         *
+         *     Attributes:
+         *         v (int): Schema version number for migration support
+         *         id (str): Unique identifier for the model instance
+         *         path (Path): File system path where the model is stored
+         *         created_at (datetime): Timestamp when the model was created
+         *         created_by (str): User ID of the creator
+         */
+        "KilnBaseModel-Input": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+        };
+        /**
+         * KilnBaseModel
+         * @description Base model for all Kiln data models with common functionality for persistence and versioning.
+         *
+         *     Attributes:
+         *         v (int): Schema version number for migration support
+         *         id (str): Unique identifier for the model instance
+         *         path (Path): File system path where the model is stored
+         *         created_at (datetime): Timestamp when the model was created
+         *         created_by (str): User ID of the creator
+         */
+        "KilnBaseModel-Output": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /** KilnFileResponse */
+        KilnFileResponse: {
+            /** File Path */
+            file_path: string | null;
+        };
+        /**
+         * KilnToolServerDescription
+         * @description This class is used to describe the external tool server under Settings -> Manage Tools UI.
+         */
+        KilnToolServerDescription: {
+            /** Name */
+            name: string;
+            /** Id */
+            id: string | null;
+            type: components["schemas"]["ToolServerType"];
+            /** Description */
+            description: string | null;
+        };
+        /** LocalToolServerCreationRequest */
+        LocalToolServerCreationRequest: {
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /** Command */
+            command: string;
+            /** Args */
+            args: string[];
+            /** Env Vars */
+            env_vars?: {
+                [key: string]: string;
+            };
+        };
+        /** MeanUsage */
+        MeanUsage: {
+            /** Mean Input Tokens */
+            mean_input_tokens?: number | null;
+            /** Mean Output Tokens */
+            mean_output_tokens?: number | null;
+            /** Mean Total Tokens */
+            mean_total_tokens?: number | null;
+            /** Mean Cost */
+            mean_cost?: number | null;
+        };
+        /** ModelDetails */
+        ModelDetails: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Supports Structured Output */
+            supports_structured_output: boolean;
+            /** Supports Data Gen */
+            supports_data_gen: boolean;
+            /** Suggested For Data Gen */
+            suggested_for_data_gen: boolean;
+            /** Supports Logprobs */
+            supports_logprobs: boolean;
+            /** Suggested For Evals */
+            suggested_for_evals: boolean;
+            /** Supports Function Calling */
+            supports_function_calling: boolean;
+            /** Uncensored */
+            uncensored: boolean;
+            /** Suggested For Uncensored Data Gen */
+            suggested_for_uncensored_data_gen: boolean;
+            structured_output_mode: components["schemas"]["StructuredOutputMode"];
+            /**
+             * Untested Model
+             * @default false
+             */
+            untested_model: boolean;
+            /** Task Filter */
+            task_filter?: string[] | null;
+        };
+        /**
+         * ModelProviderName
+         * @description Enumeration of supported AI model providers.
+         * @enum {string}
+         */
+        ModelProviderName: "openai" | "groq" | "amazon_bedrock" | "ollama" | "openrouter" | "fireworks_ai" | "kiln_fine_tune" | "kiln_custom_registry" | "openai_compatible" | "anthropic" | "gemini_api" | "azure_openai" | "huggingface" | "vertex" | "together_ai" | "siliconflow_cn" | "cerebras" | "docker_model_runner";
+        /** OllamaConnection */
+        OllamaConnection: {
+            /** Message */
+            message: string;
+            /** Version */
+            version?: string | null;
+            /** Supported Models */
+            supported_models: string[];
+            /** Untested Models */
+            untested_models?: string[];
+        };
+        /**
+         * Priority
+         * @description Defines priority levels for tasks and requirements, where P0 is highest priority.
+         * @enum {integer}
+         */
+        Priority: 0 | 1 | 2 | 3;
+        /**
+         * Project
+         * @description A collection of related tasks.
+         *
+         *     Projects organize tasks into logical groups and provide high-level descriptions
+         *     of the overall goals.
+         */
+        "Project-Input": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description The name of the project.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A description of the project for you and your team. Will not be used in prompts/training/validation.
+             */
+            description?: string | null;
+        };
+        /**
+         * Project
+         * @description A collection of related tasks.
+         *
+         *     Projects organize tasks into logical groups and provide high-level descriptions
+         *     of the overall goals.
+         */
+        "Project-Output": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description The name of the project.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A description of the project for you and your team. Will not be used in prompts/training/validation.
+             */
+            description?: string | null;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * Prompt
+         * @description A prompt for a task. This is the custom prompt parented by a task.
+         */
+        Prompt: {
+            /**
+             * Name
+             * @description The name of the prompt.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A more detailed description of the prompt.
+             */
+            description?: string | null;
+            /**
+             * Generator Id
+             * @description The id of the generator that created this prompt.
+             */
+            generator_id?: string | null;
+            /**
+             * Prompt
+             * @description The prompt for the task.
+             */
+            prompt: string;
+            /**
+             * Chain Of Thought Instructions
+             * @description Instructions for the model 'thinking' about the requirement prior to answering. Used for chain of thought style prompting. COT will not be used unless this is provided.
+             */
+            chain_of_thought_instructions?: string | null;
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /** PromptApiResponse */
+        PromptApiResponse: {
+            /** Prompt */
+            prompt: string;
+            /** Prompt Id */
+            prompt_id: string;
+        };
+        /** PromptCreateRequest */
+        PromptCreateRequest: {
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /** Prompt */
+            prompt: string;
+            /** Chain Of Thought Instructions */
+            chain_of_thought_instructions?: string | null;
+        };
+        /** PromptGenerator */
+        PromptGenerator: {
+            /** Id */
+            id: string;
+            /** Short Description */
+            short_description: string;
+            /** Description */
+            description: string;
+            /** Name */
+            name: string;
+            /** Chain Of Thought */
+            chain_of_thought: boolean;
+        };
+        /** PromptResponse */
+        PromptResponse: {
+            /** Generators */
+            generators: components["schemas"]["PromptGenerator"][];
+            /** Prompts */
+            prompts: components["schemas"]["ApiPrompt"][];
+        };
+        /** PromptUpdateRequest */
+        PromptUpdateRequest: {
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+        };
+        /** ProviderModel */
+        ProviderModel: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+        };
+        /** ProviderModels */
+        ProviderModels: {
+            /** Models */
+            models: {
+                [key: string]: components["schemas"]["ProviderModel"];
+            };
+        };
+        /** RatingOption */
+        RatingOption: {
+            requirement: components["schemas"]["TaskRequirement"];
+            /** Show For All */
+            show_for_all: boolean;
+            /** Show For Tags */
+            show_for_tags: string[];
+        };
+        /** RatingOptionResponse */
+        RatingOptionResponse: {
+            /** Options */
+            options: components["schemas"]["RatingOption"][];
+        };
+        /** RepairRunPost */
+        RepairRunPost: {
+            repair_run: components["schemas"]["TaskRun-Input"];
+            /** Evaluator Feedback */
+            evaluator_feedback: string;
+        };
+        /** RepairTaskApiInput */
+        RepairTaskApiInput: {
+            /**
+             * Evaluator Feedback
+             * @description Feedback from an evaluator on how to repair the task run.
+             */
+            evaluator_feedback: string;
+        };
+        /**
+         * RequirementRating
+         * @description Rating for a specific requirement within a task output.
+         */
+        RequirementRating: {
+            /**
+             * Value
+             * @description The rating value. Interpretation depends on rating type
+             */
+            value: number;
+            /** @description The type of rating */
+            type: components["schemas"]["TaskOutputRatingType"];
+        };
+        /** RunConfigEvalResult */
+        RunConfigEvalResult: {
+            /** Eval Id */
+            eval_id: string | null;
+            /** Eval Name */
+            eval_name: string;
+            /** Dataset Size */
+            dataset_size: number;
+            eval_config_result: components["schemas"]["EvalConfigResult"] | null;
+            /** Missing Default Eval Config */
+            missing_default_eval_config: boolean;
+        };
+        /** RunConfigEvalScoresSummary */
+        RunConfigEvalScoresSummary: {
+            /** Eval Results */
+            eval_results: components["schemas"]["RunConfigEvalResult"][];
+            mean_usage?: components["schemas"]["MeanUsage"] | null;
+        };
+        /**
+         * RunConfigProperties
+         * @description A configuration for running a task.
+         *
+         *     This includes everything needed to run a task, except the input and task ID. Running the same RunConfig with the same input should make identical calls to the model (output may vary as models are non-deterministic).
+         */
+        RunConfigProperties: {
+            /**
+             * Model Name
+             * @description The model to use for this run config.
+             */
+            model_name: string;
+            /** @description The provider to use for this run config. */
+            model_provider_name: components["schemas"]["ModelProviderName"];
+            /**
+             * Prompt Id
+             * @description The prompt to use for this run config. Defaults to building a simple prompt from the task if not provided.
+             */
+            prompt_id: string;
+            /**
+             * Top P
+             * @description The top-p value to use for this run config. Defaults to 1.0.
+             * @default 1
+             */
+            top_p: number;
+            /**
+             * Temperature
+             * @description The temperature to use for this run config. Defaults to 1.0.
+             * @default 1
+             */
+            temperature: number;
+            /** @description The structured output mode to use for this run config. */
+            structured_output_mode: components["schemas"]["StructuredOutputMode"];
+            /** @description The tools config to use for this run config, defining which tools are available to the model. */
+            tools_config?: components["schemas"]["ToolsRunConfig"] | null;
+        };
+        /** RunSummary */
+        RunSummary: {
+            /** Id */
+            id: string | null;
+            rating?: components["schemas"]["TaskOutputRating-Output"] | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Input Preview */
+            input_preview?: string | null;
+            /** Output Preview */
+            output_preview?: string | null;
+            /** Repair State */
+            repair_state?: string | null;
+            /** Model Name */
+            model_name?: string | null;
+            /** Input Source */
+            input_source?: string | null;
+            /** Tags */
+            tags?: string[] | null;
+        };
+        /**
+         * RunTaskRequest
+         * @description Request model for running a task.
+         */
+        RunTaskRequest: {
+            run_config_properties: components["schemas"]["RunConfigProperties"];
+            /** Plaintext Input */
+            plaintext_input?: string | null;
+            /** Structured Input */
+            structured_input?: Record<string, never> | null;
+            /** Tags */
+            tags?: string[] | null;
+        };
+        /** ScoreSummary */
+        ScoreSummary: {
+            /** Mean Score */
+            mean_score: number;
+        };
+        /**
+         * StructuredOutputMode
+         * @description Enumeration of supported structured output modes.
+         *
+         *     - json_schema: request json using API capabilities for json_schema
+         *     - function_calling: request json using API capabilities for function calling
+         *     - json_mode: request json using API's JSON mode, which should return valid JSON, but isn't checking/passing the schema
+         *     - json_instructions: append instructions to the prompt to request json matching the schema. No API capabilities are used. You should have a custom parser on these models as they will be returning strings.
+         *     - json_instruction_and_object: append instructions to the prompt to request json matching the schema. Also request the response as json_mode via API capabilities (returning dictionaries).
+         *     - json_custom_instructions: The model should output JSON, but custom instructions are already included in the system prompt. Don't append additional JSON instructions.
+         *     - default: let the adapter decide (legacy, do not use for new use cases)
+         *     - unknown: used for cases where the structured output mode is not known (on old models where it wasn't saved). Should lookup best option at runtime.
+         * @enum {string}
+         */
+        StructuredOutputMode: "default" | "json_schema" | "function_calling_weak" | "function_calling" | "json_mode" | "json_instructions" | "json_instruction_and_object" | "json_custom_instructions" | "unknown";
+        /**
+         * Task
+         * @description Represents a specific task to be performed, with associated requirements and validation rules.
+         *
+         *     Contains the task definition, requirements, input/output schemas, and maintains
+         *     a collection of task runs.
+         */
+        Task: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description The name of the task.
+             */
+            name: string;
+            /**
+             * Description
+             * @description A description of the task for you and your team. Will not be used in prompts/training/validation.
+             */
+            description?: string | null;
+            /**
+             * Instruction
+             * @description The instructions for the task. Will be used in prompts/training/validation.
+             */
+            instruction: string;
+            /**
+             * Requirements
+             * @default []
+             */
+            requirements: components["schemas"]["TaskRequirement"][];
+            /** Output Json Schema */
+            output_json_schema?: string | null;
+            /** Input Json Schema */
+            input_json_schema?: string | null;
+            /**
+             * Thinking Instruction
+             * @description Instructions for the model 'thinking' about the requirement prior to answering. Used for chain of thought style prompting.
+             */
+            thinking_instruction?: string | null;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * TaskOutput
+         * @description An output for a specific task run.
+         *
+         *     Contains the actual output content, its source (human or synthetic),
+         *     and optional rating information.
+         */
+        "TaskOutput-Input": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Output
+             * @description The output of the task. JSON formatted for structured output, plaintext for unstructured output.
+             */
+            output: string;
+            /** @description The source of the output: human or synthetic. */
+            source?: components["schemas"]["DataSource-Input"] | null;
+            /** @description The rating of the output */
+            rating?: components["schemas"]["TaskOutputRating-Input"] | null;
+        };
+        /**
+         * TaskOutput
+         * @description An output for a specific task run.
+         *
+         *     Contains the actual output content, its source (human or synthetic),
+         *     and optional rating information.
+         */
+        "TaskOutput-Output": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Output
+             * @description The output of the task. JSON formatted for structured output, plaintext for unstructured output.
+             */
+            output: string;
+            /** @description The source of the output: human or synthetic. */
+            source?: components["schemas"]["DataSource-Output"] | null;
+            /** @description The rating of the output */
+            rating?: components["schemas"]["TaskOutputRating-Output"] | null;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * TaskOutputRating
+         * @description A rating for a task output, including an overall rating and ratings for each requirement.
+         *
+         *     Supports:
+         *     - five_star: 1-5 star ratings
+         *     - pass_fail: boolean pass/fail (1.0 = pass, 0.0 = fail)
+         *     - pass_fail_critical: tri-state (1.0 = pass, 0.0 = fail, -1.0 = critical fail)
+         */
+        "TaskOutputRating-Input": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /** @default five_star */
+            type: components["schemas"]["TaskOutputRatingType"];
+            /**
+             * Value
+             * @description The rating value. Interpretation depends on rating type:
+             *     - five_star: 1-5 stars
+             *     - pass_fail: 1.0 (pass) or 0.0 (fail)
+             *     - pass_fail_critical: 1.0 (pass), 0.0 (fail), or -1.0 (critical fail)
+             */
+            value?: number | null;
+            /**
+             * Requirement Ratings
+             * @description The ratings of the requirements of the task. The ID can be either a task_requirement_id or a named rating for an eval_output_score name (in format 'named::<name>').
+             * @default {}
+             */
+            requirement_ratings: {
+                [key: string]: components["schemas"]["RequirementRating"];
+            };
+        };
+        /**
+         * TaskOutputRating
+         * @description A rating for a task output, including an overall rating and ratings for each requirement.
+         *
+         *     Supports:
+         *     - five_star: 1-5 star ratings
+         *     - pass_fail: boolean pass/fail (1.0 = pass, 0.0 = fail)
+         *     - pass_fail_critical: tri-state (1.0 = pass, 0.0 = fail, -1.0 = critical fail)
+         */
+        "TaskOutputRating-Output": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /** @default five_star */
+            type: components["schemas"]["TaskOutputRatingType"];
+            /**
+             * Value
+             * @description The rating value. Interpretation depends on rating type:
+             *     - five_star: 1-5 stars
+             *     - pass_fail: 1.0 (pass) or 0.0 (fail)
+             *     - pass_fail_critical: 1.0 (pass), 0.0 (fail), or -1.0 (critical fail)
+             */
+            value?: number | null;
+            /**
+             * Requirement Ratings
+             * @description The ratings of the requirements of the task. The ID can be either a task_requirement_id or a named rating for an eval_output_score name (in format 'named::<name>').
+             * @default {}
+             */
+            requirement_ratings: {
+                [key: string]: components["schemas"]["RequirementRating"];
+            };
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * TaskOutputRatingType
+         * @description Defines the types of rating systems available for task outputs.
+         * @enum {string}
+         */
+        TaskOutputRatingType: "five_star" | "pass_fail" | "pass_fail_critical" | "custom";
+        /**
+         * TaskRequirement
+         * @description Defines a specific requirement that should be met by task outputs.
+         *
+         *     Includes an identifier, name, description, instruction for meeting the requirement,
+         *     priority level, and rating type (five_star, pass_fail, pass_fail_critical, custom).
+         */
+        TaskRequirement: {
+            /** Id */
+            id?: string | null;
+            /**
+             * Name
+             * @description The name of the task requirement.
+             */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /** Instruction */
+            instruction: string;
+            /** @default 2 */
+            priority: components["schemas"]["Priority"];
+            /** @default five_star */
+            type: components["schemas"]["TaskOutputRatingType"];
+        };
+        /**
+         * TaskRun
+         * @description Represents a single execution of a Task.
+         *
+         *     Contains the input used, its source, the output produced, and optional
+         *     repair information if the output needed correction.
+         */
+        "TaskRun-Input": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            parent?: components["schemas"]["KilnBaseModel-Input"] | null;
+            /**
+             * Input
+             * @description The inputs to the task. JSON formatted for structured input, plaintext for unstructured input.
+             */
+            input: string;
+            /** @description The source of the input: human or synthetic. */
+            input_source?: components["schemas"]["DataSource-Input"] | null;
+            /** @description The output of the task run. */
+            output: components["schemas"]["TaskOutput-Input"];
+            /**
+             * Repair Instructions
+             * @description Instructions for fixing the output. Should define what is wrong, and how to fix it. Will be used by models for both generating a fixed output, and evaluating future models.
+             */
+            repair_instructions?: string | null;
+            /** @description An version of the output with issues fixed. This must be a 'fixed' version of the existing output, and not an entirely new output. If you wish to generate an ideal curatorial output for this task unrelated to this output, generate a new TaskOutput with type 'human' instead of using this field. */
+            repaired_output?: components["schemas"]["TaskOutput-Input"] | null;
+            /**
+             * Intermediate Outputs
+             * @description Intermediate outputs from the task run. Keys are the names of the intermediate output steps (cot=chain of thought, etc), values are the output data.
+             */
+            intermediate_outputs?: {
+                [key: string]: string;
+            } | null;
+            /**
+             * Tags
+             * @description Tags for the task run. Tags are used to categorize task runs for filtering and reporting.
+             * @default []
+             */
+            tags: string[];
+            /** @description Usage information for the task run. This includes the number of input tokens, output tokens, and total tokens used. */
+            usage?: components["schemas"]["Usage"] | null;
+            /**
+             * Trace
+             * @description The trace of the task run in OpenAI format. This is the list of messages that were sent to/from the model.
+             */
+            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParam"] | components["schemas"]["ChatCompletionSystemMessageParam"] | components["schemas"]["ChatCompletionUserMessageParam-Input"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper-Input"] | components["schemas"]["ChatCompletionToolMessageParam"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
+        };
+        /**
+         * TaskRun
+         * @description Represents a single execution of a Task.
+         *
+         *     Contains the input used, its source, the output produced, and optional
+         *     repair information if the output needed correction.
+         */
+        "TaskRun-Output": {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Input
+             * @description The inputs to the task. JSON formatted for structured input, plaintext for unstructured input.
+             */
+            input: string;
+            /** @description The source of the input: human or synthetic. */
+            input_source?: components["schemas"]["DataSource-Output"] | null;
+            /** @description The output of the task run. */
+            output: components["schemas"]["TaskOutput-Output"];
+            /**
+             * Repair Instructions
+             * @description Instructions for fixing the output. Should define what is wrong, and how to fix it. Will be used by models for both generating a fixed output, and evaluating future models.
+             */
+            repair_instructions?: string | null;
+            /** @description An version of the output with issues fixed. This must be a 'fixed' version of the existing output, and not an entirely new output. If you wish to generate an ideal curatorial output for this task unrelated to this output, generate a new TaskOutput with type 'human' instead of using this field. */
+            repaired_output?: components["schemas"]["TaskOutput-Output"] | null;
+            /**
+             * Intermediate Outputs
+             * @description Intermediate outputs from the task run. Keys are the names of the intermediate output steps (cot=chain of thought, etc), values are the output data.
+             */
+            intermediate_outputs?: {
+                [key: string]: string;
+            } | null;
+            /**
+             * Tags
+             * @description Tags for the task run. Tags are used to categorize task runs for filtering and reporting.
+             * @default []
+             */
+            tags: string[];
+            /** @description Usage information for the task run. This includes the number of input tokens, output tokens, and total tokens used. */
+            usage?: components["schemas"]["Usage"] | null;
+            /**
+             * Trace
+             * @description The trace of the task run in OpenAI format. This is the list of messages that were sent to/from the model.
+             */
+            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParam"] | components["schemas"]["ChatCompletionSystemMessageParam"] | components["schemas"]["ChatCompletionUserMessageParam-Output"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper-Output"] | components["schemas"]["ChatCompletionToolMessageParam"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /**
+         * TaskRunConfig
+         * @description A Kiln model for persisting a run config in a Kiln Project, nested under a task.
+         *
+         *     Typically used to save a method of running a task for evaluation.
+         *
+         *     A run config includes everything needed to run a task, except the input. Running the same RunConfig with the same input should make identical calls to the model (output may vary as models are non-deterministic).
+         */
+        TaskRunConfig: {
+            /**
+             * V
+             * @default 1
+             */
+            v: number;
+            /** Id */
+            id?: string | null;
+            /** Path */
+            path?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at?: string;
+            /** Created By */
+            created_by?: string;
+            /**
+             * Name
+             * @description The name of the task run config.
+             */
+            name: string;
+            /**
+             * Description
+             * @description The description of the task run config.
+             */
+            description?: string | null;
+            /** @description The run config properties to use for this task run. */
+            run_config_properties: components["schemas"]["RunConfigProperties"];
+            /** @description A prompt to use for run config. */
+            prompt?: components["schemas"]["BasePrompt"] | null;
+            /** Model Type */
+            readonly model_type: string;
+        };
+        /** ToolApiDescription */
+        ToolApiDescription: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+        };
+        /**
+         * ToolServerType
+         * @description Enumeration of supported external tool server types.
+         * @enum {string}
+         */
+        ToolServerType: "remote_mcp" | "local_mcp";
+        /** ToolSetApiDescription */
+        ToolSetApiDescription: {
+            /** Set Name */
+            set_name: string;
+            /** Tools */
+            tools: components["schemas"]["ToolApiDescription"][];
+        };
+        /**
+         * ToolsRunConfig
+         * @description A config describing which tools are available to a task.
+         */
+        ToolsRunConfig: {
+            /**
+             * Tools
+             * @description The IDs of the tools available to the task.
+             */
+            tools: string[];
+        };
+        /** UpdateEvalRequest */
+        UpdateEvalRequest: {
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+        };
+        /** UpdateFavouriteRequest */
+        UpdateFavouriteRequest: {
+            /** Favourite */
+            favourite: boolean;
+        };
+        /**
+         * UpdateFinetuneRequest
+         * @description Request to update a finetune
+         */
+        UpdateFinetuneRequest: {
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+        };
+        /** Usage */
+        Usage: {
+            /**
+             * Input Tokens
+             * @description The number of input tokens used in the task run.
+             */
+            input_tokens?: number | null;
+            /**
+             * Output Tokens
+             * @description The number of output tokens used in the task run.
+             */
+            output_tokens?: number | null;
+            /**
+             * Total Tokens
+             * @description The total number of tokens used in the task run.
+             */
+            total_tokens?: number | null;
+            /**
+             * Cost
+             * @description The cost of the task run in US dollars, saved at runtime (prices can change over time).
+             */
+            cost?: number | null;
+        };
+        /** ValidationError */
+        ValidationError: {
+            /** Location */
+            loc: (string | number)[];
+            /** Message */
+            msg: string;
+            /** Error Type */
+            type: string;
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
-export type $defs = Record<string, never>
+export type $defs = Record<string, never>;
 export interface operations {
-  ping_ping_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-    }
-  }
-  create_project_api_project_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["Project-Input"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Project-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_project_api_project__project_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": Record<string, never>
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Project-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_projects_api_projects_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Project-Output"][]
-        }
-      }
-    }
-  }
-  get_project_api_projects__project_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Project-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_project_api_projects__project_id__delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": Record<string, never>
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  import_project_api_import_project_post: {
-    parameters: {
-      query: {
-        project_path: string
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Project-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_task_api_projects__project_id__task_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": Record<string, never>
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Task"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_task_api_projects__project_id__task__task_id__delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_task_api_projects__project_id__task__task_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": Record<string, never>
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Task"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_tasks_api_projects__project_id__tasks_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Task"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_task_api_projects__project_id__tasks__task_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Task"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_rating_options_api_projects__project_id__tasks__task_id__rating_options_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["RatingOptionResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_prompt_api_projects__project_id__task__task_id__prompt_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PromptCreateRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Prompt"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_prompts_api_projects__project_id__task__task_id__prompts_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["PromptResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_prompt_api_projects__project_id__tasks__task_id__prompts__prompt_id__delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        prompt_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_prompt_api_projects__project_id__tasks__task_id__prompts__prompt_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        prompt_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PromptUpdateRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Prompt"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_run_api_projects__project_id__tasks__task_id__runs__run_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        run_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRun-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_run_api_projects__project_id__tasks__task_id__runs__run_id__delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        run_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_run_api_projects__project_id__tasks__task_id__runs__run_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        run_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": Record<string, never>
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRun-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_runs_api_projects__project_id__tasks__task_id__runs_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRun-Output"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_runs_summary_api_projects__project_id__tasks__task_id__runs_summaries_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["RunSummary"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_runs_api_projects__project_id__tasks__task_id__runs_delete_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": string[]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  run_task_api_projects__project_id__tasks__task_id__run_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["RunTaskRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRun-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["Body_edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "multipart/form-data": components["schemas"]["Body_bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["BulkUploadResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_providers_models_api_providers_models_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["ProviderModels"]
-        }
-      }
-    }
-  }
-  get_available_models_api_available_models_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["AvailableModels"][]
-        }
-      }
-    }
-  }
-  connect_ollama_api_api_provider_ollama_connect_get: {
-    parameters: {
-      query?: {
-        custom_ollama_url?: string | null
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["OllamaConnection"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  connect_docker_model_runner_api_api_provider_docker_model_runner_connect_get: {
-    parameters: {
-      query?: {
-        docker_model_runner_custom_url?: string | null
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["DockerModelRunnerConnection"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  save_openai_compatible_providers_api_provider_openai_compatible_post: {
-    parameters: {
-      query: {
-        name: string
-        base_url: string
-        api_key: string
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_openai_compatible_providers_api_provider_openai_compatible_delete: {
-    parameters: {
-      query: {
-        name: string
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  connect_api_key_api_provider_connect_api_key_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": Record<string, never>
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  disconnect_api_key_api_provider_disconnect_api_key_post: {
-    parameters: {
-      query: {
-        provider_id: string
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  generate_prompt_api_projects__project_id__task__task_id__gen_prompt__prompt_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        prompt_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["PromptApiResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  run_repair_api_projects__project_id__tasks__task_id__runs__run_id__run_repair_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        run_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["RepairTaskApiInput"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRun-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  post_repair_run_api_projects__project_id__tasks__task_id__runs__run_id__repair_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        run_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["RepairRunPost"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRun-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  read_settings_api_settings_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": Record<string, never>
-        }
-      }
-    }
-  }
-  update_settings_api_settings_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": {
-          [key: string]: number | string | boolean | unknown[] | null
-        }
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  read_setting_item_api_settings__item_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        item_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  open_logs_api_open_logs_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-    }
-  }
-  generate_categories_api_projects__project_id__tasks__task_id__generate_categories_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["DataGenCategoriesApiInput"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRun-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  generate_samples_api_projects__project_id__tasks__task_id__generate_inputs_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["DataGenSampleApiInput"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRun-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  save_sample_api_projects__project_id__tasks__task_id__save_sample_post: {
-    parameters: {
-      query?: {
-        session_id?: string | null
-      }
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["DataGenSaveSamplesApiInput"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRun-Output"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  dataset_splits_api_projects__project_id__tasks__task_id__dataset_splits_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["DatasetSplit"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_dataset_split_api_projects__project_id__tasks__task_id__dataset_splits_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateDatasetSplitRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["DatasetSplit"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  finetunes_api_projects__project_id__tasks__task_id__finetunes_get: {
-    parameters: {
-      query?: {
-        update_status?: boolean
-      }
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Finetune"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_finetune_api_projects__project_id__tasks__task_id__finetunes_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateFinetuneRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Finetune"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  finetune_api_projects__project_id__tasks__task_id__finetunes__finetune_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        finetune_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["FinetuneWithStatus"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_finetune_api_projects__project_id__tasks__task_id__finetunes__finetune_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        finetune_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateFinetuneRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Finetune"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  finetune_providers_api_finetune_providers_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["FinetuneProvider"][]
-        }
-      }
-    }
-  }
-  finetune_hyperparameters_api_finetune_hyperparameters__provider_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        provider_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["FineTuneParameter"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  finetune_dataset_info_api_projects__project_id__tasks__task_id__finetune_dataset_info_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["FinetuneDatasetInfo"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  download_dataset_jsonl_api_download_dataset_jsonl_get: {
-    parameters: {
-      query: {
-        project_id: string
-        task_id: string
-        dataset_id: string
-        split_name: string
-        format_type: string
-        data_strategy: string
-        system_message_generator?: string | null
-        custom_system_message?: string | null
-        custom_thinking_instructions?: string | null
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_evaluator_api_projects__project_id__tasks__task_id__create_evaluator_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateEvaluatorRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Eval"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_task_run_configs_api_projects__project_id__tasks__task_id__task_run_configs_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRunConfig"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_eval_api_projects__project_id__tasks__task_id__eval__eval_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Eval"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_eval_api_projects__project_id__tasks__task_id__eval__eval_id__delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_eval_api_projects__project_id__tasks__task_id__eval__eval_id__patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateEvalRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Eval"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  update_eval_favourite_api_projects__project_id__tasks__task_id__eval__eval_id__fav_patch: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateFavouriteRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Eval"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_evals_api_projects__project_id__tasks__task_id__evals_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Eval"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_eval_configs_api_projects__project_id__tasks__task_id__eval__eval_id__eval_configs_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EvalConfig"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-        eval_config_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EvalConfig"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_task_run_config_api_projects__project_id__tasks__task_id__task_run_config_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateTaskRunConfigRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["TaskRunConfig"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  create_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__create_eval_config_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateEvalConfigRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EvalConfig"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  run_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__run_task_run_eval_get: {
-    parameters: {
-      query?: {
-        run_config_ids?: string[]
-        all_run_configs?: boolean
-      }
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-        eval_config_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  set_default_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__set_current_eval_config__eval_config_id__post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-        eval_config_id: string | null
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Eval"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  set_default_run_config_api_projects__project_id__tasks__task_id__eval__eval_id__set_current_run_config__run_config_id__post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-        run_config_id: string | null
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["Eval"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  run_eval_config_eval_api_projects__project_id__tasks__task_id__eval__eval_id__run_eval_config_eval_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_eval_run_results_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__run_config__run_config_id__results_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-        eval_config_id: string
-        run_config_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EvalRunResult"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_eval_progress_api_projects__project_id__tasks__task_id__eval__eval_id__progress_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EvalProgress"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_eval_config_score_summary_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__score_summary_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-        eval_config_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EvalResultSummary"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_eval_configs_score_summary_api_projects__project_id__tasks__task_id__eval__eval_id__eval_configs_score_summary_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        eval_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["EvalConfigCompareSummary"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_run_config_eval_scores_api_projects__project_id__tasks__task_id__run_config__run_config_id__eval_scores_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        task_id: string
-        run_config_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["RunConfigEvalScoresSummary"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  select_kiln_file_api_select_kiln_file_get: {
-    parameters: {
-      query?: {
-        title?: string
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["KilnFileResponse"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_available_tools_api_projects__project_id__available_tools_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["ToolSetApiDescription"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_available_tool_servers_api_projects__project_id__available_tool_servers_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["KilnToolServerDescription"][]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_tool_server_api_projects__project_id__tool_servers__tool_server_id__get: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        tool_server_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["ExternalToolServerApiDescription"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  delete_tool_server_api_projects__project_id__tool_servers__tool_server_id__delete: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-        tool_server_id: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": unknown
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  connect_remote_mcp_api_projects__project_id__connect_remote_mcp_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ExternalToolServerCreationRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["ExternalToolServer"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  connect_local_mcp_api_projects__project_id__connect_local_mcp_post: {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        project_id: string
-      }
-      cookie?: never
-    }
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["LocalToolServerCreationRequest"]
-      }
-    }
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["ExternalToolServer"]
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
-  get_demo_tools_api_demo_tools_get: {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": boolean
-        }
-      }
-    }
-  }
-  set_demo_tools_api_demo_tools_post: {
-    parameters: {
-      query: {
-        enable_demo_tools: boolean
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": boolean
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"]
-        }
-      }
-    }
-  }
+    ping_ping_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    create_project_api_project_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Project-Input"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_project_api_project__project_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_projects_api_projects_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project-Output"][];
+                };
+            };
+        };
+    };
+    get_project_api_projects__project_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_project_api_projects__project_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_project_api_import_project_post: {
+        parameters: {
+            query: {
+                project_path: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_task_api_projects__project_id__task_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Task"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_task_api_projects__project_id__task__task_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_task_api_projects__project_id__task__task_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Task"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_tasks_api_projects__project_id__tasks_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Task"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_task_api_projects__project_id__tasks__task_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Task"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_rating_options_api_projects__project_id__tasks__task_id__rating_options_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RatingOptionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_prompt_api_projects__project_id__task__task_id__prompt_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PromptCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Prompt"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_prompts_api_projects__project_id__task__task_id__prompts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PromptResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_prompt_api_projects__project_id__tasks__task_id__prompts__prompt_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                prompt_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_prompt_api_projects__project_id__tasks__task_id__prompts__prompt_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                prompt_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PromptUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Prompt"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_run_api_projects__project_id__tasks__task_id__runs__run_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRun-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_run_api_projects__project_id__tasks__task_id__runs__run_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_run_api_projects__project_id__tasks__task_id__runs__run_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRun-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_runs_api_projects__project_id__tasks__task_id__runs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRun-Output"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_runs_summary_api_projects__project_id__tasks__task_id__runs_summaries_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunSummary"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_runs_api_projects__project_id__tasks__task_id__runs_delete_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": string[];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_task_api_projects__project_id__tasks__task_id__run_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RunTaskRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRun-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["Body_edit_tags_api_projects__project_id__tasks__task_id__runs_edit_tags_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_bulk_upload_api_projects__project_id__tasks__task_id__runs_bulk_upload_post"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BulkUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_providers_models_api_providers_models_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderModels"];
+                };
+            };
+        };
+    };
+    get_available_models_api_available_models_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AvailableModels"][];
+                };
+            };
+        };
+    };
+    connect_ollama_api_api_provider_ollama_connect_get: {
+        parameters: {
+            query?: {
+                custom_ollama_url?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OllamaConnection"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    connect_docker_model_runner_api_api_provider_docker_model_runner_connect_get: {
+        parameters: {
+            query?: {
+                docker_model_runner_custom_url?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DockerModelRunnerConnection"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    save_openai_compatible_providers_api_provider_openai_compatible_post: {
+        parameters: {
+            query: {
+                name: string;
+                base_url: string;
+                api_key: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_openai_compatible_providers_api_provider_openai_compatible_delete: {
+        parameters: {
+            query: {
+                name: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    connect_api_key_api_provider_connect_api_key_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    disconnect_api_key_api_provider_disconnect_api_key_post: {
+        parameters: {
+            query: {
+                provider_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_prompt_api_projects__project_id__task__task_id__gen_prompt__prompt_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                prompt_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PromptApiResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_repair_api_projects__project_id__tasks__task_id__runs__run_id__run_repair_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RepairTaskApiInput"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRun-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    post_repair_run_api_projects__project_id__tasks__task_id__runs__run_id__repair_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RepairRunPost"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRun-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_settings_api_settings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
+    update_settings_api_settings_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    [key: string]: number | string | boolean | unknown[] | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_setting_item_api_settings__item_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                item_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    open_logs_api_open_logs_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    generate_categories_api_projects__project_id__tasks__task_id__generate_categories_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DataGenCategoriesApiInput"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRun-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_samples_api_projects__project_id__tasks__task_id__generate_inputs_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DataGenSampleApiInput"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRun-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    save_sample_api_projects__project_id__tasks__task_id__save_sample_post: {
+        parameters: {
+            query?: {
+                session_id?: string | null;
+            };
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DataGenSaveSamplesApiInput"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRun-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    dataset_splits_api_projects__project_id__tasks__task_id__dataset_splits_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasetSplit"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_dataset_split_api_projects__project_id__tasks__task_id__dataset_splits_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDatasetSplitRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DatasetSplit"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    finetunes_api_projects__project_id__tasks__task_id__finetunes_get: {
+        parameters: {
+            query?: {
+                update_status?: boolean;
+            };
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Finetune"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_finetune_api_projects__project_id__tasks__task_id__finetunes_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateFinetuneRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Finetune"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    finetune_api_projects__project_id__tasks__task_id__finetunes__finetune_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                finetune_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FinetuneWithStatus"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_finetune_api_projects__project_id__tasks__task_id__finetunes__finetune_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                finetune_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateFinetuneRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Finetune"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    finetune_providers_api_finetune_providers_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FinetuneProvider"][];
+                };
+            };
+        };
+    };
+    finetune_hyperparameters_api_finetune_hyperparameters__provider_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FineTuneParameter"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    finetune_dataset_info_api_projects__project_id__tasks__task_id__finetune_dataset_info_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FinetuneDatasetInfo"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_dataset_jsonl_api_download_dataset_jsonl_get: {
+        parameters: {
+            query: {
+                project_id: string;
+                task_id: string;
+                dataset_id: string;
+                split_name: string;
+                format_type: string;
+                data_strategy: string;
+                system_message_generator?: string | null;
+                custom_system_message?: string | null;
+                custom_thinking_instructions?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_evaluator_api_projects__project_id__tasks__task_id__create_evaluator_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateEvaluatorRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Eval"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_task_run_configs_api_projects__project_id__tasks__task_id__task_run_configs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRunConfig"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_eval_api_projects__project_id__tasks__task_id__eval__eval_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Eval"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_eval_api_projects__project_id__tasks__task_id__eval__eval_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_eval_api_projects__project_id__tasks__task_id__eval__eval_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateEvalRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Eval"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_eval_favourite_api_projects__project_id__tasks__task_id__eval__eval_id__fav_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateFavouriteRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Eval"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_evals_api_projects__project_id__tasks__task_id__evals_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Eval"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_eval_configs_api_projects__project_id__tasks__task_id__eval__eval_id__eval_configs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalConfig"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+                eval_config_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalConfig"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_task_run_config_api_projects__project_id__tasks__task_id__task_run_config_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTaskRunConfigRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRunConfig"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__create_eval_config_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateEvalConfigRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalConfig"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__run_task_run_eval_get: {
+        parameters: {
+            query?: {
+                run_config_ids?: string[];
+                all_run_configs?: boolean;
+            };
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+                eval_config_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_default_eval_config_api_projects__project_id__tasks__task_id__eval__eval_id__set_current_eval_config__eval_config_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+                eval_config_id: string | null;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Eval"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_default_run_config_api_projects__project_id__tasks__task_id__eval__eval_id__set_current_run_config__run_config_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+                run_config_id: string | null;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Eval"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_eval_config_eval_api_projects__project_id__tasks__task_id__eval__eval_id__run_eval_config_eval_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_eval_run_results_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__run_config__run_config_id__results_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+                eval_config_id: string;
+                run_config_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalRunResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_eval_progress_api_projects__project_id__tasks__task_id__eval__eval_id__progress_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalProgress"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_eval_config_score_summary_api_projects__project_id__tasks__task_id__eval__eval_id__eval_config__eval_config_id__score_summary_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+                eval_config_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalResultSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_eval_configs_score_summary_api_projects__project_id__tasks__task_id__eval__eval_id__eval_configs_score_summary_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                eval_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EvalConfigCompareSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_run_config_eval_scores_api_projects__project_id__tasks__task_id__run_config__run_config_id__eval_scores_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                task_id: string;
+                run_config_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunConfigEvalScoresSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    select_kiln_file_api_select_kiln_file_get: {
+        parameters: {
+            query?: {
+                title?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KilnFileResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_available_tools_api_projects__project_id__available_tools_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ToolSetApiDescription"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_available_tool_servers_api_projects__project_id__available_tool_servers_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KilnToolServerDescription"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_tool_server_api_projects__project_id__tool_servers__tool_server_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                tool_server_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExternalToolServerApiDescription"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_tool_server_api_projects__project_id__tool_servers__tool_server_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                tool_server_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    connect_remote_mcp_api_projects__project_id__connect_remote_mcp_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExternalToolServerCreationRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExternalToolServer"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    connect_local_mcp_api_projects__project_id__connect_local_mcp_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LocalToolServerCreationRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExternalToolServer"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_demo_tools_api_demo_tools_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": boolean;
+                };
+            };
+        };
+    };
+    set_demo_tools_api_demo_tools_post: {
+        parameters: {
+            query: {
+                enable_demo_tools: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": boolean;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
 }

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2219,6 +2219,8 @@ export interface components {
             properties: Record<string, never>;
             /** Available Tools */
             available_tools: components["schemas"]["ExternalToolApiDescription"][];
+            /** Missing Secrets */
+            missing_secrets: string[];
         };
         /** ExternalToolServerCreationRequest */
         ExternalToolServerCreationRequest: {

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1309,8 +1309,12 @@ export interface components {
         };
         /**
          * ChatCompletionAssistantMessageParamWrapper
-         * @description Almost exact copy of ChatCompletionAssistantMessageParam, but with List[T] instead of Iterable[T] for tool_calls.
+         * @description Almost exact copy of ChatCompletionAssistantMessageParam, but two changes.
+         *
+         *     First change: List[T] instead of Iterable[T] for tool_calls. Addresses pydantic issue.
          *     https://github.com/pydantic/pydantic/issues/9541
+         *
+         *     Second change: Add reasoning_content to the message. A LiteLLM property for reasoning data.
          */
         "ChatCompletionAssistantMessageParamWrapper-Input": {
             /**
@@ -1321,6 +1325,8 @@ export interface components {
             audio?: components["schemas"]["Audio"] | null;
             /** Content */
             content?: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartRefusalParam"])[] | null;
+            /** Reasoning Content */
+            reasoning_content?: string | null;
             function_call?: components["schemas"]["FunctionCall"] | null;
             /** Name */
             name?: string;
@@ -1331,8 +1337,12 @@ export interface components {
         };
         /**
          * ChatCompletionAssistantMessageParamWrapper
-         * @description Almost exact copy of ChatCompletionAssistantMessageParam, but with List[T] instead of Iterable[T] for tool_calls.
+         * @description Almost exact copy of ChatCompletionAssistantMessageParam, but two changes.
+         *
+         *     First change: List[T] instead of Iterable[T] for tool_calls. Addresses pydantic issue.
          *     https://github.com/pydantic/pydantic/issues/9541
+         *
+         *     Second change: Add reasoning_content to the message. A LiteLLM property for reasoning data.
          */
         "ChatCompletionAssistantMessageParamWrapper-Output": {
             /**
@@ -1343,6 +1353,8 @@ export interface components {
             audio?: components["schemas"]["Audio"] | null;
             /** Content */
             content?: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartRefusalParam"])[] | null;
+            /** Reasoning Content */
+            reasoning_content?: string | null;
             function_call?: components["schemas"]["FunctionCall"] | null;
             /** Name */
             name?: string;

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2593,6 +2593,8 @@ export interface components {
             env_vars?: {
                 [key: string]: string;
             };
+            /** Secret Env Var Keys */
+            secret_env_var_keys?: string[];
         };
         /** MeanUsage */
         MeanUsage: {

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2580,6 +2580,8 @@ export interface components {
             type: components["schemas"]["ToolServerType"];
             /** Description */
             description: string | null;
+            /** Missing Secrets */
+            missing_secrets: string[];
         };
         /** LocalToolServerCreationRequest */
         LocalToolServerCreationRequest: {

--- a/app/web_ui/src/lib/tools.ts
+++ b/app/web_ui/src/lib/tools.ts
@@ -1,0 +1,6 @@
+export type McpServerKeyValuePair = {
+  key: string
+  value: string
+  placeholder: string | null
+  is_secret: boolean
+}

--- a/app/web_ui/src/lib/ui/property_list.svelte
+++ b/app/web_ui/src/lib/ui/property_list.svelte
@@ -1,13 +1,6 @@
 <script lang="ts">
   import InfoTooltip from "./info_tooltip.svelte"
-
-  type UiProperty = {
-    name: string
-    value: string | number
-    tooltip?: string
-    link?: string
-    error?: boolean
-  }
+  import type { UiProperty } from "./property_list"
 
   export let properties: UiProperty[]
   export let title: string

--- a/app/web_ui/src/lib/ui/property_list.svelte
+++ b/app/web_ui/src/lib/ui/property_list.svelte
@@ -22,11 +22,13 @@
         <InfoTooltip tooltip_text={property.tooltip} />
       {/if}
     </div>
-    <div class="flex items-center text-gray-500 overflow-x-hidden">
+    <div
+      class="flex items-center overflow-x-hidden {property.error
+        ? 'text-error'
+        : 'text-gray-500'}"
+    >
       {#if property.link}
         <a href={property.link} class="link">{property.value}</a>
-      {:else if property.error}
-        <span class="text-error">{property.value}</span>
       {:else}
         {property.value}
       {/if}

--- a/app/web_ui/src/lib/ui/property_list.svelte
+++ b/app/web_ui/src/lib/ui/property_list.svelte
@@ -6,6 +6,7 @@
     value: string | number
     tooltip?: string
     link?: string
+    error?: boolean
   }
 
   export let properties: UiProperty[]
@@ -24,6 +25,8 @@
     <div class="flex items-center text-gray-500 overflow-x-hidden">
       {#if property.link}
         <a href={property.link} class="link">{property.value}</a>
+      {:else if property.error}
+        <span class="text-error">{property.value}</span>
       {:else}
         {property.value}
       {/if}

--- a/app/web_ui/src/lib/ui/property_list.ts
+++ b/app/web_ui/src/lib/ui/property_list.ts
@@ -1,0 +1,7 @@
+export type UiProperty = {
+  name: string
+  value: string | number
+  tooltip?: string
+  link?: string
+  error?: boolean
+}

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
@@ -21,6 +21,7 @@
   import { progress_ui_state } from "$lib/stores/progress_ui_store"
   import PropertyList from "$lib/ui/property_list.svelte"
   import EditDialog from "$lib/ui/edit_dialog.svelte"
+  import type { UiProperty } from "$lib/ui/property_list"
 
   $: project_id = $page.params.project_id
   $: task_id = $page.params.task_id
@@ -98,13 +99,6 @@
     } finally {
       eval_progress_loading = false
     }
-  }
-
-  type UiProperty = {
-    name: string
-    value: string
-    tooltip?: string
-    link?: string
   }
 
   function get_eval_properties(

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -36,6 +36,7 @@
   import AddRunMethod from "./add_run_method.svelte"
   import posthog from "posthog-js"
   import { prompt_link } from "$lib/utils/link_builder"
+  import type { UiProperty } from "$lib/ui/property_list"
 
   $: project_id = $page.params.project_id
   $: task_id = $page.params.task_id
@@ -229,11 +230,6 @@
     if (selected_id) {
       get_score_summary()
     }
-  }
-
-  type UiProperty = {
-    name: string
-    value: string
   }
 
   // A dropdown name for the eval config that is human readable and helpful

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
@@ -24,6 +24,7 @@
   import { eval_config_to_ui_name } from "$lib/utils/formatters"
   import type { TaskOutputRatingType } from "$lib/types"
   import posthog from "posthog-js"
+  import type { UiProperty } from "$lib/ui/property_list"
 
   let score_legend_dialog: Dialog | null = null
 
@@ -273,11 +274,6 @@
     } catch (error) {
       score_summary_error = createKilnError(error)
     }
-  }
-
-  type UiProperty = {
-    name: string
-    value: string
   }
 
   function get_eval_properties(

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/+page.svelte
@@ -8,6 +8,7 @@
   import type { KilnToolServerDescription } from "$lib/types"
   import { toolServerTypeToString } from "$lib/utils/formatters"
   import EmptyTools from "./empty_tools.svelte"
+  import Warning from "$lib/ui/warning.svelte"
 
   $: project_id = $page.params.project_id
   $: is_empty = !tools || tools.length == 0
@@ -125,6 +126,7 @@
               <th>Server Name</th>
               <th>Type</th>
               <th>Description</th>
+              <th>Status</th>
             </tr>
           </thead>
           <tbody>
@@ -140,6 +142,17 @@
                 <td class="font-medium">{tool.name}</td>
                 <td class="text-sm">{toolServerTypeToString(tool.type)}</td>
                 <td class="text-sm">{tool.description || "N/A"}</td>
+                <td class="text-sm">
+                  {#if tool.missing_secrets && tool.missing_secrets.length > 0}
+                    <Warning
+                      warning_message="Information Incomplete"
+                      warning_color="warning"
+                      tight={true}
+                    />
+                  {:else}
+                    <span class="text-success">✓ Ready</span>
+                  {/if}
+                </td>
               </tr>
             {/each}
             {#if demo_tools_enabled}
@@ -154,6 +167,9 @@
                   >
                     Disable
                   </button>
+                </td>
+                <td class="text-sm">
+                  <span class="text-success">✓ Ready</span>
                 </td>
               </tr>
             {/if}

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/+page.svelte
@@ -145,12 +145,15 @@
                 <td class="text-sm">
                   {#if tool.missing_secrets && tool.missing_secrets.length > 0}
                     <Warning
-                      warning_message="Information Incomplete"
+                      warning_message="Action Required"
                       warning_color="warning"
-                      tight={true}
                     />
                   {:else}
-                    <span class="text-success">✓ Ready</span>
+                    <Warning
+                      warning_message="Ready"
+                      warning_color="success"
+                      warning_icon="check"
+                    />
                   {/if}
                 </td>
               </tr>

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/+page.svelte
@@ -172,7 +172,11 @@
                   </button>
                 </td>
                 <td class="text-sm">
-                  <span class="text-success">✓ Ready</span>
+                  <Warning
+                    warning_message="Ready"
+                    warning_color="success"
+                    warning_icon="check"
+                  />
                 </td>
               </tr>
             {/if}

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/+page.svelte
@@ -4,31 +4,25 @@
   import { page } from "$app/stores"
   import SettingsSection from "$lib/ui/settings_section.svelte"
   import { client } from "$lib/api_client"
+  import type { McpServerKeyValuePair } from "$lib/tools"
 
   $: project_id = $page.params.project_id
 
-  interface KeyValuePair {
-    key: string
-    value: string
-    placeholder: string | null
-    is_secret: boolean
-  }
-
-  interface BaseMcpServer {
+  type BaseMcpServer = {
     name: string
     subtitle: string
     description: string
   }
 
-  interface RemoteMcpServer extends BaseMcpServer {
+  type RemoteMcpServer = BaseMcpServer & {
     server_url: string
-    headers: KeyValuePair[]
+    headers: McpServerKeyValuePair[]
   }
 
-  interface LocalMcpServer extends BaseMcpServer {
+  type LocalMcpServer = BaseMcpServer & {
     command: string
     args: string[]
-    env_vars: KeyValuePair[]
+    env_vars: McpServerKeyValuePair[]
     installation_instruction: string
   }
 

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/+page.svelte
@@ -7,21 +7,28 @@
 
   $: project_id = $page.params.project_id
 
-  interface RemoteMcpServer {
-    name: string
-    subtitle: string
-    description: string
-    server_url: string
-    headers: { key: string; value: string; placeholder: string | null }[]
+  interface KeyValuePair {
+    key: string
+    value: string
+    placeholder: string | null
+    is_secret: boolean
   }
 
-  interface LocalMcpServer {
+  interface BaseMcpServer {
     name: string
     subtitle: string
     description: string
+  }
+
+  interface RemoteMcpServer extends BaseMcpServer {
+    server_url: string
+    headers: KeyValuePair[]
+  }
+
+  interface LocalMcpServer extends BaseMcpServer {
     command: string
     args: string[]
-    env_vars: { key: string; value: string; placeholder: string | null }[]
+    env_vars: KeyValuePair[]
     installation_instruction: string
   }
 
@@ -61,6 +68,7 @@
           key: "Authorization",
           value: "Bearer REPLACE_WITH_GITHUB_PERSONAL_ACCESS_TOKEN",
           placeholder: "Bearer REPLACE_WITH_GITHUB_PERSONAL_ACCESS_TOKEN",
+          is_secret: true,
         },
       ],
     },
@@ -74,11 +82,13 @@
           key: "Authorization",
           value: "apikey REPLACE_WITH_TWELVE_DATA_API_KEY",
           placeholder: "apikey REPLACE_WITH_TWELVE_DATA_API_KEY",
+          is_secret: true,
         },
         {
           key: "X-OpenAPI-Key",
           value: "",
           placeholder: "REPLACE_WITH_YOUR_OPENAI_API_KEY",
+          is_secret: true,
         },
       ],
     },
@@ -96,6 +106,7 @@
           key: "FIRECRAWL_API_KEY",
           value: "",
           placeholder: "FIRECRAWL_API_KEY",
+          is_secret: true,
         },
       ],
       installation_instruction:

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/+page.svelte
@@ -9,20 +9,13 @@
   import { goto } from "$app/navigation"
   import { onMount } from "svelte"
   import Warning from "$lib/ui/warning.svelte"
-
-  // Environment Variables as array of key/value pairs
-  interface KeyValuePair {
-    key: string
-    value: string
-    placeholder: string | null
-    is_secret: boolean
-  }
+  import type { McpServerKeyValuePair } from "$lib/tools"
 
   // Form fields
   let name = ""
   let command = ""
   let args = ""
-  let env_vars: KeyValuePair[] = []
+  let env_vars: McpServerKeyValuePair[] = []
   let description = ""
   let installation_instruction = ""
   // Form state
@@ -64,8 +57,8 @@
 
     for (const envVar of env_vars) {
       if (envVar.key.trim() && envVar.value.trim()) {
-        const key = envVar.key.trim()
-        envVarsObj[key] = envVar.value.trim()
+        const key = envVar.key
+        envVarsObj[key] = envVar.value
 
         if (envVar.is_secret) {
           secretEnvVarKeys.push(key)
@@ -95,9 +88,9 @@
             },
           },
           body: {
-            name: name.trim(),
-            description: description.trim() || null,
-            command: command.trim(),
+            name: name,
+            description: description || null,
+            command: command,
             args: args.trim() ? args.trim().split(/\s+/) : [], // Split into argv list; empty -> []
             env_vars: envVarsData.envVarsObj,
             secret_env_var_keys: envVarsData.secret_env_var_keys,
@@ -225,16 +218,16 @@
               bind:value={env_vars[item_index].value}
             />
           </div>
-          <div class="flex-1 max-w-[100px]">
+          <div class="flex-1 max-w-[140px]">
             <FormElement
               inputType="select"
               label="Secret"
               id="secret_{item_index}"
-              info_description="If this environment variable is a secret such as an API key, select 'Yes' to prevent it from being synced. Kiln will store the secret in your project's settings."
+              info_description="If this environment variable is a secret such as an API key, select 'Secret' to prevent it from being synced. Kiln will store the secret in your project's settings."
               light_label={true}
               select_options={[
-                [false, "No"],
-                [true, "Yes"],
+                [false, "No Secret"],
+                [true, "Secret"],
               ]}
               bind:value={env_vars[item_index].is_secret}
             />

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/+page.svelte
@@ -11,7 +11,7 @@
   import Warning from "$lib/ui/warning.svelte"
 
   // Environment Variables as array of key/value pairs
-  interface EnvVarPair {
+  interface KeyValuePair {
     key: string
     value: string
     placeholder: string | null
@@ -22,7 +22,7 @@
   let name = ""
   let command = ""
   let args = ""
-  let env_vars: EnvVarPair[] = []
+  let env_vars: KeyValuePair[] = []
   let description = ""
   let installation_instruction = ""
   // Form state
@@ -138,7 +138,7 @@
       />
     </div>
   {/if}
-  <div class="max-w-2xl">
+  <div class="max-w-4xl">
     <FormContainer
       submit_label="Connect"
       on:submit={connect_local_mcp}
@@ -225,13 +225,17 @@
               bind:value={env_vars[item_index].value}
             />
           </div>
-          <div class="flex-1 max-w-[20px]">
+          <div class="flex-1 max-w-[100px]">
             <FormElement
-              inputType="checkbox"
-              label="Is Secret?"
+              inputType="select"
+              label="Secret"
               id="secret_{item_index}"
-              info_description="If this header is a secret such as an API key, check this box to prevent it from being synced. Kiln will store the secret in your project's settings."
+              info_description="If this environment variable is a secret such as an API key, select 'Yes' to prevent it from being synced. Kiln will store the secret in your project's settings."
               light_label={true}
+              select_options={[
+                [false, "No"],
+                [true, "Yes"],
+              ]}
               bind:value={env_vars[item_index].is_secret}
             />
           </div>

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/remote_mcp/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/remote_mcp/+page.svelte
@@ -8,21 +8,14 @@
   import { goto } from "$app/navigation"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
   import { onMount } from "svelte"
+  import type { McpServerKeyValuePair } from "$lib/tools"
 
   // Form fields
   let name = ""
   let server_url = ""
   let description = ""
 
-  // Headers as array of key/value pairs
-  interface KeyValuePair {
-    key: string
-    value: string
-    placeholder: string | null
-    is_secret: boolean
-  }
-
-  let headers: KeyValuePair[] = []
+  let headers: McpServerKeyValuePair[] = []
 
   // Form state
   let error: KilnError | null = null
@@ -56,8 +49,8 @@
 
     for (const header of headers) {
       if (header.key.trim() && header.value.trim()) {
-        const key = header.key.trim()
-        headersObj[key] = header.value.trim()
+        const key = header.key
+        headersObj[key] = header.value
 
         if (header.is_secret) {
           secretHeaderKeys.push(key)
@@ -194,16 +187,16 @@
               bind:value={headers[item_index].value}
             />
           </div>
-          <div class="flex-1 max-w-[100px]">
+          <div class="flex-1 max-w-[140px]">
             <FormElement
               inputType="select"
               label="Secret"
               id="secret_{item_index}"
-              info_description="If this header is a secret such as an API key, select 'Yes' to prevent it from being synced. Kiln will store the secret in your project's settings."
+              info_description="If this header is a secret such as an API key, select 'Secret' to prevent it from being synced. Kiln will store the secret in your project's settings."
               light_label={true}
               select_options={[
-                [false, "No"],
-                [true, "Yes"],
+                [false, "No Secret"],
+                [true, "Secret"],
               ]}
               bind:value={headers[item_index].is_secret}
             />

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/remote_mcp/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/remote_mcp/+page.svelte
@@ -15,14 +15,14 @@
   let description = ""
 
   // Headers as array of key/value pairs
-  interface HeaderPair {
+  interface KeyValuePair {
     key: string
     value: string
     placeholder: string | null
     is_secret: boolean
   }
 
-  let headers: HeaderPair[] = []
+  let headers: KeyValuePair[] = []
 
   // Form state
   let error: KilnError | null = null
@@ -119,7 +119,7 @@
   subtitle="Connect to a remote Model Context Protocol (MCP) server to add external
         tools to your project."
 >
-  <div class="max-w-2xl">
+  <div class="max-w-4xl">
     <FormContainer
       submit_label="Connect"
       on:submit={connect_remote_mcp}
@@ -169,6 +169,7 @@
         empty_content={{
           key: "",
           value: "",
+          is_secret: false,
         }}
         let:item_index
       >
@@ -193,13 +194,17 @@
               bind:value={headers[item_index].value}
             />
           </div>
-          <div class="flex-1 max-w-[20px]">
+          <div class="flex-1 max-w-[100px]">
             <FormElement
-              inputType="checkbox"
-              label="Is Secret?"
+              inputType="select"
+              label="Secret"
               id="secret_{item_index}"
-              info_description="If this header is a secret such as an API key, check this box to prevent it from being synced. Kiln will store the secret in your project's settings."
+              info_description="If this header is a secret such as an API key, select 'Yes' to prevent it from being synced. Kiln will store the secret in your project's settings."
               light_label={true}
+              select_options={[
+                [false, "No"],
+                [true, "Yes"],
+              ]}
               bind:value={headers[item_index].is_secret}
             />
           </div>

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
@@ -150,7 +150,31 @@
       if (!(key in headers)) {
         properties.push({
           name: key,
-          value: "****",
+          value: "●●●●●●",
+        })
+      }
+    })
+
+    return properties
+  }
+
+  function getEnvVarProperties(tool: ExternalToolServerApiDescription) {
+    const envVars = tool.properties["env_vars"] || {}
+    const secretEnvVarKeys = (tool.properties["secret_env_var_keys"] ||
+      []) as string[]
+
+    const properties = Object.entries(envVars).map(([key, value]) => ({
+      name: key,
+      value: String(value ?? "N/A"),
+    }))
+
+    // Add secret environment variables with masked values
+    secretEnvVarKeys.forEach((key: string) => {
+      // Only add if not already in regular env_vars
+      if (!(key in envVars)) {
+        properties.push({
+          name: key,
+          value: "●●●●●●",
         })
       }
     })
@@ -266,12 +290,7 @@
             />
             <div class="mt-8">
               <PropertyList
-                properties={Object.entries(
-                  tool_server.properties["env_vars"] || {},
-                ).map(([key, value]) => ({
-                  name: key,
-                  value: String(value ?? "N/A"),
-                }))}
+                properties={getEnvVarProperties(tool_server)}
                 title="Environment Variables"
               />
             </div>

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
@@ -134,6 +134,30 @@
     return properties
   }
 
+  function getHeadersProperties(tool: ExternalToolServerApiDescription) {
+    const headers = tool.properties["headers"] || {}
+    const secretHeaderKeys = (tool.properties["secret_header_keys"] ||
+      []) as string[]
+
+    const properties = Object.entries(headers).map(([key, value]) => ({
+      name: key,
+      value: String(value ?? "N/A"),
+    }))
+
+    // Add secret headers with masked values
+    secretHeaderKeys.forEach((key: string) => {
+      // Only add if not already in regular headers
+      if (!(key in headers)) {
+        properties.push({
+          name: key,
+          value: "****",
+        })
+      }
+    })
+
+    return properties
+  }
+
   interface Argument {
     name: string
     type: string
@@ -231,12 +255,7 @@
             <!-- Manually add a gap between the connection details and the headers -->
             <div class="mt-8">
               <PropertyList
-                properties={Object.entries(
-                  tool_server.properties["headers"] || {},
-                ).map(([key, value]) => ({
-                  name: key,
-                  value: String(value ?? "N/A"),
-                }))}
+                properties={getHeadersProperties(tool_server)}
                 title="Headers"
               />
             </div>

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
@@ -303,7 +303,8 @@
               properties={getConnectionProperties(tool_server)}
               title="Run Configuration"
             />
-            {#if tool_server.properties["env_vars"] && Object.keys(tool_server.properties["env_vars"]).length > 0}
+            <!-- Check if there are any environment variables or secret environment variables -->
+            {#if (tool_server.properties["env_vars"] && Object.keys(tool_server.properties["env_vars"]).length > 0) || (tool_server.properties["secret_env_var_keys"] && Object.keys(tool_server.properties["secret_env_var_keys"]).length > 0)}
               <div class="mt-8">
                 <PropertyList
                   properties={buildPropertiesWithSecrets(

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
@@ -9,6 +9,7 @@
   import type { ExternalToolServerApiDescription } from "$lib/types"
   import { toolServerTypeToString } from "$lib/utils/formatters"
   import DeleteDialog from "$lib/ui/delete_dialog.svelte"
+  import type { UiProperty } from "$lib/ui/property_list"
 
   $: project_id = $page.params.project_id
   $: tool_server_id = $page.params.tool_server_id
@@ -134,40 +135,29 @@
     return properties
   }
 
-  type UiProperty = {
-    name: string
-    value: string
-    error?: boolean
-  }
-
   /**
    * Helper function to build properties list with secret handling
-   * @param noneSecretProperties - Object containing non-secret key-value pairs
+   * @param nonSecretProperties - Object containing non-secret key-value pairs
    * @param secretKeys - Array of secret key names
    * @param missingSecrets - Array of missing secret key names
    * @returns Array of UiProperty objects
    */
   function buildPropertiesWithSecrets(
-    noneSecretProperties: Record<string, string>,
+    nonSecretProperties: Record<string, string>,
     secretKeys: string[],
     missingSecrets: string[],
   ): UiProperty[] {
     // Non-secret values
     const properties: UiProperty[] = []
     properties.push(
-      ...Object.entries(noneSecretProperties).map(([key, value]) => ({
+      ...Object.entries(nonSecretProperties).map(([key, value]) => ({
         name: key,
         value: String(value ?? "N/A"),
       })),
     )
 
-    // Make sure secretKeys is an array of strings
-    const secretKeysArray: string[] = Array.isArray(secretKeys)
-      ? [...secretKeys.filter((k): k is string => typeof k === "string")]
-      : []
-
     // Add secret values with masked values or error state
-    secretKeysArray.forEach((key: string) => {
+    secretKeys.forEach((key: string) => {
       // Check if the secret is missing
       if (missingSecrets.includes(key)) {
         properties.push({
@@ -175,7 +165,7 @@
           value: "Value missing",
           error: true,
         })
-      } else if (!(key in noneSecretProperties)) {
+      } else if (!(key in nonSecretProperties)) {
         // Only add if not already in regular values
         properties.push({
           name: key,

--- a/libs/core/kiln_ai/datamodel/external_tool_server.py
+++ b/libs/core/kiln_ai/datamodel/external_tool_server.py
@@ -147,6 +147,28 @@ class ExternalToolServer(KilnParentedModel):
 
         return secrets
 
+    def missing_secrets(self) -> list[str]:
+        """
+        Check if the tool server has missing secrets.
+
+        Returns:
+            List of secret key names that are missing values in Config
+        """
+        missing_secrets = []
+        secret_keys = self.get_secret_keys()
+
+        if secret_keys and len(secret_keys) > 0:
+            config = Config.shared()
+            mcp_secrets = config.get_value(MCP_SECRETS_KEY)
+
+            for key_name in secret_keys:
+                secret_key = self._config_secret_key(key_name)
+                # Check if the secret is missing or empty
+                if not mcp_secrets or not mcp_secrets.get(secret_key):
+                    missing_secrets.append(key_name)
+
+        return missing_secrets
+
     def save_secrets(self) -> None:
         """
         Save secrets to the configuration system.

--- a/libs/core/kiln_ai/datamodel/external_tool_server.py
+++ b/libs/core/kiln_ai/datamodel/external_tool_server.py
@@ -62,6 +62,16 @@ class ExternalToolServer(KilnParentedModel):
                     raise ValueError(
                         "headers must be a dictionary for external tools of type 'remote_mcp'"
                     )
+
+                secret_headers_keys = self.properties.get("secret_headers_keys", None)
+                # Secret headers keys are optional, but if they are set, they must be a list of strings
+                if secret_headers_keys is not None and not isinstance(
+                    secret_headers_keys, list
+                ):
+                    raise ValueError(
+                        "secret_headers_keys must be a list for external tools of type 'remote_mcp'"
+                    )
+
             case ToolServerType.local_mcp:
                 command = self.properties.get("command", None)
                 if not isinstance(command, str):

--- a/libs/core/kiln_ai/datamodel/external_tool_server.py
+++ b/libs/core/kiln_ai/datamodel/external_tool_server.py
@@ -63,13 +63,13 @@ class ExternalToolServer(KilnParentedModel):
                         "headers must be a dictionary for external tools of type 'remote_mcp'"
                     )
 
-                secret_headers_keys = self.properties.get("secret_headers_keys", None)
-                # Secret headers keys are optional, but if they are set, they must be a list of strings
-                if secret_headers_keys is not None and not isinstance(
-                    secret_headers_keys, list
+                secret_header_keys = self.properties.get("secret_header_keys", None)
+                # Secret header keys are optional, but if they are set, they must be a list of strings
+                if secret_header_keys is not None and not isinstance(
+                    secret_header_keys, list
                 ):
                     raise ValueError(
-                        "secret_headers_keys must be a list for external tools of type 'remote_mcp'"
+                        "secret_header_keys must be a list for external tools of type 'remote_mcp'"
                     )
 
             case ToolServerType.local_mcp:

--- a/libs/core/kiln_ai/datamodel/test_external_tool_server.py
+++ b/libs/core/kiln_ai/datamodel/test_external_tool_server.py
@@ -1,0 +1,345 @@
+import pytest
+from pydantic import ValidationError
+
+from kiln_ai.datamodel.external_tool_server import ExternalToolServer, ToolServerType
+
+
+class TestExternalToolServerValidation:
+    """Tests for ExternalToolServer model validation, including secret header keys."""
+
+    def test_remote_mcp_valid_minimal(self):
+        """Test ExternalToolServer with minimal valid remote MCP configuration."""
+        server = ExternalToolServer(
+            name="test_server",
+            type=ToolServerType.remote_mcp,
+            properties={
+                "server_url": "https://example.com/mcp",
+                "headers": {},
+            },
+        )
+
+        assert server.name == "test_server"
+        assert server.type == ToolServerType.remote_mcp
+        assert server.properties["server_url"] == "https://example.com/mcp"
+        assert server.properties["headers"] == {}
+
+    def test_remote_mcp_valid_with_headers(self):
+        """Test ExternalToolServer with valid remote MCP configuration including headers."""
+        server = ExternalToolServer(
+            name="test_server_with_headers",
+            type=ToolServerType.remote_mcp,
+            properties={
+                "server_url": "https://api.example.com/mcp",
+                "headers": {
+                    "Authorization": "Bearer token123",
+                    "Content-Type": "application/json",
+                },
+            },
+        )
+
+        assert server.name == "test_server_with_headers"
+        assert len(server.properties["headers"]) == 2
+        assert server.properties["headers"]["Authorization"] == "Bearer token123"
+
+    def test_remote_mcp_valid_with_secret_header_keys(self):
+        """Test ExternalToolServer with valid secret header keys."""
+        server = ExternalToolServer(
+            name="secret_server",
+            type=ToolServerType.remote_mcp,
+            properties={
+                "server_url": "https://example.com/mcp",
+                "headers": {
+                    "Authorization": "Bearer secret",
+                    "X-API-Key": "api-key",
+                    "Content-Type": "application/json",
+                },
+                "secret_header_keys": ["Authorization", "X-API-Key"],
+            },
+        )
+
+        assert server.name == "secret_server"
+        assert server.properties["secret_header_keys"] == ["Authorization", "X-API-Key"]
+
+    def test_remote_mcp_valid_with_empty_secret_header_keys(self):
+        """Test ExternalToolServer with empty secret header keys list."""
+        server = ExternalToolServer(
+            name="no_secrets_server",
+            type=ToolServerType.remote_mcp,
+            properties={
+                "server_url": "https://example.com/mcp",
+                "headers": {"Content-Type": "application/json"},
+                "secret_header_keys": [],
+            },
+        )
+
+        assert server.properties["secret_header_keys"] == []
+
+    def test_remote_mcp_missing_server_url(self):
+        """Test ExternalToolServer rejects remote MCP without server_url."""
+        with pytest.raises(ValidationError, match="server_url must be a string"):
+            ExternalToolServer(
+                name="missing_url_server",
+                type=ToolServerType.remote_mcp,
+                properties={
+                    "headers": {},
+                },
+            )
+
+    def test_remote_mcp_invalid_server_url_type(self):
+        """Test ExternalToolServer rejects non-string server_url."""
+        with pytest.raises(
+            ValidationError, match="server_url must be a string for external tools"
+        ):
+            ExternalToolServer(
+                name="invalid_url_type_server",
+                type=ToolServerType.remote_mcp,
+                properties={
+                    "server_url": 12345,  # Invalid type
+                    "headers": {},
+                },
+            )
+
+    def test_remote_mcp_empty_server_url(self):
+        """Test ExternalToolServer rejects empty server_url."""
+        with pytest.raises(
+            ValidationError,
+            match="server_url is required to connect to a remote MCP server",
+        ):
+            ExternalToolServer(
+                name="empty_url_server",
+                type=ToolServerType.remote_mcp,
+                properties={
+                    "server_url": "",  # Empty string
+                    "headers": {},
+                },
+            )
+
+    def test_remote_mcp_missing_headers(self):
+        """Test ExternalToolServer rejects remote MCP without headers."""
+        with pytest.raises(
+            ValidationError, match="headers must be set when type is 'remote_mcp'"
+        ):
+            ExternalToolServer(
+                name="missing_headers_server",
+                type=ToolServerType.remote_mcp,
+                properties={
+                    "server_url": "https://example.com/mcp",
+                    # No headers
+                },
+            )
+
+    def test_remote_mcp_invalid_headers_type(self):
+        """Test ExternalToolServer rejects non-dict headers."""
+        with pytest.raises(
+            ValidationError, match="headers must be a dictionary for external tools"
+        ):
+            ExternalToolServer(
+                name="invalid_headers_type_server",
+                type=ToolServerType.remote_mcp,
+                properties={
+                    "server_url": "https://example.com/mcp",
+                    "headers": "not a dict",  # Invalid type
+                },
+            )
+
+    def test_remote_mcp_invalid_secret_header_keys_type(self):
+        """Test ExternalToolServer rejects non-list secret_header_keys."""
+        with pytest.raises(
+            ValidationError,
+            match="secret_header_keys must be a list for external tools",
+        ):
+            ExternalToolServer(
+                name="invalid_secret_keys_type_server",
+                type=ToolServerType.remote_mcp,
+                properties={
+                    "server_url": "https://example.com/mcp",
+                    "headers": {},
+                    "secret_header_keys": "not a list",  # Invalid type
+                },
+            )
+
+    def test_local_mcp_valid_minimal(self):
+        """Test ExternalToolServer with minimal valid local MCP configuration."""
+        server = ExternalToolServer(
+            name="local_server",
+            type=ToolServerType.local_mcp,
+            properties={
+                "command": "python",
+                "args": ["-m", "my_server"],
+                "env_vars": {},
+            },
+        )
+
+        assert server.name == "local_server"
+        assert server.type == ToolServerType.local_mcp
+        assert server.properties["command"] == "python"
+        assert server.properties["args"] == ["-m", "my_server"]
+
+    def test_local_mcp_valid_with_env_vars(self):
+        """Test ExternalToolServer with valid local MCP configuration including env vars."""
+        server = ExternalToolServer(
+            name="local_server_with_env",
+            type=ToolServerType.local_mcp,
+            properties={
+                "command": "node",
+                "args": ["server.js"],
+                "env_vars": {
+                    "API_KEY": "secret123",
+                    "PORT": "3000",
+                },
+            },
+        )
+
+        assert server.properties["env_vars"]["API_KEY"] == "secret123"
+        assert server.properties["env_vars"]["PORT"] == "3000"
+
+    def test_local_mcp_missing_command(self):
+        """Test ExternalToolServer rejects local MCP without command."""
+        with pytest.raises(ValidationError, match="command must be a string"):
+            ExternalToolServer(
+                name="missing_command_server",
+                type=ToolServerType.local_mcp,
+                properties={
+                    "args": [],
+                    "env_vars": {},
+                },
+            )
+
+    def test_local_mcp_invalid_command_type(self):
+        """Test ExternalToolServer rejects non-string command."""
+        with pytest.raises(ValidationError, match="command must be a string"):
+            ExternalToolServer(
+                name="invalid_command_type_server",
+                type=ToolServerType.local_mcp,
+                properties={
+                    "command": 123,  # Invalid type
+                    "args": [],
+                    "env_vars": {},
+                },
+            )
+
+    def test_local_mcp_empty_command(self):
+        """Test ExternalToolServer rejects empty command."""
+        with pytest.raises(
+            ValidationError, match="command is required to start a local MCP server"
+        ):
+            ExternalToolServer(
+                name="empty_command_server",
+                type=ToolServerType.local_mcp,
+                properties={
+                    "command": "",  # Empty string
+                    "args": [],
+                    "env_vars": {},
+                },
+            )
+
+    def test_local_mcp_whitespace_only_command(self):
+        """Test ExternalToolServer rejects whitespace-only command."""
+        with pytest.raises(
+            ValidationError, match="command is required to start a local MCP server"
+        ):
+            ExternalToolServer(
+                name="whitespace_command_server",
+                type=ToolServerType.local_mcp,
+                properties={
+                    "command": "   ",  # Whitespace only
+                    "args": [],
+                    "env_vars": {},
+                },
+            )
+
+    def test_local_mcp_missing_args(self):
+        """Test ExternalToolServer rejects local MCP without args."""
+        with pytest.raises(ValidationError, match="arguments must be a list"):
+            ExternalToolServer(
+                name="missing_args_server",
+                type=ToolServerType.local_mcp,
+                properties={
+                    "command": "python",
+                    "env_vars": {},
+                },
+            )
+
+    def test_local_mcp_invalid_args_type(self):
+        """Test ExternalToolServer rejects non-list args."""
+        with pytest.raises(ValidationError, match="arguments must be a list"):
+            ExternalToolServer(
+                name="invalid_args_type_server",
+                type=ToolServerType.local_mcp,
+                properties={
+                    "command": "python",
+                    "args": "not a list",  # Invalid type
+                    "env_vars": {},
+                },
+            )
+
+    def test_local_mcp_invalid_env_vars_type(self):
+        """Test ExternalToolServer rejects non-dict env_vars."""
+        with pytest.raises(
+            ValidationError, match="environment variables must be a dictionary"
+        ):
+            ExternalToolServer(
+                name="invalid_env_vars_type_server",
+                type=ToolServerType.local_mcp,
+                properties={
+                    "command": "python",
+                    "args": [],
+                    "env_vars": "not a dict",  # Invalid type
+                },
+            )
+
+    def test_local_mcp_empty_args_allowed(self):
+        """Test ExternalToolServer allows empty args list."""
+        server = ExternalToolServer(
+            name="empty_args_server",
+            type=ToolServerType.local_mcp,
+            properties={
+                "command": "python",
+                "args": [],  # Empty list should be allowed
+                "env_vars": {},
+            },
+        )
+
+        assert server.properties["args"] == []
+
+    def test_local_mcp_missing_env_vars_defaults_to_empty_dict(self):
+        """Test ExternalToolServer defaults env_vars to empty dict when missing."""
+        server = ExternalToolServer(
+            name="default_env_vars_server",
+            type=ToolServerType.local_mcp,
+            properties={
+                "command": "python",
+                "args": [],
+                # No env_vars - should default to {}
+            },
+        )
+
+        # The validator should set it to {} when missing
+        assert server.properties.get("env_vars", {}) == {}
+
+    def test_server_with_description(self):
+        """Test ExternalToolServer with optional description."""
+        server = ExternalToolServer(
+            name="described_server",
+            type=ToolServerType.remote_mcp,
+            description="This is a test server for demonstrations",
+            properties={
+                "server_url": "https://example.com/mcp",
+                "headers": {},
+            },
+        )
+
+        assert server.description == "This is a test server for demonstrations"
+
+    def test_server_without_description(self):
+        """Test ExternalToolServer without description (should be None)."""
+        server = ExternalToolServer(
+            name="undescribed_server",
+            type=ToolServerType.remote_mcp,
+            properties={
+                "server_url": "https://example.com/mcp",
+                "headers": {},
+            },
+        )
+
+        assert server.description is None

--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -64,7 +64,8 @@ class MCPSessionManager:
         if not server_url:
             raise ValueError("server_url is required")
 
-        headers = tool_server.properties.get("headers", {})
+        # Make a copy of the headers to avoid modifying the original object
+        headers = tool_server.properties.get("headers", {}).copy()
 
         # Retrieve secret headers from configuration and merge with regular headers
         secret_headers_keys = tool_server.properties.get("secret_header_keys", [])

--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -68,18 +68,8 @@ class MCPSessionManager:
         headers = tool_server.properties.get("headers", {}).copy()
 
         # Retrieve secret headers from configuration and merge with regular headers
-        secret_headers_keys = tool_server.properties.get("secret_header_keys", [])
-
-        if secret_headers_keys and len(secret_headers_keys) > 0:
-            config = Config.shared()
-            mcp_secrets = config.get_value("mcp_secrets")
-
-            # Look for secrets with the pattern: mcp_server_id::header_name
-            if mcp_secrets:  # Only proceed if mcp_secrets is not None
-                for header_name in secret_headers_keys:
-                    header_value = mcp_secrets.get(f"{tool_server.id}::{header_name}")
-                    if header_value:
-                        headers[header_name] = header_value
+        secret_headers = tool_server.retrieve_secrets()
+        headers.update(secret_headers)
 
         async with streamablehttp_client(server_url, headers=headers) as (
             read_stream,
@@ -115,18 +105,8 @@ class MCPSessionManager:
         env_vars = tool_server.properties.get("env_vars", {}).copy()
 
         # Retrieve secret environment variables from configuration and merge with regular env_vars
-        secret_env_var_keys = tool_server.properties.get("secret_env_var_keys", [])
-
-        if secret_env_var_keys and len(secret_env_var_keys) > 0:
-            config = Config.shared()
-            mcp_secrets = config.get_value("mcp_secrets")
-
-            # Look for secrets with the pattern: mcp_server_id::env_var_name
-            if mcp_secrets:  # Only proceed if mcp_secrets is not None
-                for env_var_name in secret_env_var_keys:
-                    env_var_value = mcp_secrets.get(f"{tool_server.id}::{env_var_name}")
-                    if env_var_value:
-                        env_vars[env_var_name] = env_var_value
+        secret_env_vars = tool_server.retrieve_secrets()
+        env_vars.update(secret_env_vars)
 
         # Set PATH, only if not explicitly set during MCP tool setup
         if "PATH" not in env_vars:

--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -74,10 +74,11 @@ class MCPSessionManager:
             mcp_secrets = config.get_value("mcp_secrets")
 
             # Look for secrets with the pattern: mcp_server_id::header_name
-            for header_name in secret_headers_keys:
-                header_value = mcp_secrets.get(f"{tool_server.id}::{header_name}")
-                if header_value:
-                    headers[header_name] = header_value
+            if mcp_secrets:  # Only proceed if mcp_secrets is not None
+                for header_name in secret_headers_keys:
+                    header_value = mcp_secrets.get(f"{tool_server.id}::{header_name}")
+                    if header_value:
+                        headers[header_name] = header_value
 
         async with streamablehttp_client(server_url, headers=headers) as (
             read_stream,

--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -66,6 +66,19 @@ class MCPSessionManager:
 
         headers = tool_server.properties.get("headers", {})
 
+        # Retrieve secret headers from configuration and merge with regular headers
+        secret_headers_keys = tool_server.properties.get("secret_header_keys", [])
+
+        if secret_headers_keys and len(secret_headers_keys) > 0:
+            config = Config.shared()
+            mcp_secrets = config.get_value("mcp_secrets")
+
+            # Look for secrets with the pattern: mcp_server_id::header_name
+            for header_name in secret_headers_keys:
+                header_value = mcp_secrets.get(f"{tool_server.id}::{header_name}")
+                if header_value:
+                    headers[header_name] = header_value
+
         async with streamablehttp_client(server_url, headers=headers) as (
             read_stream,
             write_stream,

--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -68,7 +68,7 @@ class MCPSessionManager:
         headers = tool_server.properties.get("headers", {}).copy()
 
         # Retrieve secret headers from configuration and merge with regular headers
-        secret_headers = tool_server.retrieve_secrets()
+        secret_headers, _ = tool_server.retrieve_secrets()
         headers.update(secret_headers)
 
         async with streamablehttp_client(server_url, headers=headers) as (
@@ -105,7 +105,7 @@ class MCPSessionManager:
         env_vars = tool_server.properties.get("env_vars", {}).copy()
 
         # Retrieve secret environment variables from configuration and merge with regular env_vars
-        secret_env_vars = tool_server.retrieve_secrets()
+        secret_env_vars, _ = tool_server.retrieve_secrets()
         env_vars.update(secret_env_vars)
 
         # Set PATH, only if not explicitly set during MCP tool setup

--- a/libs/core/kiln_ai/tools/test_mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/test_mcp_session_manager.py
@@ -748,6 +748,162 @@ class TestMCPSessionManager:
             async with manager.mcp_client(tool_server):
                 pass
 
+    @patch("kiln_ai.tools.mcp_session_manager.stdio_client")
+    @patch("kiln_ai.utils.config.Config.shared")
+    async def test_local_mcp_session_with_secrets(self, mock_config, mock_client):
+        """Test local MCP session creation with secret environment variables."""
+        # Mock config to return different values based on the key
+        mock_config_instance = MagicMock()
+
+        def mock_get_value(key):
+            if key == "mcp_secrets":
+                return {
+                    "test_server_id::SECRET_API_KEY": "secret_value_123",
+                    "test_server_id::ANOTHER_SECRET": "another_secret_value",
+                }
+            elif key == "custom_mcp_path":
+                return None  # No custom path, will use shell path
+            return None
+
+        mock_config_instance.get_value.side_effect = mock_get_value
+        mock_config.return_value = mock_config_instance
+
+        # Mock the streams
+        mock_read_stream = MagicMock()
+        mock_write_stream = MagicMock()
+
+        # Configure the mock client context manager
+        mock_client.return_value.__aenter__.return_value = (
+            mock_read_stream,
+            mock_write_stream,
+        )
+
+        # Create a tool server with secret env var keys
+        tool_server = ExternalToolServer(
+            name="test_server",
+            type=ToolServerType.local_mcp,
+            description="Test server with secrets",
+            properties={
+                "command": "python",
+                "args": ["-m", "my_server"],
+                "env_vars": {"PUBLIC_VAR": "public_value"},
+                "secret_env_var_keys": ["SECRET_API_KEY", "ANOTHER_SECRET"],
+            },
+        )
+        # Set the server ID to match our mock secrets
+        tool_server.id = "test_server_id"
+
+        manager = MCPSessionManager.shared()
+
+        # Mock get_shell_path to return a simple PATH
+        with (
+            patch.object(manager, "get_shell_path", return_value="/usr/bin:/bin"),
+            patch(
+                "kiln_ai.tools.mcp_session_manager.ClientSession"
+            ) as mock_session_class,
+        ):
+            mock_session_instance = AsyncMock()
+            mock_session_class.return_value.__aenter__.return_value = (
+                mock_session_instance
+            )
+
+            async with manager.mcp_client(tool_server) as session:
+                # Verify session is returned
+                assert session is mock_session_instance
+
+                # Verify initialize was called
+                mock_session_instance.initialize.assert_called_once()
+
+        # Verify config was accessed for mcp_secrets
+        assert mock_config_instance.get_value.call_count == 2
+        mock_config_instance.get_value.assert_any_call("mcp_secrets")
+        mock_config_instance.get_value.assert_any_call("custom_mcp_path")
+
+        # Verify stdio_client was called with correct parameters including secrets
+        call_args = mock_client.call_args[0][0]  # Get the StdioServerParameters
+        assert call_args.command == "python"
+        assert call_args.args == ["-m", "my_server"]
+
+        # Verify that both public and secret env vars are included
+        assert "PUBLIC_VAR" in call_args.env
+        assert call_args.env["PUBLIC_VAR"] == "public_value"
+        assert "SECRET_API_KEY" in call_args.env
+        assert call_args.env["SECRET_API_KEY"] == "secret_value_123"
+        assert "ANOTHER_SECRET" in call_args.env
+        assert call_args.env["ANOTHER_SECRET"] == "another_secret_value"
+        assert "PATH" in call_args.env
+
+        # Verify original properties were not modified (security check)
+        original_env_vars = tool_server.properties.get("env_vars", {})
+        assert "SECRET_API_KEY" not in original_env_vars
+        assert "ANOTHER_SECRET" not in original_env_vars
+        assert original_env_vars.get("PUBLIC_VAR") == "public_value"
+
+    @patch("kiln_ai.tools.mcp_session_manager.stdio_client")
+    @patch("kiln_ai.utils.config.Config.shared")
+    async def test_local_mcp_session_with_no_secrets_config(
+        self, mock_config, mock_client
+    ):
+        """Test local MCP session creation when config has no mcp_secrets."""
+        # Mock config to return None for mcp_secrets
+        mock_config_instance = MagicMock()
+
+        def mock_get_value(key):
+            if key == "mcp_secrets":
+                return None
+            elif key == "custom_mcp_path":
+                return None  # No custom path, will use shell path
+            return None
+
+        mock_config_instance.get_value.side_effect = mock_get_value
+        mock_config.return_value = mock_config_instance
+
+        # Mock the streams
+        mock_read_stream = MagicMock()
+        mock_write_stream = MagicMock()
+        mock_client.return_value.__aenter__.return_value = (
+            mock_read_stream,
+            mock_write_stream,
+        )
+
+        # Create a tool server with secret env var keys but no secrets in config
+        tool_server = ExternalToolServer(
+            name="no_secrets_config_server",
+            type=ToolServerType.local_mcp,
+            description="Server with no secrets in config",
+            properties={
+                "command": "python",
+                "args": ["-m", "my_server"],
+                "env_vars": {"PUBLIC_VAR": "public_value"},
+                "secret_env_var_keys": ["SECRET_API_KEY"],
+            },
+        )
+        tool_server.id = "test_server_id"
+
+        manager = MCPSessionManager.shared()
+
+        # Mock get_shell_path to return a simple PATH
+        with (
+            patch.object(manager, "get_shell_path", return_value="/usr/bin:/bin"),
+            patch(
+                "kiln_ai.tools.mcp_session_manager.ClientSession"
+            ) as mock_session_class,
+        ):
+            mock_session_instance = AsyncMock()
+            mock_session_class.return_value.__aenter__.return_value = (
+                mock_session_instance
+            )
+
+            async with manager.mcp_client(tool_server):
+                pass  # Should not raise any errors
+
+        # Verify stdio_client was called and only public vars are included
+        call_args = mock_client.call_args[0][0]
+        assert "PUBLIC_VAR" in call_args.env
+        assert call_args.env["PUBLIC_VAR"] == "public_value"
+        assert "SECRET_API_KEY" not in call_args.env  # Secret not found in config
+        assert "PATH" in call_args.env
+
     @patch("kiln_ai.utils.config.Config.shared")
     def test_get_path_with_custom_mcp_path(self, mock_config):
         """Test _get_path() returns custom MCP path when configured."""

--- a/libs/core/kiln_ai/tools/test_mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/test_mcp_session_manager.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from kiln_ai.datamodel.external_tool_server import ExternalToolServer, ToolServerType
 from kiln_ai.tools.mcp_session_manager import MCPSessionManager
+from kiln_ai.utils.config import MCP_SECRETS_KEY
 
 
 class TestMCPSessionManager:
@@ -183,7 +184,7 @@ class TestMCPSessionManager:
                 assert session is mock_session_instance
 
         # Verify config was accessed for mcp_secrets
-        mock_config_instance.get_value.assert_called_once_with("mcp_secrets")
+        mock_config_instance.get_value.assert_called_once_with(MCP_SECRETS_KEY)
 
         # Verify streamablehttp_client was called with merged headers
         expected_headers = {
@@ -528,7 +529,7 @@ class TestMCPSessionManager:
         secret_headers_keys = tool_server.properties.get("secret_header_keys", [])
         if secret_headers_keys:
             config = mock_config_instance
-            mcp_secrets = config.get_value("mcp_secrets")
+            mcp_secrets = config.get_value(MCP_SECRETS_KEY)
             if mcp_secrets:
                 for header_name in secret_headers_keys:
                     header_value = mcp_secrets.get(f"{tool_server.id}::{header_name}")
@@ -756,7 +757,7 @@ class TestMCPSessionManager:
         mock_config_instance = MagicMock()
 
         def mock_get_value(key):
-            if key == "mcp_secrets":
+            if key == MCP_SECRETS_KEY:
                 return {
                     "test_server_id::SECRET_API_KEY": "secret_value_123",
                     "test_server_id::ANOTHER_SECRET": "another_secret_value",
@@ -816,7 +817,7 @@ class TestMCPSessionManager:
 
         # Verify config was accessed for mcp_secrets
         assert mock_config_instance.get_value.call_count == 2
-        mock_config_instance.get_value.assert_any_call("mcp_secrets")
+        mock_config_instance.get_value.assert_any_call(MCP_SECRETS_KEY)
         mock_config_instance.get_value.assert_any_call("custom_mcp_path")
 
         # Verify stdio_client was called with correct parameters including secrets
@@ -849,7 +850,7 @@ class TestMCPSessionManager:
         mock_config_instance = MagicMock()
 
         def mock_get_value(key):
-            if key == "mcp_secrets":
+            if key == MCP_SECRETS_KEY:
                 return None
             elif key == "custom_mcp_path":
                 return None  # No custom path, will use shell path

--- a/libs/core/kiln_ai/utils/config.py
+++ b/libs/core/kiln_ai/utils/config.py
@@ -161,6 +161,11 @@ class Config:
                 str,
                 env_var="CUSTOM_MCP_PATH",
             ),
+            # Allow the user to set secrets for MCP servers, the key is mcp_server_id::key_name
+            "mcp_secrets": ConfigProperty(
+                dict[str, str],
+                sensitive=True,
+            ),
         }
         self._lock = threading.Lock()
         self._settings = self.load_settings()

--- a/libs/core/kiln_ai/utils/config.py
+++ b/libs/core/kiln_ai/utils/config.py
@@ -6,6 +6,9 @@ from typing import Any, Callable, Dict, List, Optional
 
 import yaml
 
+# Configuration keys
+MCP_SECRETS_KEY = "mcp_secrets"
+
 
 class ConfigProperty:
     def __init__(
@@ -162,7 +165,7 @@ class Config:
                 env_var="CUSTOM_MCP_PATH",
             ),
             # Allow the user to set secrets for MCP servers, the key is mcp_server_id::key_name
-            "mcp_secrets": ConfigProperty(
+            MCP_SECRETS_KEY: ConfigProperty(
                 dict[str, str],
                 sensitive=True,
             ),

--- a/libs/core/kiln_ai/utils/test_config.py
+++ b/libs/core/kiln_ai/utils/test_config.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from kiln_ai.utils.config import Config, ConfigProperty, _get_user_id
+from kiln_ai.utils.config import MCP_SECRETS_KEY, Config, ConfigProperty, _get_user_id
 
 
 @pytest.fixture
@@ -359,13 +359,13 @@ def test_mcp_secrets_sensitive_hiding():
 
     # Test without hiding sensitive data
     visible_settings = config.settings(hide_sensitive=False)
-    assert "mcp_secrets" in visible_settings
-    assert visible_settings["mcp_secrets"] == secrets
+    assert MCP_SECRETS_KEY in visible_settings
+    assert visible_settings[MCP_SECRETS_KEY] == secrets
 
     # Test with hiding sensitive data
     hidden_settings = config.settings(hide_sensitive=True)
-    assert "mcp_secrets" in hidden_settings
-    assert hidden_settings["mcp_secrets"] == "[hidden]"
+    assert MCP_SECRETS_KEY in hidden_settings
+    assert hidden_settings[MCP_SECRETS_KEY] == "[hidden]"
 
 
 def test_mcp_secrets_persistence(mock_yaml_file):
@@ -386,7 +386,7 @@ def test_mcp_secrets_persistence(mock_yaml_file):
         # Check that the value was saved to the YAML file
         with open(mock_yaml_file, "r") as f:
             saved_settings = yaml.safe_load(f)
-        assert saved_settings["mcp_secrets"] == secrets
+        assert saved_settings[MCP_SECRETS_KEY] == secrets
 
         # Create a new config instance to test loading from YAML
         new_config = Config()
@@ -400,14 +400,14 @@ def test_mcp_secrets_get_value():
     config = Config.shared()
 
     # Initially should be None
-    assert config.get_value("mcp_secrets") is None
+    assert config.get_value(MCP_SECRETS_KEY) is None
 
     # Set some secrets
     secrets = {"server::key": "value"}
     config.mcp_secrets = secrets
 
     # Should be retrievable via get_value
-    assert config.get_value("mcp_secrets") == secrets
+    assert config.get_value(MCP_SECRETS_KEY) == secrets
 
 
 def test_mcp_secrets_update_settings():
@@ -416,7 +416,7 @@ def test_mcp_secrets_update_settings():
 
     # Set initial secrets
     initial_secrets = {"server1::key1": "value1"}
-    config.update_settings({"mcp_secrets": initial_secrets})
+    config.update_settings({MCP_SECRETS_KEY: initial_secrets})
     assert config.mcp_secrets == initial_secrets
 
     # Update with new secrets (should replace, not merge)
@@ -424,7 +424,7 @@ def test_mcp_secrets_update_settings():
         "server1::key1": "updated_value1",
         "server2::key2": "value2",
     }
-    config.update_settings({"mcp_secrets": new_secrets})
+    config.update_settings({MCP_SECRETS_KEY: new_secrets})
     assert config.mcp_secrets == new_secrets
     assert config.mcp_secrets["server1::key1"] == "updated_value1"
     assert config.mcp_secrets["server2::key2"] == "value2"


### PR DESCRIPTION
## What does this PR do?

Headers and Env Vars previous were stored as part of the data model which can be synced. This PR adds the ability for tool servers to save their "secrets" such as API Key inside Kiln Settings. 

* Add logic to handle secrets lifecycle in ExternalToolServer.
* Update _Tool Server_ screen to mask secrets and indicate if a key is missing simulating initial sync state. 
* Add status column to  _Manage Tool_ screen to indicate if a tool server has missing keys. 
* Update connect tool server screen to mark if a header or env var is a secret. 

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

<img width="1802" height="621" alt="image" src="https://github.com/user-attachments/assets/03cdefb5-76d5-4751-9994-7b957fb29af6" />
<img width="1278" height="851" alt="image" src="https://github.com/user-attachments/assets/89cdd454-dc6d-4225-8c17-cdddb6cb9700" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Centralized MCP secret storage (MCP_SECRETS_KEY); tool-server secrets tracked separately, masked in UI, and listings expose missing_secrets with Status (Ready / Action Required).

- **Refactor**
  - Unified key/value model for headers/env vars with per-item "Secret" toggles in add-tool UIs. Creation payloads include secret_header_keys/secret_env_var_keys. Sessions merge secrets into requests/env without mutating originals. Shared UiProperty type introduced for property lists.

- **Tests**
  - Expanded tests for validation, secret lifecycle, session merging, UI flows, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->