### PR TITLE
feat: filesystem cache for pdf pages

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/default_extractor_prompts.ts
+++ b/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/default_extractor_prompts.ts
@@ -6,7 +6,7 @@ export function default_extractor_document_prompts(output_format: string) {
 - If the document contains tables, reproduce them in the output using the correct format, and also add a brief descriptive sentence summarizing the table as a whole.
 - Preserve the structure and order of the document.
 - Format the output as valid ${output_format}.
-- Do not transcribe non-informational text such as repetitive whitespace characters, a horizontal rule repeated multiple times.
+- Do not transcribe formatting elements such as bold, italic, underline, newlines, etc.
 - Do NOT include any prefatory or explanatory text outside of the transcription itself.
 `
 }

--- a/libs/core/kiln_ai/adapters/extractors/extractor_registry.py
+++ b/libs/core/kiln_ai/adapters/extractors/extractor_registry.py
@@ -7,11 +7,13 @@ from kiln_ai.adapters.provider_tools import (
 )
 from kiln_ai.datamodel.extraction import ExtractorConfig, ExtractorType
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
+from kiln_ai.utils.filesystem_cache import FilesystemCache
 
 
 def extractor_adapter_from_type(
     extractor_type: ExtractorType,
     extractor_config: ExtractorConfig,
+    filesystem_cache: FilesystemCache | None = None,
 ) -> BaseExtractor:
     match extractor_type:
         case ExtractorType.LITELLM:
@@ -35,6 +37,7 @@ def extractor_adapter_from_type(
             return LitellmExtractor(
                 extractor_config,
                 provider_config,
+                filesystem_cache,
             )
         case _:
             # type checking will catch missing cases

--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -1,3 +1,5 @@
+import hashlib
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -14,8 +16,11 @@ from kiln_ai.adapters.ml_model_list import built_in_models_from_provider
 from kiln_ai.adapters.provider_tools import LiteLlmCoreConfig
 from kiln_ai.datamodel.datamodel_enums import ModelProviderName
 from kiln_ai.datamodel.extraction import ExtractorConfig, ExtractorType, Kind
+from kiln_ai.utils.filesystem_cache import FilesystemCache
 from kiln_ai.utils.litellm import get_litellm_provider_info
 from kiln_ai.utils.pdf_utils import split_pdf_into_pages
+
+logger = logging.getLogger(__name__)
 
 MIME_TYPES_SUPPORTED = {
     Kind.DOCUMENT: [
@@ -84,6 +89,7 @@ class LitellmExtractor(BaseExtractor):
         self,
         extractor_config: ExtractorConfig,
         litellm_core_config: LiteLlmCoreConfig,
+        filesystem_cache: FilesystemCache | None = None,
     ):
         if extractor_config.extractor_type != ExtractorType.LITELLM:
             raise ValueError(
@@ -105,6 +111,8 @@ class LitellmExtractor(BaseExtractor):
         if prompt_image is None or prompt_image == "":
             raise ValueError("properties.prompt_image is required for LitellmExtractor")
 
+        self.filesystem_cache = filesystem_cache
+
         super().__init__(extractor_config)
         self.prompt_for_kind = {
             Kind.DOCUMENT: prompt_document,
@@ -115,6 +123,34 @@ class LitellmExtractor(BaseExtractor):
 
         self.litellm_core_config = litellm_core_config
 
+    def pdf_page_cache_key(self, pdf_path: Path, page_number: int) -> str:
+        if self.extractor_config.id is None:
+            raise ValueError("Extractor config ID is required for PDF page cache key")
+
+        return (
+            self.extractor_config.id
+            + "_"
+            + hashlib.md5(f"{pdf_path.name}_{page_number}".encode("utf-8")).hexdigest()
+        )
+
+    def get_page_content_from_cache(
+        self, pdf_path: Path, page_number: int
+    ) -> str | None:
+        if self.filesystem_cache is None:
+            return None
+
+        page_bytes = self.filesystem_cache.get(
+            self.pdf_page_cache_key(pdf_path, page_number)
+        )
+
+        if page_bytes is not None:
+            logger.debug(f"Cache hit for page {page_number} of {pdf_path}")
+            content = page_bytes.decode("utf-8")
+            return content
+
+        logger.debug(f"Cache miss for page {page_number} of {pdf_path}")
+        return None
+
     async def _extract_from_pdf_pages(self, pdf_path: Path, prompt: str) -> str:
         combined_content = []
 
@@ -124,6 +160,11 @@ class LitellmExtractor(BaseExtractor):
             # start summarizing the later pages
             for i, page_path in enumerate(page_paths):
                 try:
+                    page_content = self.get_page_content_from_cache(pdf_path, i)
+                    if page_content is not None:
+                        combined_content.append(page_content)
+                        continue
+
                     page_input = ExtractionInput(
                         path=str(page_path), mime_type="application/pdf"
                     )
@@ -155,6 +196,12 @@ class LitellmExtractor(BaseExtractor):
                 if not content:
                     raise ValueError(
                         f"No text returned from extraction model when extracting page {i + 1} for {pdf_path}"
+                    )
+
+                if self.filesystem_cache is not None:
+                    logger.debug(f"Caching page {i + 1} of {pdf_path} in cache")
+                    self.filesystem_cache.set(
+                        self.pdf_page_cache_key(pdf_path, i), content.encode("utf-8")
                     )
 
                 combined_content.append(content)

--- a/libs/core/kiln_ai/adapters/extractors/test_litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/test_litellm_extractor.py
@@ -16,6 +16,7 @@ from kiln_ai.adapters.extractors.litellm_extractor import (
 from kiln_ai.adapters.ml_model_list import built_in_models
 from kiln_ai.adapters.provider_tools import LiteLlmCoreConfig
 from kiln_ai.datamodel.extraction import ExtractorType
+from kiln_ai.utils.filesystem_cache import FilesystemCache
 
 PROMPTS_FOR_KIND: dict[str, str] = {
     "document": "prompt for documents",
@@ -752,3 +753,268 @@ async def test_provider_bad_request(tmp_path, model_name, provider_name):
                 mime_type="application/pdf",
             )
         )
+
+
+# Cache-related tests for PDF processing
+@pytest.fixture
+def mock_litellm_extractor_with_cache(tmp_path):
+    """Create a LitellmExtractor with a filesystem cache for testing."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()  # Ensure cache directory exists
+    cache = FilesystemCache(cache_dir)
+    return LitellmExtractor(
+        ExtractorConfig(
+            id="test_extractor_123",  # Required for cache key generation
+            name="mock_with_cache",
+            extractor_type=ExtractorType.LITELLM,
+            model_name="gpt_4o",
+            model_provider_name="openai",
+            properties={
+                "prompt_document": PROMPTS_FOR_KIND["document"],
+                "prompt_image": PROMPTS_FOR_KIND["image"],
+                "prompt_video": PROMPTS_FOR_KIND["video"],
+                "prompt_audio": PROMPTS_FOR_KIND["audio"],
+            },
+        ),
+        litellm_core_config=LiteLlmCoreConfig(
+            base_url="https://test.com",
+            additional_body_options={"api_key": "test-key"},
+            default_headers={},
+        ),
+        filesystem_cache=cache,
+    )
+
+
+@pytest.fixture
+def mock_litellm_extractor_without_cache():
+    """Create a LitellmExtractor without a filesystem cache for testing."""
+    return LitellmExtractor(
+        ExtractorConfig(
+            id="test_extractor_456",  # Required for cache key generation
+            name="mock_without_cache",
+            extractor_type=ExtractorType.LITELLM,
+            model_name="gpt_4o",
+            model_provider_name="openai",
+            properties={
+                "prompt_document": PROMPTS_FOR_KIND["document"],
+                "prompt_image": PROMPTS_FOR_KIND["image"],
+                "prompt_video": PROMPTS_FOR_KIND["video"],
+                "prompt_audio": PROMPTS_FOR_KIND["audio"],
+            },
+        ),
+        litellm_core_config=LiteLlmCoreConfig(
+            base_url="https://test.com",
+            additional_body_options={"api_key": "test-key"},
+            default_headers={},
+        ),
+        filesystem_cache=None,  # Explicitly no cache
+    )
+
+
+def test_pdf_page_cache_key_generation(mock_litellm_extractor_with_cache):
+    """Test that PDF page cache keys are generated correctly."""
+    pdf_path = Path("test_document.pdf")
+    page_number = 0
+
+    cache_key = mock_litellm_extractor_with_cache.pdf_page_cache_key(
+        pdf_path, page_number
+    )
+
+    # Should include extractor ID and a hash of the PDF name and page number
+    assert cache_key.startswith("test_extractor_123_")
+    assert len(cache_key) > len("test_extractor_123_")  # Should have hash suffix
+
+    # Same PDF and page should generate same key
+    cache_key2 = mock_litellm_extractor_with_cache.pdf_page_cache_key(
+        pdf_path, page_number
+    )
+    assert cache_key == cache_key2
+
+    # Different page should generate different key
+    cache_key3 = mock_litellm_extractor_with_cache.pdf_page_cache_key(pdf_path, 1)
+    assert cache_key != cache_key3
+
+
+def test_pdf_page_cache_key_requires_extractor_id():
+    """Test that PDF page cache key generation requires extractor ID."""
+    extractor_config = ExtractorConfig(
+        id=None,  # No ID
+        name="mock",
+        extractor_type=ExtractorType.LITELLM,
+        model_name="gpt_4o",
+        model_provider_name="openai",
+        properties={
+            "prompt_document": PROMPTS_FOR_KIND["document"],
+            "prompt_image": PROMPTS_FOR_KIND["image"],
+            "prompt_video": PROMPTS_FOR_KIND["video"],
+            "prompt_audio": PROMPTS_FOR_KIND["audio"],
+        },
+    )
+
+    extractor = LitellmExtractor(
+        extractor_config,
+        LiteLlmCoreConfig(
+            base_url="https://test.com",
+            additional_body_options={"api_key": "test-key"},
+            default_headers={},
+        ),
+    )
+
+    with pytest.raises(
+        ValueError, match="Extractor config ID is required for PDF page cache key"
+    ):
+        extractor.pdf_page_cache_key(Path("test.pdf"), 0)
+
+
+async def test_extract_pdf_with_cache_storage(
+    mock_file_factory, mock_litellm_extractor_with_cache
+):
+    """Test that PDF extraction stores content in cache when cache is available."""
+    test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
+
+    # Mock responses for each page (PDF has 2 pages)
+    mock_responses = []
+    for i in range(2):
+        mock_response = AsyncMock(spec=ModelResponse)
+        mock_choice = AsyncMock(spec=Choices)
+        mock_message = AsyncMock()
+        mock_message.content = f"Content from page {i + 1}"
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+        mock_responses.append(mock_response)
+
+    with patch("litellm.acompletion", side_effect=mock_responses) as mock_acompletion:
+        result = await mock_litellm_extractor_with_cache.extract(
+            ExtractionInput(
+                path=str(test_file),
+                mime_type="application/pdf",
+            )
+        )
+
+    # Verify that the completion was called for each page
+    assert mock_acompletion.call_count == 2
+
+    # Verify content is stored in cache
+    pdf_path = Path(test_file)
+    for i in range(2):
+        cached_content = mock_litellm_extractor_with_cache.get_page_content_from_cache(
+            pdf_path, i
+        )
+        assert cached_content == f"Content from page {i + 1}"
+
+    # Verify the output contains content from both pages
+    assert "Content from page 1" in result.content
+    assert "Content from page 2" in result.content
+
+
+async def test_extract_pdf_with_cache_retrieval(
+    mock_file_factory, mock_litellm_extractor_with_cache
+):
+    """Test that PDF extraction retrieves content from cache when available."""
+    test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
+    pdf_path = Path(test_file)
+
+    # Pre-populate cache with content
+    for i in range(2):
+        cache_key = mock_litellm_extractor_with_cache.pdf_page_cache_key(pdf_path, i)
+        mock_litellm_extractor_with_cache.filesystem_cache.set(
+            cache_key, f"Cached content from page {i + 1}".encode("utf-8")
+        )
+
+    # Mock responses (should not be called due to cache hits)
+    mock_responses = []
+    for i in range(2):
+        mock_response = AsyncMock(spec=ModelResponse)
+        mock_choice = AsyncMock(spec=Choices)
+        mock_message = AsyncMock()
+        mock_message.content = f"Fresh content from page {i + 1}"
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+        mock_responses.append(mock_response)
+
+    with patch("litellm.acompletion", side_effect=mock_responses) as mock_acompletion:
+        result = await mock_litellm_extractor_with_cache.extract(
+            ExtractionInput(
+                path=str(test_file),
+                mime_type="application/pdf",
+            )
+        )
+
+    # Verify that litellm.acompletion was NOT called (cache hits)
+    assert mock_acompletion.call_count == 0
+
+    # Verify the output contains cached content, not fresh content
+    assert "Cached content from page 1" in result.content
+    assert "Cached content from page 2" in result.content
+    assert "Fresh content from page 1" not in result.content
+    assert "Fresh content from page 2" not in result.content
+
+
+async def test_extract_pdf_without_cache(
+    mock_file_factory, mock_litellm_extractor_without_cache
+):
+    """Test that PDF extraction works normally when no cache is provided."""
+    test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
+
+    # Mock responses for each page (PDF has 2 pages)
+    mock_responses = []
+    for i in range(2):
+        mock_response = AsyncMock(spec=ModelResponse)
+        mock_choice = AsyncMock(spec=Choices)
+        mock_message = AsyncMock()
+        mock_message.content = f"Content from page {i + 1}"
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+        mock_responses.append(mock_response)
+
+    with patch("litellm.acompletion", side_effect=mock_responses) as mock_acompletion:
+        result = await mock_litellm_extractor_without_cache.extract(
+            ExtractionInput(
+                path=str(test_file),
+                mime_type="application/pdf",
+            )
+        )
+
+    # Verify that the completion was called for each page
+    assert mock_acompletion.call_count == 2
+
+    # Verify the output contains content from both pages
+    assert "Content from page 1" in result.content
+    assert "Content from page 2" in result.content
+
+
+async def test_extract_pdf_mixed_cache_hits_and_misses(
+    mock_file_factory, mock_litellm_extractor_with_cache
+):
+    """Test PDF extraction with some pages cached and others not."""
+    test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
+    pdf_path = Path(test_file)
+
+    # Pre-populate cache with only page 0 content
+    cache_key = mock_litellm_extractor_with_cache.pdf_page_cache_key(pdf_path, 0)
+    mock_litellm_extractor_with_cache.filesystem_cache.set(
+        cache_key, "Cached content from page 1".encode("utf-8")
+    )
+
+    # Mock responses for page 1 only (page 0 should hit cache)
+    mock_response = AsyncMock(spec=ModelResponse)
+    mock_choice = AsyncMock(spec=Choices)
+    mock_message = AsyncMock()
+    mock_message.content = "Fresh content from page 2"
+    mock_choice.message = mock_message
+    mock_response.choices = [mock_choice]
+
+    with patch("litellm.acompletion", return_value=mock_response) as mock_acompletion:
+        result = await mock_litellm_extractor_with_cache.extract(
+            ExtractionInput(
+                path=str(test_file),
+                mime_type="application/pdf",
+            )
+        )
+
+    # Verify that litellm.acompletion was called only once (for page 1)
+    assert mock_acompletion.call_count == 1
+
+    # Verify the output contains both cached and fresh content
+    assert "Cached content from page 1" in result.content
+    assert "Fresh content from page 2" in result.content

--- a/libs/core/kiln_ai/adapters/rag/rag_runners.py
+++ b/libs/core/kiln_ai/adapters/rag/rag_runners.py
@@ -37,6 +37,7 @@ from kiln_ai.datamodel.rag import RagConfig
 from kiln_ai.datamodel.vector_store import VectorStoreConfig
 from kiln_ai.utils.async_job_runner import AsyncJobRunner, AsyncJobRunnerObserver
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
+from kiln_ai.utils.filesystem_cache import FilesystemCache
 from kiln_ai.utils.lock import shared_async_lock_manager
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -229,12 +230,14 @@ class RagExtractionStepRunner(AbstractRagStepRunner):
         extractor_config: ExtractorConfig,
         concurrency: int = 10,
         rag_config: RagConfig | None = None,
+        filesystem_cache: FilesystemCache | None = None,
     ):
         self.project = project
         self.extractor_config = extractor_config
         self.lock_key = f"docs:extract:{self.extractor_config.id}"
         self.concurrency = concurrency
         self.rag_config = rag_config
+        self.filesystem_cache = filesystem_cache
 
     def stage(self) -> RagWorkflowStepNames:
         return RagWorkflowStepNames.EXTRACTING
@@ -281,6 +284,7 @@ class RagExtractionStepRunner(AbstractRagStepRunner):
             extractor = extractor_adapter_from_type(
                 self.extractor_config.extractor_type,
                 self.extractor_config,
+                self.filesystem_cache,
             )
 
             observer = GenericErrorCollector()

--- a/libs/core/kiln_ai/adapters/rag/test_rag_runners.py
+++ b/libs/core/kiln_ai/adapters/rag/test_rag_runners.py
@@ -2058,7 +2058,9 @@ class TestRagWorkflowIntegration:
 
             # Verify that jobs were collected and runner was created
             mock_adapter_factory.assert_called_once_with(
-                mock_extractor_config.extractor_type, mock_extractor_config
+                mock_extractor_config.extractor_type,
+                mock_extractor_config,
+                None,
             )
             mock_job_runner_class.assert_called_once()
             assert len(progress_values) > 0

--- a/libs/core/kiln_ai/utils/filesystem_cache.py
+++ b/libs/core/kiln_ai/utils/filesystem_cache.py
@@ -1,0 +1,57 @@
+import logging
+import tempfile
+from pathlib import Path
+
+from kiln_ai.datamodel.basemodel import name_validator
+
+logger = logging.getLogger(__name__)
+
+
+class FilesystemCache:
+    def __init__(self, path: Path):
+        # the key must be a valid filename
+        validate_key = name_validator(min_length=1, max_length=120)
+        self.validate_key = validate_key
+        self.cache_dir_path = path
+
+    def get_path(self, key: str) -> Path:
+        self.validate_key(key)
+        return self.cache_dir_path / key
+
+    def get(self, key: str) -> bytes | None:
+        # check if the file exists
+        if not self.get_path(key).exists():
+            return None
+
+        # we don't want to raise because of internal cache corruption issues
+        try:
+            with open(self.get_path(key), "rb") as f:
+                return f.read()
+        except Exception:
+            logger.error(f"Error reading file {self.get_path(key)}", exc_info=True)
+            return None
+
+    def set(self, key: str, value: bytes) -> Path:
+        logger.debug(f"Caching {key} at {self.get_path(key)}")
+        self.validate_key(key)
+        path = self.get_path(key)
+        path.write_bytes(value)
+        return path
+
+
+class TemporaryFilesystemCache:
+    _shared_instance = None
+
+    def __init__(self):
+        self._cache_temp_dir = tempfile.mkdtemp(prefix="kiln_cache_")
+        self.filesystem_cache = FilesystemCache(path=Path(self._cache_temp_dir))
+
+        logger.debug(
+            f"Created temporary filesystem cache directory: {self._cache_temp_dir}"
+        )
+
+    @classmethod
+    def shared(cls) -> FilesystemCache:
+        if cls._shared_instance is None:
+            cls._shared_instance = cls()
+        return cls._shared_instance.filesystem_cache

--- a/libs/core/kiln_ai/utils/test_filesystem_cache.py
+++ b/libs/core/kiln_ai/utils/test_filesystem_cache.py
@@ -1,0 +1,322 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from kiln_ai.utils.filesystem_cache import FilesystemCache, TemporaryFilesystemCache
+
+
+class TestFilesystemCache:
+    @pytest.fixture
+    def temp_dir(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            yield Path(tmp_dir)
+
+    @pytest.fixture
+    def cache(self, temp_dir):
+        return FilesystemCache(temp_dir)
+
+    def test_init(self, temp_dir):
+        cache = FilesystemCache(temp_dir)
+        assert cache.cache_dir_path == temp_dir
+        assert cache.validate_key is not None
+
+    def test_get_path_valid_key(self, cache):
+        key = "test_file"
+        expected_path = cache.cache_dir_path / key
+        assert cache.get_path(key) == expected_path
+
+    def test_get_path_invalid_key_empty(self, cache):
+        with pytest.raises(ValueError):
+            cache.get_path("")
+
+    def test_get_path_invalid_key_too_long(self, cache):
+        long_key = "x" * 121  # exceeds max_length=120
+        with pytest.raises(ValueError):
+            cache.get_path(long_key)
+
+    def test_get_path_invalid_key_special_chars(self, cache):
+        with pytest.raises(ValueError):
+            cache.get_path("invalid/key")
+
+    def test_get_nonexistent_file(self, cache):
+        result = cache.get("nonexistent")
+        assert result is None
+
+    def test_get_existing_file(self, cache, temp_dir):
+        key = "test"
+        content = b"Hello, World!"
+        file_path = temp_dir / key
+        file_path.write_bytes(content)
+
+        result = cache.get(key)
+        assert result == content
+
+    def test_get_file_read_error(self, cache, temp_dir):
+        key = "test"
+        file_path = temp_dir / key
+        file_path.write_bytes(b"test")
+
+        with patch("builtins.open", mock_open()) as mock_file:
+            mock_file.side_effect = IOError("Read error")
+            result = cache.get(key)
+            assert result is None
+
+    def test_set_valid_data(self, cache, temp_dir):
+        key = "test"
+        content = b"Hello, World!"
+
+        result_path = cache.set(key, content)
+        expected_path = temp_dir / key
+
+        assert result_path == expected_path
+        assert expected_path.exists()
+        assert expected_path.read_bytes() == content
+
+    def test_set_invalid_key_empty(self, cache):
+        with pytest.raises(ValueError):
+            cache.set("", b"content")
+
+    def test_set_invalid_key_too_long(self, cache):
+        long_key = "x" * 121
+        with pytest.raises(ValueError):
+            cache.set(long_key, b"content")
+
+    def test_set_invalid_key_special_chars(self, cache):
+        with pytest.raises(ValueError):
+            cache.set("invalid/key", b"content")
+
+    def test_set_overwrites_existing(self, cache, temp_dir):
+        key = "test"
+        original_content = b"Original content"
+        new_content = b"New content"
+
+        # Set original content
+        cache.set(key, original_content)
+        assert (temp_dir / key).read_bytes() == original_content
+
+        # Overwrite with new content
+        cache.set(key, new_content)
+        assert (temp_dir / key).read_bytes() == new_content
+
+    def test_set_creates_parent_directory(self, cache, temp_dir):
+        # Test that set method creates parent directories if they don't exist
+        # Note: This test demonstrates a limitation - the current implementation
+        # doesn't support directory paths due to name_validator restrictions
+        key = "subdir_test"  # Using underscore instead of slash
+        content = b"Test content"
+
+        result_path = cache.set(key, content)
+        expected_path = temp_dir / key
+
+        assert result_path == expected_path
+        assert expected_path.exists()
+        assert expected_path.read_bytes() == content
+
+    def test_set_with_nested_directories(self, cache, temp_dir):
+        # Test that set method creates deeply nested directories
+        # Note: This test demonstrates a limitation - the current implementation
+        # doesn't support directory paths due to name_validator restrictions
+        key = "level1_level2_level3_test"  # Using underscores instead of slashes
+        content = b"Deeply nested content"
+
+        result_path = cache.set(key, content)
+        expected_path = temp_dir / key
+
+        assert result_path == expected_path
+        assert expected_path.exists()
+        assert expected_path.read_bytes() == content
+
+    def test_directory_paths_not_supported(self, cache):
+        # Test that demonstrates the current limitation - directory paths are not supported
+        # due to name_validator forbidding forward slashes
+        with pytest.raises(ValueError, match="Name is invalid"):
+            cache.set("subdir/test", b"content")
+
+        with pytest.raises(ValueError, match="Name is invalid"):
+            cache.get("subdir/test")
+
+    def test_roundtrip_get_set(self, cache):
+        key = "roundtrip"
+        content = b"Roundtrip test content"
+
+        # Set content
+        cache.set(key, content)
+
+        # Get content back
+        retrieved = cache.get(key)
+        assert retrieved == content
+
+    def test_multiple_files(self, cache, temp_dir):
+        files = {
+            "file1": b"Content 1",
+            "file2": b"Content 2",
+            "subdir_file3": b"Content 3",  # Using underscore instead of slash
+        }
+
+        # Set all files
+        for key, content in files.items():
+            cache.set(key, content)
+
+        # Verify all files exist and have correct content
+        for key, expected_content in files.items():
+            actual_content = cache.get(key)
+            assert actual_content == expected_content
+
+    def test_empty_bytes(self, cache):
+        key = "empty"
+        content = b""
+
+        cache.set(key, content)
+        retrieved = cache.get(key)
+        assert retrieved == content
+
+    def test_large_content(self, cache):
+        key = "large"
+        content = b"x" * 10000  # 10KB of data
+
+        cache.set(key, content)
+        retrieved = cache.get(key)
+        assert retrieved == content
+
+    @pytest.mark.parametrize(
+        "unicode_text",
+        [
+            "Simple ASCII text",
+            "中文文本测试",
+            "Mixed 中文 and English text",
+            "Emojis: 🎉🚀💻🔥",
+            "Complex: 你好世界! Hello 世界! 🌍 This is 测试 with 中文, emojis 🚀, and English.",
+            "Special chars: ñáéíóú àèìòù çüöä",
+            "Math symbols: ∑∆π∫∞±≤≥≠",
+            "Currency: €£¥$₹₽",
+        ],
+    )
+    def test_unicode_text_retrieval_integrity(self, cache, unicode_text):
+        # Test that Unicode text is not corrupted during storage and retrieval
+        key = "unicode_integrity"
+        content = unicode_text.encode("utf-8")
+
+        # Store the text
+        cache.set(key, content)
+
+        # Retrieve and verify
+        retrieved = cache.get(key)
+        assert retrieved == content
+        assert retrieved.decode("utf-8") == unicode_text
+
+    def test_key_overwrite_behavior(self, cache):
+        # Test that setting at the same key overwrites whatever was there
+        key = "overwrite_test"
+
+        # Set initial content
+        initial_content = "Initial content".encode("utf-8")
+        cache.set(key, initial_content)
+
+        # Verify initial content is stored
+        retrieved = cache.get(key)
+        assert retrieved == initial_content
+        assert retrieved.decode("utf-8") == "Initial content"
+
+        # Overwrite with different content
+        new_content = "New content with 中文 and emojis 🚀".encode("utf-8")
+        cache.set(key, new_content)
+
+        # Verify the content was overwritten
+        retrieved = cache.get(key)
+        assert retrieved == new_content
+        assert retrieved.decode("utf-8") == "New content with 中文 and emojis 🚀"
+        assert retrieved != initial_content
+
+        # Overwrite again with empty content
+        empty_content = b""
+        cache.set(key, empty_content)
+
+        # Verify empty content is stored
+        retrieved = cache.get(key)
+        assert retrieved == empty_content
+        assert retrieved.decode("utf-8") == ""
+
+    @pytest.mark.parametrize(
+        "invalid_key",
+        [
+            "",
+            "x" * 121,
+            "invalid/key",
+            "invalid\\key",
+            "invalid:key",
+            "invalid*key",
+            "invalid?key",
+            "invalid<key",
+            "invalid>key",
+            "invalid|key",
+        ],
+    )
+    def test_invalid_keys(self, cache, invalid_key):
+        with pytest.raises(ValueError):
+            cache.get_path(invalid_key)
+
+        with pytest.raises(ValueError):
+            cache.set(invalid_key, b"content")
+
+
+class TestTemporaryFilesystemCache:
+    def test_temporary_cache_creation(self):
+        """Test that TemporaryFilesystemCache creates a temporary directory."""
+        # Reset the singleton for clean testing
+        TemporaryFilesystemCache._shared_instance = None
+
+        temp_cache = TemporaryFilesystemCache()
+
+        # Should create a temporary directory
+        assert temp_cache._cache_temp_dir is not None
+        assert Path(temp_cache._cache_temp_dir).exists()
+
+        # Check that the directory name (not full path) starts with the prefix
+        temp_dir_name = Path(temp_cache._cache_temp_dir).name
+        assert temp_dir_name.startswith("kiln_cache_")
+
+        # Should have a FilesystemCache instance
+        assert isinstance(temp_cache.filesystem_cache, FilesystemCache)
+        assert temp_cache.filesystem_cache.cache_dir_path == Path(
+            temp_cache._cache_temp_dir
+        )
+
+    def test_multiple_instances_share_same_cache(self):
+        """Test that multiple calls to shared() return the same cache instance."""
+        # Reset the singleton for clean testing
+        TemporaryFilesystemCache._shared_instance = None
+
+        # Get cache instances
+        cache1 = TemporaryFilesystemCache.shared()
+        cache2 = TemporaryFilesystemCache.shared()
+
+        # Should be the same instance
+        assert cache1 is cache2
+
+        # Test that they share the same cache directory
+        assert cache1.cache_dir_path == cache2.cache_dir_path
+
+        # Test that content set in one is available in the other
+        key = "shared_test"
+        content = b"shared content"
+
+        cache1.set(key, content)
+        retrieved = cache2.get(key)
+        assert retrieved == content
+
+    def test_cache_directory_naming(self):
+        """Test that the temporary cache directory has the correct naming pattern."""
+        # Reset the singleton for clean testing
+        TemporaryFilesystemCache._shared_instance = None
+
+        temp_cache = TemporaryFilesystemCache()
+        temp_dir_name = Path(temp_cache._cache_temp_dir).name
+
+        # Should start with the expected prefix
+        assert temp_dir_name.startswith("kiln_cache_")
+
+        # Should be a valid directory name
+        assert len(temp_dir_name) > len("kiln_cache_")
+        assert "/" not in temp_dir_name  # Should not contain path separators

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -57,6 +57,7 @@ from kiln_ai.datamodel.rag import RagConfig
 from kiln_ai.datamodel.vector_store import VectorStoreConfig, VectorStoreType
 from kiln_ai.utils import shared_async_lock_manager
 from kiln_ai.utils.filesystem import open_folder
+from kiln_ai.utils.filesystem_cache import TemporaryFilesystemCache
 from kiln_ai.utils.mime_type import guess_mime_type
 from kiln_ai.utils.name_generator import generate_memorable_name
 from pydantic import BaseModel, Field, model_validator
@@ -540,6 +541,7 @@ async def build_rag_workflow_runner(
                     extractor_config,
                     concurrency=20,
                     rag_config=rag_config,
+                    filesystem_cache=TemporaryFilesystemCache.shared(),
                 ),
                 RagChunkingStepRunner(
                     project,


### PR DESCRIPTION
## What does this PR do?

Extracting long PDFs is slow. The PDF splitting itself is fast, getting the response from the LLM is slow. Sometimes, it may happen that a PDF fails after extracting a number of its pages successfully - when that happens on the next run, we start processing it from the first page again, which is slow and expensive.

Fix:
- add filesystem cache; before extracting a PDF page, we query the cache; after each successful extraction we store the extraction as bytes in a file
- the filesystem cache is implemented as a singleton pointing to a temporary directory that is created on app start (if the user quits the app, the next time around, the dir will be different; but it survives refreshes etc.)
- key for each PDF page is `{extractor_config_id}_{hash of [pdf_path _ page number]}`

This allows resuming processing a PDF from where it last left off.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
