### PR TITLE
feat: RagConfig filters docs by tags

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -4027,6 +4027,8 @@ export interface components {
             chunker_config: components["schemas"]["ChunkerConfig"];
             embedding_config: components["schemas"]["EmbeddingConfig"];
             vector_store_config: components["schemas"]["VectorStoreConfig"];
+            /** Tags */
+            tags: string[] | null;
         };
         /** RagProgress */
         RagProgress: {

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -403,6 +403,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/projects/{project_id}/documents/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Document Tags */
+        get: operations["get_document_tags_api_projects__project_id__documents_tags_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/projects/{project_id}/documents/{document_id}": {
         parameters: {
             query?: never;
@@ -2310,6 +2327,11 @@ export interface components {
              * @description The vector store config to use for the RAG workflow.
              */
             vector_store_config_id: string | null;
+            /**
+             * Tags
+             * @description List of document tags to filter by. If None, all documents in the project are used.
+             */
+            tags?: string[] | null;
         };
         /** CreateTaskRunConfigRequest */
         CreateTaskRunConfigRequest: {
@@ -3978,6 +4000,11 @@ export interface components {
              * @description The ID of the vector store config used to store the documents.
              */
             vector_store_config_id: string | null;
+            /**
+             * Tags
+             * @description List of document tags to filter by. If None, all documents in the project are used.
+             */
+            tags?: string[] | null;
             /** Model Type */
             readonly model_type: string;
         };
@@ -5746,6 +5773,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Document"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_document_tags_api_projects__project_id__documents_tags_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string[];
                 };
             };
             /** @description Validation Error */

--- a/app/web_ui/src/lib/utils/form_element.svelte
+++ b/app/web_ui/src/lib/utils/form_element.svelte
@@ -30,6 +30,7 @@
   export let disabled: boolean = false
   export let info_msg: string | null = null
   export let tall: boolean | "medium" | "xl" = false
+  export let empty_label: string = "Select an option"
 
   function is_empty(value: unknown): boolean {
     if (value === null || value === undefined) {
@@ -215,6 +216,7 @@
         bind:options={fancy_select_options}
         bind:selected={value}
         multi_select={inputType === "multi_select"}
+        {empty_label}
       />
     {/if}
     {#if inline_error || (inputType === "select" && error_message)}

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
@@ -408,22 +408,22 @@
                 },
               ]}
             />
-            <div class="text-xl font-bold">Tags</div>
-            <div class="flex flex-row flex-wrap gap-2">
-              {#if sorted_tags}
-                {#each sorted_tags as tag}
-                  <div
-                    class="badge bg-gray-200 text-gray-500 py-3 px-3 max-w-full"
-                  >
-                    <span class="truncate">{tag}</span>
-                  </div>
-                {/each}
-              {:else}
-                <div class="text-gray-500">
-                  Not tags. This Search Tool targets all documents in the
-                  project.
-                </div>
-              {/if}
+            <div>
+              <div class="text-xl font-bold mb-1">Documents</div>
+              <div class="flex flex-row flex-wrap gap-2 text-sm text-gray-500">
+                {#if sorted_tags && sorted_tags.length > 0}
+                  Search is limited to documents with the tags:
+                  {#each sorted_tags as tag}
+                    <div
+                      class="badge bg-gray-200 text-gray-500 py-3 px-3 max-w-full"
+                    >
+                      <span class="truncate">{tag}</span>
+                    </div>
+                  {/each}
+                {:else}
+                  All documents in library.
+                {/if}
+              </div>
             </div>
           </div>
         </div>

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
@@ -406,6 +406,16 @@
                 },
               ]}
             />
+            <div class="text-xl font-bold">Tags</div>
+            <div class="flex flex-row flex-wrap gap-2">
+              {#each (rag_config.tags || []).sort() as tag}
+                <div
+                  class="badge bg-gray-200 text-gray-500 py-3 px-3 max-w-full"
+                >
+                  <span class="truncate">{tag}</span>
+                </div>
+              {/each}
+            </div>
           </div>
         </div>
       </div>

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
@@ -134,6 +134,8 @@
     event.preventDefault()
     await performSearch()
   }
+
+  $: sorted_tags = rag_config?.tags ? rag_config.tags.toSorted() : null
 </script>
 
 <div class="max-w-[1400px]">
@@ -408,13 +410,20 @@
             />
             <div class="text-xl font-bold">Tags</div>
             <div class="flex flex-row flex-wrap gap-2">
-              {#each (rag_config.tags || []).sort() as tag}
-                <div
-                  class="badge bg-gray-200 text-gray-500 py-3 px-3 max-w-full"
-                >
-                  <span class="truncate">{tag}</span>
+              {#if sorted_tags}
+                {#each sorted_tags as tag}
+                  <div
+                    class="badge bg-gray-200 text-gray-500 py-3 px-3 max-w-full"
+                  >
+                    <span class="truncate">{tag}</span>
+                  </div>
+                {/each}
+              {:else}
+                <div class="text-gray-500">
+                  Not tags. This Search Tool targets all documents in the
+                  project.
                 </div>
-              {/each}
+              {/if}
             </div>
           </div>
         </div>

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/+page.svelte
@@ -13,6 +13,7 @@
   import CreateChunkerForm from "./create_chunker_form.svelte"
   import CreateEmbeddingForm from "./create_embedding_form.svelte"
   import CreateVectorStoreForm from "./create_vector_store_form.svelte"
+  import TagSelector from "./tag_selector.svelte"
   import type {
     ExtractorConfig,
     ChunkerConfig,
@@ -34,6 +35,7 @@
   let error: KilnError | null = null
   let name: string | null = null
   let description: string = ""
+  let selected_tags: string[] = []
 
   let show_create_extractor_dialog: Dialog | null = null
   let show_create_chunker_dialog: Dialog | null = null
@@ -421,6 +423,7 @@
             chunker_config_id: selected_chunker_config_id,
             embedding_config_id: selected_embedding_config_id,
             vector_store_config_id: selected_vector_store_config_id,
+            tags: selected_tags.length > 0 ? selected_tags : null,
           },
         },
       )
@@ -545,6 +548,14 @@
                 inputType="fancy_select"
               />
             {/if}
+          </div>
+
+          <div class="flex flex-col gap-2">
+            <TagSelector
+              {project_id}
+              bind:selected_tags
+              on:change={(e) => (selected_tags = e.detail.selected_tags)}
+            />
           </div>
         </div>
 

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/tag_selector.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/tag_selector.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import { client } from "$lib/api_client"
+  import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
+  import { createEventDispatcher, onMount } from "svelte"
+
+  const dispatch = createEventDispatcher()
+
+  export let project_id: string
+  export let selected_tags: string[] = []
+
+  let available_tags: string[] = []
+  let loading_tags = false
+  let error: KilnError | null = null
+
+  onMount(async () => {
+    await loadAvailableTags()
+  })
+
+  async function loadAvailableTags() {
+    try {
+      loading_tags = true
+      error = null
+
+      const { data, error: fetch_error } = await client.GET(
+        "/api/projects/{project_id}/documents/tags",
+        {
+          params: {
+            path: {
+              project_id,
+            },
+          },
+        },
+      )
+
+      if (fetch_error) {
+        error = createKilnError(fetch_error)
+        return
+      }
+
+      available_tags = data || []
+    } finally {
+      loading_tags = false
+    }
+  }
+
+  function toggleTag(tag: string) {
+    if (selected_tags.includes(tag)) {
+      selected_tags = selected_tags.filter((t) => t !== tag)
+    } else {
+      selected_tags = [...selected_tags, tag]
+    }
+    dispatch("change", { selected_tags })
+  }
+
+  function removeTag(tag: string) {
+    selected_tags = selected_tags.filter((t) => t !== tag)
+    dispatch("change", { selected_tags })
+  }
+
+  function clearAllTags() {
+    selected_tags = []
+    dispatch("change", { selected_tags })
+  }
+
+  $: unselected_tags = available_tags.filter(
+    (tag) => !selected_tags.includes(tag),
+  )
+</script>
+
+<div class="flex flex-col gap-4">
+  {#if loading_tags}
+    <div class="flex items-center gap-2">
+      <div class="loading loading-spinner loading-sm"></div>
+      <span class="text-sm">Loading tags...</span>
+    </div>
+  {:else if error}
+    <div class="text-error text-sm">{error.message}</div>
+  {:else}
+    {#if selected_tags.length > 0}
+      <div>
+        <div class="flex items-center gap-2 mb-2">
+          <div class="text-sm font-medium">Selected Tags:</div>
+          <button
+            class="text-xs text-gray-500 hover:text-gray-700 underline"
+            on:click={clearAllTags}
+          >
+            Clear all
+          </button>
+        </div>
+        <div class="flex flex-row gap-2 flex-wrap">
+          {#each selected_tags as tag}
+            <div class="badge badge-primary py-3 px-3 max-w-full">
+              <span class="truncate">{tag}</span>
+              <button
+                class="pl-3 font-medium shrink-0 text-white hover:text-gray-200"
+                on:click={() => removeTag(tag)}
+              >
+                ✕
+              </button>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if unselected_tags.length > 0}
+      <div>
+        <div class="text-sm font-medium mb-2">
+          {selected_tags.length > 0
+            ? "Add more tags:"
+            : "Select tags to filter documents:"}
+        </div>
+        <div class="flex flex-row gap-2 flex-wrap">
+          {#each unselected_tags as tag}
+            <button
+              class="badge bg-gray-200 text-gray-700 py-3 px-3 max-w-full hover:bg-gray-300 transition-colors"
+              on:click={() => toggleTag(tag)}
+            >
+              {tag}
+            </button>
+          {/each}
+        </div>
+      </div>
+    {:else if selected_tags.length === 0}
+      <div class="text-sm text-gray-500">
+        No document tags found in this project.
+      </div>
+    {/if}
+
+    {#if available_tags.length > 0 && selected_tags.length === 0}
+      <div class="text-xs text-gray-500">
+        Leave empty to include all documents, or select specific tags to only
+        include documents with those tags.
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/tag_selector.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/tag_selector.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import { client } from "$lib/api_client"
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
-  import { createEventDispatcher, onMount } from "svelte"
-
-  const dispatch = createEventDispatcher()
+  import FormElement from "$lib/utils/form_element.svelte"
+  import { onMount } from "svelte"
 
   export let project_id: string
   export let selected_tags: string[] = []
@@ -45,98 +44,55 @@
     }
   }
 
-  function toggleTag(tag: string) {
-    if (selected_tags.includes(tag)) {
-      selected_tags = selected_tags.filter((t) => t !== tag)
-    } else {
-      selected_tags = [...selected_tags, tag]
+  function get_fancy_select_options(
+    document_tags: string[],
+    loading_tags: boolean,
+  ) {
+    if (loading_tags) {
+      return [
+        {
+          label: "Loading document tags. Please wait...",
+          options: [],
+        },
+      ]
     }
-    dispatch("change", { selected_tags })
+    if (document_tags.length === 0) {
+      return [
+        {
+          label:
+            "No documents have tags. Add tags in the document library to create a filter.",
+          options: [],
+        },
+      ]
+    }
+    return [
+      {
+        label: "Filter by Document Tag",
+        options: document_tags.map((tag) => ({
+          label: tag,
+          value: tag,
+        })),
+      },
+    ]
   }
-
-  function removeTag(tag: string) {
-    selected_tags = selected_tags.filter((t) => t !== tag)
-    dispatch("change", { selected_tags })
-  }
-
-  function clearAllTags() {
-    selected_tags = []
-    dispatch("change", { selected_tags })
-  }
-
-  $: unselected_tags = available_tags.filter(
-    (tag) => !selected_tags.includes(tag),
-  )
 </script>
 
 <div class="flex flex-col gap-4">
-  {#if loading_tags}
-    <div class="flex items-center gap-2">
-      <div class="loading loading-spinner loading-sm"></div>
-      <span class="text-sm">Loading tags...</span>
-    </div>
-  {:else if error}
+  {#if error}
     <div class="text-error text-sm">{error.message}</div>
   {:else}
-    {#if selected_tags.length > 0}
-      <div>
-        <div class="flex items-center gap-2 mb-2">
-          <div class="text-sm font-medium">Selected Tags:</div>
-          <button
-            type="button"
-            class="text-xs text-gray-500 hover:text-gray-700 underline"
-            on:click={clearAllTags}
-          >
-            Clear all
-          </button>
-        </div>
-        <div class="flex flex-row gap-2 flex-wrap">
-          {#each selected_tags as tag}
-            <div class="badge badge-primary py-3 px-3 max-w-full">
-              <span class="truncate">{tag}</span>
-              <button
-                type="button"
-                class="pl-3 font-medium shrink-0 text-white hover:text-gray-200"
-                on:click={() => removeTag(tag)}
-              >
-                ✕
-              </button>
-            </div>
-          {/each}
-        </div>
-      </div>
-    {/if}
-
-    {#if unselected_tags.length > 0}
-      <div>
-        <div class="text-sm font-medium mb-2">
-          {selected_tags.length > 0
-            ? "Add more tags:"
-            : "Select tags to filter documents:"}
-        </div>
-        <div class="flex flex-row gap-2 flex-wrap">
-          {#each unselected_tags as tag}
-            <button
-              type="button"
-              class="badge bg-gray-200 text-gray-700 py-3 px-3 max-w-full hover:bg-gray-300 transition-colors"
-              on:click={() => toggleTag(tag)}
-            >
-              {tag}
-            </button>
-          {/each}
-        </div>
-      </div>
-    {:else if selected_tags.length === 0}
-      <div class="text-sm text-gray-500">
-        No document tags found in this project.
-      </div>
-    {/if}
-
-    {#if available_tags.length > 0 && selected_tags.length === 0}
-      <div class="text-xs text-gray-500">
-        Leave empty to include all documents, or select specific tags to only
-        include documents with those tags.
-      </div>
-    {/if}
+    <FormElement
+      id="tags_selector"
+      label="Document Selection"
+      description="Define which documents can be retrieved."
+      info_description="If a tag filter is applied, only documents with those tags will be searched by this tool. You can add tags to your documents in the document library."
+      inputType="multi_select"
+      empty_label="All Documents in Library"
+      fancy_select_options={get_fancy_select_options(
+        available_tags,
+        loading_tags,
+      )}
+      bind:value={selected_tags}
+    />
   {/if}
 </div>

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/tag_selector.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/tag_selector.svelte
@@ -81,6 +81,7 @@
         <div class="flex items-center gap-2 mb-2">
           <div class="text-sm font-medium">Selected Tags:</div>
           <button
+            type="button"
             class="text-xs text-gray-500 hover:text-gray-700 underline"
             on:click={clearAllTags}
           >
@@ -92,6 +93,7 @@
             <div class="badge badge-primary py-3 px-3 max-w-full">
               <span class="truncate">{tag}</span>
               <button
+                type="button"
                 class="pl-3 font-medium shrink-0 text-white hover:text-gray-200"
                 on:click={() => removeTag(tag)}
               >
@@ -113,6 +115,7 @@
         <div class="flex flex-row gap-2 flex-wrap">
           {#each unselected_tags as tag}
             <button
+              type="button"
               class="badge bg-gray-200 text-gray-700 py-3 px-3 max-w-full hover:bg-gray-300 transition-colors"
               on:click={() => toggleTag(tag)}
             >

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/tag_selector.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/tag_selector.svelte
@@ -17,11 +17,11 @@
   })
 
   async function loadAvailableTags() {
-    try {
-      loading_tags = true
-      error = null
+    loading_tags = true
+    error = null
 
-      const { data, error: fetch_error } = await client.GET(
+    try {
+      const { data, error: load_available_tags_error } = await client.GET(
         "/api/projects/{project_id}/documents/tags",
         {
           params: {
@@ -32,12 +32,14 @@
         },
       )
 
-      if (fetch_error) {
-        error = createKilnError(fetch_error)
-        return
+      if (load_available_tags_error) {
+        throw load_available_tags_error
       }
 
       available_tags = data || []
+    } catch (e) {
+      error = createKilnError(e as unknown)
+      available_tags = []
     } finally {
       loading_tags = false
     }

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/table_rag_config_row.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/table_rag_config_row.svelte
@@ -118,6 +118,13 @@
           <div class="text-xs text-gray-500">
             Created {formatDate(rag_config.created_at)}
           </div>
+          <div class="text-xs text-gray-500 flex flex-row flex-wrap gap-2 w-80">
+            {#each rag_config.tags || [] as tag}
+              <div class="badge bg-gray-200 text-gray-500 text-xs">
+                {tag}
+              </div>
+            {/each}
+          </div>
         </div>
       </div>
     </td>

--- a/libs/core/kiln_ai/adapters/rag/deduplication.py
+++ b/libs/core/kiln_ai/adapters/rag/deduplication.py
@@ -3,7 +3,7 @@ from typing import DefaultDict
 
 from kiln_ai.datamodel.chunk import ChunkedDocument
 from kiln_ai.datamodel.embedding import ChunkEmbeddings
-from kiln_ai.datamodel.extraction import Extraction
+from kiln_ai.datamodel.extraction import Document, Extraction
 
 
 def deduplicate_extractions(items: list[Extraction]) -> list[Extraction]:
@@ -33,3 +33,17 @@ def deduplicate_chunk_embeddings(items: list[ChunkEmbeddings]) -> list[ChunkEmbe
             raise ValueError("Embedding config ID is required")
         grouped_items[item.embedding_config_id].append(item)
     return [min(group, key=lambda x: x.created_at) for group in grouped_items.values()]
+
+
+def filter_documents_by_tags(
+    documents: list[Document], tags: list[str] | None
+) -> list[Document]:
+    if not tags:
+        return documents
+
+    filtered_documents = []
+    for document in documents:
+        if document.tags and any(tag in document.tags for tag in tags):
+            filtered_documents.append(document)
+
+    return filtered_documents

--- a/libs/core/kiln_ai/adapters/rag/rag_runners.py
+++ b/libs/core/kiln_ai/adapters/rag/rag_runners.py
@@ -14,6 +14,7 @@ from kiln_ai.adapters.rag.deduplication import (
     deduplicate_chunk_embeddings,
     deduplicate_chunked_documents,
     deduplicate_extractions,
+    filter_documents_by_tags,
 )
 from kiln_ai.adapters.rag.progress import LogMessage, RagProgress
 from kiln_ai.adapters.vector_store.base_vector_store_adapter import (
@@ -227,11 +228,13 @@ class RagExtractionStepRunner(AbstractRagStepRunner):
         project: Project,
         extractor_config: ExtractorConfig,
         concurrency: int = 10,
+        rag_config: RagConfig | None = None,
     ):
         self.project = project
         self.extractor_config = extractor_config
         self.lock_key = f"docs:extract:{self.extractor_config.id}"
         self.concurrency = concurrency
+        self.rag_config = rag_config
 
     def stage(self) -> RagWorkflowStepNames:
         return RagWorkflowStepNames.EXTRACTING
@@ -247,7 +250,12 @@ class RagExtractionStepRunner(AbstractRagStepRunner):
     ) -> list[ExtractorJob]:
         jobs: list[ExtractorJob] = []
         target_extractor_config_id = self.extractor_config.id
-        for document in self.project.documents(readonly=True):
+
+        documents = self.project.documents(readonly=True)
+        if self.rag_config and self.rag_config.tags:
+            documents = filter_documents_by_tags(documents, self.rag_config.tags)
+
+        for document in documents:
             if (
                 document_ids is not None
                 and len(document_ids) > 0
@@ -311,12 +319,14 @@ class RagChunkingStepRunner(AbstractRagStepRunner):
         extractor_config: ExtractorConfig,
         chunker_config: ChunkerConfig,
         concurrency: int = 10,
+        rag_config: RagConfig | None = None,
     ):
         self.project = project
         self.extractor_config = extractor_config
         self.chunker_config = chunker_config
         self.lock_key = f"docs:chunk:{self.chunker_config.id}"
         self.concurrency = concurrency
+        self.rag_config = rag_config
 
     def stage(self) -> RagWorkflowStepNames:
         return RagWorkflowStepNames.CHUNKING
@@ -334,7 +344,11 @@ class RagChunkingStepRunner(AbstractRagStepRunner):
         target_chunker_config_id = self.chunker_config.id
 
         jobs: list[ChunkerJob] = []
-        for document in self.project.documents(readonly=True):
+        documents = self.project.documents(readonly=True)
+        if self.rag_config and self.rag_config.tags:
+            documents = filter_documents_by_tags(documents, self.rag_config.tags)
+
+        for document in documents:
             if (
                 document_ids is not None
                 and len(document_ids) > 0
@@ -402,12 +416,14 @@ class RagEmbeddingStepRunner(AbstractRagStepRunner):
         chunker_config: ChunkerConfig,
         embedding_config: EmbeddingConfig,
         concurrency: int = 10,
+        rag_config: RagConfig | None = None,
     ):
         self.project = project
         self.extractor_config = extractor_config
         self.chunker_config = chunker_config
         self.embedding_config = embedding_config
         self.concurrency = concurrency
+        self.rag_config = rag_config
         self.lock_key = f"docs:embedding:{self.embedding_config.id}"
 
     def stage(self) -> RagWorkflowStepNames:
@@ -427,7 +443,11 @@ class RagEmbeddingStepRunner(AbstractRagStepRunner):
         target_embedding_config_id = self.embedding_config.id
 
         jobs: list[EmbeddingJob] = []
-        for document in self.project.documents(readonly=True):
+        documents = self.project.documents(readonly=True)
+        if self.rag_config and self.rag_config.tags:
+            documents = filter_documents_by_tags(documents, self.rag_config.tags)
+
+        for document in documents:
             if (
                 document_ids is not None
                 and len(document_ids) > 0
@@ -535,7 +555,11 @@ class RagIndexingStepRunner(AbstractRagStepRunner):
 
         # (document_id, chunked_document, embedding)
         jobs: list[DocumentWithChunksAndEmbeddings] = []
-        for document in self.project.documents(readonly=True):
+        documents = self.project.documents(readonly=True)
+        if self.rag_config and self.rag_config.tags:
+            documents = filter_documents_by_tags(documents, self.rag_config.tags)
+
+        for document in documents:
             if (
                 document_ids is not None
                 and len(document_ids) > 0

--- a/libs/core/kiln_ai/adapters/rag/test_deduplication.py
+++ b/libs/core/kiln_ai/adapters/rag/test_deduplication.py
@@ -1,0 +1,195 @@
+from unittest.mock import MagicMock
+
+from kiln_ai.adapters.rag.deduplication import (
+    deduplicate_chunk_embeddings,
+    deduplicate_chunked_documents,
+    deduplicate_extractions,
+    filter_documents_by_tags,
+)
+from kiln_ai.datamodel.chunk import ChunkedDocument
+from kiln_ai.datamodel.embedding import ChunkEmbeddings
+from kiln_ai.datamodel.extraction import Document, Extraction
+
+
+class TestFilterDocumentsByTags:
+    def test_filter_documents_by_tags_with_none_tags(self):
+        """Test that None tags returns all documents"""
+        doc1 = MagicMock(spec=Document)
+        doc1.tags = ["tag1", "tag2"]
+        doc2 = MagicMock(spec=Document)
+        doc2.tags = ["tag3"]
+
+        documents = [doc1, doc2]
+        result = filter_documents_by_tags(documents, None)
+
+        assert result == documents
+        assert len(result) == 2
+
+    def test_filter_documents_by_tags_with_empty_tags(self):
+        """Test that empty tags list returns all documents"""
+        doc1 = MagicMock(spec=Document)
+        doc1.tags = ["tag1", "tag2"]
+        doc2 = MagicMock(spec=Document)
+        doc2.tags = ["tag3"]
+
+        documents = [doc1, doc2]
+        result = filter_documents_by_tags(documents, [])
+
+        assert result == documents
+        assert len(result) == 2
+
+    def test_filter_documents_by_tags_single_matching_tag(self):
+        """Test filtering with a single matching tag"""
+        doc1 = MagicMock(spec=Document)
+        doc1.tags = ["tag1", "tag2"]
+        doc2 = MagicMock(spec=Document)
+        doc2.tags = ["tag3"]
+        doc3 = MagicMock(spec=Document)
+        doc3.tags = ["tag1", "tag4"]
+
+        documents = [doc1, doc2, doc3]
+        result = filter_documents_by_tags(documents, ["tag1"])
+
+        assert len(result) == 2
+        assert doc1 in result
+        assert doc3 in result
+        assert doc2 not in result
+
+    def test_filter_documents_by_tags_multiple_matching_tags(self):
+        """Test filtering with multiple tags (OR logic)"""
+        doc1 = MagicMock(spec=Document)
+        doc1.tags = ["tag1", "tag2"]
+        doc2 = MagicMock(spec=Document)
+        doc2.tags = ["tag3"]
+        doc3 = MagicMock(spec=Document)
+        doc3.tags = ["tag4", "tag5"]
+        doc4 = MagicMock(spec=Document)
+        doc4.tags = ["tag2", "tag6"]
+
+        documents = [doc1, doc2, doc3, doc4]
+        result = filter_documents_by_tags(documents, ["tag1", "tag3"])
+
+        assert len(result) == 2
+        assert doc1 in result  # has tag1
+        assert doc2 in result  # has tag3
+        assert doc3 not in result
+        assert doc4 not in result
+
+    def test_filter_documents_by_tags_no_matching_documents(self):
+        """Test filtering when no documents match the tags"""
+        doc1 = MagicMock(spec=Document)
+        doc1.tags = ["tag1", "tag2"]
+        doc2 = MagicMock(spec=Document)
+        doc2.tags = ["tag3"]
+
+        documents = [doc1, doc2]
+        result = filter_documents_by_tags(documents, ["tag4", "tag5"])
+
+        assert len(result) == 0
+
+    def test_filter_documents_by_tags_documents_with_no_tags(self):
+        """Test filtering when some documents have no tags"""
+        doc1 = MagicMock(spec=Document)
+        doc1.tags = ["tag1", "tag2"]
+        doc2 = MagicMock(spec=Document)
+        doc2.tags = None
+        doc3 = MagicMock(spec=Document)
+        doc3.tags = []
+        doc4 = MagicMock(spec=Document)
+        doc4.tags = ["tag1"]
+
+        documents = [doc1, doc2, doc3, doc4]
+        result = filter_documents_by_tags(documents, ["tag1"])
+
+        assert len(result) == 2
+        assert doc1 in result
+        assert doc4 in result
+        assert doc2 not in result  # None tags
+        assert doc3 not in result  # empty tags
+
+    def test_filter_documents_by_tags_empty_document_list(self):
+        """Test filtering with empty document list"""
+        documents = []
+        result = filter_documents_by_tags(documents, ["tag1"])
+
+        assert len(result) == 0
+
+    def test_filter_documents_by_tags_case_sensitive(self):
+        """Test that tag filtering is case sensitive"""
+        doc1 = MagicMock(spec=Document)
+        doc1.tags = ["Tag1", "tag2"]
+        doc2 = MagicMock(spec=Document)
+        doc2.tags = ["tag1", "tag3"]
+
+        documents = [doc1, doc2]
+        result = filter_documents_by_tags(documents, ["tag1"])
+
+        assert len(result) == 1
+        assert doc2 in result
+        assert doc1 not in result  # "Tag1" != "tag1"
+
+    def test_filter_documents_by_tags_partial_match(self):
+        """Test that only exact tag matches work, not partial matches"""
+        doc1 = MagicMock(spec=Document)
+        doc1.tags = ["tag1", "tag12"]
+        doc2 = MagicMock(spec=Document)
+        doc2.tags = ["tag", "other"]
+
+        documents = [doc1, doc2]
+        result = filter_documents_by_tags(documents, ["tag"])
+
+        assert len(result) == 1
+        assert doc2 in result
+        assert doc1 not in result  # "tag1" and "tag12" don't match "tag"
+
+
+class TestDeduplicationFunctions:
+    """Basic tests to ensure existing deduplication functions still work"""
+
+    def test_deduplicate_extractions_basic(self):
+        """Test basic deduplication of extractions"""
+        extraction1 = MagicMock(spec=Extraction)
+        extraction1.extractor_config_id = "config1"
+        extraction1.created_at = "2024-01-01"
+
+        extraction2 = MagicMock(spec=Extraction)
+        extraction2.extractor_config_id = "config1"
+        extraction2.created_at = "2024-01-02"
+
+        extractions = [extraction1, extraction2]
+        result = deduplicate_extractions(extractions)
+
+        assert len(result) == 1
+        assert result[0] == extraction1  # earlier created_at
+
+    def test_deduplicate_chunked_documents_basic(self):
+        """Test basic deduplication of chunked documents"""
+        chunked1 = MagicMock(spec=ChunkedDocument)
+        chunked1.chunker_config_id = "config1"
+        chunked1.created_at = "2024-01-01"
+
+        chunked2 = MagicMock(spec=ChunkedDocument)
+        chunked2.chunker_config_id = "config1"
+        chunked2.created_at = "2024-01-02"
+
+        chunked_docs = [chunked1, chunked2]
+        result = deduplicate_chunked_documents(chunked_docs)
+
+        assert len(result) == 1
+        assert result[0] == chunked1  # earlier created_at
+
+    def test_deduplicate_chunk_embeddings_basic(self):
+        """Test basic deduplication of chunk embeddings"""
+        embedding1 = MagicMock(spec=ChunkEmbeddings)
+        embedding1.embedding_config_id = "config1"
+        embedding1.created_at = "2024-01-01"
+
+        embedding2 = MagicMock(spec=ChunkEmbeddings)
+        embedding2.embedding_config_id = "config1"
+        embedding2.created_at = "2024-01-02"
+
+        embeddings = [embedding1, embedding2]
+        result = deduplicate_chunk_embeddings(embeddings)
+
+        assert len(result) == 1
+        assert result[0] == embedding1  # earlier created_at

--- a/libs/core/kiln_ai/adapters/rag/test_progress.py
+++ b/libs/core/kiln_ai/adapters/rag/test_progress.py
@@ -78,13 +78,14 @@ def create_mock_extraction(extractor_config_id, chunked_documents=None):
     return mock_extraction
 
 
-def create_mock_document(extractions=None):
+def create_mock_document(extractions=None, tags=None):
     """Helper to create a mock document with the specified extractions"""
     if extractions is None:
         extractions = []
 
     mock_document = MagicMock(spec=Document)
     mock_document.extractions.return_value = extractions
+    mock_document.tags = tags
     return mock_document
 
 
@@ -94,6 +95,7 @@ def create_mock_rag_config(
     chunker_config_id,
     embedding_config_id,
     vector_store_config_id="vector_store_1",
+    tags=None,
 ):
     """Helper to create a mock RAG config with the specified IDs"""
     mock_rag_config = MagicMock(spec=RagConfig)
@@ -102,6 +104,7 @@ def create_mock_rag_config(
     mock_rag_config.chunker_config_id = chunker_config_id
     mock_rag_config.embedding_config_id = embedding_config_id
     mock_rag_config.vector_store_config_id = vector_store_config_id
+    mock_rag_config.tags = tags
     return mock_rag_config
 
 
@@ -600,3 +603,183 @@ class TestCountRecordsInVectorStoreForRagConfig:
                 )
 
             mock_from_id.assert_called_once_with("vector_store_1", mock_project.path)
+
+
+class TestComputeCurrentProgressForRagConfigsWithTags:
+    """Test progress computation with document tag filtering"""
+
+    @pytest.mark.asyncio
+    async def test_rag_config_with_matching_tags(
+        self, mock_project_magic, mock_vector_store_count
+    ):
+        """Test RAG config that filters by tags - some documents match"""
+        # Create documents with different tags
+        doc1 = create_mock_document([], tags=["python", "backend"])
+        doc2 = create_mock_document([], tags=["javascript", "frontend"])
+        doc3 = create_mock_document([], tags=["python", "ml"])
+        doc4 = create_mock_document([], tags=["java", "backend"])
+
+        # RAG config that filters for "python" tag
+        rag_config = create_mock_rag_config(
+            "rag1", "ext1", "chunk1", "embed1", tags=["python"]
+        )
+
+        mock_project_magic.documents.return_value = [doc1, doc2, doc3, doc4]
+        result = await compute_current_progress_for_rag_configs(
+            mock_project_magic, [rag_config]
+        )
+
+        # Should only count doc1 and doc3 (have "python" tag)
+        assert len(result) == 1
+        assert "rag1" in result
+        assert result["rag1"].total_document_count == 2
+
+    @pytest.mark.asyncio
+    async def test_rag_config_with_multiple_tags(
+        self, mock_project_magic, mock_vector_store_count
+    ):
+        """Test RAG config with multiple tags (OR logic)"""
+        # Create documents with different tags
+        doc1 = create_mock_document([], tags=["python", "backend"])
+        doc2 = create_mock_document([], tags=["javascript", "frontend"])
+        doc3 = create_mock_document([], tags=["rust", "systems"])
+        doc4 = create_mock_document([], tags=["go", "backend"])
+
+        # RAG config that filters for "python" OR "javascript"
+        rag_config = create_mock_rag_config(
+            "rag1", "ext1", "chunk1", "embed1", tags=["python", "javascript"]
+        )
+
+        mock_project_magic.documents.return_value = [doc1, doc2, doc3, doc4]
+        result = await compute_current_progress_for_rag_configs(
+            mock_project_magic, [rag_config]
+        )
+
+        # Should count doc1 (python) and doc2 (javascript)
+        assert len(result) == 1
+        assert "rag1" in result
+        assert result["rag1"].total_document_count == 2
+
+    @pytest.mark.asyncio
+    async def test_rag_config_with_no_matching_tags(
+        self, mock_project_magic, mock_vector_store_count
+    ):
+        """Test RAG config where no documents match the tags"""
+        # Create documents with tags that don't match filter
+        doc1 = create_mock_document([], tags=["python", "backend"])
+        doc2 = create_mock_document([], tags=["javascript", "frontend"])
+
+        # RAG config that filters for "rust" tag
+        rag_config = create_mock_rag_config(
+            "rag1", "ext1", "chunk1", "embed1", tags=["rust"]
+        )
+
+        mock_project_magic.documents.return_value = [doc1, doc2]
+        result = await compute_current_progress_for_rag_configs(
+            mock_project_magic, [rag_config]
+        )
+
+        # Should count 0 documents
+        assert len(result) == 1
+        assert "rag1" in result
+        assert result["rag1"].total_document_count == 0
+
+    @pytest.mark.asyncio
+    async def test_rag_config_with_tags_and_extractions(
+        self, mock_project_magic, mock_vector_store_count
+    ):
+        """Test progress calculation with tag filtering and existing extractions"""
+        # Create documents with tags and extractions
+        embedding1 = create_mock_embedding("embed1")
+        chunked_doc1 = create_mock_chunked_document(
+            "chunk1", [embedding1], num_chunks=3
+        )
+        extraction1 = create_mock_extraction("ext1", [chunked_doc1])
+        doc1 = create_mock_document([extraction1], tags=["python", "ml"])
+
+        # Document with different tag - should be filtered out
+        embedding2 = create_mock_embedding("embed1")
+        chunked_doc2 = create_mock_chunked_document(
+            "chunk1", [embedding2], num_chunks=2
+        )
+        extraction2 = create_mock_extraction("ext1", [chunked_doc2])
+        doc2 = create_mock_document([extraction2], tags=["java", "web"])
+
+        # Document with matching tag but no extractions
+        doc3 = create_mock_document([], tags=["python", "backend"])
+
+        rag_config = create_mock_rag_config(
+            "rag1", "ext1", "chunk1", "embed1", tags=["python"]
+        )
+
+        mock_project_magic.documents.return_value = [doc1, doc2, doc3]
+        result = await compute_current_progress_for_rag_configs(
+            mock_project_magic, [rag_config]
+        )
+
+        # Should only consider doc1 and doc3 (have "python" tag)
+        assert len(result) == 1
+        assert "rag1" in result
+        progress = result["rag1"]
+
+        assert progress.total_document_count == 2  # doc1 and doc3
+        assert progress.total_document_extracted_count == 1  # only doc1 has extraction
+        assert progress.total_document_chunked_count == 1  # only doc1 has chunks
+        assert progress.total_document_embedded_count == 1  # only doc1 has embeddings
+        assert progress.total_chunk_count == 3  # doc1 has 3 chunks
+
+    @pytest.mark.asyncio
+    async def test_multiple_rag_configs_different_tag_filters(
+        self, mock_project_magic, mock_vector_store_count
+    ):
+        """Test multiple RAG configs with different tag filters"""
+        # Create documents with various tags
+        doc1 = create_mock_document([], tags=["python", "ml"])
+        doc2 = create_mock_document([], tags=["javascript", "frontend"])
+        doc3 = create_mock_document([], tags=["python", "web"])
+        doc4 = create_mock_document([], tags=["rust", "systems"])
+
+        # Two RAG configs with different tag filters
+        rag_config1 = create_mock_rag_config(
+            "rag1", "ext1", "chunk1", "embed1", tags=["python"]
+        )
+        rag_config2 = create_mock_rag_config(
+            "rag2", "ext1", "chunk1", "embed1", tags=["javascript", "rust"]
+        )
+
+        mock_project_magic.documents.return_value = [doc1, doc2, doc3, doc4]
+        result = await compute_current_progress_for_rag_configs(
+            mock_project_magic, [rag_config1, rag_config2]
+        )
+
+        assert len(result) == 2
+
+        # rag1 should count doc1 and doc3 (python)
+        assert result["rag1"].total_document_count == 2
+
+        # rag2 should count doc2 (javascript) and doc4 (rust)
+        assert result["rag2"].total_document_count == 2
+
+    @pytest.mark.asyncio
+    async def test_rag_config_documents_with_no_tags(
+        self, mock_project_magic, mock_vector_store_count
+    ):
+        """Test RAG config filtering when some documents have no tags"""
+        # Mix of documents with and without tags
+        doc1 = create_mock_document([], tags=["python", "ml"])
+        doc2 = create_mock_document([], tags=None)  # No tags
+        doc3 = create_mock_document([], tags=[])  # Empty tags
+        doc4 = create_mock_document([], tags=["python", "web"])
+
+        rag_config = create_mock_rag_config(
+            "rag1", "ext1", "chunk1", "embed1", tags=["python"]
+        )
+
+        mock_project_magic.documents.return_value = [doc1, doc2, doc3, doc4]
+        result = await compute_current_progress_for_rag_configs(
+            mock_project_magic, [rag_config]
+        )
+
+        # Should only count doc1 and doc4 (have "python" tag)
+        assert len(result) == 1
+        assert result["rag1"].total_document_count == 2

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -271,9 +271,6 @@ class Document(
         description="The kind of document. The kind is a broad family of filetypes that can be handled in a similar way"
     )
 
-    # NOTE: could extract {tags + validate_tags} into a reusable Taggable model and inherit from that here
-    # and in TaskRun
-    # thoughts?
     tags: List[str] = Field(
         default_factory=list,
         description="Tags for the document. Tags are used to categorize documents for filtering and reporting.",

--- a/libs/core/kiln_ai/datamodel/test_rag.py
+++ b/libs/core/kiln_ai/datamodel/test_rag.py
@@ -331,3 +331,62 @@ def test_rag_config_parent_project_none():
     )
 
     assert rag_config.parent_project() is None
+
+
+def test_rag_config_tags_with_none():
+    """Test that tags field can be explicitly set to None."""
+    rag_config = RagConfig(
+        name="Test Config",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+        vector_store_config_id="vector_store123",
+        tags=None,
+    )
+
+    assert rag_config.tags is None
+
+
+def test_rag_config_tags_with_valid_tags():
+    """Test that tags field accepts a valid list of strings."""
+    tags = ["python", "ml", "backend", "api"]
+    rag_config = RagConfig(
+        name="Test Config",
+        extractor_config_id="extractor123",
+        chunker_config_id="chunker456",
+        embedding_config_id="embedding789",
+        vector_store_config_id="vector_store123",
+        tags=tags,
+    )
+
+    assert rag_config.tags == tags
+    assert isinstance(rag_config.tags, list)
+    assert all(isinstance(tag, str) for tag in rag_config.tags)
+
+
+@pytest.mark.parametrize(
+    "invalid_tags,expected_error",
+    [
+        ([], "Tags cannot be an empty list"),
+        (
+            ["python", "with spaces", "ml"],
+            "Tags cannot contain spaces. Try underscores.",
+        ),
+        (["python", "   ", "ml"], "Tags cannot contain spaces. Try underscores."),
+        (["python", " leading_space"], "Tags cannot contain spaces. Try underscores."),
+        (["trailing_space ", "ml"], "Tags cannot contain spaces. Try underscores."),
+        (["", "ml"], "Tags cannot be empty."),
+    ],
+)
+def test_rag_config_tags_invalid(invalid_tags, expected_error):
+    """Test that tags field rejects invalid inputs."""
+    with pytest.raises(ValueError) as exc_info:
+        RagConfig(
+            name="Test Config",
+            extractor_config_id="extractor123",
+            chunker_config_id="chunker456",
+            embedding_config_id="embedding789",
+            vector_store_config_id="vector_store123",
+            tags=invalid_tags,
+        )
+    assert expected_error in str(exc_info.value)

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -193,6 +193,7 @@ class RagConfigWithSubConfigs(BaseModel):
     chunker_config: ChunkerConfig
     embedding_config: EmbeddingConfig
     vector_store_config: VectorStoreConfig
+    tags: list[str] | None
 
 
 class CreateRagConfigRequest(BaseModel):
@@ -1313,6 +1314,7 @@ def connect_document_api(app: FastAPI):
                     id=rag_config.id,
                     name=rag_config.name,
                     description=rag_config.description,
+                    tags=rag_config.tags,
                     created_at=rag_config.created_at,
                     created_by=rag_config.created_by,
                     extractor_config=extractor_config,
@@ -1386,6 +1388,7 @@ def connect_document_api(app: FastAPI):
             chunker_config=chunker_config,
             embedding_config=embedding_config,
             vector_store_config=vector_store_config,
+            tags=rag_config.tags,
         )
 
     # JS SSE client (EventSource) doesn't work with POST requests, so we use GET, even though post would be better

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -216,6 +216,10 @@ class CreateRagConfigRequest(BaseModel):
     vector_store_config_id: ID_TYPE = Field(
         description="The vector store config to use for the RAG workflow.",
     )
+    tags: list[str] | None = Field(
+        description="List of document tags to filter by. If None, all documents in the project are used.",
+        default=None,
+    )
 
 
 class CreateChunkerConfigRequest(BaseModel):
@@ -499,12 +503,14 @@ async def build_rag_workflow_runner(
                     project,
                     extractor_config,
                     concurrency=50,
+                    rag_config=rag_config,
                 ),
                 RagChunkingStepRunner(
                     project,
                     extractor_config,
                     chunker_config,
                     concurrency=50,
+                    rag_config=rag_config,
                 ),
                 RagEmbeddingStepRunner(
                     project,
@@ -512,6 +518,7 @@ async def build_rag_workflow_runner(
                     chunker_config,
                     embedding_config,
                     concurrency=50,
+                    rag_config=rag_config,
                 ),
                 RagIndexingStepRunner(
                     project,
@@ -624,6 +631,18 @@ def connect_document_api(app: FastAPI):
     ) -> list[Document]:
         project = project_from_id(project_id)
         return project.documents(readonly=True)
+
+    @app.get("/api/projects/{project_id}/documents/tags")
+    async def get_document_tags(
+        project_id: str,
+    ) -> list[str]:
+        project = project_from_id(project_id)
+        documents = project.documents(readonly=True)
+        all_tags = set()
+        for document in documents:
+            if document.tags:
+                all_tags.update(document.tags)
+        return sorted(list(all_tags))
 
     @app.get("/api/projects/{project_id}/documents/{document_id}")
     async def get_document(
@@ -1239,6 +1258,7 @@ def connect_document_api(app: FastAPI):
             chunker_config_id=chunker_config.id,
             embedding_config_id=embedding_config.id,
             vector_store_config_id=vector_store_config.id,
+            tags=request.tags,
         )
         rag_config.save_to_file()
 

--- a/libs/server/kiln_server/test_document_api.py
+++ b/libs/server/kiln_server/test_document_api.py
@@ -970,6 +970,253 @@ async def test_create_rag_config_missing_config(
 
 
 @pytest.mark.asyncio
+async def test_create_rag_config_with_tags(
+    client,
+    mock_project,
+    mock_extractor_config,
+    mock_chunker_config,
+    mock_embedding_config,
+    mock_vector_store_config,
+):
+    """Test creating a RAG config with tag filtering"""
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+    ):
+        mock_project_from_id.return_value = mock_project
+        response = client.post(
+            f"/api/projects/{mock_project.id}/rag_configs/create_rag_config",
+            json={
+                "name": "Test RAG Config with Tags",
+                "description": "Test RAG Config with tags description",
+                "extractor_config_id": mock_extractor_config.id,
+                "chunker_config_id": mock_chunker_config.id,
+                "embedding_config_id": mock_embedding_config.id,
+                "vector_store_config_id": mock_vector_store_config.id,
+                "tags": ["python", "ml", "backend"],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    result = response.json()
+    assert result["id"] is not None
+    assert result["name"] == "Test RAG Config with Tags"
+    assert result["description"] == "Test RAG Config with tags description"
+    assert result["tags"] == ["python", "ml", "backend"]
+
+
+@pytest.mark.asyncio
+async def test_create_rag_config_with_empty_tags(
+    client,
+    mock_project,
+    mock_extractor_config,
+    mock_chunker_config,
+    mock_embedding_config,
+    mock_vector_store_config,
+):
+    """Test creating a RAG config with empty tags list fails validation"""
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+    ):
+        mock_project_from_id.return_value = mock_project
+        response = client.post(
+            f"/api/projects/{mock_project.id}/rag_configs/create_rag_config",
+            json={
+                "name": "Test RAG Config empty tags",
+                "description": "Test RAG Config description",
+                "extractor_config_id": mock_extractor_config.id,
+                "chunker_config_id": mock_chunker_config.id,
+                "embedding_config_id": mock_embedding_config.id,
+                "vector_store_config_id": mock_vector_store_config.id,
+                "tags": [],  # Empty tags list should fail validation
+            },
+        )
+
+    assert response.status_code == 422
+    response_json = response.json()
+    # The validation error format may vary, so check both possible structures
+    if "detail" in response_json:
+        error_detail = response_json["detail"]
+        assert any(
+            "Tags cannot be an empty list" in str(error) for error in error_detail
+        )
+    else:
+        # Alternative error format
+        assert "Tags cannot be an empty list" in str(response_json)
+
+
+@pytest.mark.asyncio
+async def test_create_rag_config_with_invalid_tags(
+    client,
+    mock_project,
+    mock_extractor_config,
+    mock_chunker_config,
+    mock_embedding_config,
+    mock_vector_store_config,
+):
+    """Test creating a RAG config with invalid tags (empty strings) fails validation"""
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+    ):
+        mock_project_from_id.return_value = mock_project
+        response = client.post(
+            f"/api/projects/{mock_project.id}/rag_configs/create_rag_config",
+            json={
+                "name": "Test RAG Config invalid tags",
+                "description": "Test RAG Config description",
+                "extractor_config_id": mock_extractor_config.id,
+                "chunker_config_id": mock_chunker_config.id,
+                "embedding_config_id": mock_embedding_config.id,
+                "vector_store_config_id": mock_vector_store_config.id,
+                "tags": ["python", "", "ml"],  # Empty string in tags should fail
+            },
+        )
+
+    assert response.status_code == 422
+    response_json = response.json()
+    assert "Tags cannot be empty" in response_json["message"]
+
+
+@pytest.mark.asyncio
+async def test_create_rag_config_with_null_tags(
+    client,
+    mock_project,
+    mock_extractor_config,
+    mock_chunker_config,
+    mock_embedding_config,
+    mock_vector_store_config,
+):
+    """Test creating a RAG config with null tags (no filtering)"""
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+    ):
+        mock_project_from_id.return_value = mock_project
+        response = client.post(
+            f"/api/projects/{mock_project.id}/rag_configs/create_rag_config",
+            json={
+                "name": "Test RAG Config null tags",
+                "description": "Test RAG Config description",
+                "extractor_config_id": mock_extractor_config.id,
+                "chunker_config_id": mock_chunker_config.id,
+                "embedding_config_id": mock_embedding_config.id,
+                "vector_store_config_id": mock_vector_store_config.id,
+                "tags": None,
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    result = response.json()
+    assert result["tags"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_rag_config_tags_omitted(
+    client,
+    mock_project,
+    mock_extractor_config,
+    mock_chunker_config,
+    mock_embedding_config,
+    mock_vector_store_config,
+):
+    """Test creating a RAG config without specifying tags field defaults to None"""
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+    ):
+        mock_project_from_id.return_value = mock_project
+        response = client.post(
+            f"/api/projects/{mock_project.id}/rag_configs/create_rag_config",
+            json={
+                "name": "Test RAG Config no tags field",
+                "description": "Test RAG Config description",
+                "extractor_config_id": mock_extractor_config.id,
+                "chunker_config_id": mock_chunker_config.id,
+                "embedding_config_id": mock_embedding_config.id,
+                "vector_store_config_id": mock_vector_store_config.id,
+                # tags field omitted - should default to None
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    result = response.json()
+    assert result["tags"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_document_tags_success(client):
+    """Test getting document tags from a project"""
+    # Create mock documents with various tags
+    doc1 = MagicMock()
+    doc1.tags = ["python", "ml", "backend"]
+
+    doc2 = MagicMock()
+    doc2.tags = ["javascript", "frontend", "web"]
+
+    doc3 = MagicMock()
+    doc3.tags = ["python", "web"]  # Overlapping tags
+
+    doc4 = MagicMock()
+    doc4.tags = None  # No tags
+
+    doc5 = MagicMock()
+    doc5.tags = []  # Empty tags
+
+    # Create mock project
+    mock_project = MagicMock()
+    mock_project.id = "test-project-123"
+    mock_project.documents.return_value = [doc1, doc2, doc3, doc4, doc5]
+
+    with patch("kiln_server.document_api.project_from_id") as mock_project_from_id:
+        mock_project_from_id.return_value = mock_project
+        response = client.get(f"/api/projects/{mock_project.id}/documents/tags")
+
+    assert response.status_code == 200
+    result = response.json()
+
+    # Should return sorted unique tags
+    expected_tags = ["backend", "frontend", "javascript", "ml", "python", "web"]
+    assert result == expected_tags
+
+
+@pytest.mark.asyncio
+async def test_get_document_tags_empty_project(client):
+    """Test getting document tags from a project with no documents"""
+    # Create mock project with no documents
+    mock_project = MagicMock()
+    mock_project.id = "empty-project-123"
+    mock_project.documents.return_value = []
+
+    with patch("kiln_server.document_api.project_from_id") as mock_project_from_id:
+        mock_project_from_id.return_value = mock_project
+        response = client.get(f"/api/projects/{mock_project.id}/documents/tags")
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_document_tags_no_tags(client):
+    """Test getting document tags from a project where no documents have tags"""
+    doc1 = MagicMock()
+    doc1.tags = None
+
+    doc2 = MagicMock()
+    doc2.tags = []
+
+    # Create mock project
+    mock_project = MagicMock()
+    mock_project.id = "no-tags-project-123"
+    mock_project.documents.return_value = [doc1, doc2]
+
+    with patch("kiln_server.document_api.project_from_id") as mock_project_from_id:
+        mock_project_from_id.return_value = mock_project
+        response = client.get(f"/api/projects/{mock_project.id}/documents/tags")
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result == []
+
+
+@pytest.mark.asyncio
 async def test_get_rag_configs_success(
     client,
     mock_project,


### PR DESCRIPTION
## What does this PR do?

Allow selecting one or multiple tags when creating a RagConfig to restrict the set of documents that the RagConfig sees. When multiple tags are selected, the matching set of documents is every document where at least one tag is in the union of selected tags (e.g. select `car` and `truck`, every document with either one will be matched).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tag-based filtering for RAG configs (null/empty = all documents).
  * Tag Selector when creating RAG configs; selected tags persisted and surfaced in config lists/details.
  * Workflow runs respect config tags and progress outputs now include run logs.
  * New project-level endpoint to list document tags.

* **Validation**
  * Tags validated (no empty tags or tags containing spaces).

* **UI**
  * Tag badges in config rows and details; configurable empty-label for multi-select.

* **Tests**
  * Extensive tests covering tags, progress, runners, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->