### PR TITLE
Limit max lines in fancy select

### DIFF
--- a/app/web_ui/src/lib/ui/fancy_select.svelte
+++ b/app/web_ui/src/lib/ui/fancy_select.svelte
@@ -609,7 +609,7 @@
                     </div>
                     {#if item.description}
                       <div
-                        class="text-xs font-medium text-base-content/40 w-full"
+                        class="text-xs font-medium text-base-content/40 w-full line-clamp-3"
                       >
                         {item.description}
                       </div>


### PR DESCRIPTION

Now: 

<img width="360" height="588" alt="Screenshot 2025-09-16 at 9 35 45 AM" src="https://github.com/user-attachments/assets/d7434aed-b90a-49d7-bd51-d1253374736c" />

Was:

<img width="366" height="1242" alt="Screenshot 2025-09-16 at 9 36 02 AM" src="https://github.com/user-attachments/assets/fffe8f21-9904-475d-998d-cc91359dcf87" />
