### PR TITLE
refactor: split up extractor list and add mistral ocr extractor

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -904,6 +904,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/providers/extractors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Providers Extractors */
+        get: operations["get_providers_extractors_api_providers_extractors_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/available_extractors": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Available Extractors */
+        get: operations["get_available_extractors_api_available_extractors_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/available_embedding_models": {
         parameters: {
             query?: never;
@@ -1825,6 +1859,15 @@ export interface components {
         Audio: {
             /** Id */
             id: string;
+        };
+        /** AvailableExtractors */
+        AvailableExtractors: {
+            /** Provider Name */
+            provider_name: string;
+            /** Provider Id */
+            provider_id: string;
+            /** Extractors */
+            extractors: components["schemas"]["ExtractorDetails"][];
         };
         /** AvailableModels */
         AvailableModels: {
@@ -3196,7 +3239,7 @@ export interface components {
             source: string;
             /** Output Content */
             output_content: string;
-            extractor: components["schemas"]["ExtractorSummary"];
+            extractor: components["schemas"]["kiln_server__document_api__ExtractorSummary"];
         };
         /** ExtractorConfig */
         ExtractorConfig: {
@@ -3266,24 +3309,22 @@ export interface components {
             /** Model Type */
             readonly model_type: string;
         };
-        /** ExtractorSummary */
-        ExtractorSummary: {
+        /** ExtractorDetails */
+        ExtractorDetails: {
             /** Id */
             id: string;
             /** Name */
             name: string;
-            /** Description */
-            description: string | null;
-            output_format: components["schemas"]["OutputFormat"];
-            /** Passthrough Mimetypes */
-            passthrough_mimetypes: components["schemas"]["OutputFormat"][];
-            extractor_type: components["schemas"]["ExtractorType"];
+            /** Extractor Type */
+            extractor_type: string;
+            /** Supported Mime Types */
+            supported_mime_types?: string[] | null;
         };
         /**
          * ExtractorType
          * @enum {string}
          */
-        ExtractorType: "litellm";
+        ExtractorType: "litellm" | "mistral-ocr";
         /** File */
         File: {
             file: components["schemas"]["FileFile"];
@@ -3726,7 +3767,7 @@ export interface components {
          * @description Enumeration of supported AI model providers.
          * @enum {string}
          */
-        ModelProviderName: "openai" | "groq" | "amazon_bedrock" | "ollama" | "openrouter" | "fireworks_ai" | "kiln_fine_tune" | "kiln_custom_registry" | "openai_compatible" | "anthropic" | "gemini_api" | "azure_openai" | "huggingface" | "vertex" | "together_ai" | "siliconflow_cn" | "cerebras" | "docker_model_runner";
+        ModelProviderName: "openai" | "groq" | "amazon_bedrock" | "ollama" | "openrouter" | "fireworks_ai" | "kiln_fine_tune" | "kiln_custom_registry" | "openai_compatible" | "anthropic" | "gemini_api" | "azure_openai" | "huggingface" | "vertex" | "together_ai" | "siliconflow_cn" | "cerebras" | "docker_model_runner" | "mistral";
         /** OllamaConnection */
         OllamaConnection: {
             /** Message */
@@ -3963,6 +4004,13 @@ export interface components {
             /** Models */
             models: {
                 [key: string]: components["schemas"]["ProviderModel"];
+            };
+        };
+        /** ProviderExtractors */
+        ProviderExtractors: {
+            /** Extractors */
+            extractors: {
+                [key: string]: components["schemas"]["app__desktop__studio_server__provider_api__connect_provider_api___locals___ExtractorSummary"];
             };
         };
         /** ProviderModel */
@@ -4917,6 +4965,26 @@ export interface components {
          * @enum {string}
          */
         VectorStoreType: "lancedb_fts" | "lancedb_hybrid" | "lancedb_vector";
+        /** ExtractorSummary */
+        app__desktop__studio_server__provider_api__connect_provider_api___locals___ExtractorSummary: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+        };
+        /** ExtractorSummary */
+        kiln_server__document_api__ExtractorSummary: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            output_format: components["schemas"]["OutputFormat"];
+            /** Passthrough Mimetypes */
+            passthrough_mimetypes: components["schemas"]["OutputFormat"][];
+            extractor_type: components["schemas"]["ExtractorType"];
+        };
     };
     responses: never;
     parameters: never;
@@ -6950,6 +7018,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProviderEmbeddingModels"];
+                };
+            };
+        };
+    };
+    get_providers_extractors_api_providers_extractors_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderExtractors"];
+                };
+            };
+        };
+    };
+    get_available_extractors_api_available_extractors_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AvailableExtractors"][];
                 };
             };
         };

