### PR TITLE
uncache search tools in UI when you create, archive or unarchive

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
@@ -28,6 +28,7 @@
   import { update_rag_config_archived_state } from "$lib/stores/rag_progress_store"
   import Warning from "$lib/ui/warning.svelte"
   import posthog from "posthog-js"
+  import { uncache_available_tools } from "$lib/stores"
 
   $: project_id = $page.params.project_id
   $: rag_config_id = $page.params.rag_config_id
@@ -116,6 +117,8 @@
     } finally {
       loading = false
     }
+
+    uncache_available_tools(project_id)
 
     posthog.capture(
       is_archived ? "archive_rag_config" : "unarchive_rag_config",

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/+page.svelte
@@ -35,6 +35,7 @@
   import PropertyList from "$lib/ui/property_list.svelte"
   import { tool_name_validator } from "$lib/utils/input_validators"
   import posthog from "posthog-js"
+  import { uncache_available_tools } from "$lib/stores"
 
   $: project_id = $page.params.project_id
   const template_id = $page.url.searchParams.get("template_id")
@@ -495,6 +496,8 @@
         vector_store_type: vector_store_type,
       })
 
+      uncache_available_tools(project_id)
+
       goto(`/docs/rag_configs/${project_id}`)
     } finally {
       loading = false
@@ -598,6 +601,8 @@
         custom_name: tool_name !== DEFAULT_TOOL_NAME,
         custom_description: tool_description !== DEFAULT_TOOL_DESCRIPTION,
       })
+
+      uncache_available_tools(project_id)
 
       goto(`/docs/rag_configs/${project_id}`)
     } finally {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The list of available tools now refreshes immediately after creating a RAG config, saving a template, or archiving/unarchiving a config, preventing stale tool options from appearing in the Docs UI.
  - Ensures the tools list is up to date before navigating back to the RAG config list or recording related events, improving accuracy and consistency for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->