### PR TITLE
Add timeout to local mcp server session

### DIFF
--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -173,7 +173,7 @@ class MCPSessionManager:
         try:
             async with stdio_client(server_params) as (read, write):
                 async with ClientSession(
-                    read, write, read_timeout_seconds=timedelta(seconds=30)
+                    read, write, read_timeout_seconds=timedelta(seconds=8)
                 ) as session:
                     await session.initialize()
                     yield session


### PR DESCRIPTION
## What does this PR do?

Add 30s timeout to local mcp server session so invalid command like "npx -aaaaaa" will not hug the process forever. 

New Timeout Error
`Unexpected error: MCP server failed to start. Please verify your command, arguments, and environment variables, and consult the server's documentation for the correct setup. Original error: Timed out while waiting for response to ClientRequest. Waited 30.0 seconds.`

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local connections now time out faster (8-second read timeout) to avoid hanging requests and improve responsiveness.
  * More predictable failures when a local integration becomes unresponsive, reducing stalled operations.
  * No configuration changes required; behavior is automatic for local sessions. Remote connections remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->