### PR TITLE
chore: lower concurrency for embeddings

### DIFF
--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -547,7 +547,7 @@ async def build_rag_workflow_runner(
                     project,
                     extractor_config,
                     chunker_config,
-                    concurrency=50,
+                    concurrency=5,
                     rag_config=rag_config,
                 ),
                 RagEmbeddingStepRunner(


### PR DESCRIPTION
## What does this PR do?

Embedding step:
- decrease from `20` concurrency to `5` - still very fast and avoid rate limit when we have long documents that require embedding a lot of chunks

Chunking:
- decrease from `50` to `5` - the chunking can be somewhat heavy (and maybe blocking?), still very fast even at this value


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tuned concurrency settings for background content processing to reduce parallel load and resource spikes.
* **Bug Fixes**
  * Improved reliability of long-running content ingestion and embedding tasks under heavy load, reducing timeouts and flakiness.
* **Performance**
  * Smoother, more predictable workflow execution with less contention on shared resources, especially in high-traffic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->