### PR TITLE
Update the inno-setup action.

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build Windows Installer
         if: matrix.os == 'windows-latest'
-        uses: scosman/Inno-Setup-Action-Back@v1.2.5
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.7
         with:
           path: ./app/desktop/WinInnoSetup.iss
 


### PR DESCRIPTION
 Github updated their images, which no longer inlude inno-setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows installer build process to a newer, more reliable workflow to improve release stability.
  * Ensures more consistent creation of Windows installers during our automated builds.
  * No changes to app functionality; installer usage and location remain the same.
  * End users should not notice behavioral differences, but downloads and updates may be more dependable.
  * No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->