### PR TITLE
chore: add inference and embedding models

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2763,7 +2763,7 @@ export interface components {
          * @description Enumeration of specific model versions supported by the system.
          * @enum {string}
          */
-        EmbeddingModelName: "openai_text_embedding_3_small" | "openai_text_embedding_3_large" | "gemini_text_embedding_004" | "gemini_embedding_001" | "embedding_gemma_300m" | "nomic_text_embedding_v1_5";
+        EmbeddingModelName: "openai_text_embedding_3_small" | "openai_text_embedding_3_large" | "gemini_text_embedding_004" | "gemini_embedding_001" | "embedding_gemma_300m" | "nomic_text_embedding_v1_5" | "qwen_3_embedding_0p6b" | "qwen_3_embedding_4b" | "qwen_3_embedding_8b";
         /** EmbeddingProvider */
         EmbeddingProvider: {
             /** Provider Name */

--- a/conftest.py
+++ b/conftest.py
@@ -163,8 +163,6 @@ def mock_file_factory(
                 filename = test_data_dir / "document_ice_cubes.html"
             case MockFileFactoryMimeType.MD:
                 filename = test_data_dir / "document_ice_cubes.md"
-            case MockFileFactoryMimeType.TXT:
-                filename = test_data_dir / "document_ice_cubes.txt"
 
             # images
             case MockFileFactoryMimeType.PNG:

--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -74,11 +74,11 @@ def encode_file_litellm_format(path: Path, mime_type: str) -> dict[str, Any]:
         "text/markdown",
         "text/plain",
     ] or any(mime_type.startswith(m) for m in ["video/", "audio/"]):
-        pdf_bytes = path.read_bytes()
+        file_bytes = path.read_bytes()
         return {
             "type": "file",
             "file": {
-                "file_data": to_base64_url(mime_type, pdf_bytes),
+                "file_data": to_base64_url(mime_type, file_bytes),
             },
         }
 

--- a/libs/core/kiln_ai/adapters/ml_embedding_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_embedding_model_list.py
@@ -17,6 +17,7 @@ class KilnEmbeddingModelFamily(str, Enum):
     gemini = "gemini"
     gemma = "gemma"
     nomic = "nomic"
+    qwen = "qwen"
 
 
 class EmbeddingModelName(str, Enum):
@@ -33,6 +34,9 @@ class EmbeddingModelName(str, Enum):
     gemini_embedding_001 = "gemini_embedding_001"
     embedding_gemma_300m = "embedding_gemma_300m"
     nomic_text_embedding_v1_5 = "nomic_text_embedding_v1_5"
+    qwen_3_embedding_0p6b = "qwen_3_embedding_0p6b"
+    qwen_3_embedding_4b = "qwen_3_embedding_4b"
+    qwen_3_embedding_8b = "qwen_3_embedding_8b"
 
 
 class KilnEmbeddingModelProvider(BaseModel):
@@ -165,9 +169,70 @@ built_in_embedding_models: List[KilnEmbeddingModel] = [
                 n_dimensions=768,
                 max_input_tokens=2048,
                 # the model itself does support custom dimensions, but
-                # not sure if ollama supports it
+                # currently param gets rejected by litellm
                 supports_custom_dimensions=False,
                 ollama_model_aliases=["nomic-embed-text"],
+            ),
+        ],
+    ),
+    # qwen 3
+    KilnEmbeddingModel(
+        family=KilnEmbeddingModelFamily.qwen,
+        name=EmbeddingModelName.qwen_3_embedding_0p6b,
+        friendly_name="Qwen 3 Embedding 0.6B",
+        providers=[
+            KilnEmbeddingModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen3-embedding:0.6b",
+                n_dimensions=1024,
+                max_input_tokens=32_000,
+                # the model itself does support custom dimensions, but
+                # currently param gets rejected by litellm
+                supports_custom_dimensions=False,
+            ),
+        ],
+    ),
+    KilnEmbeddingModel(
+        family=KilnEmbeddingModelFamily.qwen,
+        name=EmbeddingModelName.qwen_3_embedding_4b,
+        friendly_name="Qwen 3 Embedding 4B",
+        providers=[
+            KilnEmbeddingModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen3-embedding:4b",
+                n_dimensions=2560,
+                max_input_tokens=32_000,
+                # the model itself does support custom dimensions, but
+                # currently param gets rejected by litellm
+                supports_custom_dimensions=False,
+            ),
+        ],
+    ),
+    KilnEmbeddingModel(
+        family=KilnEmbeddingModelFamily.qwen,
+        name=EmbeddingModelName.qwen_3_embedding_8b,
+        friendly_name="Qwen 3 Embedding 8B",
+        providers=[
+            KilnEmbeddingModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen3-embedding:8b",
+                n_dimensions=4096,
+                max_input_tokens=32_000,
+                # the model itself does support custom dimensions, but
+                # currently param gets rejected by litellm
+                supports_custom_dimensions=False,
+                ollama_model_aliases=[
+                    # 8b is default
+                    "qwen3-embedding",
+                ],
+            ),
+            KilnEmbeddingModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                model_id="accounts/fireworks/models/qwen3-embedding-8b",
+                n_dimensions=4096,
+                max_input_tokens=32_000,
+                # the model itself does support custom dimensions, but not working
+                supports_custom_dimensions=False,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -124,6 +124,7 @@ class ModelName(str, Enum):
     qwen_2p5_72b = "qwen_2p5_72b"
     qwq_32b = "qwq_32b"
     deepseek_3_1 = "deepseek_3_1"
+    deepseek_3_1_terminus = "deepseek_3_1_terminus"
     deepseek_3 = "deepseek_3"
     deepseek_r1 = "deepseek_r1"
     deepseek_r1_0528 = "deepseek_r1_0528"
@@ -2331,6 +2332,20 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
+    # DeepSeek 3.1 Terminus
+    KilnModel(
+        family=ModelFamily.deepseek,
+        name=ModelName.deepseek_3_1_terminus,
+        friendly_name="DeepSeek 3.1 Terminus",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="deepseek/deepseek-v3.1-terminus",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+            ),
+        ],
+    ),
     # DeepSeek 3
     KilnModel(
         family=ModelFamily.deepseek,
@@ -2747,6 +2762,20 @@ built_in_models: List[KilnModel] = [
                 supports_data_gen=True,
                 supports_function_calling=True,
             ),
+            KilnModelProvider(
+                name=ModelProviderName.together_ai,
+                model_id="Qwen/Qwen3-Next-80B-A3B-Instruct",
+                supports_data_gen=True,
+                supports_function_calling=False,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.siliconflow_cn,
+                model_id="Qwen/Qwen3-Next-80B-A3B-Instruct",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_data_gen=True,
+                supports_function_calling=False,
+            ),
         ],
     ),
     # Qwen 3 Next 80B A3B (Thinking)
