### PR TITLE
chore: add Kimi K2 0905 and Seed OSS 36B and Step3 models

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -172,7 +172,7 @@ class ModelName(str, Enum):
     hunyuan_a13b_no_thinking = "hunyuan_a13b_no_thinking"
     minimax_m1_80k = "minimax_m1_80k"
     pangu_pro_moe_72b_a16b = "pangu_pro_moe_72b_a16b"
-    bytedance_seed_oss_36b = "bytedance_seed_oss_36b_instruct"
+    bytedance_seed_oss_36b = "bytedance_seed_oss_36b"
     stepfun_step3 = "stepfun_step3"
 
 


### PR DESCRIPTION
## What does this PR do?

Add new models:
- `Kimi K2 0905` update
- `ByteDance: Seed OSS 36B Instruct`
- `StepFun: Step3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ByteDance and StepFun model families and new models: Kimi K2 Instruct 0905, ByteDance Seed OSS 36B, StepFun Step3.
  * Expanded provider support (SiliconFlow CN, OpenRouter, Fireworks AI, Together AI, Groq) across multiple models.
  * Standardized structured-output support (prefer JSON Schema/JSON-instruction) for several models.
  * Broadened DeepSeek and GLM availability with additional provider integrations and capability updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->