### PR TITLE
fix: deduplicate consecutive whitespace and newlines before chunking

### DIFF
--- a/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, Field
 
+from kiln_ai.adapters.chunkers.helpers import clean_up_text
 from kiln_ai.datamodel.chunk import ChunkerConfig
 
 logger = logging.getLogger(__name__)
@@ -30,7 +31,11 @@ class BaseChunker(ABC):
         if not text:
             return ChunkingResult(chunks=[])
 
-        return await self._chunk(text)
+        sanitized_text = clean_up_text(text)
+        if not sanitized_text:
+            return ChunkingResult(chunks=[])
+
+        return await self._chunk(sanitized_text)
 
     @abstractmethod
     async def _chunk(self, text: str) -> ChunkingResult:

--- a/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
@@ -7,6 +7,7 @@ from kiln_ai.adapters.chunkers.base_chunker import (
     ChunkingResult,
     TextChunk,
 )
+from kiln_ai.adapters.chunkers.helpers import clean_up_text
 from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
 
 
@@ -30,6 +31,7 @@ class FixedWindowChunker(BaseChunker):
         )
 
     async def _chunk(self, text: str) -> ChunkingResult:
+        text = clean_up_text(text)
         sentences = self.splitter.split_text(text)
 
         chunks: List[TextChunk] = []

--- a/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
@@ -7,7 +7,6 @@ from kiln_ai.adapters.chunkers.base_chunker import (
     ChunkingResult,
     TextChunk,
 )
-from kiln_ai.adapters.chunkers.helpers import clean_up_text
 from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
 
 
@@ -31,10 +30,6 @@ class FixedWindowChunker(BaseChunker):
         )
 
     async def _chunk(self, text: str) -> ChunkingResult:
-        text = clean_up_text(text)
-        if not text:
-            return ChunkingResult(chunks=[])
-
         sentences = self.splitter.split_text(text)
 
         chunks: List[TextChunk] = []

--- a/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/fixed_window_chunker.py
@@ -32,6 +32,9 @@ class FixedWindowChunker(BaseChunker):
 
     async def _chunk(self, text: str) -> ChunkingResult:
         text = clean_up_text(text)
+        if not text:
+            return ChunkingResult(chunks=[])
+
         sentences = self.splitter.split_text(text)
 
         chunks: List[TextChunk] = []

--- a/libs/core/kiln_ai/adapters/chunkers/helpers.py
+++ b/libs/core/kiln_ai/adapters/chunkers/helpers.py
@@ -3,9 +3,21 @@ import re
 
 def clean_up_text(text: str) -> str:
     """
-    Clean up text by removing consecutive newlines and consecutive whitespace. Models sometimes send a lot of those.
+    Clean up text by limiting consecutive newlines and consecutive whitespace. Models sometimes send a lot of those.
     It seems to happen more when the transcription is done at low temperature.
+
+    - Replaces 6+ consecutive newlines with exactly 6 newlines
+    - Replaces 50+ consecutive spaces with exactly 50 spaces
+    - Leaves 1-5 consecutive newlines unchanged
+    - Leaves 1-49 consecutive spaces unchanged
     """
-    text = re.sub(r"\n+", "\n", text)
-    text = re.sub(" +", " ", text)
+    max_consecutive_newlines = 6
+    max_consecutive_whitespace = 50
+
+    # Replace 6+ consecutive newlines with exactly 6 newlines
+    text = re.sub(r"\n{6,}", "\n" * max_consecutive_newlines, text)
+
+    # Replace 50+ consecutive spaces with exactly 50 spaces
+    text = re.sub(r" {50,}", " " * max_consecutive_whitespace, text)
+
     return text.strip()

--- a/libs/core/kiln_ai/adapters/chunkers/helpers.py
+++ b/libs/core/kiln_ai/adapters/chunkers/helpers.py
@@ -1,0 +1,11 @@
+import re
+
+
+def clean_up_text(text: str) -> str:
+    """
+    Clean up text by removing consecutive newlines and consecutive whitespace. Models sometimes send a lot of those.
+    It seems to happen more when the transcription is done at low temperature.
+    """
+    text = re.sub(r"\n+", "\n", text)
+    text = re.sub(" +", " ", text)
+    return text.strip()

