### PR TITLE
Add Qwen 3 Max and Qwen 3 Next

### DIFF
--- a/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
+++ b/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
@@ -111,7 +111,9 @@ async def test_data_gen_all_models_providers(
     _, provider = get_model_and_provider(model_name, provider_name)
     if not provider.supports_data_gen:
         # pass if the model doesn't support data gen (testing the support flag is part of this)
-        return
+        pytest.skip(
+            f"Skipping {model_name} {provider_name} because it does not support data gen"
+        )
 
     data_gen_task = DataGenCategoriesTask(gen_type="training", guidance=None)
     data_gen_input = DataGenCategoriesTaskInput.from_task(base_task, num_subtopics=6)
@@ -257,7 +259,9 @@ async def test_data_gen_sample_all_models_providers(
     _, provider = get_model_and_provider(model_name, provider_name)
     if provider is None or not provider.supports_data_gen:
         # pass if the model doesn't support data gen (testing the support flag is part of this)
-        return
+        pytest.skip(
+            f"Skipping {model_name} {provider_name} because it does not support data gen"
+        )
 
     data_gen_task = DataGenSampleTask(
         target_task=base_task, gen_type="training", guidance=None
@@ -313,7 +317,9 @@ async def test_data_gen_sample_all_models_providers_with_structured_output(
     _, provider = get_model_and_provider(model_name, provider_name)
     if not provider.supports_data_gen:
         # pass if the model doesn't support data gen (testing the support flag is part of this)
-        return
+        pytest.skip(
+            f"Skipping {model_name} {provider_name} because it does not support data gen"
+        )
 
     data_gen_task = DataGenSampleTask(
         target_task=task, gen_type="training", guidance=None

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -138,6 +138,9 @@ class ModelName(str, Enum):
     grok_3 = "grok_3"
     grok_3_mini = "grok_3_mini"
     grok_4 = "grok_4"
+    qwen_3_next_80b_a3b = "qwen_3_next_80b_a3b"
+    qwen_3_next_80b_a3b_thinking = "qwen_3_next_80b_a3b_thinking"
+    qwen_3_max = "qwen_3_max"
     qwen_3_0p6b = "qwen_3_0p6b"
     qwen_3_0p6b_no_thinking = "qwen_3_0p6b_no_thinking"
     qwen_3_1p7b = "qwen_3_1p7b"
@@ -2529,6 +2532,53 @@ built_in_models: List[KilnModel] = [
                 supports_structured_output=True,
                 supports_data_gen=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
+            ),
+        ],
+    ),
+    # Qwen 3 Next 80B A3B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3_next_80b_a3b,
+        friendly_name="Qwen 3 Next 80B A3B (Instruct)",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3-next-80b-a3b-instruct",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_function_calling=True,
+            ),
+        ],
+    ),
+    # Qwen 3 Next 80B A3B (Thinking)
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3_next_80b_a3b_thinking,
+        friendly_name="Qwen 3 Next 80B A3B (Thinking)",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3-next-80b-a3b-thinking",
+                structured_output_mode=StructuredOutputMode.json_instructions,
+                supports_data_gen=True,
+                supports_function_calling=True,
+                reasoning_capable=True,
+                require_openrouter_reasoning=True,
+            ),
+        ],
+    ),
+    # Qwen 3 Max
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3_max,
+        friendly_name="Qwen 3 Max",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3-max",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_function_calling=True,
             ),
         ],
     ),


### PR DESCRIPTION
All tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three Qwen models via OpenRouter: Qwen 3 Next 80B A3B (Instruct), Qwen 3 Next 80B A3B (Thinking), and Qwen 3 Max.
  * All support structured output, function calling, and data generation; the Thinking variant includes a reasoning mode (requires OpenRouter reasoning).

* **Tests**
  * Data generation tests now skip unsupported providers/models with clear messages instead of exiting early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->