### PR TITLE
Update ExternalToolServer properties to be a typed dictionary

### DIFF
--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -3,7 +3,12 @@ from typing import Any, Dict, List
 
 from fastapi import FastAPI, HTTPException
 from kiln_ai.datamodel.basemodel import ID_TYPE
-from kiln_ai.datamodel.external_tool_server import ExternalToolServer, ToolServerType
+from kiln_ai.datamodel.external_tool_server import (
+    ExternalToolServer,
+    LocalServerProperties,
+    RemoteServerProperties,
+    ToolServerType,
+)
 from kiln_ai.datamodel.tool_id import (
     MCP_LOCAL_TOOL_ID_PREFIX,
     MCP_REMOTE_TOOL_ID_PREFIX,
@@ -78,7 +83,7 @@ class ExternalToolServerApiDescription(BaseModel):
     description: str | None
     created_at: datetime | None
     created_by: str | None
-    properties: Dict[str, Any]
+    properties: LocalServerProperties | RemoteServerProperties
     available_tools: list[ExternalToolApiDescription]
     missing_secrets: list[str]
 
@@ -330,7 +335,7 @@ def connect_tool_servers_api(app: FastAPI):
 
     def _remote_tool_server_properties(
         tool_data: ExternalToolServerCreationRequest,
-    ) -> dict[str, str | Dict[str, str] | List[str]]:
+    ) -> RemoteServerProperties:
         # Create the ExternalToolServer with all data for validation
         return {
             "server_url": tool_data.server_url,
@@ -389,7 +394,7 @@ def connect_tool_servers_api(app: FastAPI):
 
     def _local_tool_server_properties(
         tool_data: LocalToolServerCreationRequest,
-    ) -> dict[str, str | Dict[str, str] | List[str]]:
+    ) -> LocalServerProperties:
         return {
             "command": tool_data.command,
             "args": tool_data.args,

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2239,9 +2239,8 @@ export interface components {
             /**
              * Properties
              * @description Configuration properties specific to the tool type.
-             * @default {}
              */
-            properties: Record<string, never>;
+            properties?: components["schemas"]["LocalServerProperties"] | components["schemas"]["RemoteServerProperties"];
             /** Model Type */
             readonly model_type: string;
         };
@@ -2262,7 +2261,7 @@ export interface components {
             /** Created By */
             created_by: string | null;
             /** Properties */
-            properties: Record<string, never>;
+            properties: components["schemas"]["LocalServerProperties"] | components["schemas"]["RemoteServerProperties"];
             /** Available Tools */
             available_tools: components["schemas"]["ExternalToolApiDescription"][];
             /** Missing Secrets */
@@ -2629,6 +2628,19 @@ export interface components {
             /** Missing Secrets */
             missing_secrets: string[];
         };
+        /** LocalServerProperties */
+        LocalServerProperties: {
+            /** Command */
+            command?: string;
+            /** Args */
+            args?: string[];
+            /** Env Vars */
+            env_vars?: {
+                [key: string]: string;
+            };
+            /** Secret Env Var Keys */
+            secret_env_var_keys?: string[];
+        };
         /** LocalToolServerCreationRequest */
         LocalToolServerCreationRequest: {
             /** Name */
@@ -2903,6 +2915,17 @@ export interface components {
         RatingOptionResponse: {
             /** Options */
             options: components["schemas"]["RatingOption"][];
+        };
+        /** RemoteServerProperties */
+        RemoteServerProperties: {
+            /** Server Url */
+            server_url?: string;
+            /** Headers */
+            headers?: {
+                [key: string]: string;
+            };
+            /** Secret Header Keys */
+            secret_header_keys?: string[];
         };
         /** RepairRunPost */
         RepairRunPost: {

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2240,7 +2240,7 @@ export interface components {
              * Properties
              * @description Configuration properties specific to the tool type.
              */
-            properties?: components["schemas"]["LocalServerProperties"] | components["schemas"]["RemoteServerProperties"];
+            properties: components["schemas"]["LocalServerProperties"] | components["schemas"]["RemoteServerProperties"];
             /** Model Type */
             readonly model_type: string;
         };
@@ -2631,9 +2631,9 @@ export interface components {
         /** LocalServerProperties */
         LocalServerProperties: {
             /** Command */
-            command?: string;
+            command: string;
             /** Args */
-            args?: string[];
+            args: string[];
             /** Env Vars */
             env_vars?: {
                 [key: string]: string;
@@ -2919,7 +2919,7 @@ export interface components {
         /** RemoteServerProperties */
         RemoteServerProperties: {
             /** Server Url */
-            server_url?: string;
+            server_url: string;
             /** Headers */
             headers?: {
                 [key: string]: string;

--- a/app/web_ui/src/lib/types.ts
+++ b/app/web_ui/src/lib/types.ts
@@ -50,3 +50,7 @@ export type ToolServerType = components["schemas"]["ToolServerType"]
 export type ToolApiDescription = components["schemas"]["ToolApiDescription"]
 export type ToolSetApiDescription =
   components["schemas"]["ToolSetApiDescription"]
+export type LocalServerProperties =
+  components["schemas"]["LocalServerProperties"]
+export type RemoteServerProperties =
+  components["schemas"]["RemoteServerProperties"]

--- a/libs/core/kiln_ai/datamodel/external_tool_server.py
+++ b/libs/core/kiln_ai/datamodel/external_tool_server.py
@@ -1,9 +1,10 @@
 import re
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, TypedDict
 from urllib.parse import urlparse
 
 from pydantic import Field, PrivateAttr, model_validator
+from typing_extensions import NotRequired
 
 from kiln_ai.datamodel.basemodel import (
     FilenameString,
@@ -22,6 +23,19 @@ class ToolServerType(str, Enum):
     local_mcp = "local_mcp"
 
 
+class LocalServerProperties(TypedDict, total=False):
+    command: str
+    args: list[str]
+    env_vars: dict[str, str]
+    secret_env_var_keys: NotRequired[list[str]]
+
+
+class RemoteServerProperties(TypedDict, total=False):
+    server_url: str
+    headers: dict[str, str]
+    secret_header_keys: NotRequired[list[str]]
+
+
 class ExternalToolServer(KilnParentedModel):
     """
     Configuration for communicating with a external MCP (Model Context Protocol) Server for LLM tool calls. External tool servers can be remote or local.
@@ -38,8 +52,9 @@ class ExternalToolServer(KilnParentedModel):
         default=None,
         description="A description of the external tool for you and your team. Will not be used in prompts/training/validation.",
     )
-    properties: Dict[str, Any] = Field(
-        default={},
+
+    properties: LocalServerProperties | RemoteServerProperties = Field(
+        default_factory=lambda: {},
         description="Configuration properties specific to the tool type.",
     )
 

--- a/libs/core/kiln_ai/datamodel/test_external_tool_server.py
+++ b/libs/core/kiln_ai/datamodel/test_external_tool_server.py
@@ -274,7 +274,7 @@ class TestExternalToolServer:
             (
                 ToolServerType.remote_mcp,
                 {"server_url": ""},
-                "Server URL is required to connect to a remote MCP server",
+                "Server URL is not a valid URL",
             ),
             (
                 ToolServerType.remote_mcp,
@@ -295,13 +295,21 @@ class TestExternalToolServer:
                 "secret_header_keys must contain only strings",
             ),
             # Local MCP validation errors
-            (ToolServerType.local_mcp, {}, "command must be a string"),
-            (ToolServerType.local_mcp, {"command": ""}, "command is required"),
+            (
+                ToolServerType.local_mcp,
+                {},
+                "command is required to start a local MCP server",
+            ),
+            (
+                ToolServerType.local_mcp,
+                {"command": ""},
+                "Field required",
+            ),  # Required by pydantic in LocalServerProperties
             (ToolServerType.local_mcp, {"command": 123}, "command must be a string"),
             (
                 ToolServerType.local_mcp,
                 {"command": "python"},
-                "arguments must be a list",
+                "Field required",  # Required by pydantic in LocalServerProperties
             ),
             (
                 ToolServerType.local_mcp,

--- a/libs/core/kiln_ai/tools/test_mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/test_mcp_session_manager.py
@@ -937,7 +937,7 @@ class TestMCPSessionManager:
         """Test that missing command raises ValueError for local MCP."""
         with pytest.raises(
             ValidationError,
-            match="command must be a string to start a local MCP server",
+            match="command is required to start a local MCP server",
         ):
             ExternalToolServer(
                 name="missing_command_server",
@@ -954,7 +954,7 @@ class TestMCPSessionManager:
         """Test that missing args raises ValueError for local MCP."""
         with pytest.raises(
             ValidationError,
-            match="arguments must be a list to start a local MCP server",
+            match="Field required",  # Required by pydantic in LocalServerProperties
         ):
             ExternalToolServer(
                 name="missing_args_server",


### PR DESCRIPTION
## What does this PR do?

Update ExternalToolServer properties to be a typed dictionary. Previously this was a `dict[str, Any]` which was causing a lot of type checking to be lost. Added `LocalServerProperties` & `RemoteServerProperties` and have `properties` to be the union of these 2 dictionary. 

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib
