### PR TITLE
Add breadcrumbs

### DIFF
--- a/app/web_ui/src/routes/(app)/+layout.svelte
+++ b/app/web_ui/src/routes/(app)/+layout.svelte
@@ -7,10 +7,16 @@
   import { update_update_store, update_info } from "$lib/utils/update"
   import { onMount } from "svelte"
   import ProgressWidget from "$lib/ui/progress_widget.svelte"
+  import { beforeNavigate } from "$app/navigation"
+  import { setContext } from "svelte"
+  import { writable } from "svelte/store"
 
   onMount(async () => {
     update_update_store()
   })
+
+  const lastPageUrlStore = writable<URL | undefined>(undefined)
+  setContext("lastPageUrl", lastPageUrlStore)
 
   enum Section {
     Dataset,
@@ -62,6 +68,10 @@
       menu.open = false
     }
   }
+
+  beforeNavigate((nav) => {
+    lastPageUrlStore.set(nav.from?.url)
+  })
 </script>
 
 <div class="drawer lg:drawer-open">

--- a/app/web_ui/src/routes/(app)/app_page.svelte
+++ b/app/web_ui/src/routes/(app)/app_page.svelte
@@ -7,8 +7,13 @@
   export let sub_subtitle: string = ""
   export let sub_subtitle_link: string | undefined = undefined
   export let no_y_padding: boolean = false
-
   export let action_buttons: ActionButton[] = []