@@ -2763,6 +2792,15 @@ built_in_models: List[KilnModel] = [
                 supports_function_calling=True,
                 reasoning_capable=True,
                 require_openrouter_reasoning=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.siliconflow_cn,
+                model_id="Qwen/Qwen3-Next-80B-A3B-Thinking",
+                structured_output_mode=StructuredOutputMode.json_instructions,
+                supports_data_gen=True,
+                supports_function_calling=True,
+                reasoning_capable=True,
+                siliconflow_enable_thinking=True,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -2336,6 +2336,29 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
+    # DeepSeek 3.1 Terminus
+    KilnModel(
+        family=ModelFamily.deepseek,
+        name=ModelName.deepseek_3_1_terminus,
+        friendly_name="DeepSeek 3.1 Terminus",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="deepseek/deepseek-v3.1-terminus",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                model_id="accounts/fireworks/models/deepseek-v3p1-terminus",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_data_gen=True,
+                # the model page states it supports function calling, but our test fails
+                # for this particular provider
+                supports_function_calling=False,
+            ),
+        ],
+    ),
     # DeepSeek 3.1
     KilnModel(
         family=ModelFamily.deepseek,
@@ -2359,29 +2382,6 @@ built_in_models: List[KilnModel] = [
                 model_id="Pro/deepseek-ai/DeepSeek-V3.1",
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_data_gen=True,
-            ),
-        ],
-    ),
-    # DeepSeek 3.1 Terminus
-    KilnModel(
-        family=ModelFamily.deepseek,
-        name=ModelName.deepseek_3_1_terminus,
-        friendly_name="DeepSeek 3.1 Terminus",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.openrouter,
-                model_id="deepseek/deepseek-v3.1-terminus",
-                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
-                supports_data_gen=True,
-            ),
-            KilnModelProvider(
-                name=ModelProviderName.fireworks_ai,
-                model_id="accounts/fireworks/models/deepseek-v3p1-terminus",
-                structured_output_mode=StructuredOutputMode.json_schema,
-                supports_data_gen=True,
-                # the model page states it supports function calling, but our test fails
-                # for this particular provider
-                supports_function_calling=False,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -298,6 +298,8 @@ built_in_models: List[KilnModel] = [
                 multimodal_mime_types=[
                     # documents
                     KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
                     # images
                     KilnMimeType.JPG,
                     KilnMimeType.PNG,
@@ -309,6 +311,17 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 suggested_for_data_gen=True,
                 suggested_for_evals=True,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
             ),
         ],
     ),
