### PR TITLE
refactor: parallelize PDF page extraction

### DIFF
--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -25,7 +25,7 @@ from kiln_ai.utils.pdf_utils import split_pdf_into_pages
 def max_pdf_page_concurrency_for_model(model_name: str) -> int:
     # we assume each batch takes ~5s to complete (likely more in practice)
     # lowest rate limit is 150 RPM for Tier 1 accounts for gemini-2.5-pro
-    if model_name == "gemini-2.5-pro":
+    if model_name == "gemini/gemini-2.5-pro":
         return 2
     # other models support at least 500 RPM for lowest tier accounts
     return 5

--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -1,7 +1,8 @@
+import asyncio
 import hashlib
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, List, Literal
 
 import litellm
 from litellm.types.utils import Choices, ModelResponse
@@ -124,6 +125,10 @@ class LitellmExtractor(BaseExtractor):
         self.litellm_core_config = litellm_core_config
 
     def pdf_page_cache_key(self, pdf_path: Path, page_number: int) -> str:
+        """
+        Generate a cache key for a page of a PDF. The PDF path must be the full path to the PDF file,
+        not the path to the page - since page path is temporary and changes on each run.
+        """
         if self.extractor_config.id is None:
             raise ValueError("Extractor config ID is required for PDF page cache key")
 
@@ -156,73 +161,108 @@ class LitellmExtractor(BaseExtractor):
         logger.debug(f"Cache miss for page {page_number} of {pdf_path}")
         return None
 
-    async def _extract_from_pdf_pages(self, pdf_path: Path, prompt: str) -> str:
-        combined_content = []
+    async def extract_from_pdf_page(
+        self, pdf_path: Path, page_path: Path, prompt: str, page_number: int
+    ) -> str:
+        try:
+            page_input = ExtractionInput(
+                path=str(page_path), mime_type="application/pdf"
+            )
+            completion_kwargs = self._build_completion_kwargs(prompt, page_input)
+            response = await litellm.acompletion(**completion_kwargs)
+        except Exception as e:
+            raise RuntimeError(
+                f"Error extracting page {page_number} in file {page_path}: {e}"
+            ) from e
 
+        if (
+            not isinstance(response, ModelResponse)
+            or not response.choices
+            or len(response.choices) == 0
+            or not isinstance(response.choices[0], Choices)
+        ):
+            raise RuntimeError(
+                f"Expected ModelResponse with Choices for page {page_number}, got {type(response)}."
+            )
+
+        if response.choices[0].message.content is None:
+            raise ValueError(
+                f"No text returned from LiteLLM when extracting page {page_number}"
+            )
+
+        content = response.choices[0].message.content
+        if not content:
+            raise ValueError(
+                f"No text returned from extraction model when extracting page {page_number} for {page_path}"
+            )
+
+        if self.filesystem_cache is not None:
+            # we don't want to fail the whole extraction just because cache write fails
+            # as that would block the whole flow
+            try:
+                logger.debug(f"Caching page {page_number} of {page_path} in cache")
+                await self.filesystem_cache.set(
+                    self.pdf_page_cache_key(pdf_path, page_number),
+                    content.encode("utf-8"),
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to cache page %s of %s; continuing without cache.",
+                    page_number,
+                    page_path,
+                    exc_info=True,
+                )
+
+        return content
+
+    async def _extract_from_pdf_pages(self, pdf_path: Path, prompt: str) -> str:
         async with split_pdf_into_pages(pdf_path) as page_paths:
+            page_outcomes: List[str | Exception | None] = [None] * len(page_paths)
+
+            batch_completed_count = 0
+            batch_size = 10
+
+            extract_page_jobs: list = []
             # we extract from each page individually and then combine the results
             # this ensures the model stays focused on the current page and does not
             # start summarizing the later pages
             for i, page_path in enumerate(page_paths):
-                try:
-                    page_content = await self.get_page_content_from_cache(pdf_path, i)
-                    if page_content is not None:
-                        combined_content.append(page_content)
-                        continue
+                page_content = await self.get_page_content_from_cache(pdf_path, i)
+                if page_content is not None:
+                    page_outcomes[i] = page_content
+                    continue
 
-                    page_input = ExtractionInput(
-                        path=str(page_path), mime_type="application/pdf"
-                    )
-                    completion_kwargs = self._build_completion_kwargs(
-                        prompt, page_input
-                    )
-                    response = await litellm.acompletion(**completion_kwargs)
-                except Exception as e:
-                    raise RuntimeError(
-                        f"Error extracting page {i + 1} in file {pdf_path}: {e}"
-                    ) from e
+                extract_page_jobs.append(
+                    self.extract_from_pdf_page(pdf_path, page_path, prompt, i)
+                )
 