+
+  type Breadcrumb = {
+    label: string
+    href: string
+  }
+  export let breadcrumbs: Breadcrumb[] = []
 
   function run_action_button(action_button: ActionButton) {
     if (action_button.handler) {
@@ -46,6 +51,17 @@
 
 <svelte:window on:keydown={handle_key_down} />
 
+{#if breadcrumbs.length > 0}
+  <div class="breadcrumbs text-sm pt-0">
+    <ul>
+      {#each breadcrumbs as breadcrumb}
+        <li><a href={breadcrumb.href}>{breadcrumb.label}</a></li>
+      {/each}
+      <!-- Adds the last ">" separator -->
+      <li></li>
+    </ul>
+  </div>
+{/if}
 <div class="flex flex-row">
   <div class="flex flex-col grow">
     <h1 class="text-2xl font-bold">{title}</h1>

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
@@ -296,18 +296,16 @@
     try {
       const referrerPath = $lastPageUrl.pathname
 
-      // Check if the referrer matches the pattern /dataset/{project_id}/{task_id}
+      // Check if the referrer path is /dataset/{project_id}/{task_id}
+      // since we only want to breadcrumb back to that page
       const expectedPath = `/dataset/${$page.params.project_id}/${$page.params.task_id}`
 
       if (referrerPath === expectedPath) {
-        // Include the full URL with search params
-        const navUrl = $lastPageUrl.search
-          ? $lastPageUrl.pathname + "?" + $lastPageUrl.search
-          : $lastPageUrl.pathname
         return [
           {
             label: "Dataset",
-            href: navUrl,
+            // Include the full URL with search params to a
+            href: $lastPageUrl.pathname + $lastPageUrl.search,
           },
         ]
       }

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/add_data/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/add_data/+page.svelte
@@ -46,6 +46,15 @@
         : "Add Data for Fine-tuning"
   $: reason_name =
     reason === "generic" ? "dataset" : reason === "eval" ? "eval" : "fine tune"
+  $: breadcrumbs =
+    reason === "eval"
+      ? [
+          {
+            label: "Evals",
+            href: `/evals/${$page.params.project_id}/${$page.params.task_id}`,
+          },
+        ]
+      : []
 
   $: data_source_descriptions = [
     {
@@ -120,7 +129,7 @@
   }
 </script>
 
-<AppPage {title} sub_subtitle={splits_subtitle}>
+<AppPage {title} sub_subtitle={splits_subtitle} {breadcrumbs}>
   {#if completed}
     <Completed
       title="Data Added"

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
@@ -390,6 +390,7 @@
     subtitle="Follow these steps to find the best way to evaluate and run your task"
     sub_subtitle="Read the Docs"
     sub_subtitle_link="https://docs.kiln.tech/docs/evaluations"
+    breadcrumbs={[{ label: "Evals", href: `/evals/${project_id}/${task_id}` }]}
     action_buttons={[
       {
         label: "Edit",

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_methods/+page.svelte
@@ -411,6 +411,16 @@
   subtitle="Find the best method of running your task."
   sub_subtitle="Read the Docs"
   sub_subtitle_link="https://docs.kiln.tech/docs/evaluations#finding-the-ideal-run-method"
+  breadcrumbs={[
+    {
+      label: "Evals",
+      href: `/evals/${$page.params.project_id}/${$page.params.task_id}`,
+    },
+    {
+      label: evaluator?.name || "Eval",
+      href: `/evals/${$page.params.project_id}/${$page.params.task_id}/${$page.params.eval_id}`,
+    },
+  ]}
   action_buttons={[
     {
       label: "Compare Judges",

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/eval_configs/+page.svelte
@@ -421,6 +421,16 @@
   subtitle="Find the judge that best matches human preferences"
   sub_subtitle="Read the docs"
   sub_subtitle_link="https://docs.kiln.tech/docs/evaluations#finding-the-ideal-eval-method"
+  breadcrumbs={[
+    {
+      label: "Evals",
+      href: `/evals/${$page.params.project_id}/${$page.params.task_id}`,
+    },
+    {
+      label: evaluator?.name || "Eval",
+      href: `/evals/${$page.params.project_id}/${$page.params.task_id}/${$page.params.eval_id}`,
+    },
+  ]}
   action_buttons={eval_configs?.length
     ? [
         {

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/compare/+page.svelte
@@ -518,6 +518,7 @@
 <AppPage
   title="Compare Run Methods"
   subtitle="Compare run methods for your task using evals"
+  breadcrumbs={[{ label: "Evals", href: `/evals/${project_id}/${task_id}` }]}
 >
   {#if loading}
     <div class="w-full min-h-[50vh] flex justify-center items-center">

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/create_evaluator/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/create_evaluator/+page.svelte
@@ -140,6 +140,12 @@
   <AppPage
     title="Create a New Evaluator"
     subtitle="Evaluators judge task performance and help you find the best method of running your task."
+    breadcrumbs={[
+      {
+        label: "Evals",
+        href: `/evals/${$page.params.project_id}/${$page.params.task_id}`,
+      },
+    ]}
   >
     {#if loading}
       <div class="w-full min-h-[50vh] flex justify-center items-center">

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/+page.svelte
@@ -81,7 +81,7 @@
 </script>
 
 <AppPage
-  title="Fine Tune"
+  title="Fine Tunes"
   subtitle="Fine-tune models for the current task."
   sub_subtitle="Read the Docs"
   sub_subtitle_link="https://docs.kiln.tech/docs/fine-tuning-guide"

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
@@ -443,6 +443,9 @@
   <AppPage
     title="Create a New Fine Tune"
     subtitle="Fine-tuned models learn from your dataset."
+    breadcrumbs={[
+      { label: "Fine Tunes", href: `/fine_tune/${project_id}/${task_id}` },
+    ]}
   >
     {#if $available_models_loading}
       <div class="w-full min-h-[50vh] flex justify-center items-center">

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
@@ -184,6 +184,12 @@
   <AppPage
     title="Fine Tune"
     subtitle={finetune_loading ? undefined : `Name: ${finetune?.finetune.name}`}
+    breadcrumbs={[
+      {
+        label: "Fine Tunes",
+        href: `/fine_tune/${project_id}/${task_id}`,
+      },
+    ]}
     action_buttons={[
       ...(finetune
         ? [

--- a/app/web_ui/src/routes/(app)/settings/check_for_update/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/check_for_update/+page.svelte
@@ -15,6 +15,7 @@
 <AppPage
   title="Check for Update"
   sub_subtitle={`Current Version ${app_version}`}
+  breadcrumbs={[{ label: "Settings", href: "/settings" }]}
 >
   <div class="max-w-2xl">
     {#if $update_info.update_loading}

--- a/app/web_ui/src/routes/(app)/settings/edit_project/[slug]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/edit_project/[slug]/+page.svelte
@@ -10,7 +10,11 @@
 </script>
 
 <div class="max-w-[800px]">
-  <AppPage title="Edit Project" subtitle={project?.name}>
+  <AppPage
+    title="Edit Project"
+    subtitle={project?.name}
+    breadcrumbs={[{ label: "Settings", href: "/settings" }]}
+  >
     <EditProject {project} />
   </AppPage>
 </div>

--- a/app/web_ui/src/routes/(app)/settings/edit_task/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/edit_task/[project_id]/[task_id]/+page.svelte
@@ -30,6 +30,7 @@
   <AppPage
     title="Edit Task"
     subtitle={task_id ? `Task ID: ${task_id}` : undefined}
+    breadcrumbs={[{ label: "Settings", href: "/settings" }]}
     action_buttons={[
       {
         icon: "/images/delete.svg",

--- a/app/web_ui/src/routes/(app)/settings/manage_projects/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_projects/+page.svelte
@@ -37,6 +37,7 @@
 <AppPage
   title="Manage Projects"
   subtitle="Add or remove projects"
+  breadcrumbs={[{ label: "Settings", href: "/settings" }]}
   action_buttons={[
     { label: "Create Project", href: "/settings/create_project" },
     {

--- a/app/web_ui/src/routes/(app)/settings/providers/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/providers/+page.svelte
@@ -8,6 +8,7 @@
   title="AI Providers"
   sub_subtitle="Read the Docs"
   sub_subtitle_link="https://docs.kiln.tech/docs/models-and-ai-providers"
+  breadcrumbs={[{ label: "Settings", href: "/settings" }]}
   action_buttons={[
     {
       label: "Custom Models",

--- a/app/web_ui/src/routes/(app)/settings/providers/add_models/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/providers/add_models/+page.svelte
@@ -6,6 +6,8 @@
   import FormElement from "$lib/utils/form_element.svelte"
   import { provider_name_from_id } from "$lib/stores"
   import Dialog from "$lib/ui/dialog.svelte"
+  import { getContext } from "svelte"
+  import type { Writable } from "svelte/store"
 
   let connected_providers: [string, string][] = []
   let loading_providers = true
@@ -148,11 +150,24 @@
     let [provider, ..._] = model_id.split("::")
     return provider_name_from_id(provider)
   }
+
+  // You can get here 2 ways, build a breadcrumb for each
+  const lastPageUrl = getContext<Writable<URL | undefined>>("lastPageUrl")
+  function get_breadcrumbs() {
+    const breadcrumbs = [{ label: "Settings", href: "/settings" }]
+
+    if ($lastPageUrl && $lastPageUrl.pathname === "/settings/providers") {
+      breadcrumbs.push({ label: "AI Providers", href: "/settings/providers" })
+    }
+
+    return breadcrumbs
+  }
 </script>
 
 <AppPage
   title="Manage Custom Models"
   sub_subtitle="Add/remove additional models from your connected AI providers, on top of those already included with Kiln."
+  breadcrumbs={get_breadcrumbs()}
   action_buttons={custom_models && custom_models.length > 0
     ? [
         {


### PR DESCRIPTION
Example: 
<img width="426" height="138" alt="Screenshot 2025-09-05 at 3 24 14 PM" src="https://github.com/user-attachments/assets/9d9d74c3-1dc8-45ff-964d-1f51b9a999d0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breadcrumb navigation added across Evals, Dataset Run, Fine Tunes, and Settings pages.
  * Breadcrumbs preserve source page and query parameters when returning from dataset runs.
  * Dynamic breadcrumb behavior on Settings → Providers → Add Models based on previous page.
  * Exposed last‑visited page info to improve back-link behavior.
* **Style**
  * Page title updated to “Fine Tunes.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->