### PR TITLE
Make RAG work on Windows

### DIFF
--- a/app/desktop/desktop.py
+++ b/app/desktop/desktop.py
@@ -10,6 +10,7 @@ import sys
 import tkinter as tk
 import webbrowser
 
+from kiln_ai.utils.config import Config
 from PIL import Image
 
 # Unused, but needed for pyinstaller to not miss this import
@@ -18,6 +19,12 @@ from uvicorn import Config as UvicornConfig
 
 from app.desktop.custom_tray import KilnMenuItem, KilnTray
 from app.desktop.desktop_server import ThreadedServer, server_config
+
+# Set writeable cache directories as soon as we start
+os.environ["LLAMA_INDEX_CACHE_DIR"] = os.path.join(
+    Config.settings_dir(), "cache", "llama_index_cache"
+)
+os.environ["NLTK_DATA"] = os.path.join(Config.settings_dir(), "cache", "nltk_data")
 
 
 class DesktopApp:


### PR DESCRIPTION
Set llama index cache directories so it works on Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automatically configures cache and NLP data directories at app startup for more reliable operation across sessions.
  * Reduces repeated downloads and improves startup performance related to indexing/NLP resources.
  * No changes to user-facing features or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->