### PR TITLE
Make "Advanced" aligned vertically

### DIFF
--- a/app/web_ui/src/lib/ui/settings_item.svelte
+++ b/app/web_ui/src/lib/ui/settings_item.svelte
@@ -27,8 +27,8 @@
   class="group flex items-center justify-between py-4 px-6 rounded-lg hover:bg-gray-50 transition-all duration-200 cursor-pointer w-full text-left"
 >
   <div class="flex-1 min-w-0">
-    <div class="flex flex-row items-center">
-      <h3 class="text-base font-medium text-gray-900 mb-1">
+    <div class="flex flex-row items-center mb-1">
+      <h3 class="text-base font-medium text-gray-900">
         {name}
       </h3>
       {#if badge_text}


### PR DESCRIPTION
Before:
<img width="259" height="34" alt="Screenshot 2025-09-18 at 11 52 29 AM" src="https://github.com/user-attachments/assets/7858c33b-2f7a-4dfa-9225-49e865979df5" />

After:
<img width="261" height="42" alt="Screenshot 2025-09-18 at 11 52 19 AM" src="https://github.com/user-attachments/assets/0cacaaf5-6029-4eed-a108-f8dc9be942b7" />

The issue was that the h3 element has mb-1 (margin-bottom) which created space below it, but the flex container has items-center which centers the badge with the entire h3 element including its bottom margin. This caused the badge to appear slightly misaligned. Fixed by removing the bottom margin from the h3 and adjusting the layout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing in settings items to improve visual consistency and readability. Headings and their surrounding content now align more cleanly, reducing extra bottom space and creating a tighter, more balanced layout.
  * Visual-only adjustment; no changes to behavior, interactions, or data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->