### PR TITLE
Fix linting error from ruff 

### DIFF
--- a/app/desktop/studio_server/repair_api.py
+++ b/app/desktop/studio_server/repair_api.py
@@ -105,7 +105,7 @@ def connect_repair_api(app: FastAPI):
     async def post_repair_run(
         project_id: str, task_id: str, run_id: str, input: RepairRunPost
     ) -> TaskRun:
-        task, run = task_and_run_from_id(project_id, task_id, run_id)
+        _, run = task_and_run_from_id(project_id, task_id, run_id)
 
         # manually edited runs are human but the user id is not set
         source = input.repair_run.output.source

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -520,7 +520,7 @@ async def test_eval_config_from_id(
     assert eval_config.config_type == EvalConfigType.g_eval
     assert eval_config.properties == {"eval_steps": ["step1", "step2"]}
 
-    with pytest.raises(HTTPException, match="Eval config not found. ID: non_existent"):
+    with pytest.raises(HTTPException, match=r"Eval config not found. ID: non_existent"):
         eval_config_from_id("project1", "task1", "eval1", "non_existent")
 
 
@@ -537,7 +537,7 @@ async def test_task_run_config_from_id(
     assert run_config.description == "Test Description"
 
     with pytest.raises(
-        HTTPException, match="Task run config not found. ID: non_existent"
+        HTTPException, match=r"Task run config not found. ID: non_existent"
     ):
         task_run_config_from_id("project1", "task1", "non_existent")
 

--- a/app/desktop/studio_server/test_finetune_api.py
+++ b/app/desktop/studio_server/test_finetune_api.py
@@ -460,7 +460,7 @@ def test_create_dataset_split(
         # Verify the mocks were called correctly
         mock_task_from_id_disk_backed.assert_called_once_with("project1", "task1")
         from_task_mock.assert_called_once()
-        args, kwargs = from_task_mock.call_args
+        _, kwargs = from_task_mock.call_args
         assert kwargs["filter_id"] == "high_rating"
         save_mock.assert_called_once()
 
@@ -818,7 +818,7 @@ def test_create_finetune_prompt_builder_error(
     mock_prompt_builder,
 ):
     mock_finetune_registry["test_provider"] = mock_finetune_adapter
-    prompt_builder_mock, builder = mock_prompt_builder
+    _, builder = mock_prompt_builder
 
     # Make the prompt builder raise an error
     builder.build_prompt.side_effect = ValueError("Invalid prompt configuration")

--- a/app/desktop/test_desktop.py
+++ b/app/desktop/test_desktop.py
@@ -83,7 +83,7 @@ class TestDesktopApp:
 
             # Verify dock callback is registered
             mock_tk_root.createcommand.assert_called_once()
-            command_name, callback = mock_tk_root.createcommand.call_args[0]
+            command_name, _ = mock_tk_root.createcommand.call_args[0]
             assert command_name == "tk::mac::ReopenApplication"
 
             # Verify tray is started

--- a/libs/core/kiln_ai/adapters/eval/test_base_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/test_base_eval.py
@@ -307,9 +307,7 @@ async def test_run_method():
     evaluator = EvalTester(eval_config, run_config.run_config())
 
     # Run the evaluation
-    task_run, eval_scores, intermediate_outputs = await evaluator.run_task_and_eval(
-        "test input"
-    )
+    task_run, eval_scores, _ = await evaluator.run_task_and_eval("test input")
 
     # Verify task run was created
     assert task_run.input == "test input"

--- a/libs/core/kiln_ai/adapters/eval/test_g_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/test_g_eval.py
@@ -188,7 +188,7 @@ async def test_run_g_eval_e2e(
     g_eval = GEval(test_eval_config, test_run_config)
 
     # Run the evaluation
-    task_run, scores, intermediate_outputs = await g_eval.run_task_and_eval("chickens")
+    _, scores, intermediate_outputs = await g_eval.run_task_and_eval("chickens")
 
     # Verify the evaluation results
     assert isinstance(scores, dict)

--- a/libs/core/kiln_ai/adapters/fine_tune/test_dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/test_dataset_formatter.py
@@ -206,7 +206,7 @@ def test_generate_chat_message_toolcall(mock_training_chat_two_step_json):
 
 def test_generate_chat_message_toolcall_invalid_json(mock_training_chat_two_step_json):
     mock_training_chat_two_step_json[-1].content = "invalid json"
-    with pytest.raises(ValueError, match="^Last message is not JSON"):
+    with pytest.raises(ValueError, match=r"^Last message is not JSON"):
         generate_chat_message_toolcall(mock_training_chat_two_step_json)
 
 
@@ -536,7 +536,7 @@ def test_generate_huggingface_chat_template_toolcall_invalid_json(
 ):
     mock_training_chat_two_step_json[-1].content = "invalid json"
 
-    with pytest.raises(ValueError, match="^Last message is not JSON"):
+    with pytest.raises(ValueError, match=r"^Last message is not JSON"):
         generate_huggingface_chat_template_toolcall(mock_training_chat_two_step_json)
 
 

--- a/libs/core/kiln_ai/adapters/fine_tune/test_fireworks_tinetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/test_fireworks_tinetune.py
@@ -1053,7 +1053,7 @@ async def test_fetch_all_deployments_invalid_json(fireworks_finetune, mock_api_k
 
         with pytest.raises(
             ValueError,
-            match="Invalid response from Fireworks. Expected list of deployments in 'deployments' key",
+            match=r"Invalid response from Fireworks. Expected list of deployments in 'deployments' key",
         ):
             await fireworks_finetune._fetch_all_deployments()
 

--- a/libs/core/kiln_ai/adapters/fine_tune/test_together_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/test_together_finetune.py
@@ -105,7 +105,7 @@ def mock_api_key():
 def test_init_missing_api_key(finetune):
     with patch.object(Config, "shared") as mock_config:
         mock_config.return_value.together_api_key = None
-        with pytest.raises(ValueError, match="Together.ai API key not set"):
+        with pytest.raises(ValueError, match=r"Together.ai API key not set"):
             TogetherFinetune(datamodel=finetune)
 
 

--- a/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
@@ -456,7 +456,7 @@ When asked for a final result, this is the format (for an equilateral example):
 """
     task.output_json_schema = json.dumps(triangle_schema)
     task.save_to_file()
-    response, adapter, _ = await run_structured_input_task_no_validation(
+    response, _, _ = await run_structured_input_task_no_validation(
         task, model_name, provider_name, "simple_chain_of_thought_prompt_builder"
     )
 

--- a/libs/core/kiln_ai/adapters/test_prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_builders.py
@@ -359,7 +359,7 @@ def test_prompt_builder_from_id(task_with_examples):
 
     with pytest.raises(
         ValueError,
-        match="Invalid fine-tune ID format. Expected 'project_id::task_id::fine_tune_id'",
+        match=r"Invalid fine-tune ID format. Expected 'project_id::task_id::fine_tune_id'",
     ):
         prompt_builder_from_id("fine_tune_prompt::123", task)
 

--- a/libs/core/kiln_ai/datamodel/test_basemodel.py
+++ b/libs/core/kiln_ai/datamodel/test_basemodel.py
@@ -605,7 +605,7 @@ async def test_invoke_parsing_flow(adapter):
         mock_provider.reasoning_capable = True
         with pytest.raises(
             RuntimeError,
-            match="Reasoning is required for this model, but no reasoning was returned.",
+            match=r"^Reasoning is required for this model, but no reasoning was returned.$",
         ):
             await adapter.invoke("test input")
 

--- a/libs/core/kiln_ai/datamodel/test_dataset_split.py
+++ b/libs/core/kiln_ai/datamodel/test_dataset_split.py
@@ -120,7 +120,7 @@ def test_dataset_split_validation():
         DatasetSplitDefinition(name="train", percentage=0.8),
         DatasetSplitDefinition(name="test", percentage=0.3),
     ]
-    with pytest.raises(ValueError, match="sum of split percentages must be 1.0"):
+    with pytest.raises(ValueError, match=r"sum of split percentages must be 1.0"):
         DatasetSplit(
             name="test_split",
             splits=invalid_splits,

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -402,13 +402,13 @@ def test_eval_run_five_star_score_validation(valid_eval_config, valid_eval_run_d
     assert run.scores["accuracy"] == 4.5
 
     # Invalid scores
-    with pytest.raises(ValueError, match="must be a float between 1.0 and 5.0"):
+    with pytest.raises(ValueError, match=r"must be a float between 1.0 and 5.0"):
         run = EvalRun(
             parent=valid_eval_config,
             **{**valid_eval_run_data, "scores": {"accuracy": 0.5}},
         )
 
-    with pytest.raises(ValueError, match="must be a float between 1.0 and 5.0"):
+    with pytest.raises(ValueError, match=r"must be a float between 1.0 and 5.0"):
         run = EvalRun(
             parent=valid_eval_config,
             **{**valid_eval_run_data, "scores": {"accuracy": 5.5}},
@@ -442,13 +442,13 @@ def test_eval_run_pass_fail_score_validation(valid_eval_config, valid_eval_run_d
     assert run.scores["check"] == 0.0
 
     # Invalid scores
-    with pytest.raises(ValueError, match="must be a float between 0.0 and 1.0"):
+    with pytest.raises(ValueError, match=r"must be a float between 0.0 and 1.0"):
         run = EvalRun(
             parent=valid_eval_config,
             **{**valid_eval_run_data, "scores": {"check": -0.1}},
         )
 
-    with pytest.raises(ValueError, match="must be a float between 0.0 and 1.0"):
+    with pytest.raises(ValueError, match=r"must be a float between 0.0 and 1.0"):
         run = EvalRun(
             parent=valid_eval_config,
             **{**valid_eval_run_data, "scores": {"check": 1.1}},
@@ -485,13 +485,13 @@ def test_eval_run_pass_fail_critical_score_validation(
     assert run.scores["critical"] == -1.0
 
     # Invalid scores
-    with pytest.raises(ValueError, match="must be a float between -1.0 and 1.0"):
+    with pytest.raises(ValueError, match=r"must be a float between -1.0 and 1.0"):
         run = EvalRun(
             parent=valid_eval_config,
             **{**valid_eval_run_data, "scores": {"critical": -1.1}},
         )
 
-    with pytest.raises(ValueError, match="must be a float between -1.0 and 1.0"):
+    with pytest.raises(ValueError, match=r"must be a float between -1.0 and 1.0"):
         run = EvalRun(
             parent=valid_eval_config,
             **{**valid_eval_run_data, "scores": {"critical": 1.1}},

--- a/libs/core/kiln_ai/tools/test_mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/test_mcp_session_manager.py
@@ -364,7 +364,7 @@ class TestMCPSessionManager:
 
         # Should extract the HTTP error from the nested structure
         with pytest.raises(
-            ValueError, match="The MCP server rejected the request. Status 401"
+            ValueError, match=r"The MCP server rejected the request. Status 401"
         ):
             async with manager.mcp_client(tool_server):
                 pass

--- a/libs/core/kiln_ai/tools/test_tool_registry.py
+++ b/libs/core/kiln_ai/tools/test_tool_registry.py
@@ -143,7 +143,7 @@ class TestToolRegistry:
         tool_id = f"{MCP_LOCAL_TOOL_ID_PREFIX}test_server::test_tool"
         with pytest.raises(
             ValueError,
-            match="Unable to resolve tool from id.*Requires a parent project/task",
+            match=r"Unable to resolve tool from id.*Requires a parent project/task",
         ):
             tool_from_id(tool_id, task=None)
 
@@ -406,7 +406,7 @@ class TestToolRegistry:
 
         with pytest.raises(
             ValueError,
-            match="Unable to resolve tool from id.*Requires a parent project/task",
+            match=r"Unable to resolve tool from id.*Requires a parent project/task",
         ):
             tool_from_id(mcp_tool_id, task=None)
 

--- a/libs/server/kiln_server/run_api.py
+++ b/libs/server/kiln_server/run_api.py
@@ -137,7 +137,7 @@ class BulkUploadResponse(BaseModel):
 
 
 def run_from_id(project_id: str, task_id: str, run_id: str) -> TaskRun:
-    task, run = task_and_run_from_id(project_id, task_id, run_id)
+    _, run = task_and_run_from_id(project_id, task_id, run_id)
     return run
 
 


### PR DESCRIPTION
## What does this PR do?

Fix some ruff linting errors on main. Mostly around 

RUF059 Unpacked variable `XXX` is never used
RUF043 Pattern passed to `match=` contains metacharacters but is neither escaped nor raw
* This is a weird, there are occurrences in the code with `match="FOO` that does not trigger the error. This PR only fixed the errors triggered by ./check.sh

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Cleaned up internal handlers by removing unused variables. No user-facing behavior changes.

- Tests
  - Updated test assertions to use raw-string regex patterns for clearer matching.
  - Simplified argument unpacking in several tests to ignore unused values.
  - Tightened one error-message assertion to require an exact match.
  - General test formatting improvements without changing test outcomes.

- Chores
  - Minor code hygiene improvements across modules to enhance readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->