### PR TITLE
Search suggestion carousel tooltips clip, quick fix (proper fix needed later)

### DIFF
--- a/app/web_ui/src/lib/ui/feature_carousel.svelte
+++ b/app/web_ui/src/lib/ui/feature_carousel.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <div
-  class="carousel carousel-center max-w-full p-4 space-x-4 bg-base-200 rounded-box"
+  class="carousel carousel-center max-w-full p-4 space-x-4 bg-base-200 rounded-box overflow-visible"
 >
   {#each features as feature, index}
     <div class="carousel-item">
@@ -44,7 +44,7 @@
         </div>
 
         {#if feature.tooltip}
-          <div class="absolute top-1 right-1">
+          <div class="absolute top-1 right-1 text-gray-500">
             <InfoTooltip
               tooltip_text={feature.tooltip}
               no_pad={true}

--- a/app/web_ui/src/lib/ui/feature_carousel.svelte
+++ b/app/web_ui/src/lib/ui/feature_carousel.svelte
@@ -44,7 +44,7 @@
         </div>
 
         {#if feature.tooltip}
-          <div class="absolute top-1 right-1 text-gray-500">
+          <div class="absolute top-1 right-1">
             <InfoTooltip
               tooltip_text={feature.tooltip}
               no_pad={true}


### PR DESCRIPTION
Before:
<img width="491" height="419" alt="Screenshot 2025-09-18 at 11 49 38 AM" src="https://github.com/user-attachments/assets/19da2b65-58ee-418b-b3dc-ee983be2865d" />
After:
<img width="754" height="370" alt="Screenshot 2025-09-18 at 11 50 06 AM" src="https://github.com/user-attachments/assets/6c102b2e-de46-4319-9594-90f612a428c7" />

Downside with fix:
zooming all the way in no longer clips the card to the carousel, but I think the tradeoff is worth it to not spend too much time on a proper fix because more people will look at the tooltip at a normal zoom level than zoom in x100
<img width="411" height="557" alt="Screenshot 2025-09-18 at 11 50 22 AM" src="https://github.com/user-attachments/assets/b5d82f3d-06cc-41ce-9e91-71c964934404" />
before:
<img width="405" height="575" alt="Screenshot 2025-09-18 at 11 50 43 AM" src="https://github.com/user-attachments/assets/9f1ebe0b-0758-482e-a988-d0301a2d9fc4" />
