### PR TITLE
Check http/https links for remote tools

### DIFF
--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -49,8 +49,7 @@ class ExternalToolServerCreationRequest(BaseModel):
         # Check for leading whitespace in URL
         if server_url != server_url.lstrip():
             raise ValueError("Server URL must not have leading whitespace")
-        # Check if the URL is valid without stripping
-        if not urlparse(server_url).scheme:
+        if urlparse(server_url).scheme not in ["http", "https"]:
             raise ValueError("Server URL must start with http:// or https://")
         if not urlparse(server_url).netloc:
             raise ValueError("Server URL is not a valid URL")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced HTTP/HTTPS for external tool server URLs; non-HTTP schemes (e.g., ftp, ssh, tcp, file, mailto) are no longer accepted.
  * Displays a clearer validation error indicating that the server URL must start with http:// or https:// when an unsupported scheme or missing protocol is entered.
  * Prevents misconfiguration and connection issues caused by entering unsupported URL schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->