### PR TITLE
DRAFT: expand custom model configuration

### DIFF
--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -1409,17 +1409,16 @@ async def test_connect_ollama_does_not_save_unchanged_url():
 
 
 def test_custom_models():
-    # Mock Config.shared().custom_models
-    mock_custom_models = [
-        "openai::model1",
-        "groq::model2",
-        "invalid_model_format",
-        "openai::model::with::delimiters",
+    mock_custom_providers = [
+        {"name": "openai", "model_id": "model1", "supports_structured_output": False},
+        {"name": "groq", "model_id": "model2"},
+        {"invalid": "data"},
     ]
 
     with patch("app.desktop.studio_server.provider_api.Config.shared") as mock_config:
         mock_config_instance = MagicMock()
-        mock_config_instance.custom_models = mock_custom_models
+        mock_config_instance.custom_model_providers = mock_custom_providers
+        mock_config_instance.custom_models = []
         mock_config.return_value = mock_config_instance
 
         result = custom_models()
@@ -1427,37 +1426,19 @@ def test_custom_models():
         assert result is not None
         assert result.provider_name == "Custom Models"
         assert result.provider_id == ModelProviderName.kiln_custom_registry
-        assert len(result.models) == 3  # Only valid models should be included
-
-        # Verify first model details
-        assert result.models[0].id == "openai::model1"
-        assert result.models[0].name == "OpenAI: model1"
+        assert len(result.models) == 2
         assert result.models[0].supports_structured_output is False
-        assert result.models[0].supports_data_gen is False
-        assert result.models[0].untested_model is True
+        assert result.models[1].supports_structured_output is True
 
-        # Verify second model details
-        assert result.models[1].id == "groq::model2"
-        assert result.models[1].name == "Groq: model2"
-        assert result.models[1].supports_structured_output is False
-        assert result.models[1].supports_data_gen is False
-        assert result.models[1].untested_model is True
-
-        # Verify third model details
-        assert result.models[2].id == "openai::model::with::delimiters"
-        assert result.models[2].name == "OpenAI: model::with::delimiters"
-        assert result.models[2].supports_structured_output is False
-        assert result.models[2].supports_data_gen is False
-        assert result.models[2].untested_model is True
-
-    # Test case: No custom models
     with patch("app.desktop.studio_server.provider_api.Config.shared") as mock_config:
         mock_config_instance = MagicMock()
-        mock_config_instance.custom_models = []
+        mock_config_instance.custom_model_providers = []
+        mock_config_instance.custom_models = ["openai::model1"]
         mock_config.return_value = mock_config_instance
 
         result = custom_models()
-        assert result is None
+        assert result is not None
+        assert result.models[0].id == "openai::model1"
 
 
 @pytest.mark.asyncio

--- a/app/web_ui/src/routes/(app)/settings/providers/add_models/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/providers/add_models/+page.svelte
@@ -6,15 +6,102 @@
   import FormElement from "$lib/utils/form_element.svelte"
   import { provider_name_from_id } from "$lib/stores"
   import Dialog from "$lib/ui/dialog.svelte"
+  import Collapse from "$lib/ui/collapse.svelte"
   import { getContext } from "svelte"
   import type { Writable } from "svelte/store"
 
   let connected_providers: [string, string][] = []
   let loading_providers = true
   let error: KilnError | null = null
-  let custom_models: string[] = []
+  let custom_model_providers: any[] = []
   let new_model_provider: string | null = null
   let new_model_name: string | null = null
+  let new_model: any = {}
+  let edit_model_index: number | null = null
+
+  const default_provider_values = {
+    supports_structured_output: true,
+    supports_data_gen: true,
+    suggested_for_data_gen: false,
+    untested_model: false,
+    provider_finetune_id: null,
+    structured_output_mode: "default",
+    parser: null,
+    formatter: null,
+    reasoning_capable: false,
+    supports_logprobs: false,
+    suggested_for_evals: false,
+    supports_function_calling: true,
+    uncensored: false,
+    suggested_for_uncensored_data_gen: false,
+    tuned_chat_strategy: null,
+    r1_openrouter_options: false,
+    require_openrouter_reasoning: false,
+    logprobs_openrouter_options: false,
+    openrouter_skip_required_parameters: false,
+    thinking_level: null,
+    ollama_model_aliases: null,
+    anthropic_extended_thinking: false,
+    gemini_reasoning_enabled: false,
+    siliconflow_enable_thinking: null,
+    reasoning_optional_for_structured_output: null,
+  }
+
+  let structured_output_mode = "default"
+  let parser = ""
+  let formatter = ""
+  let tuned_chat_strategy = ""
+  let thinking_level = ""
+  let siliconflow_enable_thinking = "null"
+  let reasoning_optional_for_structured_output = "null"
+  let ollama_model_aliases_string = ""
+
+  const bool_optional_options: [string, string][] = [
+    ["null", "Default"],
+    ["true", "True"],
+    ["false", "False"],
+  ]
+
+  const structured_output_mode_options: [string, string][] = [
+    ["default", "default"],
+    ["json_schema", "json_schema"],
+    ["function_calling_weak", "function_calling_weak"],
+    ["function_calling", "function_calling"],
+    ["json_mode", "json_mode"],
+    ["json_instructions", "json_instructions"],
+    ["json_instruction_and_object", "json_instruction_and_object"],
+    ["json_custom_instructions", "json_custom_instructions"],
+    ["unknown", "unknown"],
+  ]
+
+  const parser_options: [string, string][] = [
+    ["", "(none)"],
+    ["r1_thinking", "r1_thinking"],
+    ["optional_r1_thinking", "optional_r1_thinking"],
+  ]
+
+  const formatter_options: [string, string][] = [
+    ["", "(none)"],
+    ["qwen3_style_no_think", "qwen3_style_no_think"],
+  ]
+
+  const chat_strategy_options: [string, string][] = [
+    ["", "(none)"],
+    ["final_only", "final_only"],
+    ["final_and_intermediate", "final_and_intermediate"],
+    ["two_message_cot", "two_message_cot"],
+    [
+      "final_and_intermediate_r1_compatible",
+      "final_and_intermediate_r1_compatible",
+    ],
+  ]
+
+  const thinking_level_options: [string, string][] = [
+    ["", "(none)"],
+    ["low", "low"],
+    ["medium", "medium"],
+    ["high", "high"],
+  ]
 
   const load_existing_providers = async () => {
     try {
@@ -28,7 +115,18 @@
       if (!settings) {
         throw new KilnError("Settings not found", null)
       }
-      custom_models = settings["custom_models"] || []
+      custom_model_providers = settings["custom_model_providers"] || []
+      if (
+        (!custom_model_providers || custom_model_providers.length === 0) &&
+        settings["custom_models"]
+      ) {
+        custom_model_providers = settings["custom_models"].map(
+          (model_id: string) => {
+            const [provider, model] = model_id.split("::", 2)
+            return { name: provider, model_id: model, ...default_provider_values }
+          },
+        )
+      }
       if (settings["open_ai_api_key"]) {
         connected_providers.push(["openai", "OpenAI"])
       }
@@ -68,7 +166,6 @@
       if (settings["siliconflow_cn_api_key"]) {
         connected_providers.push(["siliconflow_cn", "SiliconFlow (硅基流动)"])
       }
-      // Skipping Ollama -- we pull all models from it automatically
       if (connected_providers.length > 0) {
         new_model_provider = connected_providers[0][0] || null
       } else {
@@ -86,14 +183,62 @@
   })
 
   function remove_model(model_index: number) {
-    custom_models = custom_models.filter((_, index) => index !== model_index)
+    custom_model_providers = custom_model_providers.filter(
+      (_, index) => index !== model_index,
+    )
     save_model_list()
   }
 
   let add_model_dialog: Dialog | null = null
 
-  function show_add_model_modal() {
+  function show_add_model_modal(index: number | null = null) {
+    edit_model_index = index
+    if (index !== null) {
+      new_model = { ...default_provider_values, ...custom_model_providers[index] }
+      new_model_provider = new_model.name
+      new_model_name = new_model.model_id
+      structured_output_mode = new_model.structured_output_mode || "default"
+      parser = new_model.parser || ""
+      formatter = new_model.formatter || ""
+      tuned_chat_strategy = new_model.tuned_chat_strategy || ""
+      thinking_level = new_model.thinking_level || ""
+      siliconflow_enable_thinking =
+        new_model.siliconflow_enable_thinking === null ||
+        new_model.siliconflow_enable_thinking === undefined
+          ? "null"
+          : new_model.siliconflow_enable_thinking
+          ? "true"
+          : "false"
+      reasoning_optional_for_structured_output =
+        new_model.reasoning_optional_for_structured_output === null ||
+        new_model.reasoning_optional_for_structured_output === undefined
+          ? "null"
+          : new_model.reasoning_optional_for_structured_output
+          ? "true"
+          : "false"
+      ollama_model_aliases_string = new_model.ollama_model_aliases
+        ? new_model.ollama_model_aliases.join(",")
+        : ""
+    } else {
+      new_model = { ...default_provider_values }
+      new_model_provider = connected_providers[0]?.[0] || null
+      new_model_name = null
+      structured_output_mode = "default"
+      parser = ""
+      formatter = ""
+      tuned_chat_strategy = ""
+      thinking_level = ""
+      siliconflow_enable_thinking = "null"
+      reasoning_optional_for_structured_output = "null"
+      ollama_model_aliases_string = ""
+    }
     add_model_dialog?.show()
+  }
+
+  function parse_optional_bool(val: string): boolean | null {
+    if (val === "true") return true
+    if (val === "false") return false
+    return null
   }
 
   async function add_model() {
@@ -103,8 +248,31 @@
       new_model_name &&
       new_model_name.length > 0
     ) {
-      let model_id = new_model_provider + "::" + new_model_name
-      custom_models = [...custom_models, model_id]
+      new_model.name = new_model_provider
+      new_model.model_id = new_model_name
+      new_model.structured_output_mode = structured_output_mode
+      new_model.parser = parser || null
+      new_model.formatter = formatter || null
+      new_model.tuned_chat_strategy = tuned_chat_strategy || null
+      new_model.thinking_level = thinking_level || null
+      new_model.siliconflow_enable_thinking = parse_optional_bool(
+        siliconflow_enable_thinking,
+      )
+      new_model.reasoning_optional_for_structured_output = parse_optional_bool(
+        reasoning_optional_for_structured_output,
+      )
+      new_model.ollama_model_aliases = ollama_model_aliases_string
+        ? ollama_model_aliases_string
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0)
+        : null
+      if (edit_model_index !== null) {
+        custom_model_providers[edit_model_index] = new_model
+        custom_model_providers = [...custom_model_providers]
+      } else {
+        custom_model_providers = [...custom_model_providers, new_model]
+      }
       await save_model_list()
       new_model_name = null
     } else {
@@ -124,7 +292,7 @@
       saving_model_list = true
       let { data: save_result, error: save_error } = await client.POST(
         "/api/settings",
-        { body: { custom_models: custom_models } },
+        { body: { custom_model_providers: custom_model_providers } },
       )
       if (save_error) {
         throw save_error
@@ -141,17 +309,14 @@
     }
   }
 
-  function get_model_name(model_id: string) {
-    let [_, ...model_name_parts] = model_id.split("::")
-    return model_name_parts.join("::")
+  function get_model_name(model: any) {
+    return model.model_id
   }
 
-  function get_provider_name(model_id: string) {
-    let [provider, ..._] = model_id.split("::")
-    return provider_name_from_id(provider)
+  function get_provider_name(model: any) {
+    return provider_name_from_id(model.name)
   }
 
-  // You can get here 2 ways, build a breadcrumb for each
   const lastPageUrl = getContext<Writable<URL | undefined>>("lastPageUrl")
   function get_breadcrumbs() {
     const breadcrumbs = [{ label: "Settings", href: "/settings" }]
@@ -168,12 +333,12 @@
   title="Manage Custom Models"
   sub_subtitle="Add/remove additional models from your connected AI providers, on top of those already included with Kiln."
   breadcrumbs={get_breadcrumbs()}
-  action_buttons={custom_models && custom_models.length > 0
+  action_buttons={custom_model_providers && custom_model_providers.length > 0
     ? [
         {
           label: "Add Model",
           primary: true,
-          handler: show_add_model_modal,
+          handler: () => show_add_model_modal(null),
         },
       ]
     : []}
@@ -188,9 +353,9 @@
         <span>{error.message}</span>
       </div>
     </div>
-  {:else if custom_models.length > 0}
+  {:else if custom_model_providers.length > 0}
     <div class="flex flex-col gap-4">
-      {#each custom_models as model, index}
+      {#each custom_model_providers as model, index}
         <div class="flex flex-row gap-2 card bg-base-200 py-2 px-4">
           <div class="font-medium min-w-24">
             {get_provider_name(model)}
@@ -198,6 +363,11 @@
           <div class="grow">
             {get_model_name(model)}
           </div>
+          <button
+            on:click={() => show_add_model_modal(index)}
+            class="link text-sm text-gray-500"
+            >Edit</button
+          >
           <button
             on:click={() => remove_model(index)}
             class="link text-sm text-gray-500">Remove</button
@@ -209,7 +379,7 @@
     <div class="flex flex-col gap-4 justify-center items-center min-h-[30vh]">
       <button
         class="btn btn-wide btn-primary mt-4"
-        on:click={show_add_model_modal}
+        on:click={() => show_add_model_modal(null)}
       >
         Add Model
       </button>
@@ -229,16 +399,16 @@
 
 <Dialog
   bind:this={add_model_dialog}
-  title="Add Model"
-  action_buttons={[
+  title={edit_model_index !== null ? "Edit Model" : "Add Model"}
+  action_buttons=[
     { label: "Cancel", isCancel: true },
     {
-      label: "Add Model",
+      label: edit_model_index !== null ? "Save Model" : "Add Model",
       asyncAction: add_model,
       disabled: !new_model_provider || !new_model_name,
       isPrimary: true,
     },
-  ]}
+  ]
 >
   <div class="text-sm">Add a model from an existing provider.</div>
   <div class="text-sm text-gray-500 mt-3">
@@ -259,5 +429,166 @@
       inputType="input"
       bind:value={new_model_name}
     />
+    <Collapse title="Advanced">
+      <FormElement
+        label="Supports Structured Output"
+        id="supports_structured_output"
+        inputType="checkbox"
+        bind:value={new_model.supports_structured_output}
+      />
+      <FormElement
+        label="Supports Data Generation"
+        id="supports_data_gen"
+        inputType="checkbox"
+        bind:value={new_model.supports_data_gen}
+      />
+      <FormElement
+        label="Suggested for Data Generation"
+        id="suggested_for_data_gen"
+        inputType="checkbox"
+        bind:value={new_model.suggested_for_data_gen}
+      />
+      <FormElement
+        label="Untested Model"
+        id="untested_model"
+        inputType="checkbox"
+        bind:value={new_model.untested_model}
+      />
+      <FormElement
+        label="Provider Finetune ID"
+        id="provider_finetune_id"
+        inputType="input"
+        bind:value={new_model.provider_finetune_id}
+        optional={true}
+      />
+      <FormElement
+        label="Structured Output Mode"
+        id="structured_output_mode"
+        inputType="select"
+        select_options={structured_output_mode_options}
+        bind:value={structured_output_mode}
+      />
+      <FormElement
+        label="Parser"
+        id="parser"
+        inputType="select"
+        select_options={parser_options}
+        bind:value={parser}
+      />
+      <FormElement
+        label="Formatter"
+        id="formatter"
+        inputType="select"
+        select_options={formatter_options}
+        bind:value={formatter}
+      />
+      <FormElement
+        label="Reasoning Capable"
+        id="reasoning_capable"
+        inputType="checkbox"
+        bind:value={new_model.reasoning_capable}
+      />
+      <FormElement
+        label="Supports Logprobs"
+        id="supports_logprobs"
+        inputType="checkbox"
+        bind:value={new_model.supports_logprobs}
+      />
+      <FormElement
+        label="Suggested for Evals"
+        id="suggested_for_evals"
+        inputType="checkbox"
+        bind:value={new_model.suggested_for_evals}
+      />
+      <FormElement
+        label="Supports Function Calling"
+        id="supports_function_calling"
+        inputType="checkbox"
+        bind:value={new_model.supports_function_calling}
+      />
+      <FormElement
+        label="Uncensored"
+        id="uncensored"
+        inputType="checkbox"
+        bind:value={new_model.uncensored}
+      />
+      <FormElement
+        label="Suggested for Uncensored Data Gen"
+        id="suggested_for_uncensored_data_gen"
+        inputType="checkbox"
+        bind:value={new_model.suggested_for_uncensored_data_gen}
+      />
+      <FormElement
+        label="Tuned Chat Strategy"
+        id="tuned_chat_strategy"
+        inputType="select"
+        select_options={chat_strategy_options}
+        bind:value={tuned_chat_strategy}
+      />
+      <FormElement
+        label="R1 OpenRouter Options"
+        id="r1_openrouter_options"
+        inputType="checkbox"
+        bind:value={new_model.r1_openrouter_options}
+      />
+      <FormElement
+        label="Require OpenRouter Reasoning"
+        id="require_openrouter_reasoning"
+        inputType="checkbox"
+        bind:value={new_model.require_openrouter_reasoning}
+      />
+      <FormElement
+        label="Logprobs OpenRouter Options"
+        id="logprobs_openrouter_options"
+        inputType="checkbox"
+        bind:value={new_model.logprobs_openrouter_options}
+      />
+      <FormElement
+        label="OpenRouter Skip Required Parameters"
+        id="openrouter_skip_required_parameters"
+        inputType="checkbox"
+        bind:value={new_model.openrouter_skip_required_parameters}
+      />
+      <FormElement
+        label="Thinking Level"
+        id="thinking_level"
+        inputType="select"
+        select_options={thinking_level_options}
+        bind:value={thinking_level}
+      />
+      <FormElement
+        label="Ollama Model Aliases"
+        id="ollama_model_aliases"
+        inputType="input"
+        bind:value={ollama_model_aliases_string}
+        optional={true}
+      />
+      <FormElement
+        label="Anthropic Extended Thinking"
+        id="anthropic_extended_thinking"
+        inputType="checkbox"
+        bind:value={new_model.anthropic_extended_thinking}
+      />
+      <FormElement
+        label="Gemini Reasoning Enabled"
+        id="gemini_reasoning_enabled"
+        inputType="checkbox"
+        bind:value={new_model.gemini_reasoning_enabled}
+      />
+      <FormElement
+        label="SiliconFlow Enable Thinking"
+        id="siliconflow_enable_thinking"
+        inputType="select"
+        select_options={bool_optional_options}
+        bind:value={siliconflow_enable_thinking}
+      />
+      <FormElement
+        label="Reasoning Optional for Structured Output"
+        id="reasoning_optional_for_structured_output"
+        inputType="select"
+        select_options={bool_optional_options}
+        bind:value={reasoning_optional_for_structured_output}
+      />
+    </Collapse>
   </div>
 </Dialog>

--- a/libs/core/kiln_ai/adapters/provider_tools.py
+++ b/libs/core/kiln_ai/adapters/provider_tools.py
@@ -169,6 +169,17 @@ def kiln_model_provider_from(
     # For custom registry, get the provider name and model name from the model id
     if provider_name == ModelProviderName.kiln_custom_registry:
         provider_name, name = parse_custom_model_id(name)
+        custom_providers = Config.shared().custom_model_providers or []
+        provider_data = next(
+            (
+                p
+                for p in custom_providers
+                if p.get("name") == provider_name.value and p.get("model_id") == name
+            ),
+            None,
+        )
+        if provider_data:
+            return KilnModelProvider.model_validate(provider_data)
     else:
         logger.warning(
             f"Unexpected model/provider pair. Will treat as custom model but check your model settings. Provider: {provider_name}/{name}"

--- a/libs/core/kiln_ai/adapters/test_kiln_model_provider_defaults.py
+++ b/libs/core/kiln_ai/adapters/test_kiln_model_provider_defaults.py
@@ -1,0 +1,13 @@
+from kiln_ai.adapters.ml_model_list import (
+    KilnModelProvider,
+    ModelProviderName,
+    StructuredOutputMode,
+)
+
+
+def test_kiln_model_provider_defaults_for_missing_fields():
+    data = {"name": ModelProviderName.openai, "model_id": "gpt-4.1"}
+    provider = KilnModelProvider.model_validate(data)
+    assert provider.supports_structured_output is True
+    assert provider.supports_data_gen is True
+    assert provider.structured_output_mode == StructuredOutputMode.default

--- a/libs/core/kiln_ai/utils/config.py
+++ b/libs/core/kiln_ai/utils/config.py
@@ -144,6 +144,10 @@ class Config:
                 list,
                 default_lambda=lambda: [],
             ),
+            "custom_model_providers": ConfigProperty(
+                list,
+                default_lambda=lambda: [],
+            ),
             "openai_compatible_providers": ConfigProperty(
                 list,
                 default_lambda=lambda: [],


### PR DESCRIPTION
## CDX Prompt

I want to add the ability to add more parameters when adding custom models, and edit those parameters on existing models.

The UI path to add/edit custom models: “/settings/providers/add_models”

The add function currently only supports provider+model name. I want to add an “Advanced” collapse.svelte section with all the properties of the class KilnModelProvider. 

Part 1:
- Update the add custom model modal to include an “Advanced” collapse.svelte section with all the properties of the class KilnModelProvider. They should all default to their default values.
- Update the add custom model API to take a KilnModelProvider object.
- Update config.py to save a dictionary containing the KilnModelProvider properties. TBD on design, but likely a new top level key?
- Properly load the KilnModelProvider for custom models where needed. available_models for certain, maybe other places.
- Write a test confirming that if we add properties to KilnModelProvider, loading older configs will continue to work, and they will get the default value for any new properties.

## Summary
- support persisting full `KilnModelProvider` settings for custom models
- expose advanced provider fields when adding or editing custom models in the UI
- load custom model provider details for available models and runtime lookups

## Testing
- `uv run pytest libs/core/kiln_ai/adapters/test_kiln_model_provider_defaults.py libs/core/kiln_ai/adapters/test_provider_tools.py::test_kiln_model_provider_from_custom_model_valid libs/core/kiln_ai/adapters/test_provider_tools.py::test_kiln_model_provider_from_custom_registry app/desktop/studio_server/test_provider_api.py::test_custom_models -q`
- `./checks.sh --staged-only` *(failed: many missing imports in pyright)*


------
https://chatgpt.com/codex/tasks/task_e_68c1794259488332869f71f38107e205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces “Custom Model Providers” with an Add/Edit modal, including an Advanced section for rich per-model settings (structured output, parsing/formatting, tuning, thinking levels, aliases, and more).
  - Automatically migrates legacy custom model entries to the new structured format.
- Improvements
  - New configurable setting to manage custom model providers.
  - More reliable custom model resolution with dynamic capability defaults.
  - Enhanced error handling and logging during provider processing.
- Bug Fixes
  - Fallback to legacy custom models when no providers are configured.
  - Corrected display names and model identifiers in listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->