### PR TITLE
Better error messages when connecting tool servers 

### DIFF
--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "boto3>=1.37.10",
     "coverage>=7.6.4",
+    "exceptiongroup>=1.0.0; python_version<'3.11'",
     "google-cloud-aiplatform>=1.84.0",
     "jsonschema>=4.23.0",
     "litellm>=1.72.6",

--- a/uv.lock
+++ b/uv.lock
@@ -1006,6 +1006,7 @@ source = { editable = "libs/core" }
 dependencies = [
     { name = "boto3" },
     { name = "coverage" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "google-cloud-aiplatform" },
     { name = "jsonschema" },
     { name = "litellm" },
@@ -1034,6 +1035,7 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.37.10" },
     { name = "coverage", specifier = ">=7.6.4" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.0.0" },
     { name = "google-cloud-aiplatform", specifier = ">=1.84.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "litellm", specifier = ">=1.72.6" },


### PR DESCRIPTION
## What does this PR do?

"unhandled errors in a TaskGroup" is often returned back to UI when failing to connect to mcp servers. Catch common errors for both remote & local mcp servers and return user friendly error messages. 

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clear, user-friendly errors during remote/local MCP session setup (HTTP status, connectivity, startup failures), and preserved original error causes.
  * Prevent unintended mutation when merging secret headers and environment variables.
  * More reliable PATH and shell resolution across platforms.

* **Tests**
  * Extensive coverage for error mapping, nested/aggregated exceptions, secret/header/env merging, session creation scenarios, and path handling.

* **Chores**
  * Conditional dependency added for ExceptionGroup compatibility on older Python versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->