-                if (
-                    not isinstance(response, ModelResponse)
-                    or not response.choices
-                    or len(response.choices) == 0
-                    or not isinstance(response.choices[0], Choices)
-                ):
-                    raise RuntimeError(
-                        f"Expected ModelResponse with Choices for page {i + 1}, got {type(response)}."
+                if len(extract_page_jobs) >= batch_size or i == len(page_paths) - 1:
+                    extraction_results = await asyncio.gather(
+                        *extract_page_jobs, return_exceptions=True
                     )
 
-                if response.choices[0].message.content is None:
-                    raise ValueError(
-                        f"No text returned from LiteLLM when extracting page {i + 1}"
-                    )
+                    for batch_i, extraction_result in enumerate(extraction_results):
+                        page_index = batch_completed_count * batch_size + batch_i
+                        # we let it continue even if there is an error - the success results will be cached
+                        # and can be reused on the next run
+                        if isinstance(extraction_result, Exception):
+                            page_outcomes[page_index] = extraction_result
+                        elif isinstance(extraction_result, str):
+                            page_outcomes[page_index] = extraction_result
+                        else:
+                            raise ValueError(
+                                f"Unexpected type {type(extraction_result)} for page {page_index}"
+                            )
+                    extract_page_jobs.clear()
+                    batch_completed_count += 1
 
-                content = response.choices[0].message.content
-                if not content:
-                    raise ValueError(
-                        f"No text returned from extraction model when extracting page {i + 1} for {pdf_path}"
-                    )
+        # check if any of the page outcomes are exceptions
+        if any(isinstance(result, Exception) for result in page_outcomes):
+            raise RuntimeError(f"Error extracting PDF {pdf_path}: {page_outcomes}")
 
-                if self.filesystem_cache is not None:
-                    # we don't want to fail the whole extraction just because cache write fails
-                    # as that would block the whole flow
-                    try:
-                        logger.debug(f"Caching page {i + 1} of {pdf_path} in cache")
-                        await self.filesystem_cache.set(
-                            self.pdf_page_cache_key(pdf_path, i),
-                            content.encode("utf-8"),
-                        )
-                    except Exception:
-                        logger.warning(
-                            "Failed to cache page %s of %s; continuing without cache.",
-                            i + 1,
-                            pdf_path,
-                            exc_info=True,
-                        )
-
-                combined_content.append(content)
-
-        return "\n\n".join(combined_content)
+        return "\n\n".join(
+            [outcome for outcome in page_outcomes if isinstance(outcome, str)]
+        )
 
     def _get_kind_from_mime_type(self, mime_type: str) -> Kind | None:
         for kind, mime_types in MIME_TYPES_SUPPORTED.items():

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -539,7 +539,7 @@ async def build_rag_workflow_runner(
                 RagExtractionStepRunner(
                     project,
                     extractor_config,
-                    concurrency=20,
+                    concurrency=10,
                     rag_config=rag_config,
                     filesystem_cache=TemporaryFilesystemCache.shared(),
                 ),

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -539,7 +539,7 @@ async def build_rag_workflow_runner(
                 RagExtractionStepRunner(
                     project,
                     extractor_config,
-                    concurrency=10,
+                    concurrency=5,
                     rag_config=rag_config,
                     filesystem_cache=TemporaryFilesystemCache.shared(),
                 ),


### PR DESCRIPTION
## What does this PR do?

Some PDFs are very slow to extract - it is better since increasing the temperature (as it was taking a very long time due to getting stuck returning the same character a million times in a row), but still slow.

This parallelize PDF page extraction in groups of 10 - we trigger the 10 extractions and wait for all of them to be settled before moving on to the next batch, because it is easier than a semaphore, but also because we do not know the exact rate limit, so batching until the slowest page has completed is conservative in this regard and should help avoid pushing request rate to the models too much.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-page batched PDF extraction with model-specific concurrency and per-page caching to speed repeat runs.

- Performance
  - Concurrent per-page processing for faster PDF handling; overall parallelism reduced in one workflow runner to lower resource contention.

- Reliability
  - Page-aware error reporting and aggregated PDF errors; cache writes are non-fatal and mixed page outcomes are handled robustly.

- Tests
  - Added tests for parallel page processing, caching behavior, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->