@@ -329,6 +342,8 @@ built_in_models: List[KilnModel] = [
                 multimodal_mime_types=[
                     # documents
                     KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
                     # images
                     KilnMimeType.JPG,
                     KilnMimeType.PNG,
@@ -340,6 +355,17 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
             ),
         ],
     ),
@@ -358,6 +384,8 @@ built_in_models: List[KilnModel] = [
                 multimodal_mime_types=[
                     # documents
                     KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
                     # images
                     KilnMimeType.JPG,
                     KilnMimeType.PNG,
@@ -367,6 +395,17 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.openrouter,
                 model_id="openai/gpt-5-nano",
                 structured_output_mode=StructuredOutputMode.json_schema,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
             ),
         ],
     ),
@@ -431,15 +470,6 @@ built_in_models: List[KilnModel] = [
                 model_id="gpt-4.1",
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
-                supports_doc_extraction=True,
-                multimodal_capable=True,
-                multimodal_mime_types=[
-                    # documents
-                    KilnMimeType.PDF,
-                    # images
-                    KilnMimeType.JPG,
-                    KilnMimeType.PNG,
-                ],
             ),
         ],
     ),
@@ -3844,6 +3874,12 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
                 supports_function_calling=False,
+                # image only is not sufficient for doc extraction
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -2374,6 +2374,15 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=True,
             ),
+            KilnModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                model_id="accounts/fireworks/models/deepseek-v3p1-terminus",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_data_gen=True,
+                # the model page states it supports function calling, but our test fails
+                # for this particular provider
+                supports_function_calling=False,
+            ),
         ],
     ),
     # DeepSeek 3

--- a/libs/core/kiln_ai/adapters/test_ml_embedding_model_list.py
+++ b/libs/core/kiln_ai/adapters/test_ml_embedding_model_list.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from typing import List
 
 import pytest
 
@@ -29,15 +29,11 @@ def litellm_adapter():
     return adapter
 
 
-def get_all_embedding_models_and_providers(
-    filter: Callable[[KilnEmbeddingModel, KilnEmbeddingModelProvider], bool] = lambda _,
-    __: True,
-) -> List[tuple[str, str]]:
+def get_all_embedding_models_and_providers() -> List[tuple[str, str]]:
     return [
         (model.name, provider.name)
         for model in built_in_embedding_models
         for provider in model.providers
-        if filter(model, provider)
     ]
 
 

--- a/libs/core/kiln_ai/adapters/test_ml_embedding_model_list.py
+++ b/libs/core/kiln_ai/adapters/test_ml_embedding_model_list.py
@@ -1,5 +1,8 @@
+from typing import Callable, List
+
 import pytest
 
