### PR TITLE
feat: add doc extraction with GPT-5, GPT-5 Mini, GPT-5 Nano

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/rag_config_templates.ts
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/rag_config_templates.ts
@@ -137,16 +137,16 @@ export const rag_config_templates: Record<string, RagConfigTemplate> = {
     preview_description:
       "We suggest Gemini, but if you need to use OpenAI try this template.",
     preview_tooltip:
-      "GPT-4.1 extraction, OpenAI Embedding 3 Large (3072 dimensions), and LanceDB hybrid search (vector + full-text).",
+      "GPT-5 extraction, OpenAI Embedding 3 Large (3072 dimensions), and LanceDB hybrid search (vector + full-text).",
     required_api_keys: "Openai",
     notice_text: "Does not support audio or video files.",
     notice_tooltip:
-      "GPT 4.1 does not support extracting audio or video files. We suggest using Gemini if you require audio or video support.",
+      "GPT 5 does not support extracting audio or video files. We suggest using Gemini if you require audio or video support.",
     extractor: {
-      config_name: "GPT-4p1 w Default Prompts",
-      description: "GPT-4.1",
+      config_name: "GPT-5 w Default Prompts",
+      description: "GPT-5",
       model_provider_name: "openai",
-      model_name: "gpt_4_1",
+      model_name: "gpt_5",
     },
     chunker: default_chunker,
     embedding: {
@@ -156,7 +156,7 @@ export const rag_config_templates: Record<string, RagConfigTemplate> = {
       model_name: "openai_text_embedding_3_large",
     },
     vector_store: default_vector_store,
-    rag_config_name: "OpenAI Based - GPT-4_1 Hybrid Search",
+    rag_config_name: "OpenAI Based - GPT-5 Hybrid Search",
   },
 }
 

--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -246,7 +246,6 @@ class LitellmExtractor(BaseExtractor):
                     ],
                 }
             ],
-            "temperature": 0.8,
         }
 
         if self.litellm_core_config.base_url:

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -292,6 +292,15 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 suggested_for_data_gen=True,
                 suggested_for_evals=True,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
@@ -314,6 +323,15 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
@@ -334,6 +352,15 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.openai,
                 model_id="gpt-5-nano",
                 structured_output_mode=StructuredOutputMode.json_schema,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,


### PR DESCRIPTION
## What does this PR do?

1. Add doc extraction support for
- GPT-5
- GPT-5 Mini
- GPT-5 Nano

2. Update current OpenAI-based RAG Config template to use GPT-5 instead of GPT-4.1.

3. Remove explicit `temperature` in LiteLLM extractor call - only the default `1` is supported for the GPT-5 models in this particular call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Enabled document extraction and multimodal inputs (PDF, JPG, PNG) for GPT-5, GPT-5 Mini, and GPT-5 Nano models.

* Style
  * Updated UI labels, tooltips, and template names from GPT-4.1 to GPT-5 across RAG config templates and the add-search tool flow, including “OpenAI Based - GPT-5 Hybrid Search.”

* Refactor
  * Adjusted generation settings to rely on provider defaults instead of a fixed temperature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->