### PR TITLE
chore: clear warnings in tests

### DIFF
--- a/app/desktop/test_desktop.py
+++ b/app/desktop/test_desktop.py
@@ -10,6 +10,13 @@ from uvicorn import Config as UvicornConfig
 import app.desktop.desktop_server as desktop_server
 from app.desktop.desktop import DesktopApp, DesktopServer
 
+# Suppress third-party DeprecationWarnings from websockets during this test module
+pytestmark = pytest.mark.filterwarnings(
+    "ignore::DeprecationWarning:websockets\\.legacy",
+    "ignore::DeprecationWarning:websockets\\.server",
+    "ignore:.*WebSocketServerProtocol is deprecated:DeprecationWarning:uvicorn\\.protocols\\.websockets\\.websockets_impl",
+)
+
 
 @pytest.fixture(autouse=True)
 def mock_gui_modules():

--- a/libs/core/kiln_ai/datamodel/test_attachment.py
+++ b/libs/core/kiln_ai/datamodel/test_attachment.py
@@ -14,7 +14,7 @@ from kiln_ai.datamodel.basemodel import KilnAttachmentModel, KilnBaseModel
 
 
 class ModelWithAttachment(KilnBaseModel):
-    attachment: KilnAttachmentModel = Field(default=None)
+    attachment: KilnAttachmentModel | None = Field(default=None)
     attachment_list: Optional[List[KilnAttachmentModel]] = Field(default=None)
     attachment_dict: Optional[Dict[str, KilnAttachmentModel]] = Field(default=None)
 
@@ -516,7 +516,7 @@ class ModelWithAttachmentNameOverrideList(KilnBaseModel):
     @field_serializer("attachment_list")
     def serialize_attachment_list(
         self, attachment_list: List[KilnAttachmentModel], info: SerializationInfo
-    ) -> dict:
+    ) -> List[dict]:
         context = info.context or {}
         context["filename_prefix"] = "attachment_override"
         return [
@@ -555,7 +555,7 @@ def test_attachment_filename_override_list(test_base_kiln_file, mock_file_factor
 
 
 class ModelWithAttachmentNoNameOverride(KilnBaseModel):
-    attachment: KilnAttachmentModel = Field(default=None)
+    attachment: KilnAttachmentModel | None = Field(default=None)
 
 
 def test_attachment_filename_no_override(test_base_kiln_file, mock_file_factory):

--- a/libs/core/kiln_ai/datamodel/test_external_tool_server.py
+++ b/libs/core/kiln_ai/datamodel/test_external_tool_server.py
@@ -16,6 +16,7 @@ class TestExternalToolServer:
             config_instance = Mock()
             config_instance.get_value.return_value = {}
             config_instance.update_settings = Mock()
+            config_instance.user_id = "test-user"
             mock_shared.return_value = config_instance
             yield config_instance
 


### PR DESCRIPTION
## What does this PR do?

Warnings were showing when running tests (`./checks.sh`):
- some due to mistyped mocks
- some third-party deprecation warnings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Suppressed specific third-party deprecation warnings to reduce noise in test output.
  * Updated attachment-related tests to support optional attachments and adjusted expected serialization to lists.
  * Enhanced external tool server tests by including a user identifier in the mocked configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->