### PR TITLE
Add docs links

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/[project_id]/+page.svelte
@@ -10,6 +10,8 @@
   title="Documents & Search"
   subtitle="Add searchable knowledge to your tasks"
   limit_max_width
+  sub_subtitle="Read the Docs"
+  sub_subtitle_link="https://docs.kiln.tech/docs/documents-and-search-rag"
 >
   <MultiIntro
     intros={[

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
@@ -473,6 +473,8 @@
     title="Document Library"
     subtitle="Add or Browse Documents"
     no_y_padding
+    sub_subtitle="Read the Docs"
+    sub_subtitle_link="https://docs.kiln.tech/docs/documents-and-search-rag#document-library"
     breadcrumbs={[{ label: "Docs & Search", href: `/docs/${project_id}` }]}
     action_buttons={documents && documents.length == 0
       ? []

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
@@ -185,6 +185,8 @@
 <AppPage
   title="Document"
   subtitle={`${document?.name || document?.original_file.filename}`}
+  sub_subtitle="Read the Docs"
+  sub_subtitle_link="https://docs.kiln.tech/docs/documents-and-search-rag#building-a-search-tool"
   limit_max_width
   breadcrumbs={[
     {
@@ -192,7 +194,7 @@
       href: `/docs/${project_id}`,
     },
     {
-      label: "Doc Library",
+      label: "Document Library",
       href: `/docs/library/${project_id}`,
     },
   ]}

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/+page.svelte
@@ -86,6 +86,8 @@
   <AppPage
     title="Search Tools (RAG)"
     subtitle="Enable tasks to search documents for knowledge."
+    sub_subtitle="Read the Docs"
+    sub_subtitle_link="https://docs.kiln.tech/docs/documents-and-search-rag#building-a-search-tool"
     no_y_padding={!!(all_rag_configs && all_rag_configs.length == 0)}
     breadcrumbs={[{ label: "Docs & Search", href: `/docs/${project_id}` }]}
     action_buttons={all_rag_configs && all_rag_configs.length == 0

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
@@ -203,6 +203,8 @@
   <AppPage
     title="Search Tool (RAG)"
     subtitle={rag_config?.name ? `Name: ${rag_config.name}` : undefined}
+    sub_subtitle="Read the Docs"
+    sub_subtitle_link="https://docs.kiln.tech/docs/documents-and-search-rag#building-a-search-tool"
     breadcrumbs={[
       {
         label: "Docs & Search",

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/+page.svelte
@@ -126,6 +126,8 @@
 <AppPage
   title="Add a Search Tool (RAG)"
   subtitle="A tool to search for information in documents"
+  sub_subtitle="Read the Docs"
+  sub_subtitle_link="https://docs.kiln.tech/docs/documents-and-search-rag#building-a-search-tool"
   breadcrumbs={[
     {
       label: "Docs & Search",

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/+page.svelte
@@ -559,6 +559,8 @@
 <AppPage
   title="Create Search Tool (RAG)"
   subtitle="Define parameters for how this tool will search and retrieve your documents"
+  sub_subtitle="Read the Docs"
+  sub_subtitle_link="https://docs.kiln.tech/docs/documents-and-search-rag#building-a-search-tool"
   breadcrumbs={[
     {
       label: "Docs & Search",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a secondary “Read the Docs” subtitle with a direct link in page headers across Docs, Document Library, and RAG Config pages (including detail, create, and add tool views) for quick access to relevant documentation.
- Style
  - Updated breadcrumb label from “Doc Library” to “Document Library” for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->