### PR TITLE
fix: invalidate available model list after adding or removing a provider

### DIFF
--- a/app/web_ui/src/lib/stores.ts
+++ b/app/web_ui/src/lib/stores.ts
@@ -225,6 +225,11 @@ export async function load_available_models() {
   }
 }
 
+export function clear_available_models_cache() {
+  available_models_loaded = "not_loaded"
+  available_models.set([])
+}
+
 // Model Info
 export const model_info = writable<ProviderModels | null>(null)
 

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
@@ -11,6 +11,7 @@
   import { client, base_url } from "$lib/api_client"
   import Warning from "$lib/ui/warning.svelte"
   import { available_tuning_models } from "$lib/stores/fine_tune_store"
+  import { clear_available_models_cache } from "$lib/stores"
   import { get_provider_image } from "$lib/ui/provider_image"
   import posthog from "posthog-js"
 
@@ -396,6 +397,8 @@
 
       // Clear the available models list
       available_tuning_models.set(null)
+      // Clear the available models cache so it refreshes next time
+      clear_available_models_cache()
     } catch (e) {
       console.error("disconnect_provider error", e)
       alert("Failed to disconnect provider. Unknown error.")
@@ -484,6 +487,8 @@
     }
     status.ollama.error = null
     status.ollama.connected = true
+    // Clear the available models cache so it refreshes next time
+    clear_available_models_cache()
     const supported_models_str =
       data.supported_models.length > 0
         ? "The following supported models are available: " +
@@ -560,6 +565,8 @@
     }
     status.docker_model_runner.error = null
     status.docker_model_runner.connected = true
+    // Clear the available models cache so it refreshes next time
+    clear_available_models_cache()
     const supported_models_str =
       data.supported_models.length > 0
         ? "The following supported models are available: " +
@@ -640,6 +647,8 @@
 
       // Clear the available models list
       available_tuning_models.set(null)
+      // Clear the available models cache so it refreshes next time
+      clear_available_models_cache()
     } catch (e) {
       console.error("submit_api_key error", e)
       api_key_message = "Failed to connect to provider (Exception: " + e + ")"
@@ -799,6 +808,8 @@
       new_provider_error = null
 
       status.openai_compatible.connected = true
+      // Clear the available models cache so it refreshes next time
+      clear_available_models_cache()
       // @ts-expect-error daisyui does not add types
       document.getElementById("openai_compatible_dialog")?.close()
     } catch (e) {
@@ -837,6 +848,8 @@
       if (custom_openai_compatible_providers.length === 0) {
         status.openai_compatible.connected = false
       }
+      // Clear the available models cache so it refreshes next time
+      clear_available_models_cache()
     } catch (e) {
       alert("Failed to remove provider: " + e)
     }


### PR DESCRIPTION
## What does this PR do?

Similar problem as https://github.com/Kiln-AI/Kiln/pull/564

Bug:
1. Don't have OpenAI connected (hard refresh if you have just disconnected it)
2. Navigate to the `Run` page, check out the models in the dropdown in the right sidebar
3. Click on `Settings` in the nav sidebar to the left 
4. Go into `AI Providers`
5. Connect OpenAI, set an API key and connect
6. Go back into `Run` (via the sidebar)
7. `OpenAI` models are not showing up in the model dropdown in the sidebar to the left because the model list has not been refreshed

Fix:
- invalidate the model list in the store after adding / removing any provider


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The available models list now refreshes immediately after connecting or disconnecting providers (including Ollama, Docker Model Runner, and OpenAI-compatible).
  * Updating provider settings—such as submitting API keys, adding new OpenAI-compatible providers, or removing them—now correctly updates the models list.
  * Prevents stale or outdated model listings after any provider connectivity or configuration change, ensuring users always see the current set of available models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->