+from kiln_ai.adapters.embedding.embedding_registry import embedding_adapter_from_type
 from kiln_ai.adapters.ml_embedding_model_list import (
     EmbeddingModelName,
     KilnEmbeddingModel,
@@ -10,24 +13,32 @@ from kiln_ai.adapters.ml_embedding_model_list import (
     get_model_by_name,
 )
 from kiln_ai.datamodel.datamodel_enums import ModelProviderName
+from kiln_ai.datamodel.embedding import EmbeddingConfig
 
 
-class TestEmbeddingModelName:
-    """Test cases for EmbeddingModelName enum"""
+@pytest.fixture
+def litellm_adapter():
+    adapter = embedding_adapter_from_type(
+        EmbeddingConfig(
+            name="test-embedding",
+            model_provider_name=ModelProviderName.openai,
+            model_name=EmbeddingModelName.openai_text_embedding_3_small,
+            properties={},
+        )
+    )
+    return adapter
 
-    def test_enum_values(self):
-        """Test that enum values are correctly defined"""
-        assert (
-            EmbeddingModelName.openai_text_embedding_3_small
-            == "openai_text_embedding_3_small"
-        )
-        assert (
-            EmbeddingModelName.openai_text_embedding_3_large
-            == "openai_text_embedding_3_large"
-        )
-        assert (
-            EmbeddingModelName.gemini_text_embedding_004 == "gemini_text_embedding_004"
-        )
+
+def get_all_embedding_models_and_providers(
+    filter: Callable[[KilnEmbeddingModel, KilnEmbeddingModelProvider], bool] = lambda _,
+    __: True,
+) -> List[tuple[str, str]]:
+    return [
+        (model.name, provider.name)
+        for model in built_in_embedding_models
+        for provider in model.providers
+        if filter(model, provider)
+    ]
 
 
 class TestKilnEmbeddingModelProvider:
@@ -120,222 +131,40 @@ class TestKilnEmbeddingModel:
         assert model.providers[1].name == ModelProviderName.anthropic
 
 
-class TestEmbeddingModelsList:
-    """Test cases for the embedding_models list"""
-
-    def test_embedding_models_not_empty(self):
-        """Test that the embedding_models list is not empty"""
-        assert len(built_in_embedding_models) > 0
-
-    def test_all_models_have_required_fields(self):
-        """Test that all models in the list have required fields"""
-        for model in built_in_embedding_models:
-            assert hasattr(model, "family")
-            assert hasattr(model, "name")
-            assert hasattr(model, "friendly_name")
-            assert hasattr(model, "providers")
-            assert isinstance(model.name, str)
-            assert isinstance(model.friendly_name, str)
-            assert isinstance(model.providers, list)
-            assert len(model.providers) > 0
-
-    def test_all_providers_have_required_fields(self):
-        """Test that all providers in all models have required fields"""
-        for model in built_in_embedding_models:
-            for provider in model.providers:
-                assert hasattr(provider, "name")
-                assert isinstance(provider.name, ModelProviderName)
-
-    def test_model_names_are_unique(self):
-        """Test that all model names in the list are unique"""
-        model_names = [model.name for model in built_in_embedding_models]
-        assert len(model_names) == len(set(model_names))
-
-    def test_specific_models_exist(self):
-        """Test that specific expected models exist in the list"""
-        model_names = [model.name for model in built_in_embedding_models]
-
-        assert EmbeddingModelName.openai_text_embedding_3_small in model_names
-        assert EmbeddingModelName.openai_text_embedding_3_large in model_names
-        assert EmbeddingModelName.gemini_text_embedding_004 in model_names
-
-    def test_openai_embedding_models(self):
-        """Test specific OpenAI embedding models"""
-        openai_models = [
-            model
-            for model in built_in_embedding_models
-            if model.family == KilnEmbeddingModelFamily.openai
-        ]
-
-        assert len(openai_models) >= 2  # Should have at least 2 OpenAI models
-
-        # Check for specific OpenAI models
-        openai_model_names = [model.name for model in openai_models]
-        assert EmbeddingModelName.openai_text_embedding_3_small in openai_model_names
-        assert EmbeddingModelName.openai_text_embedding_3_large in openai_model_names
-
-    def test_gemini_embedding_models(self):
-        """Test specific Gemini embedding models"""
-        gemini_models = [
-            model
-            for model in built_in_embedding_models
-            if model.family == KilnEmbeddingModelFamily.gemini
-        ]
-
-        assert len(gemini_models) >= 1  # Should have at least 1 Gemini model
-
-        # Check for specific Gemini model
-        gemini_model_names = [model.name for model in gemini_models]
-        assert EmbeddingModelName.gemini_text_embedding_004 in gemini_model_names
-
-    def test_openai_text_embedding_3_small_details(self):
-        """Test specific details of OpenAI text-embedding-3-small model"""
-        model = get_model_by_name(EmbeddingModelName.openai_text_embedding_3_small)
-
-        assert model.family == KilnEmbeddingModelFamily.openai
-        assert model.friendly_name == "Text Embedding 3 Small"
-        assert len(model.providers) == 1
-
-        provider = model.providers[0]
-        assert provider.name == ModelProviderName.openai
-        assert provider.model_id == "text-embedding-3-small"
-        assert provider.n_dimensions == 1536
-        assert provider.max_input_tokens == 8192
-        assert provider.supports_custom_dimensions is True
-
-    def test_openai_text_embedding_3_large_details(self):
-        """Test specific details of OpenAI text-embedding-3-large model"""
-        model = get_model_by_name(EmbeddingModelName.openai_text_embedding_3_large)
-
-        assert model.family == KilnEmbeddingModelFamily.openai
-        assert model.friendly_name == "Text Embedding 3 Large"
-        assert len(model.providers) == 1
-
-        provider = model.providers[0]
-        assert provider.name == ModelProviderName.openai
-        assert provider.model_id == "text-embedding-3-large"
-        assert provider.n_dimensions == 3072
-        assert provider.max_input_tokens == 8192
-        assert provider.supports_custom_dimensions is True
-
-    def test_gemini_text_embedding_004_details(self):
-        """Test specific details of Gemini text-embedding-004 model"""
-        model = get_model_by_name(EmbeddingModelName.gemini_text_embedding_004)
-
-        assert model.family == KilnEmbeddingModelFamily.gemini
-        assert model.friendly_name == "Text Embedding 004"
-        assert len(model.providers) == 1
-
-        provider = model.providers[0]
-        assert provider.name == ModelProviderName.gemini_api
-        assert provider.model_id == "text-embedding-004"
-        assert provider.n_dimensions == 768
-        assert provider.max_input_tokens == 2048
-        assert provider.supports_custom_dimensions is False
-
-
 class TestGetModelByName:
-    """Test cases for get_model_by_name function"""
-
-    def test_get_existing_model(self):
-        """Test getting an existing model by name"""
-        model = get_model_by_name(EmbeddingModelName.openai_text_embedding_3_small)
-        assert model.name == EmbeddingModelName.openai_text_embedding_3_small
-        assert model.family == KilnEmbeddingModelFamily.openai
-
-    def test_get_all_existing_models(self):
-        """Test getting all existing models by name"""
-        for model_name in EmbeddingModelName:
-            model = get_model_by_name(model_name)
-            assert model.name == model_name
-
     def test_get_nonexistent_model_raises_error(self):
         """Test that getting a nonexistent model raises ValueError"""
         with pytest.raises(
             ValueError, match="Embedding model nonexistent_model not found"
         ):
-            get_model_by_name("nonexistent_model")
-
-    def test_get_model_with_invalid_enum_value(self):
-        """Test that getting a model with invalid enum value raises ValueError"""
-        with pytest.raises(ValueError, match="Embedding model invalid_enum not found"):
-            get_model_by_name("invalid_enum")
+            get_model_by_name("nonexistent_model")  # type: ignore
 
     @pytest.mark.parametrize(
-        "model_name,expected_family,expected_friendly_name",
-        [
-            (
-                EmbeddingModelName.openai_text_embedding_3_small,
-                KilnEmbeddingModelFamily.openai,
-                "Text Embedding 3 Small",
-            ),
-            (
-                EmbeddingModelName.openai_text_embedding_3_large,
-                KilnEmbeddingModelFamily.openai,
-                "Text Embedding 3 Large",
-            ),
-            (
-                EmbeddingModelName.gemini_text_embedding_004,
-                KilnEmbeddingModelFamily.gemini,
-                "Text Embedding 004",
-            ),
-        ],
+        "model_name",
+        [model.name for model in built_in_embedding_models],
     )
-    def test_parametrized_model_retrieval(
-        self, model_name, expected_family, expected_friendly_name
-    ):
+    def test_model_retrieval(self, model_name):
         """Test retrieving models with parametrized test cases"""
         model = get_model_by_name(model_name)
-        assert model.family == expected_family
-        assert model.friendly_name == expected_friendly_name
+        assert model.family == model.family
+        assert model.friendly_name == model.friendly_name
 
 
 class TestBuiltInEmbeddingModelsFromProvider:
-    """Test cases for built_in_embedding_models_from_provider function"""
-
-    def test_get_existing_provider_for_model(self):
-        """Test getting an existing provider for a model"""
-        provider = built_in_embedding_models_from_provider(
-            provider_name=ModelProviderName.openai,
-            model_name=EmbeddingModelName.openai_text_embedding_3_small,
-        )
+    @pytest.mark.parametrize(
+        "model_name,provider_name", get_all_embedding_models_and_providers()
+    )
+    def test_get_all_existing_models_and_providers(self, model_name, provider_name):
+        provider = built_in_embedding_models_from_provider(provider_name, model_name)
 
         assert provider is not None
-        assert provider.name == ModelProviderName.openai
-        assert provider.model_id == "text-embedding-3-small"
-        assert provider.n_dimensions == 1536
-
-    def test_get_all_existing_provider_model_combinations(self):
-        """Test getting all existing provider-model combinations"""
-        combinations = [
-            (
-                ModelProviderName.openai,
-                EmbeddingModelName.openai_text_embedding_3_small,
-            ),
-            (
-                ModelProviderName.openai,
-                EmbeddingModelName.openai_text_embedding_3_large,
-            ),
-            (
-                ModelProviderName.gemini_api,
-                EmbeddingModelName.gemini_text_embedding_004,
-            ),
-        ]
-
-        for provider_name, model_name in combinations:
-            provider = built_in_embedding_models_from_provider(
-                provider_name, model_name
-            )
-            assert provider is not None
-            assert provider.name == provider_name
-
-    def test_get_nonexistent_provider_returns_none(self):
-        """Test that getting a nonexistent provider returns None"""
-        provider = built_in_embedding_models_from_provider(
-            provider_name=ModelProviderName.anthropic,  # Not used for embeddings
-            model_name=EmbeddingModelName.openai_text_embedding_3_small,
+        assert provider.name == provider_name
+        assert provider.model_id == provider.model_id
+        assert provider.n_dimensions == provider.n_dimensions
+        assert provider.max_input_tokens == provider.max_input_tokens
+        assert (
+            provider.supports_custom_dimensions == provider.supports_custom_dimensions
         )
-        assert provider is None
 
     def test_get_nonexistent_model_returns_none(self):
         """Test that getting a nonexistent model returns None"""
@@ -353,77 +182,62 @@ class TestBuiltInEmbeddingModelsFromProvider:
         )
         assert provider is None
 
-    def test_get_openai_text_embedding_3_small_provider_details(self):
-        """Test specific details of OpenAI text-embedding-3-small provider"""
-        provider = built_in_embedding_models_from_provider(
-            provider_name=ModelProviderName.openai,
-            model_name=EmbeddingModelName.openai_text_embedding_3_small,
-        )
 
-        assert provider is not None
-        assert provider.name == ModelProviderName.openai
-        assert provider.model_id == "text-embedding-3-small"
-        assert provider.n_dimensions == 1536
-        assert provider.max_input_tokens == 8192
-        assert provider.supports_custom_dimensions is True
-
-    def test_get_openai_text_embedding_3_large_provider_details(self):
-        """Test specific details of OpenAI text-embedding-3-large provider"""
-        provider = built_in_embedding_models_from_provider(
-            provider_name=ModelProviderName.openai,
-            model_name=EmbeddingModelName.openai_text_embedding_3_large,
-        )
-
-        assert provider is not None
-        assert provider.name == ModelProviderName.openai
-        assert provider.model_id == "text-embedding-3-large"
-        assert provider.n_dimensions == 3072
-        assert provider.max_input_tokens == 8192
-        assert provider.supports_custom_dimensions is True
-
-    def test_get_gemini_text_embedding_004_provider_details(self):
-        """Test specific details of Gemini text-embedding-004 provider"""
-        provider = built_in_embedding_models_from_provider(
-            provider_name=ModelProviderName.gemini_api,
-            model_name=EmbeddingModelName.gemini_text_embedding_004,
-        )
-
-        assert provider is not None
-        assert provider.name == ModelProviderName.gemini_api
-        assert provider.model_id == "text-embedding-004"
-        assert provider.n_dimensions == 768
-        assert provider.max_input_tokens == 2048
-        assert provider.supports_custom_dimensions is False
+class TestGenerateEmbedding:
+    """Test cases for generate_embedding function"""
 
     @pytest.mark.parametrize(
-        "provider_name,model_name,expected_model_id,expected_dimensions",
-        [
-            (
-                ModelProviderName.openai,
-                EmbeddingModelName.openai_text_embedding_3_small,
-                "text-embedding-3-small",
-                1536,
-            ),
-            (
-                ModelProviderName.openai,
-                EmbeddingModelName.openai_text_embedding_3_large,
-                "text-embedding-3-large",
-                3072,
-            ),
-            (
-                ModelProviderName.gemini_api,
-                EmbeddingModelName.gemini_text_embedding_004,
-                "text-embedding-004",
-                768,
-            ),
-        ],
+        "model_name,provider_name", get_all_embedding_models_and_providers()
     )
-    def test_parametrized_provider_retrieval(
-        self, provider_name, model_name, expected_model_id, expected_dimensions
-    ):
-        """Test retrieving providers with parametrized test cases"""
-        provider = built_in_embedding_models_from_provider(provider_name, model_name)
+    @pytest.mark.paid
+    async def test_generate_embedding(self, model_name, provider_name):
+        """Test generating an embedding"""
+        model_provider = built_in_embedding_models_from_provider(
+            provider_name, model_name
+        )
+        assert model_provider is not None
 
-        assert provider is not None
-        assert provider.model_id == expected_model_id
-        assert provider.n_dimensions == expected_dimensions
+        embedding = embedding_adapter_from_type(
+            EmbeddingConfig(
+                name="test-embedding",
+                model_provider_name=provider_name,
+                model_name=model_name,
+                properties={},
+            )
+        )
+        embedding = await embedding.generate_embeddings(["Hello, world!"])
+        assert len(embedding.embeddings) == 1
+        assert len(embedding.embeddings[0].vector) == model_provider.n_dimensions
+
+    @pytest.mark.parametrize(
+        "model_name,provider_name", get_all_embedding_models_and_providers()
+    )
+    @pytest.mark.paid
+    async def test_generate_embedding_with_user_supplied_dimensions(
+        self, model_name, provider_name
+    ):
+        """Test generating an embedding with user supplied dimensions"""
+        model_provider = built_in_embedding_models_from_provider(
+            provider_name=provider_name,
+            model_name=model_name,
+        )
+        assert model_provider is not None
+
+        if not model_provider.supports_custom_dimensions:
+            pytest.skip("Model does not support custom dimensions")
+
+        # max dim
+        max_dimensions = model_provider.n_dimensions
+        dimensions_target = max_dimensions // 2
+
+        embedding = embedding_adapter_from_type(
+            EmbeddingConfig(
+                name="test-embedding",
+                model_provider_name=provider_name,
+                model_name=model_name,
+                properties={"dimensions": dimensions_target},
+            )
+        )
+        embedding = await embedding.generate_embeddings(["Hello, world!"])
+        assert len(embedding.embeddings) == 1
+        assert len(embedding.embeddings[0].vector) == dimensions_target

--- a/libs/core/kiln_ai/adapters/test_ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/test_ml_model_list.py
@@ -360,16 +360,6 @@ def test_uncensored():
         assert provider.suggested_for_uncensored_data_gen
 
 
-def test_multimodal_capable():
-    """Test that multimodal_capable is set correctly"""
-    model = get_model_by_name(ModelName.gpt_4_1)
-    for provider in model.providers:
-        assert provider.multimodal_capable
-        assert provider.supports_doc_extraction
-        assert provider.multimodal_mime_types is not None
-        assert len(provider.multimodal_mime_types) > 0
-
-
 def test_no_empty_multimodal_mime_types():
     """Ensure that multimodal fields are self-consistent as they are interdependent"""
     for model in built_in_models:


### PR DESCRIPTION
## What does this PR do?

Add:
- `DeepSeek 3.1 Terminus` on OpenRouter
- Add SiliconFlow and Together for `Qwen3-Next-80B-A3B-Instruct`
- Add SiliconFlow for `Qwen3-Next-80B-A3B-Thinking` (Together has it too, but could not get it to work correctly)
- Add Qwen3 embedding models (0.6B, 4B, 8B variants) on ollama, and 8B on Fireworks
- Refactor / chore: improve some multimodal tests to see what models can support what filetypes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek 3.1 Terminus model with structured JSON output and data‑generation support.
  * Added three Qwen 3 embedding variants.

* **Improvements**
  * Expanded multimodal/document support to include TXT and MD across many providers; added JPG/PNG support for an additional provider.
  * Extended GPT‑5 family provider capabilities and provider coverage for Qwen 3 Next 80B A3B variants.
  * GPT‑4.1 Azure: removed doc‑extraction and multimodal support.

* **Tests / Chores**
  * Simplified tests and mock file handling; extractor test construction and fixtures updated; one multimodal capability test removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->