### PR TITLE
Multi select should stay open allowing you to... multi select

### DIFF
--- a/app/web_ui/src/lib/ui/fancy_select.svelte
+++ b/app/web_ui/src/lib/ui/fancy_select.svelte
@@ -97,14 +97,16 @@
       }
       // Update selected, which is what we expose outside the component
       selected = selected_values
+
+      // Note: we don't close the dropdown for multi-select
     } else {
       selected = option
-    }
 
-    // Delay hiding the dropdown to ensure the click event is fully processed
-    setTimeout(() => {
-      listVisible = false
-    }, 0)
+      // Delay hiding the dropdown to ensure the click event is fully processed
+      setTimeout(() => {
+        listVisible = false
+      }, 0)
+    }
   }
 
   // Make it reactive, when selected changes, update the selected_values
@@ -434,6 +436,9 @@
       listVisible = true
     }}
     on:blur={(_) => {
+      if (multi_select) {
+        return
+      }
       // Only close if focus is not moving to the dropdown
       setTimeout(() => {
         if (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-select dropdown now remains open after selecting an option, enabling uninterrupted selection of multiple items.
  * Prevents unintended closing on blur in multi-select mode, reducing accidental dismissals while interacting with the trigger.
  * Preserves previous behavior for single-select: dropdown still auto-closes on selection for quick, one-choice workflows.
  * Overall improves reliability and user experience when working with lists requiring multiple selections, minimizing extra clicks and mis-click frustrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->