--- a/app/web_ui/src/lib/ui/provider_image.ts
+++ b/app/web_ui/src/lib/ui/provider_image.ts
@@ -20,6 +20,7 @@ const provider_image_map: Record<ModelProviderName | "wandb", string> = {
   wandb: "/images/wandb.svg",
   siliconflow_cn: "/images/siliconflow.svg",
   cerebras: "/images/cerebras.svg",
+  mistral: "/images/mistral.svg",
 }
 
 export function get_provider_image(provider_name: string) {

--- a/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/available_extractors_dropdown.svelte
+++ b/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/available_extractors_dropdown.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { onMount } from "svelte"
+  import FormElement from "$lib/utils/form_element.svelte"
+  import { client } from "$lib/api_client"
+  import type { OptionGroup } from "$lib/ui/fancy_select_types"
+  import { mime_type_to_string } from "$lib/utils/formatters"
+
+  export let extractor: string | null = null
+  export let label: string = "Extractor"
+  export let description: string | undefined = undefined
+  export let info_description: string | undefined = undefined
+  export let error_message: string | null = null
+
+  let extractor_options: OptionGroup[] = []
+
+  onMount(async () => {
+    const { data, error } = await client.GET("/api/available_extractors")
+    if (error) {
+      console.error(error)
+      extractor_options = []
+      return
+    }
+
+    const options: OptionGroup[] = []
+    for (const provider of data) {
+      const opts = (provider.extractors || []).map((ex) => {
+        const value = provider.provider_id + "/" + ex.id
+        let description: string | undefined = undefined
+        const mime_types = ex.supported_mime_types || []
+        if (mime_types.length) {
+          description =
+            "Supports " +
+            mime_types.map((m) => mime_type_to_string(m)).join(", ")
+        }
+        return {
+          value,
+          label: ex.name,
+          description,
+        }
+      })
+      if (opts.length > 0) {
+        options.push({ label: provider.provider_name, options: opts })
+      }
+    }
+    extractor_options = options
+  })
+</script>
+
+<div>
+  <FormElement
+    {label}
+    {description}
+    {info_description}
+    bind:value={extractor}
+    id="extractor"
+    inputType="fancy_select"
+    bind:error_message
+    fancy_select_options={extractor_options}
+    placeholder="Select an extractor"
+  />
+</div>

--- a/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/create_extractor_form.svelte
+++ b/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/create_extractor/create_extractor_form.svelte
@@ -6,7 +6,7 @@
   import FormElement from "$lib/utils/form_element.svelte"
   import FormContainer from "$lib/utils/form_container.svelte"
   import { createEventDispatcher } from "svelte"
-  import AvailableModelsDropdown from "../../../../run/available_models_dropdown.svelte"
+  import AvailableExtractorsDropdown from "./available_extractors_dropdown.svelte"
   import Collapse from "$lib/ui/collapse.svelte"
   import {
     default_extractor_document_prompts,
@@ -92,13 +92,11 @@
   {keyboard_submit}
 >
   <div class="flex flex-col gap-4">
-    <AvailableModelsDropdown
-      label="Extraction Model"
-      description="The model to use to transform your documents into text."
-      info_description="Files like PDFs, audio and video must be converted to text before they can be indexed and searched. This model extracts text from these files."
-      bind:model={selected_extractor_option}
-      filter_models_predicate={(m) => m.supports_doc_extraction}
-      suggested_mode="doc_extraction"
+    <AvailableExtractorsDropdown
+      label="Extractor"
+      description="The extractor used to transform your documents into text."
+      info_description="Files like PDFs, audio and video must be converted to text before they can be indexed and searched. This extractor converts them to text."
+      bind:extractor={selected_extractor_option}
     />
     <FormElement
       label="Output Format"
@@ -126,6 +124,7 @@
     />
   </div>
   <Collapse title="Advanced Options">
+    <!-- TODO: hide prompts for non-model extractors -->
     <div>
       <div class="font-medium">Prompt Options</div>
       <div class="text-sm text-gray-500 mt-1">

--- a/app/web_ui/static/images/mistral.svg
+++ b/app/web_ui/static/images/mistral.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 129 91" version="1.1"
+    xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xml:space="preserve" xmlns:serif="http://www.serif.com/"><g><rect x="18.292" y="0" width="18.293" height="18.123"/><rect x="91.473" y="0" width="18.293" height="18.123"/><rect x="18.292" y="18.121" width="36.586" height="18.123"/><rect x="73.181" y="18.121" width="36.586" height="18.123"/><rect x="18.292" y="36.243" width="91.476" height="18.122"/><rect x="18.292" y="54.37" width="18.293" height="18.123"/><rect x="54.883" y="54.37" width="18.293" height="18.123"/><rect x="91.473" y="54.37" width="18.293" height="18.123"/><rect x="0" y="72.504" width="54.89" height="18.123"/><rect x="73.181" y="72.504" width="54.89" height="18.123"/></g></svg>

--- a/libs/core/kiln_ai/adapters/extractor_list.py
+++ b/libs/core/kiln_ai/adapters/extractor_list.py
@@ -1,0 +1,387 @@
+from enum import Enum
+from typing import List
+
+from pydantic import BaseModel
+
+from kiln_ai.datamodel.datamodel_enums import KilnMimeType, ModelProviderName
+from kiln_ai.datamodel.extraction import ExtractorType
+
+
+class ExtractorProviderName(str, Enum):
+    mistral = "mistral"
+
+
+class ExtractorFamily(str, Enum):
+    mistral = "mistral"
+    gemini = "gemini"
+    gpt = "gpt"
+
+
+class ExtractorName(str, Enum):
+    gemini_2_5_pro = "gemini_2_5_pro"
+    gemini_2_5_flash = "gemini_2_5_flash"
+    gemini_2_0_flash = "gemini_2_0_flash"
+    gemini_2_0_flash_lite = "gemini_2_0_flash_lite"
+    gpt_5 = "gpt_5"
+    gpt_5_mini = "gpt_5_mini"
+    gpt_5_nano = "gpt_5_nano"
+    gpt_4_1 = "gpt_4_1"
+    mistral_ocr = "mistral_ocr"
+
+
+class KilnExtractorProvider(BaseModel):
+    name: str
+    extractor_type: ExtractorType
+    extractor_id: str
+    supported_mime_types: List[str] | None = None
+
+
+class KilnExtractor(BaseModel):
+    name: ExtractorName
+    family: ExtractorFamily
+    friendly_name: str
+    providers: List[KilnExtractorProvider]
+
+
+# Static copy of all model-backed extractors (supports_doc_extraction=True in model list)
+built_in_extractors: List[KilnExtractor] = [
+    KilnExtractor(
+        name=ExtractorName.gpt_5,
+        family=ExtractorFamily.gpt,
+        friendly_name="GPT-5",
+        providers=[
+            KilnExtractorProvider(
+                name=ModelProviderName.openai,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="gpt-5",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnExtractorProvider(
+                name=ModelProviderName.openrouter,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="openai/gpt-5",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+    KilnExtractor(
+        name=ExtractorName.gpt_5_mini,
+        family=ExtractorFamily.gpt,
+        friendly_name="GPT-5 Mini",
+        providers=[
+            KilnExtractorProvider(
+                name=ModelProviderName.openai,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="gpt-5-mini",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnExtractorProvider(
+                name=ModelProviderName.openrouter,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="openai/gpt-5-mini",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+    KilnExtractor(
+        name=ExtractorName.gpt_5_nano,
+        family=ExtractorFamily.gpt,
+        friendly_name="GPT-5 Nano",
+        providers=[
+            KilnExtractorProvider(
+                name=ModelProviderName.openai,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="gpt-5-nano",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnExtractorProvider(
+                name=ModelProviderName.openrouter,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="openai/gpt-5-nano",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+    KilnExtractor(
+        name=ExtractorName.gpt_4_1,
+        family=ExtractorFamily.gpt,
+        friendly_name="GPT 4.1",
+        providers=[
+            KilnExtractorProvider(
+                name=ModelProviderName.openai,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="gpt-4.1",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnExtractorProvider(
+                name=ModelProviderName.openrouter,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="openai/gpt-4.1",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+    KilnExtractor(
+        name=ExtractorName.gemini_2_5_pro,
+        family=ExtractorFamily.gemini,
+        friendly_name="Gemini 2.5 Pro",
+        providers=[
+            KilnExtractorProvider(
+                name=ModelProviderName.openrouter,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="google/gemini-2.5-pro",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.CSV,
+                    KilnMimeType.TXT,
+                    KilnMimeType.HTML,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnExtractorProvider(
+                name=ModelProviderName.gemini_api,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="gemini-2.5-pro",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.CSV,
+                    KilnMimeType.TXT,
+                    KilnMimeType.HTML,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    # audio
+                    KilnMimeType.MP3,
+                    KilnMimeType.WAV,
+                    KilnMimeType.OGG,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
+                ],
+            ),
+        ],
+    ),
+    KilnExtractor(
+        name=ExtractorName.gemini_2_5_flash,
+        family=ExtractorFamily.gemini,
+        friendly_name="Gemini 2.5 Flash",
+        providers=[
+            KilnExtractorProvider(
+                name=ModelProviderName.openrouter,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="google/gemini-2.5-flash",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.CSV,
+                    KilnMimeType.TXT,
+                    KilnMimeType.HTML,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnExtractorProvider(
+                name=ModelProviderName.gemini_api,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="gemini-2.5-flash",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.CSV,
+                    KilnMimeType.TXT,
+                    KilnMimeType.HTML,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    # audio
+                    KilnMimeType.MP3,
+                    KilnMimeType.WAV,
+                    KilnMimeType.OGG,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
+                ],
+            ),
+        ],
+    ),
+    KilnExtractor(
+        name=ExtractorName.gemini_2_0_flash,
+        family=ExtractorFamily.gemini,
+        friendly_name="Gemini 2.0 Flash",
+        providers=[
+            KilnExtractorProvider(
+                name=ModelProviderName.openrouter,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="google/gemini-2.0-flash-001",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.CSV,
+                    KilnMimeType.TXT,
+                    KilnMimeType.HTML,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnExtractorProvider(
+                name="ModelProviderName.gemini_api",
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="gemini-2.0-flash",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.CSV,
+                    KilnMimeType.TXT,
+                    KilnMimeType.HTML,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    # audio
+                    KilnMimeType.MP3,
+                    KilnMimeType.WAV,
+                    KilnMimeType.OGG,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
+                ],
+            ),
+        ],
+    ),
+    KilnExtractor(
+        name=ExtractorName.gemini_2_0_flash_lite,
+        family=ExtractorFamily.gemini,
+        friendly_name="Gemini 2.0 Flash Lite",
+        providers=[
+            KilnExtractorProvider(
+                name=ModelProviderName.openrouter,
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="google/gemini-2.0-flash-lite-001",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.CSV,
+                    KilnMimeType.TXT,
+                    KilnMimeType.HTML,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnExtractorProvider(
+                name="ModelProviderName.gemini_api",
+                extractor_type=ExtractorType.LITELLM,
+                extractor_id="gemini-2.0-flash-lite",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.CSV,
+                    KilnMimeType.TXT,
+                    KilnMimeType.HTML,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    # audio
+                    KilnMimeType.MP3,
+                    KilnMimeType.WAV,
+                    KilnMimeType.OGG,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
+                ],
+            ),
+        ],
+    ),
+    KilnExtractor(
+        name=ExtractorName.mistral_ocr,
+        family=ExtractorFamily.mistral,
+        friendly_name="Mistral OCR",
+        providers=[
+            KilnExtractorProvider(
+                name=ModelProviderName.mistral,
+                extractor_type=ExtractorType.MISTRAL_OCR,
+                extractor_id="mistral-ocr-latest",
+                supported_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+]
+
+
+def built_in_extractors_from_provider(
+    provider_name: ModelProviderName,
+    extractor_name: str,
+) -> KilnExtractorProvider | None:
+    for extractor in built_in_extractors:
+        if extractor.name == extractor_name:
+            for provider in extractor.providers:
+                if provider.name == provider_name:
+                    return provider
+    return None

--- a/libs/core/kiln_ai/adapters/extractors/extractor_registry.py
+++ b/libs/core/kiln_ai/adapters/extractors/extractor_registry.py
@@ -1,11 +1,13 @@
 from kiln_ai.adapters.extractors.base_extractor import BaseExtractor
 from kiln_ai.adapters.extractors.litellm_extractor import LitellmExtractor
+from kiln_ai.adapters.extractors.mistralocr_extractor import MistralOcrExtractor
 from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.provider_tools import (
     core_provider,
     lite_llm_core_config_for_provider,
 )
 from kiln_ai.datamodel.extraction import ExtractorConfig, ExtractorType
+from kiln_ai.utils.config import Config
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 from kiln_ai.utils.filesystem_cache import FilesystemCache
 
@@ -38,6 +40,11 @@ def extractor_adapter_from_type(
                 extractor_config,
                 provider_config,
                 filesystem_cache,
+            )
+        case ExtractorType.MISTRAL_OCR:
+            return MistralOcrExtractor(
+                Config.shared().mistral_api_key,
+                extractor_config,
             )
         case _:
             # type checking will catch missing cases

--- a/libs/core/kiln_ai/adapters/extractors/mistralocr_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/mistralocr_extractor.py
@@ -1,0 +1,99 @@
+import base64
+from functools import cached_property
+from pathlib import Path
+from typing import Literal, TypedDict
+
+from mistralai import DocumentTypedDict, Mistral
+
+from kiln_ai.adapters.extractor_list import built_in_extractors_from_provider
+from kiln_ai.adapters.extractors.base_extractor import (
+    BaseExtractor,
+    ExtractionInput,
+    ExtractionOutput,
+)
+from kiln_ai.datamodel.datamodel_enums import ModelProviderName
+from kiln_ai.datamodel.extraction import ExtractorConfig, ExtractorType, OutputFormat
+
+
+class MistralOcrPdfEncoded(TypedDict):
+    type: Literal["document_url"]
+    document_url: str
+
+
+class MistralOcrImageEncoded(TypedDict):
+    type: Literal["image_url"]
+    image_url: str
+
+
+def encode_pdf_for_mistral_ocr(pdf_path: Path) -> DocumentTypedDict:
+    """Encode the pdf to base64."""
+    with open(pdf_path, "rb") as pdf_file:
+        base64_pdf = base64.b64encode(pdf_file.read()).decode("utf-8")
+        return {
+            "type": "document_url",
+            "document_url": f"data:application/pdf;base64,{base64_pdf}",
+        }
+
+
+def encode_image_for_mistral_ocr(image_path: Path) -> DocumentTypedDict:
+    """Encode the image to base64."""
+    with open(image_path, "rb") as image_file:
+        base64_image = base64.b64encode(image_file.read()).decode("utf-8")
+        return {
+            "type": "image_url",
+            "image_url": f"data:image/jpeg;base64,{base64_image}",
+        }
+
+
+def encode_file_for_mistral_ocr(
+    extraction_input: ExtractionInput,
+) -> DocumentTypedDict:
+    if extraction_input.mime_type == "application/pdf":
+        return encode_pdf_for_mistral_ocr(Path(extraction_input.path))
+    elif extraction_input.mime_type == "image/jpeg":
+        return encode_image_for_mistral_ocr(Path(extraction_input.path))
+    else:
+        raise ValueError(f"Unsupported MIME type: {extraction_input.mime_type}")
+
+
+# https://docs.litellm.ai/docs/pass_through/mistral
+class MistralOcrExtractor(BaseExtractor):
+    def __init__(self, mistral_api_key: str, extractor_config: ExtractorConfig):
+        if extractor_config.extractor_type != ExtractorType.MISTRAL_OCR:
+            raise ValueError(
+                f"MistralOcrExtractor must be initialized with a mistral-ocr extractor_type config. Got {extractor_config.extractor_type}"
+            )
+
+        self.mistral_api_key = mistral_api_key
+        self.client = Mistral(api_key=self.mistral_api_key)
+        super().__init__(extractor_config)
+
+    async def _extract(self, extraction_input: ExtractionInput) -> ExtractionOutput:
+        # TODO: extract images and transcribe them individually with the OCR again?
+        ocr_response = await self.client.ocr.process_async(
+            model=self.model_name,
+            document=encode_file_for_mistral_ocr(extraction_input),
+            include_image_base64=False,
+        )
+
+        if ocr_response.pages is None:
+            raise ValueError("No pages returned from Mistral OCR")
+
+        pages_text = "\n\n".join([page.markdown for page in ocr_response.pages])
+
+        return ExtractionOutput(
+            is_passthrough=False,
+            content=pages_text,
+            content_format=OutputFormat.MARKDOWN,
+        )
+
+    @cached_property
+    def model_name(self) -> str:
+        extractor = built_in_extractors_from_provider(
+            provider_name=ModelProviderName.mistral,
+            extractor_name=self.extractor_config.model_name,
+        )
+        if extractor is None:
+            raise ValueError(f"Extractor {self.extractor_config.model_name} not found")
+
+        return extractor.extractor_id

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -276,6 +276,7 @@ class KilnModel(BaseModel):
     family: str
     name: str
     friendly_name: str
+    type: Literal["llm", "extractor"] = "llm"
     providers: List[KilnModelProvider]
 
 

--- a/libs/core/kiln_ai/datamodel/datamodel_enums.py
+++ b/libs/core/kiln_ai/datamodel/datamodel_enums.py
@@ -100,6 +100,7 @@ class ModelProviderName(str, Enum):
     siliconflow_cn = "siliconflow_cn"
     cerebras = "cerebras"
     docker_model_runner = "docker_model_runner"
+    mistral = "mistral"
 
 
 class KilnMimeType(str, Enum):

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -45,6 +45,7 @@ class OutputFormat(str, Enum):
 
 class ExtractorType(str, Enum):
     LITELLM = "litellm"
+    MISTRAL_OCR = "mistral-ocr"
 
 
 SUPPORTED_MIME_TYPES = {
@@ -164,6 +165,7 @@ class ExtractorConfig(KilnParentedModel):
     def validate_properties(
         cls, properties: dict[str, Any], info: ValidationInfo
     ) -> dict[str, Any]:
+        # TODO: validation for non-litellm extractors
         def get_property(key: str) -> str:
             value = properties.get(key)
             if value is None or value == "" or not isinstance(value, str):

--- a/libs/core/kiln_ai/utils/config.py
+++ b/libs/core/kiln_ai/utils/config.py
@@ -154,6 +154,11 @@ class Config:
                 env_var="CEREBRAS_API_KEY",
                 sensitive=True,
             ),
+            "mistral_api_key": ConfigProperty(
+                str,
+                env_var="MISTRAL_API_KEY",
+                sensitive=True,
+            ),
             "enable_demo_tools": ConfigProperty(
                 bool,
                 env_var="ENABLE_DEMO_TOOLS",

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "llama-index-vector-stores-lancedb>=0.3.3",
     "llama-index>=0.13.3",
     "anyio>=4.10.0",
+    "mistralai>=1.9.10",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -1072,6 +1072,15 @@ wheels = [
 ]
 
 [[package]]
+name = "invoke"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/42/127e6d792884ab860defc3f4d80a8f9812e48ace584ffc5a346de58cdc6c/invoke-2.2.0.tar.gz", hash = "sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5", size = 299835, upload-time = "2023-07-12T18:05:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/66/7f8c48009c72d73bc6bbe6eb87ac838d6a526146f7dab14af671121eb379/invoke-2.2.0-py3-none-any.whl", hash = "sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820", size = 160274, upload-time = "2023-07-12T18:05:16.294Z" },
+]
+
+[[package]]
 name = "isort"
 version = "5.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1209,6 +1218,7 @@ dependencies = [
     { name = "litellm" },
     { name = "llama-index" },
     { name = "llama-index-vector-stores-lancedb" },
+    { name = "mistralai" },
     { name = "openai" },
     { name = "pdoc" },
     { name = "pydantic" },
@@ -1244,6 +1254,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.72.6" },
     { name = "llama-index", specifier = ">=0.13.3" },
     { name = "llama-index-vector-stores-lancedb", specifier = ">=0.3.3" },
+    { name = "mistralai", specifier = ">=1.9.10" },
     { name = "openai", specifier = ">=1.53.0" },
     { name = "pdoc", specifier = ">=15.0.0" },
     { name = "pydantic", specifier = ">=2.9.2" },
@@ -1810,6 +1821,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mistralai"
+version = "1.9.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "eval-type-backport" },
+    { name = "httpx" },
+    { name = "invoke" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/a3/1ae43c9db1fc612176d5d3418c12cd363852e954c5d12bf3a4477de2e4a6/mistralai-1.9.10.tar.gz", hash = "sha256:a95721276f035bf86c7fdc1373d7fb7d056d83510226f349426e0d522c0c0965", size = 205043, upload-time = "2025-09-02T07:44:38.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/40/646448b5ad66efec097471bd5ab25f5b08360e3f34aecbe5c4fcc6845c01/mistralai-1.9.10-py3-none-any.whl", hash = "sha256:cf0a2906e254bb4825209a26e1957e6e0bacbbe61875bd22128dc3d5d51a7b0a", size = 440538, upload-time = "2025-09-02T07:44:37.5Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Some extractors work very differently from normal models - they have different constraints, endpoints, outputs and so on. For example, `docling` and `MistralOCR`. They do not support inference for runs either, and as such have very little overlap with other models. Making them fit the shape of normal models risks making both extractors and models more fragile.

Changes:
- refactor: split up the extractor list from the ml_model_list
- feat: add Mistral OCR

WIP:
- provider connection UI not set up yet - but can test by setting `MISTRAL_API_KEY=` in the `.env`
- the parts that work are also unfinished

### Open questions:
1. Should the extractor list and the `ml_model_list` be completely decoupled? An alternative would be to dynamically append the extractors that are derived from the `ml_model_list`. The only requirement for a model to be an extractor is that it supports some mimetypes - that information will need to be in the `ml_model_list` in any case for when we add support for file inputs in messages.
2. Mistral OCR requires an API key, but for an extractor in this case. Should it be displayed among the other providers, or in a somewhat distinct UI?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Mistral as a connectable provider, including API key connect/disconnect.
  - Introduced Mistral OCR extractor and broader extractor support.
  - New “Available Extractors” selector in the extractor creation form, grouped by provider with MIME type hints.
  - Provider imagery updated to include the Mistral logo.

- Refactor
  - Unified extractor handling across server and UI, enabling listing and selection of both model-backed and non-model extractors.

- Chores
  - Added runtime dependency for Mistral client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->