### PR TITLE
feat: trigger all rag configs after tagging or doc deletion

### DIFF
--- a/app/web_ui/src/lib/utils/semaphore.test.ts
+++ b/app/web_ui/src/lib/utils/semaphore.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { Semaphore } from "./semaphore"
+
+describe("Semaphore", () => {
+  let semaphore: Semaphore
+
+  beforeEach(() => {
+    semaphore = new Semaphore(2) // Start with capacity of 2 for most tests
+  })
+
+  describe("basic functionality", () => {
+    it("should allow immediate acquisition when capacity is available", async () => {
+      await semaphore.acquire()
+      // Should not throw or hang
+    })
+
+    it("should allow multiple acquisitions up to capacity", async () => {
+      await semaphore.acquire()
+      await semaphore.acquire()
+      // Both should succeed immediately
+    })
+
+    it("should release capacity when release is called", async () => {
+      await semaphore.acquire()
+      await semaphore.acquire()
+
+      semaphore.release()
+
+      // Should now be able to acquire again
+      await semaphore.acquire()
+    })
+
+    it("should handle single capacity semaphore", async () => {
+      const singleSemaphore = new Semaphore(1)
+
+      await singleSemaphore.acquire()
+
+      // Second acquire should be queued
+      let secondAcquired = false
+      const secondPromise = singleSemaphore.acquire().then(() => {
+        secondAcquired = true
+      })
+
+      // Give it a moment to ensure it's queued
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      expect(secondAcquired).toBe(false)
+
+      singleSemaphore.release()
+      await secondPromise
+      expect(secondAcquired).toBe(true)
+    })
+  })
+
+  describe("concurrency limiting", () => {
+    it("should queue acquisitions when at capacity", async () => {
+      // Fill up the semaphore
+      await semaphore.acquire()
+      await semaphore.acquire()
+
+      let thirdAcquired = false
+      const thirdPromise = semaphore.acquire().then(() => {
+        thirdAcquired = true
+      })
+
+      // Give it a moment to ensure it's queued
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      expect(thirdAcquired).toBe(false)
+
+      // Release one slot
+      semaphore.release()
+      await thirdPromise
+      expect(thirdAcquired).toBe(true)
+    })
+
+    it("should process queue in FIFO order", async () => {
+      // Fill up the semaphore
+      await semaphore.acquire()
+      await semaphore.acquire()
+
+      const acquiredOrder: number[] = []
+
+      // Queue multiple acquisitions
+      const promises = [
+        semaphore.acquire().then(() => acquiredOrder.push(1)),
+        semaphore.acquire().then(() => acquiredOrder.push(2)),
+        semaphore.acquire().then(() => acquiredOrder.push(3)),
+        semaphore.acquire().then(() => acquiredOrder.push(4)),
+      ]
+
+      // Give them time to queue
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      // Release slots one by one
+      semaphore.release()
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      semaphore.release()
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      semaphore.release()
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      semaphore.release()
+      await new Promise((resolve) => setTimeout(resolve, 10))
+
+      await Promise.all(promises)
+
+      expect(acquiredOrder).toEqual([1, 2, 3, 4])
+    })
+
+    it("should handle multiple releases correctly", () => {
+      const singleSemaphore = new Semaphore(1)
+
+      // Acquire and release multiple times
+      singleSemaphore.acquire()
+      singleSemaphore.release()
+      singleSemaphore.acquire()
+      singleSemaphore.release()
+
+      // Should be able to acquire again
+      expect(singleSemaphore.acquire()).resolves.toBeUndefined()
+    })
+  })
+
+  describe("throttling scenario simulation", () => {
+    it("should simulate RAG progress store throttling behavior", async () => {
+      // Simulate the sseSlots semaphore with capacity 5
+      const sseSlots = new Semaphore(5)
+
+      const results: number[] = []
+      const startTime = Date.now()
+
+      // Simulate 10 concurrent operations (more than the semaphore capacity)
+      const operations = Array.from({ length: 10 }, (_, i) =>
+        (async () => {
+          await sseSlots.acquire()
+          try {
+            // Simulate some async work (like creating EventSource)
+            await new Promise((resolve) => setTimeout(resolve, 50))
+            results.push(i)
+          } finally {
+            sseSlots.release()
+          }
+        })(),
+      )
+
+      await Promise.all(operations)
+
+      const endTime = Date.now()
+      const duration = endTime - startTime
+
+      // Should have processed all 10 operations
+      expect(results).toHaveLength(10)
+      expect(results.sort()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+      // Should have taken some time due to throttling
+      // With capacity 5 and 10 operations, should take at least 100ms (2 batches of 50ms each)
+      expect(duration).toBeGreaterThanOrEqual(100)
+    })
+
+    it("should handle rapid acquire/release cycles", async () => {
+      const rapidSemaphore = new Semaphore(3)
+      const results: number[] = []
+
+      // Simulate rapid operations
+      const operations = Array.from({ length: 20 }, (_, i) =>
+        (async () => {
+          await rapidSemaphore.acquire()
+          try {
+            // Very short work
+            await new Promise((resolve) => setTimeout(resolve, 1))
+            results.push(i)
+          } finally {
+            rapidSemaphore.release()
+          }
+        })(),
+      )
+
+      await Promise.all(operations)
+
+      expect(results).toHaveLength(20)
+      // Results should contain all numbers 0-19, but order may vary due to concurrency
+      const sortedResults = results.sort((a, b) => a - b)
+      expect(sortedResults).toEqual(Array.from({ length: 20 }, (_, i) => i))
+    })
+
+    it("should maintain correct capacity tracking", async () => {
+      const capacity = 3
+      const testSemaphore = new Semaphore(capacity)
+
+      // Fill up to capacity
+      await testSemaphore.acquire()
+      await testSemaphore.acquire()
+      await testSemaphore.acquire()
+
+      // Next acquire should be queued
+      let queuedAcquired = false
+      const queuedPromise = testSemaphore.acquire().then(() => {
+        queuedAcquired = true
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      expect(queuedAcquired).toBe(false)
+
+      // Release one
+      testSemaphore.release()
+      await queuedPromise
+      expect(queuedAcquired).toBe(true)
+    })
+  })
+
+  describe("edge cases", () => {
+    it("should handle zero capacity semaphore", async () => {
+      const zeroSemaphore = new Semaphore(0)
+
+      // Any acquire should be queued
+      let acquired = false
+      const promise = zeroSemaphore.acquire().then(() => {
+        acquired = true
+      })
+
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      expect(acquired).toBe(false)
+
+      // Release should allow acquisition
+      zeroSemaphore.release()
+      await promise
+      expect(acquired).toBe(true)
+    })
+
+    it("should handle release when no one is waiting", () => {
+      const semaphore = new Semaphore(2)
+
+      // Release when no one is waiting should increase capacity
+      semaphore.release()
+      semaphore.release()
+
+      // Should now be able to acquire 4 times
+      expect(semaphore.acquire()).resolves.toBeUndefined()
+      expect(semaphore.acquire()).resolves.toBeUndefined()
+      expect(semaphore.acquire()).resolves.toBeUndefined()
+      expect(semaphore.acquire()).resolves.toBeUndefined()
+    })
+
+    it("should handle multiple releases without acquisitions", () => {
+      const semaphore = new Semaphore(1)
+
+      // Multiple releases without acquisitions
+      semaphore.release()
+      semaphore.release()
+      semaphore.release()
+
+      // Should be able to acquire multiple times now
+      expect(semaphore.acquire()).resolves.toBeUndefined()
+      expect(semaphore.acquire()).resolves.toBeUndefined()
+      expect(semaphore.acquire()).resolves.toBeUndefined()
+    })
+  })
+
+  describe("concurrent stress test", () => {
+    it("should handle many concurrent operations correctly", async () => {
+      const stressSemaphore = new Semaphore(5)
+      const results: number[] = []
+      const errors: Error[] = []
+
+      // Create 100 concurrent operations
+      const operations = Array.from({ length: 100 }, (_, i) =>
+        (async () => {
+          try {
+            await stressSemaphore.acquire()
+            try {
+              // Simulate some work
+              await new Promise((resolve) =>
+                setTimeout(resolve, Math.random() * 10),
+              )
+              results.push(i)
+            } finally {
+              stressSemaphore.release()
+            }
+          } catch (error) {
+            errors.push(error as Error)
+          }
+        })(),
+      )
+
+      await Promise.all(operations)
+
+      expect(errors).toHaveLength(0)
+      expect(results).toHaveLength(100)
+      // Results should contain all numbers 0-99, but order may vary due to concurrency
+      const sortedResults = results.sort((a, b) => a - b)
+      expect(sortedResults).toEqual(Array.from({ length: 100 }, (_, i) => i))
+    })
+  })
+})

--- a/app/web_ui/src/lib/utils/semaphore.ts
+++ b/app/web_ui/src/lib/utils/semaphore.ts
@@ -1,0 +1,25 @@
+export class Semaphore {
+  private q: Array<() => void> = []
+  private n: number
+
+  constructor(max: number) {
+    this.n = max
+  }
+
+  async acquire() {
+    if (this.n > 0) {
+      this.n--
+      return
+    }
+    await new Promise<void>((res) => this.q.push(res))
+  }
+
+  release() {
+    const next = this.q.shift()
+    if (next) {
+      next()
+    } else {
+      this.n++
+    }
+  }
+}

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
@@ -19,6 +19,7 @@
 
   // TODO: move to shared folder
   import TagDropdown from "../../../../../lib/ui/tag_dropdown.svelte"
+  import { ragProgressStore } from "$lib/stores/rag_progress_store"
 
   let upload_file_dialog: UploadFileDialog | null = null
 
@@ -457,6 +458,12 @@
 
       // Hide the dropdown (safari bug shows it when hidden)
       show_add_tag_dropdown = false
+
+      // trigger all rag configs to re-run because tagging documents may
+      // have changed which documents are targeted by which rag configs
+      ragProgressStore.run_all_rag_configs(project_id).catch((error) => {
+        console.error("Error running all rag configs", error)
+      })
 
       // Close modal on success
       return true

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
@@ -14,6 +14,7 @@
   import Output from "../../../../run/output.svelte"
   import { capitalize } from "$lib/utils/formatters"
   import TagDropdown from "../../../../../../lib/ui/tag_dropdown.svelte"
+  import { ragProgressStore } from "$lib/stores/rag_progress_store"
 
   let initial_document: KilnDocument | null = null
   let updated_document: KilnDocument | null = null
@@ -119,6 +120,9 @@
   let delete_document_dialog: DeleteDialog | null = null
   $: delete_document_url = `/api/projects/${project_id}/documents/${document_id}`
   function after_document_delete() {
+    ragProgressStore.run_all_rag_configs(project_id).catch((error) => {
+      console.error("Error running all rag configs", error)
+    })
     goto(`/docs/library/${project_id}`)
   }
 

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/upload_file_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/upload_file_dialog.svelte
@@ -156,7 +156,9 @@
     selected_files = []
     onUploadCompleted()
 
-    ragProgressStore.run_all_rag_configs(project_id)
+    ragProgressStore.run_all_rag_configs(project_id).catch((error) => {
+      console.error("Error running all rag configs", error)
+    })
 
     return true
   }

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/run_rag_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/run_rag_dialog.svelte
@@ -225,7 +225,14 @@
       isPrimary: true,
       label: is_running ? "Running..." : has_error_logs ? "Retry" : "Run RAG",
       asyncAction: async () => {
-        ragProgressStore.run_rag_config(project_id, rag_config_id)
+        // we don't want to await because we show the progress in the UI
+        // and don't need the built-in loading spinner
+        ragProgressStore
+          .run_rag_config(project_id, rag_config_id)
+          .catch((error) => {
+            console.error("Error running rag config", error)
+            return true
+          })
 
         // keep open so the user can see the progress
         return false


### PR DESCRIPTION
## What does this PR do?

Tagging or deleting a document may take it out of or add it into a RagConfig - e.g. a doc is tagged with the tag `truck`, and a RagConfig filters for this tag, now it needs to process and index it; similarly if such a doc is untagged or deleted, the index must be updated to remove the doc chunks.

Solution:
- after tagging / deletion, we trigger a client-side flow that retrieves all the rag configs and triggers all of them to run; this allows for UI updates the normal way
- browsers limit the number of connections that can be open in parallel, so this PR also adds a semaphore to allow queueing those requests (and avoid kicking off as many connections as the user has RagConfigs in the project + whatever replay they may have triggered by queued operations)

Some notes:
- not a problem if the user does rapid fire tagging / deletion - we call the client method to trigger all rag configs every time but:
  -  they get queued up on the frontend so eventually all of them will run (and loading state will be the state of whichever one was triggered, which is fine); 
  - they also get queued on the backend via a server side lock that timeouts acquisition attempts only after 1 hour, so all of them will eventually run or time out
- we indiscriminately trigger all rag configs to run even those that are not impacted by the operation (because the doc is and was not in the set the config targets), but that is fine since those will be very fast to complete because they have nothing to do; so their work is only marginally heavier than checking current progress

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