--- a/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from kiln_ai.adapters.chunkers.base_chunker import (
@@ -5,6 +7,7 @@ from kiln_ai.adapters.chunkers.base_chunker import (
     ChunkingResult,
     TextChunk,
 )
+from kiln_ai.adapters.chunkers.helpers import clean_up_text
 from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
 
 
@@ -34,3 +37,27 @@ async def test_base_chunker_chunk_empty_text(chunker: WhitespaceChunker):
 async def test_base_chunker_concrete_chunker(chunker: WhitespaceChunker):
     output = await chunker.chunk("Hello, world!")
     assert len(output.chunks) == 2
+
+
+async def test_base_chunker_calls_clean_up_text(chunker: WhitespaceChunker):
+    with patch(
+        "kiln_ai.adapters.chunkers.base_chunker.clean_up_text"
+    ) as mock_clean_up_text:
+        mock_clean_up_text.side_effect = clean_up_text
+        await chunker.chunk("Hello, world!")
+        mock_clean_up_text.assert_called_once_with("Hello, world!")
+
+
+async def test_base_chunker_empty_text(chunker: WhitespaceChunker):
+    chunks = await chunker.chunk("")
+    assert chunks == ChunkingResult(chunks=[])
+
+
+async def test_base_chunker_empty_text_after_clean_up(chunker: WhitespaceChunker):
+    with patch(
+        "kiln_ai.adapters.chunkers.base_chunker.clean_up_text"
+    ) as mock_clean_up_text:
+        mock_clean_up_text.side_effect = clean_up_text
+        chunks = await chunker.chunk("\n\n   ")
+        mock_clean_up_text.assert_called_once_with("\n\n   ")
+        assert chunks == ChunkingResult(chunks=[])

--- a/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
@@ -83,7 +83,7 @@ However, it's not just about the ice warming up. The real magic happens because 
 
 @pytest.mark.parametrize(
     "chunk_size,chunk_overlap,expected_chunks",
-    [(12, 6, 119), (256, 12, 4), (1024, 64, 1), (2048, 128, 1)],
+    [(12, 6, 120), (256, 12, 4), (1024, 64, 1), (2048, 128, 1)],
 )
 async def test_fixed_window_chunker_concrete_chunker_zh(
     chunk_size, chunk_overlap, expected_chunks, mock_fixed_window_chunker_factory

--- a/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
@@ -290,7 +290,7 @@ The word water comes from Old English wæter, from Proto-Germanic *watar (source
     chunker = mock_fixed_window_chunker_factory(32, 8)
 
     with patch(
-        "kiln_ai.adapters.chunkers.fixed_window_chunker.clean_up_text"
+        "kiln_ai.adapters.chunkers.base_chunker.clean_up_text"
     ) as mock_clean_up_text:
         mock_clean_up_text.side_effect = clean_up_text
         output = await chunker.chunk(text)
@@ -302,7 +302,7 @@ The word water comes from Old English wæter, from Proto-Germanic *watar (source
 @pytest.mark.paid
 @pytest.mark.parametrize(
     "number_of_sentences",
-    [10, 100, 1_000, 10_000, 100_000],
+    [10, 100, 1_000, 10_000],
 )
 async def test_fixed_window_chunker_handle_large_text(
     mock_fixed_window_chunker_factory, number_of_sentences
@@ -312,7 +312,7 @@ async def test_fixed_window_chunker_handle_large_text(
 
     chunker = mock_fixed_window_chunker_factory(32, 8)
     with patch(
-        "kiln_ai.adapters.chunkers.fixed_window_chunker.clean_up_text"
+        "kiln_ai.adapters.chunkers.base_chunker.clean_up_text"
     ) as mock_clean_up_text:
         mock_clean_up_text.side_effect = clean_up_text
         output = await chunker.chunk(text)

--- a/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
@@ -83,7 +83,7 @@ However, it's not just about the ice warming up. The real magic happens because 
 
 @pytest.mark.parametrize(
     "chunk_size,chunk_overlap,expected_chunks",
-    [(12, 6, 120), (256, 12, 4), (1024, 64, 1), (2048, 128, 1)],
+    [(12, 6, 119), (256, 12, 4), (1024, 64, 1), (2048, 128, 1)],
 )
 async def test_fixed_window_chunker_concrete_chunker_zh(
     chunk_size, chunk_overlap, expected_chunks, mock_fixed_window_chunker_factory

--- a/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_fixed_window_chunker.py
@@ -6,6 +6,7 @@ from llama_index.core.text_splitter import SentenceSplitter
 
 from kiln_ai.adapters.chunkers.base_chunker import ChunkingResult
 from kiln_ai.adapters.chunkers.fixed_window_chunker import FixedWindowChunker
+from kiln_ai.adapters.chunkers.helpers import clean_up_text
 from kiln_ai.datamodel.chunk import ChunkerConfig, ChunkerType
 
 
@@ -30,7 +31,7 @@ async def test_fixed_window_chunker_wrong_chunker_type(
         FixedWindowChunker(
             ChunkerConfig(
                 name="test-chunker",
-                chunker_type="wrong-chunker-type",
+                chunker_type="wrong-chunker-type",  # type: ignore
                 properties={"chunk_size": 100, "chunk_overlap": 10},
             )
         )
@@ -270,3 +271,50 @@ async def test_fixed_window_chunker_very_large_text(mock_fixed_window_chunker_fa
     # All chunks should have content
     for chunk in output.chunks:
         assert chunk.text.strip() != ""
+
+
+@pytest.mark.parametrize(
+    "whitespace_length",
+    [10000, 100_000, 1_000_000, 5_000_000, 10_000_000],
+)
+async def test_fixed_window_chunker_removes_consecutive_whitespace(
+    mock_fixed_window_chunker_factory, whitespace_length
+):
+    # this is a very large text due to 1M+ consecutive whitespace characters
+    # the chunker crashes with a rust error
+    text = """Water plays an important role in the world economy. Approximately 70% of the fresh water used by humans goes to agriculture.[26] Fishing in salt and fresh water bodies has been, and continues to be, a major source of food for many parts of the world, providing 6.5% of global protein.[27] Much of the long-distance trade of commodities (such as oil, natural gas, and manufactured products) is transported by boats through seas, rivers, lakes, and canals. Large quantities of water, ice, and steam are used for cooling and heating in industry and homes. Water is an excellent solvent for a wide variety of substances, both mineral and organic; as such, it is widely used in industrial processes and in cooking and washing. Water, ice, and snow are also central to many sports and other forms of entertainment, such as swimming, pleasure boating, boat racing, surfing, sport fishing, diving, ice skating, snowboarding, and skiing.
+{WHITESPACE_PROBLEM_HERE}
+The word water comes from Old English wæter, from Proto-Germanic *watar (source also of Old Saxon watar, Old Frisian wetir, Dutch water, Old High German wazzar, German Wasser, vatn, Gothic 𐍅𐌰𐍄𐍉 (wato)), from Proto-Indo-European *wod-or, suffixed form of root *wed- ('water'; 'wet').[28] Also cognate, through the Indo-European root, with Greek ύδωρ (ýdor; from Ancient Greek ὕδωρ (hýdōr), whence English 'hydro-'), Russian вода́ (vodá), Irish uisce, and Albanian ujë.
+""".replace("{WHITESPACE_PROBLEM_HERE}", " " * whitespace_length)
+
+    chunker = mock_fixed_window_chunker_factory(32, 8)
+
+    with patch(
+        "kiln_ai.adapters.chunkers.fixed_window_chunker.clean_up_text"
+    ) as mock_clean_up_text:
+        mock_clean_up_text.side_effect = clean_up_text
+        output = await chunker.chunk(text)
+        mock_clean_up_text.assert_called_once_with(text)
+        assert len(output.chunks) > 1
+
+
+# this test takes a long time to run
+@pytest.mark.paid
+@pytest.mark.parametrize(
+    "number_of_sentences",
+    [10, 100, 1_000, 10_000, 100_000],
+)
+async def test_fixed_window_chunker_handle_large_text(
+    mock_fixed_window_chunker_factory, number_of_sentences
+):
+    sentence = """Water plays an important role in the world economy. Approximately 70% of the fresh water used by humans goes to agriculture.[26] Fishing in salt and fresh water bodies has been, and continues to be, a major source of food for many parts of the world, providing 6.5% of global protein.[27] Much of the long-distance trade of commodities (such as oil, natural gas, and manufactured products) is transported by boats through seas, rivers, lakes, and canals. Large quantities of water, ice, and steam are used for cooling and heating in industry and homes. Water is an excellent solvent for a wide variety of substances, both mineral and organic; as such, it is widely used in industrial processes and in cooking and washing. Water, ice, and snow are also central to many sports and other forms of entertainment, such as swimming, pleasure boating, boat racing, surfing, sport fishing, diving, ice skating, snowboarding, and skiing."""
+    text = sentence * number_of_sentences
+
+    chunker = mock_fixed_window_chunker_factory(32, 8)
+    with patch(
+        "kiln_ai.adapters.chunkers.fixed_window_chunker.clean_up_text"
+    ) as mock_clean_up_text:
+        mock_clean_up_text.side_effect = clean_up_text
+        output = await chunker.chunk(text)
+        mock_clean_up_text.assert_called_once_with(text)
+        assert len(output.chunks) > 1

--- a/libs/core/kiln_ai/adapters/chunkers/test_helpers.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_helpers.py
@@ -1,0 +1,39 @@
+import pytest
+
+from kiln_ai.adapters.chunkers.helpers import clean_up_text
+
+
+def generate_consecutive_char_string(length: int, char: str) -> str:
+    return char * length
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Hello\n\nWorld", "Hello\nWorld"),
+        ("Hello     World", "Hello World"),
+        ("Hello\n\n\n\nWorld", "Hello\nWorld"),
+    ],
+)
+def test_clean_up_text(text, expected):
+    assert clean_up_text(text) == expected
+
+
+text = """Water is an inorganic compound with the chemical formula H2O. It is a transparent, tasteless, odorless,[c] and nearly colorless chemical substance. It is the main constituent of Earth's hydrosphere and the fluids of all known living organisms in which it acts as a solvent. Water, being a polar molecule, undergoes strong intermolecular hydrogen bonding which is a large contributor to its physical and chemical properties.[20] It is vital for all known forms of life, despite not providing food energy or being an organic micronutrient. Due to its presence in all organisms, its chemical stability, its worldwide abundance and its strong polarity relative to its small molecular size; water is often referred to as the "universal solvent".[21]"""
+
+long_whitespace_string = generate_consecutive_char_string(1000, " ")
+long_newlines_string = generate_consecutive_char_string(1000, "\n")
+
+string_with_whitespace = f"{text}{long_whitespace_string}{text}"
+string_with_newlines = f"{text}{long_newlines_string}{text}"
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (f"{text}{long_whitespace_string}{text}", f"{text} {text}"),
+        (f"{text}{long_newlines_string}{text}", f"{text}\n{text}"),
+    ],
+)
+def test_clean_up_text_large_text(text, expected):
+    assert clean_up_text(text) == expected

--- a/libs/core/kiln_ai/adapters/chunkers/test_helpers.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_helpers.py
@@ -10,9 +10,45 @@ def generate_consecutive_char_string(length: int, char: str) -> str:
 @pytest.mark.parametrize(
     "text,expected",
     [
-        ("Hello\n\nWorld", "Hello\nWorld"),
-        ("Hello     World", "Hello World"),
-        ("Hello\n\n\n\nWorld", "Hello\nWorld"),
+        # Test single newlines (should remain unchanged)
+        ("Hello\nWorld", "Hello\nWorld"),
+        ("Hello\n\nWorld", "Hello\n\nWorld"),
+        ("Hello\n\n\nWorld", "Hello\n\n\nWorld"),
+        ("Hello\n\n\n\nWorld", "Hello\n\n\n\nWorld"),
+        ("Hello\n\n\n\n\nWorld", "Hello\n\n\n\n\nWorld"),
+        # Test 6+ consecutive newlines (should be replaced with exactly 6)
+        ("Hello\n\n\n\n\n\nWorld", "Hello\n\n\n\n\n\nWorld"),  # exactly 6, unchanged
+        ("Hello\n\n\n\n\n\n\nWorld", "Hello\n\n\n\n\n\nWorld"),  # 7 newlines -> 6
+        ("Hello\n\n\n\n\n\n\n\nWorld", "Hello\n\n\n\n\n\nWorld"),  # 8 newlines -> 6
+        (
+            "Hello\n\n\n\n\n\n\n\n\n\nWorld",
+            "Hello\n\n\n\n\n\nWorld",
+        ),  # 10 newlines -> 6
+        # Test single spaces (should remain unchanged)
+        ("Hello World", "Hello World"),
+        ("Hello  World", "Hello  World"),
+        ("Hello   World", "Hello   World"),
+        ("Hello    World", "Hello    World"),
+        ("Hello     World", "Hello     World"),
+        # Test 50+ consecutive spaces (should be replaced with exactly 50)
+        (
+            "Hello" + " " * 50 + "World",
+            "Hello" + " " * 50 + "World",
+        ),  # exactly 50, unchanged
+        ("Hello" + " " * 51 + "World", "Hello" + " " * 50 + "World"),  # 51 spaces -> 50
+        (
+            "Hello" + " " * 100 + "World",
+            "Hello" + " " * 50 + "World",
+        ),  # 100 spaces -> 50
+        # Test mixed cases
+        (
+            "Hello\n\n\n\n\n\n\nWorld" + " " * 60 + "Test",
+            "Hello\n\n\n\n\n\nWorld" + " " * 50 + "Test",
+        ),
+        (
+            "Text\n\n\n\n\n\n\n\n\n\nMore" + " " * 30 + "Text",
+            "Text\n\n\n\n\n\nMore" + " " * 30 + "Text",
+        ),
     ],
 )
 def test_clean_up_text(text, expected):
@@ -31,8 +67,8 @@ string_with_newlines = f"{text}{long_newlines_string}{text}"
 @pytest.mark.parametrize(
     "text,expected",
     [
-        (f"{text}{long_whitespace_string}{text}", f"{text} {text}"),
-        (f"{text}{long_newlines_string}{text}", f"{text}\n{text}"),
+        (f"{text}{long_whitespace_string}{text}", f"{text}{' ' * 50}{text}"),
+        (f"{text}{long_newlines_string}{text}", f"{text}{chr(10) * 6}{text}"),
     ],
 )
 def test_clean_up_text_large_text(text, expected):


### PR DESCRIPTION
## What does this PR do?

Sometimes the model responds with many whitespace or newline chars (a lot of then - I had a case with 1.5M such consecutive characters). The chunker cannot handle it and crashes.

Fix:
- deduplicate consecutive `\n` and spaces in response before chunking
- increase temperature (lowering it seems to have made this worse)

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Text is now automatically cleaned before chunking: consecutive newlines are limited to six and spaces to fifty to normalize input and improve chunk quality.
- Bug Fixes
  - Whitespace-only inputs now produce no chunks.
  - More robust handling of very large texts and extreme whitespace sequences.
- Tests
  - Added comprehensive tests for whitespace normalization, large-input scenarios, and pre-chunking cleaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->