### PR TITLE
feat: llama_index pypdf extractor

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1884,6 +1884,8 @@ export interface components {
              * @description The description of the extractor config
              */
             description?: string | null;
+            /** @description The type of extractor to use */
+            extractor_type: components["schemas"]["ExtractorType"];
             /** @description The name of the model provider to use for the extractor config. */
             model_provider_name: components["schemas"]["ModelProviderName"];
             /**
@@ -2350,7 +2352,7 @@ export interface components {
          * @description Enumeration of specific model versions supported by the system.
          * @enum {string}
          */
-        EmbeddingModelName: "openai_text_embedding_3_small" | "openai_text_embedding_3_large" | "gemini_text_embedding_004" | "gemini_embedding_001" | "embedding_gemma_300m";
+        EmbeddingModelName: "openai_text_embedding_3_small" | "openai_text_embedding_3_large" | "gemini_text_embedding_004" | "gemini_embedding_001" | "embedding_gemma_300m" | "nomic_text_embedding_v1_5";
         /** EmbeddingProvider */
         EmbeddingProvider: {
             /** Provider Name */
@@ -2722,12 +2724,12 @@ export interface components {
              * Model Provider Name
              * @description The name of the model provider to use for the extractor config.
              */
-            model_provider_name: string;
+            model_provider_name: string | null;
             /**
              * Model Name
              * @description The name of the model to use for the extractor config.
              */
-            model_name: string;
+            model_name: string | null;
             /**
              * @description The format to use for the output.
              * @default text/markdown
@@ -2769,7 +2771,7 @@ export interface components {
          * ExtractorType
          * @enum {string}
          */
-        ExtractorType: "litellm";
+        ExtractorType: "litellm" | "llama_pdf_reader";
         /** FileInfo */
         FileInfo: {
             /**

--- a/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/available_extractors_dropdown.svelte
+++ b/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/available_extractors_dropdown.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+  import {
+    available_models,
+    load_available_models,
+    available_model_details,
+    ui_state,
+    provider_name_from_id,
+    model_name as model_name_from_id,
+    model_info,
+    load_model_info,
+  } from "$lib/stores"
+  import {
+    addRecentModel,
+    type RecentModel,
+    recent_model_store,
+  } from "$lib/stores/recent_model_store"
+  import type { AvailableModels, ProviderModels } from "$lib/types"
+  import { onMount } from "svelte"
+  import FormElement from "$lib/utils/form_element.svelte"
+  import Warning from "$lib/ui/warning.svelte"
+  import type { OptionGroup, Option } from "$lib/ui/fancy_select_types"
+
+  export let extractor: string = ""
+  export let label: string = "Extractor"
+  export let description: string | undefined = undefined
+  export let error_message: string | null = null
+  export let suggested_mode: "doc_extraction" | null = null
+
+  // Export the parsed extractor type, model name and provider name
+  export let extractor_type: "litellm" | "llama_pdf_reader" | null = null
+  export let model_name: string | null = null
+  export let provider_name: string | null = null
+
+  $: model_options = format_extractor_options(
+    $available_models || [],
+    $ui_state.current_task_id,
+    $recent_model_store,
+    $model_info,
+  )
+
+  function get_extractor_info(extractor_value: string) {
+    if (extractor_value === "llama_pdf_reader") {
+      extractor_type = "llama_pdf_reader"
+      model_name = null
+      provider_name = null
+    } else {
+      extractor_type = "litellm"
+      model_name = extractor_value
+        ? extractor_value.split("/").slice(1).join("/")
+        : null
+      provider_name = extractor_value ? extractor_value.split("/")[0] : null
+    }
+  }
+
+  $: get_extractor_info(extractor)
+
+  $: addRecentModel(model_name, provider_name)
+
+  onMount(async () => {
+    await load_available_models()
+    await load_model_info()
+  })
+
+  let unsupported_models: Option[] = []
+  let untested_models: Option[] = []
+  let previous_extractor: string = extractor
+
+  function get_extractor_warning(selected: string): string | null {
+    if (unsupported_models.some((m) => m.value === selected)) {
+      return "This model is not recommended for document extraction. It may not work as expected."
+    }
+
+    return null
+  }
+
+  function confirm_extractor_select(event: Event) {
+    const select = event.target as HTMLSelectElement
+    const selected = select.value
+    const warning = get_extractor_warning(selected)
+    if (warning && !confirm(warning)) {
+      select.value = previous_extractor
+      extractor = previous_extractor
+      return
+    }
+    previous_extractor = selected
+  }
+
+  function format_extractor_options(
+    providers: AvailableModels[],
+    current_task_id: string | null,
+    recent_models: RecentModel[],
+    model_data: ProviderModels | null,
+  ): OptionGroup[] {
+    let options: OptionGroup[] = []
+    unsupported_models = []
+    untested_models = []
+
+    // Add llama_pdf_reader as the first option
+    options.push({
+      label: "Specialized Extractors",
+      options: [
+        {
+          value: "llama_pdf_reader",
+          label: "Llama PDF Reader",
+          badge: "Recommended",
+        },
+      ],
+    })
+
+    // Recent models section
+    let recent_model_list: Option[] = []
+    for (const recent_model of recent_models) {
+      const model_details = available_model_details(
+        recent_model.model_id,
+        recent_model.model_provider,
+        providers,
+      )
+      if (!model_details || !model_details.supports_doc_extraction) {
+        continue
+      }
+      recent_model_list.push({
+        value: recent_model.model_provider + "/" + recent_model.model_id,
+        label:
+          model_name_from_id(recent_model.model_id, model_data) +
+          " (" +
+          provider_name_from_id(recent_model.model_provider) +
+          ")",
+      })
+    }
+    if (recent_model_list.length > 0) {
+      options.push({
+        label: "Recent Models",
+        options: recent_model_list,
+      })
+    }
+
+    // ML Models section
+    for (const provider of providers) {
+      let model_list: Option[] = []
+      for (const model of provider.models) {
+        if (!model.supports_doc_extraction) {
+          continue
+        }
+        // Exclude models that are not available for the current task
+        if (
+          model &&
+          model.task_filter &&
+          current_task_id &&
+          !model.task_filter.includes(current_task_id)
+        ) {
+          continue
+        }
+
+        let id = provider.provider_id + "/" + model.id
+        let long_label = provider.provider_name + " / " + model.name
+        if (model.untested_model) {
+          untested_models.push({
+            value: id,
+            label: long_label,
+          })
+          continue
+        }
+
+        // For now, we don't have unsupported models for doc extraction
+        // but we keep the structure for future use
+        const unsupported = false
+        if (unsupported) {
+          unsupported_models.push({
+            value: id,
+            label: long_label,
+          })
+          continue
+        }
+
+        let badge: string | undefined = undefined
+        if (
+          suggested_mode === "doc_extraction" &&
+          model.suggested_for_doc_extraction
+        ) {
+          badge = "Recommended"
+        }
+        model_list.push({
+          value: id,
+          label: model.name,
+          badge: badge,
+        })
+      }
+      if (model_list.length > 0) {
+        options.push({
+          label: provider.provider_name,
+          options: model_list,
+        })
+      }
+    }
+
+    if (untested_models.length > 0) {
+      options.push({
+        label: "Untested Models",
+        options: untested_models,
+      })
+    }
+
+    if (unsupported_models.length > 0) {
+      options.push({
+        label: "Not Recommended",
+        options: unsupported_models,
+      })
+    }
+
+    return options
+  }
+
+  // Extra check to make sure the extractor is available to use
+  export function get_selected_extractor(): string | null {
+    for (const provider of model_options) {
+      if (provider.options.find((m) => m.value === extractor)) {
+        return extractor
+      }
+    }
+    return null
+  }
+
+  $: selected_extractor_untested = untested_models.find(
+    (m) => m.value === extractor,
+  )
+  $: selected_extractor_unsupported = unsupported_models.find(
+    (m) => m.value === extractor,
+  )
+
+  $: selected_extractor_suggested_doc_extraction =
+    available_model_details(model_name, provider_name, $available_models)
+      ?.suggested_for_doc_extraction || false
+
+  $: is_llama_pdf_reader = extractor === "llama_pdf_reader"
+</script>
+
+<div>
+  <FormElement
+    {label}
+    {description}
+    bind:value={extractor}
+    id="extractor"
+    inputType="fancy_select"
+    on_select={confirm_extractor_select}
+    bind:error_message
+    fancy_select_options={model_options}
+    placeholder="Select an extractor"
+  />
+
+  {#if selected_extractor_untested}
+    <Warning
+      warning_message="This model has not been tested with Kiln. It may not work as expected."
+    />
+  {:else if selected_extractor_unsupported}
+    <Warning
+      warning_message="This model is not recommended for document extraction. It may not work as expected."
+    />
+  {:else if is_llama_pdf_reader}
+    <Warning
+      warning_icon="check"
+      warning_color="success"
+      warning_message="Llama PDF Reader is a specialized extractor optimized for PDF documents. It provides high-quality text extraction without requiring an AI model."
+    />
+  {:else if suggested_mode === "doc_extraction"}
+    <Warning
+      warning_icon={!extractor
+        ? "info"
+        : selected_extractor_suggested_doc_extraction
+          ? "check"
+          : "exclaim"}
+      warning_color={!extractor
+        ? "gray"
+        : selected_extractor_suggested_doc_extraction
+          ? "success"
+          : "warning"}
+      warning_message="For doc extraction, we recommend using a high quality multimodal model like Gemini Pro or the specialized Llama PDF Reader."
+    />
+  {/if}
+</div>

--- a/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/create_extractor_form.svelte
+++ b/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/create_extractor_form.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { page } from "$app/stores"
   import { client } from "$lib/api_client"
-  import type { ModelProviderName, OutputFormat } from "$lib/types"
+  import type {
+    ModelProviderName,
+    OutputFormat,
+    ExtractorType,
+  } from "$lib/types"
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
   import FormElement from "$lib/utils/form_element.svelte"
   import FormContainer from "$lib/utils/form_container.svelte"
@@ -48,6 +52,7 @@
             model_provider_name: model_provider_name as ModelProviderName,
             model_name: model_name,
             output_format: output_format as OutputFormat,
+            extractor_type: "litellm" as ExtractorType,
             properties: {
               model_name,
               prompt_document: prompt_document || null,

--- a/libs/core/kiln_ai/adapters/extractors/__init__.py
+++ b/libs/core/kiln_ai/adapters/extractors/__init__.py
@@ -5,7 +5,13 @@ This package provides a framework for extracting content from files
 using different extraction methods.
 """
 
-from . import base_extractor, extractor_registry, extractor_runner, litellm_extractor
+from . import (
+    base_extractor,
+    extractor_registry,
+    extractor_runner,
+    litellm_extractor,
+    llama_pdf_reader,
+)
 from .base_extractor import ExtractionInput, ExtractionOutput
 
 __all__ = [
@@ -15,4 +21,5 @@ __all__ = [
     "extractor_registry",
     "extractor_runner",
     "litellm_extractor",
+    "llama_pdf_reader",
 ]

--- a/libs/core/kiln_ai/adapters/extractors/extractor_registry.py
+++ b/libs/core/kiln_ai/adapters/extractors/extractor_registry.py
@@ -1,5 +1,6 @@
 from kiln_ai.adapters.extractors.base_extractor import BaseExtractor
 from kiln_ai.adapters.extractors.litellm_extractor import LitellmExtractor
+from kiln_ai.adapters.extractors.llama_pdf_reader import LlamaPdfReader
 from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.provider_tools import (
     core_provider,
@@ -14,7 +15,14 @@ def extractor_adapter_from_type(
     extractor_config: ExtractorConfig,
 ) -> BaseExtractor:
     match extractor_type:
+        case ExtractorType.LLAMA_PDF_READER:
+            return LlamaPdfReader(extractor_config)
         case ExtractorType.LITELLM:
+            if extractor_config.model_provider_name is None:
+                raise ValueError("model_provider_name is required for LitellmExtractor")
+            if extractor_config.model_name is None:
+                raise ValueError("model_name is required for LitellmExtractor")
+
             try:
                 provider_enum = ModelProviderName(extractor_config.model_provider_name)
             except ValueError:

--- a/libs/core/kiln_ai/adapters/extractors/llama_pdf_reader.py
+++ b/libs/core/kiln_ai/adapters/extractors/llama_pdf_reader.py
@@ -23,13 +23,9 @@ class LlamaPdfReader(BaseExtractor):
             extraction_input.path = Path(extraction_input.path)
 
         text = self.reader.load_data(extraction_input.path)
-        if not text or len(text) != 1:
-            raise ValueError(
-                f"No text returned from PDFReader for {extraction_input.path}"
-            )
 
         return ExtractionOutput(
             is_passthrough=False,
-            content=text[0].get_content(),
+            content="\n\n".join([text_i.get_content() for text_i in text]),
             content_format=self.extractor_config.output_format,
         )

--- a/libs/core/kiln_ai/adapters/extractors/llama_pdf_reader.py
+++ b/libs/core/kiln_ai/adapters/extractors/llama_pdf_reader.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from llama_index.readers.file import PDFReader
+
+from kiln_ai.adapters.extractors.base_extractor import (
+    BaseExtractor,
+    ExtractionInput,
+    ExtractionOutput,
+)
+from kiln_ai.datamodel.extraction import ExtractorConfig
+
+
+class LlamaPdfReader(BaseExtractor):
+    def __init__(
+        self,
+        extractor_config: ExtractorConfig,
+    ):
+        super().__init__(extractor_config)
+        self.reader = PDFReader()
+
+    async def _extract(self, extraction_input: ExtractionInput) -> ExtractionOutput:
+        if not isinstance(extraction_input.path, Path):
+            extraction_input.path = Path(extraction_input.path)
+
+        text = self.reader.load_data(extraction_input.path)
+        if not text or len(text) != 1:
+            raise ValueError(
+                f"No text returned from PDFReader for {extraction_input.path}"
+            )
+
+        return ExtractionOutput(
+            is_passthrough=False,
+            content=text[0].get_content(),
+            content_format=self.extractor_config.output_format,
+        )

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -376,6 +376,9 @@ class CreateExtractorConfigRequest(BaseModel):
         description="The description of the extractor config",
         default=None,
     )
+    extractor_type: ExtractorType = Field(
+        description="The type of extractor to use",
+    )
     model_provider_name: ModelProviderName = Field(
         description="The name of the model provider to use for the extractor config.",
     )
@@ -760,7 +763,7 @@ def connect_document_api(app: FastAPI):
             model_name=request.model_name,
             output_format=request.output_format,
             passthrough_mimetypes=request.passthrough_mimetypes,
-            extractor_type=ExtractorType.LITELLM,
+            extractor_type=request.extractor_type,
             properties=request.properties,
         )
         extractor_config.save_to_file()

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -308,23 +308,29 @@ class CreateExtractorConfigRequest(BaseModel):
         except ValueError:
             raise ValueError(f"Invalid model provider name: {self.model_provider_name}")
 
-        # check the model exists and is suitable as an extractor
-        model = built_in_models_from_provider(
-            provider_name=typed_model_provider_name,
-            model_name=self.model_name,
-        )
+        if self.extractor_type == ExtractorType.LLAMA_PDF_READER:
+            return self
 
-        if model is None:
-            raise ValueError(
-                f"Model {self.model_name} not found in {self.model_provider_name}"
+        if self.extractor_type == ExtractorType.LITELLM:
+            # check the model exists and is suitable as an extractor
+            model = built_in_models_from_provider(
+                provider_name=typed_model_provider_name,
+                model_name=self.model_name,
             )
 
-        if not model.supports_doc_extraction:
-            raise ValueError(
-                f"Model {self.model_name} does not support document extraction"
-            )
+            if model is None:
+                raise ValueError(
+                    f"Model {self.model_name} not found in {self.model_provider_name}"
+                )
 
-        return self
+            if not model.supports_doc_extraction:
+                raise ValueError(
+                    f"Model {self.model_name} does not support document extraction"
+                )
+
+            return self
+
+        raise ValueError(f"Invalid extractor type: {self.extractor_type}")
 
 
 class PatchDocumentRequest(BaseModel):


### PR DESCRIPTION
## What does this PR do?

The model extractor for PDFs has noise (e.g. starting transcriptions with a preface like "Here's your transcription") and the splitting by page may cause some issues - seems to be rare but I had a case with one corrupted page of a PDF making the PDF fail.

This PR adds the llama_index's `PDFReader` that uses `pypdf` (which we already had installed to do per-page extraction).

WIP:
- work on the UI to allow picking non-models in the dropdown

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Choose extractor type when creating extractor configs, including a new Llama PDF Reader.
  * Added support for the “nomic_text_embedding_v1_5” embedding model.
* API
  * Creating extractor configs now requires an extractor_type in the request.
  * Model/provider fields may be optional based on the selected extractor type.
* UI
  * Create Extractor form now submits the selected extractor type.
* Validation
  * Improved handling and clear errors for invalid extractor types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->