### PR TITLE
refactor: default extraction prompt and temperature

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/default_extractor_prompts.ts
+++ b/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/default_extractor_prompts.ts
@@ -6,6 +6,7 @@ export function default_extractor_document_prompts(output_format: string) {
 - If the document contains tables, reproduce them in the output using the correct format, and also add a brief descriptive sentence summarizing the table as a whole.
 - Preserve the structure and order of the document.
 - Format the output as valid ${output_format}.
+- Do not transcribe non-informational text such as repetitive whitespace characters, a horizontal rule repeated multiple times.
 - Do NOT include any prefatory or explanatory text outside of the transcription itself.
 `
 }

--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -183,6 +183,7 @@ class LitellmExtractor(BaseExtractor):
                     ],
                 }
             ],
+            "temperature": 0.1,
         }
 
         if self.litellm_core_config.base_url:


### PR DESCRIPTION
## What does this PR do?

Extractor models (e.g. Gemini) sometimes struggle with certain PDFs, and transcribe whitespaces / linebreaks, which causes chunks to be wasted - and it seems that since such chunks are semantically neutral (aka meaningless and so probably equidistant to everything), they seem likely to surface in results to search queries that do not have very close matches in the corpus.

Fix:
- add a clause in the prompt to explicitly tell it not to transcribe whitespace type symbols
- lower temperature to `0.1` - low temperature typically makes it more likely to repeat the same sequence, but in this case, it might help since we don't want it to start getting arbitrarily creative during transcription

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved document extraction accuracy by updating default prompts to ignore non-informational content such as repeated whitespace and horizontal rules.
  - Increased consistency of AI extraction results by adjusting generation settings for more deterministic outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->