### PR TITLE
fix: PDF page splitting is blocking the event loop

### DIFF
--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -118,7 +118,7 @@ class LitellmExtractor(BaseExtractor):
     async def _extract_from_pdf_pages(self, pdf_path: Path, prompt: str) -> str:
         combined_content = []
 
-        with split_pdf_into_pages(pdf_path) as page_paths:
+        async with split_pdf_into_pages(pdf_path) as page_paths:
             # we extract from each page individually and then combine the results
             # this ensures the model stays focused on the current page and does not
             # start summarizing the later pages

--- a/libs/core/kiln_ai/utils/pdf_utils.py
+++ b/libs/core/kiln_ai/utils/pdf_utils.py
@@ -17,7 +17,8 @@ async def split_pdf_into_pages(pdf_path: Path) -> AsyncGenerator[list[Path], Non
         page_paths = []
 
         with open(pdf_path, "rb") as file:
-            pdf_reader = PdfReader(file)
+            # Reader init can be heavy; offload to thread
+            pdf_reader = await asyncio.to_thread(PdfReader, file)
 
             for page_num in range(len(pdf_reader.pages)):
                 await asyncio.sleep(0)
@@ -29,7 +30,8 @@ async def split_pdf_into_pages(pdf_path: Path) -> AsyncGenerator[list[Path], Non
                 page_path = Path(temp_dir) / page_filename
 
                 with open(page_path, "wb") as page_file:
-                    pdf_writer.write(page_file)
+                    # Writing/compression can be expensive; offload to thread
+                    await asyncio.to_thread(pdf_writer.write, page_file)
 
                 page_paths.append(page_path)
 

--- a/libs/core/kiln_ai/utils/pdf_utils.py
+++ b/libs/core/kiln_ai/utils/pdf_utils.py
@@ -2,16 +2,17 @@
 Utilities for working with PDF files.
 """
 
+import asyncio
 import tempfile
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Generator
+from typing import AsyncGenerator
 
 from pypdf import PdfReader, PdfWriter
 
 
-@contextmanager
-def split_pdf_into_pages(pdf_path: Path) -> Generator[list[Path], None, None]:
+@asynccontextmanager
+async def split_pdf_into_pages(pdf_path: Path) -> AsyncGenerator[list[Path], None]:
     with tempfile.TemporaryDirectory(prefix="kiln_pdf_pages_") as temp_dir:
         page_paths = []
 
@@ -19,6 +20,7 @@ def split_pdf_into_pages(pdf_path: Path) -> Generator[list[Path], None, None]:
             pdf_reader = PdfReader(file)
 
             for page_num in range(len(pdf_reader.pages)):
+                await asyncio.sleep(0)
                 pdf_writer = PdfWriter()
                 pdf_writer.add_page(pdf_reader.pages[page_num])
 

--- a/libs/core/kiln_ai/utils/test_pdf_utils.py
+++ b/libs/core/kiln_ai/utils/test_pdf_utils.py
@@ -5,11 +5,11 @@ from conftest import MockFileFactoryMimeType
 from kiln_ai.utils.pdf_utils import split_pdf_into_pages
 
 
-def test_split_pdf_into_pages_success(mock_file_factory):
+async def test_split_pdf_into_pages_success(mock_file_factory):
     """Test that split_pdf_into_pages successfully splits a PDF into individual pages."""
     test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
 
-    with split_pdf_into_pages(test_file) as page_paths:
+    async with split_pdf_into_pages(test_file) as page_paths:
         # Verify we get the expected number of pages (test PDF has 2 pages)
         assert len(page_paths) == 2
 
@@ -33,14 +33,14 @@ def test_split_pdf_into_pages_success(mock_file_factory):
         assert not page_path.exists()
 
 
-def test_split_pdf_into_pages_cleanup_on_exception(mock_file_factory):
+async def test_split_pdf_into_pages_cleanup_on_exception(mock_file_factory):
     """Test that temporary files are cleaned up even when an exception occurs during normal usage."""
     test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
     captured_page_paths = []
 
     # Test that cleanup happens even when an exception occurs during the with block
     with pytest.raises(RuntimeError, match="Simulated error during usage"):
-        with split_pdf_into_pages(test_file) as page_paths:
+        async with split_pdf_into_pages(test_file) as page_paths:
             # Capture the page paths before the exception
             captured_page_paths.extend(page_paths)
             # Simulate an exception during normal usage of the context manager
@@ -56,12 +56,12 @@ def test_split_pdf_into_pages_cleanup_on_exception(mock_file_factory):
         assert not temp_dir.exists()
 
 
-def test_split_pdf_into_pages_temporary_directory_creation(mock_file_factory):
+async def test_split_pdf_into_pages_temporary_directory_creation(mock_file_factory):
     """Test that temporary directories are created with the correct prefix."""
     test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
     captured_temp_dirs = []
 
-    with split_pdf_into_pages(test_file) as page_paths:
+    async with split_pdf_into_pages(test_file) as page_paths:
         # Check that page paths are in a directory with the expected prefix
         temp_dir = page_paths[0].parent
         captured_temp_dirs.append(temp_dir)

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -526,7 +526,7 @@ async def build_rag_workflow_runner(
                 RagExtractionStepRunner(
                     project,
                     extractor_config,
-                    concurrency=50,
+                    concurrency=20,
                     rag_config=rag_config,
                 ),
                 RagChunkingStepRunner(
@@ -541,7 +541,7 @@ async def build_rag_workflow_runner(
                     extractor_config,
                     chunker_config,
                     embedding_config,
-                    concurrency=50,
+                    concurrency=20,
                     rag_config=rag_config,
                 ),
                 RagIndexingStepRunner(


### PR DESCRIPTION
## What does this PR do?

Issue:
- at high concurrency and with large PDFs (many pages), it becomes apparent that the PDF splitting is interfering with the server's ability to handle incoming requests
- appears to be due to the PDF splitting being synchronous and blocking the event loop

Fix:
- changed context manager to be async, and sneak in a `asyncio.sleep(0)` inside the loop (we read each page in a loop that goes over all the pages) to let incoming requests get processed

This seems to make it better - and also lowered concurrency for extractors and embeddings to `20`, given running multiple RAG Configs concurrently is now common (due to it being triggered automatically on tagging / doc deletion) and we don't have the level of granularity we would need to fit our max concurrency better to what is going on.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Migrated PDF page splitting and extraction to fully asynchronous flows for better responsiveness and non-blocking I/O; per-page processing now yields pages incrementally and ensures cleanup.
  - Reduced concurrency for extraction and embedding steps to improve stability and resource usage under load.

- Tests
  - Converted related tests to async to preserve coverage and validate per-page output, cleanup, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->