### PR TITLE
feat: allow rename docs and description

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2682,6 +2682,11 @@ export interface components {
              */
             name: string;
             /**
+             * Name Override
+             * @description A friendly name to identify the document. This is used for display purposes and can be different from the name.
+             */
+            name_override?: string | null;
+            /**
              * Description
              * @description A description for the file
              */
@@ -2697,6 +2702,8 @@ export interface components {
             tags?: string[];
             /** Model Type */
             readonly model_type: string;
+            /** Friendly Name */
+            readonly friendly_name: string;
         };
         /** EmbeddingConfig */
         EmbeddingConfig: {
@@ -3753,10 +3760,10 @@ export interface components {
         /** PatchDocumentRequest */
         PatchDocumentRequest: {
             /**
-             * Name
+             * Name Override
              * @description A name for this document.
              */
-            name?: string | null;
+            name_override?: string | null;
             /**
              * Description
              * @description The description of the document

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
@@ -28,7 +28,7 @@
   let loading = true
   let sortColumn = ($page.url.searchParams.get("sort") || "created_at") as
     | keyof KilnDocument
-    | "name"
+    | "friendly_name"
     | "kind"
     | "created_at"
     | "original_file.size"
@@ -57,7 +57,7 @@
 
   const columns = [
     { key: "kind", label: "Type" },
-    { key: "name", label: "Name" },
+    { key: "friendly_name", label: "Name" },
     { key: "original_file.size", label: "Size" },
     { key: "created_at", label: "Created At" },
   ]
@@ -115,9 +115,9 @@
         aValue = a.created_at
         bValue = b.created_at
         break
-      case "name":
-        aValue = a.name
-        bValue = b.name
+      case "friendly_name":
+        aValue = a.friendly_name
+        bValue = b.friendly_name
         break
       case "kind":
         aValue = a.kind + a.original_file.mime_type
@@ -629,7 +629,7 @@
                       </span>
                     </div>
                   </td>
-                  <td>{document.name}</td>
+                  <td>{document.friendly_name}</td>
                   <td>{formatSize(document.original_file.size)}</td>
                   <td>{formatDate(document.created_at)}</td>
                 </tr>

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
@@ -16,6 +16,7 @@
   import TagDropdown from "$lib/ui/tag_dropdown.svelte"
   import { ragProgressStore } from "$lib/stores/rag_progress_store"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
+  import EditDialog from "$lib/ui/edit_dialog.svelte"
 
   let initial_document: KilnDocument | null = null
   let updated_document: KilnDocument | null = null
@@ -30,6 +31,8 @@
   // dialog state
   let output_dialog: Dialog | null = null
   let dialog_extraction: ExtractionSummary | null = null
+
+  let edit_dialog: EditDialog | null = null
 
   $: download_document_url = `${base_url}/api/projects/${project_id}/documents/${document_id}/download`
 
@@ -188,7 +191,7 @@
 
 <AppPage
   title="Document"
-  subtitle={`${document?.name || document?.original_file.filename}`}
+  subtitle={document?.friendly_name}
   sub_subtitle="Read the Docs"
   sub_subtitle_link="https://docs.kiln.tech/docs/documents-and-search-rag#building-a-search-tool"
   limit_max_width
@@ -203,6 +206,12 @@
     },
   ]}
   action_buttons={[
+    {
+      label: "Edit",
+      handler: () => {
+        edit_dialog?.show()
+      },
+    },
     {
       icon: "/images/download.svg",
       href: download_document_url || "",
@@ -319,13 +328,12 @@
         <PropertyList
           properties={[
             { name: "ID", value: document.id || "Unknown" },
-            { name: "Name", value: document.name },
             {
-              name: "Original Filename",
-              value: document.original_file.filename,
+              name: "Name",
+              value: document.friendly_name,
             },
             {
-              name: "Original File Size",
+              name: "File Size",
               value: formatSize(document.original_file.size),
             },
             {
@@ -443,4 +451,34 @@
   bind:this={delete_extraction_dialog}
   delete_url={delete_extraction_url}
   after_delete={after_delete_extraction}
+/>
+
+<EditDialog
+  bind:this={edit_dialog}
+  after_save={() => {
+    get_document()
+    get_extractions()
+  }}
+  name="Document"
+  subtitle="REPLACE THIS"
+  patch_url={`/api/projects/${project_id}/documents/${document_id}`}
+  fields={[
+    {
+      label: "Name",
+      description:
+        "A name for your own reference. It does not need to contain the file extension or be unique.",
+      api_name: "name_override",
+      value: document?.friendly_name || "",
+      input_type: "input",
+      optional: true, // if empty, we revert to the original name
+    },
+    {
+      label: "Description",
+      description: "A description of the document for your own reference.",
+      api_name: "description",
+      value: document?.description || "",
+      input_type: "textarea",
+      optional: true,
+    },
+  ]}
 />

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
@@ -460,7 +460,6 @@
     get_extractions()
   }}
   name="Document"
-  subtitle="REPLACE THIS"
   patch_url={`/api/projects/${project_id}/documents/${document_id}`}
   fields={[
     {
@@ -471,6 +470,7 @@
       value: document?.friendly_name || "",
       input_type: "input",
       optional: true, // if empty, we revert to the original name
+      info_description: "If empty, the original file name will be used.",
     },
     {
       label: "Description",

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -78,9 +78,9 @@ def string_to_valid_name(name: str) -> str:
     # https://docs.python.org/3/library/unicodedata.html#unicodedata.normalize
     valid_name = unicodedata.normalize("NFKD", name)
     # Replace any forbidden chars with an underscore
-    valid_name = re.sub(FORBIDDEN_CHARS_REGEX, "_", valid_name)
+    valid_name = re.sub(FORBIDDEN_CHARS_REGEX, " ", valid_name)
     # Replace control characters with an underscore
-    valid_name = re.sub(r"[\x00-\x1F]", "_", valid_name)
+    valid_name = re.sub(r"[\x00-\x1F]", " ", valid_name)
     # Replace consecutive whitespace with a single space
     valid_name = re.sub(r"\s+", " ", valid_name)
     # Replace consecutive underscores with a single underscore

--- a/libs/core/kiln_ai/datamodel/test_basemodel.py
+++ b/libs/core/kiln_ai/datamodel/test_basemodel.py
@@ -342,12 +342,12 @@ def test_delete_no_path():
         ("Hello 👍", "Hello 👍"),
         # Invalid characters are replaced
         ("Hello@World!", "Hello@World!"),
-        ("File.name.txt", "File_name_txt"),
-        ("Special%%%Chars", "Special_Chars"),
-        ("Special#$%Chars", "Special#$_Chars"),
+        ("File.name.txt", "File name txt"),
+        ("Special%%%Chars", "Special Chars"),
+        ("Special#$%Chars", "Special#$ Chars"),
         # Consecutive invalid characters are replaced
-        ("Special%%%Chars", "Special_Chars"),
-        ("path/to/file", "path_to_file"),
+        ("Special%%%Chars", "Special Chars"),
+        ("path/to/file", "path to file"),
         # Leading/trailing special characters are removed
         ("__test__", "test"),
         ("...test...", "test"),
@@ -360,14 +360,14 @@ def test_delete_no_path():
         ("你好_世界", "你好_世界"),
         ("你好_世界_你好", "你好_世界_你好"),
         # Newlines, tabs, and other control characters are replaced
-        ("Hello\nworld", "Hello_world"),
-        ("Hello\tworld", "Hello_world"),
-        ("Hello\rworld", "Hello_world"),
-        ("Hello\fworld", "Hello_world"),
-        ("Hello\bworld", "Hello_world"),
-        ("Hello\vworld", "Hello_world"),
-        ("Hello\0world", "Hello_world"),
-        ("Hello\x00world", "Hello_world"),
+        ("Hello\nworld", "Hello world"),
+        ("Hello\tworld", "Hello world"),
+        ("Hello\rworld", "Hello world"),
+        ("Hello\fworld", "Hello world"),
+        ("Hello\bworld", "Hello world"),
+        ("Hello\vworld", "Hello world"),
+        ("Hello\0world", "Hello world"),
+        ("Hello\x00world", "Hello world"),
     ],
 )
 def test_string_to_valid_name(tmp_path, name, expected):

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -365,7 +365,7 @@ class CreateExtractorConfigRequest(BaseModel):
 
 
 class PatchDocumentRequest(BaseModel):
-    name: FilenameString | None = Field(
+    name_override: str | None = Field(
         description="A name for this document.",
         default=None,
     )
@@ -380,7 +380,9 @@ class PatchDocumentRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_at_least_one_field(self):
-        if all(field is None for field in [self.name, self.description, self.tags]):
+        if all(
+            field is None for field in [self.name_override, self.description, self.tags]
+        ):
             raise ValueError("At least one field must be provided")
         return self
 
@@ -631,6 +633,7 @@ def connect_document_api(app: FastAPI):
                 document = Document(
                     parent=project,
                     name=string_to_valid_name(document_name),
+                    name_override=document_name,
                     description="",  # No description support in bulk upload
                     kind=kind,
                     original_file=FileInfo(
@@ -710,8 +713,12 @@ def connect_document_api(app: FastAPI):
                 detail="Document not found",
             )
 
-        if request.name is not None:
-            document.name = request.name
+        if request.name_override is not None:
+            if request.name_override == "":
+                # revert to the original name
+                document.name_override = document.original_file.filename
+            else:
+                document.name_override = request.name_override
         if request.description is not None:
             document.description = request.description
         if request.tags is not None:

--- a/libs/server/kiln_server/test_document_api.py
+++ b/libs/server/kiln_server/test_document_api.py
@@ -2879,8 +2879,12 @@ async def test_create_documents_bulk_without_names(client, mock_project):
     assert len(result["failed_files"]) == 0
 
     # Should use filenames as names (with dots converted to underscores)
-    assert result["created_documents"][0]["name"] == "test1_txt"
-    assert result["created_documents"][1]["name"] == "test2_txt"
+    assert result["created_documents"][0]["name"] == "test1 txt"
+    assert result["created_documents"][1]["name"] == "test2 txt"
+
+    # Should have dots converted to spaces
+    assert result["created_documents"][0]["friendly_name"] == "test1.txt"
+    assert result["created_documents"][1]["friendly_name"] == "test2.txt"
 
 
 @pytest.mark.asyncio
@@ -2959,7 +2963,8 @@ async def test_create_documents_bulk_some_invalid_files(client, mock_project):
     # Should only have the valid file
     assert len(result["created_documents"]) == 1
     assert len(result["failed_files"]) == 2  # Two invalid files
-    assert result["created_documents"][0]["name"] == "valid_txt"
+    assert result["created_documents"][0]["name"] == "valid txt"
+    assert result["created_documents"][0]["friendly_name"] == "valid.txt"
     assert result["created_documents"][0]["kind"] == "document"
 
 
@@ -3062,8 +3067,10 @@ async def test_create_documents_bulk_duplicate_filenames(client, mock_project):
     # Both files should be processed (they have different content)
     assert len(result["created_documents"]) == 2
     assert len(result["failed_files"]) == 0
-    assert result["created_documents"][0]["name"] == "duplicate_txt"
-    assert result["created_documents"][1]["name"] == "duplicate_txt"
+    assert result["created_documents"][0]["name"] == "duplicate txt"
+    assert result["created_documents"][1]["name"] == "duplicate txt"
+    assert result["created_documents"][0]["friendly_name"] == "duplicate.txt"
+    assert result["created_documents"][1]["friendly_name"] == "duplicate.txt"
 
 
 @pytest.mark.parametrize(
@@ -3220,12 +3227,12 @@ def test_patch_document_success_name_only(client, mock_project, mock_document):
 
         response = client.patch(
             f"/api/projects/{mock_project.id}/documents/{mock_document['document'].id}",
-            json={"name": "Updated Document Name"},
+            json={"name_override": "Updated Document Name"},
         )
 
         assert response.status_code == 200
         data = response.json()
-        assert data["name"] == "Updated Document Name"
+        assert data["friendly_name"] == "Updated Document Name"
         assert (
             data["description"] == mock_document["document"].description
         )  # Should remain unchanged
@@ -3280,12 +3287,16 @@ def test_patch_document_success_all_fields(client, mock_project, mock_document):
 
         response = client.patch(
             f"/api/projects/{mock_project.id}/documents/{mock_document['document'].id}",
-            json={"name": new_name, "description": new_description, "tags": new_tags},
+            json={
+                "name_override": new_name,
+                "description": new_description,
+                "tags": new_tags,
+            },
         )
 
         assert response.status_code == 200
         data = response.json()
-        assert data["name"] == new_name
+        assert data["friendly_name"] == new_name
         assert data["description"] == new_description
         assert data["tags"] == new_tags
 
@@ -3297,7 +3308,7 @@ def test_patch_document_not_found(client, mock_project):
 
         response = client.patch(
             f"/api/projects/{mock_project.id}/documents/nonexistent_id",
-            json={"name": "Updated Name"},
+            json={"name_override": "Updated Name"},
         )
 
         assert response.status_code == 404
@@ -3333,6 +3344,34 @@ def test_patch_document_invalid_tags_empty_string(client, mock_project, mock_doc
         assert response.status_code == 422
         data = response.json()
         assert "Tags cannot be empty strings" in data["message"]
+
+
+def test_patch_document_name_revert_to_original_name(
+    client, mock_project, mock_document
+):
+    """Test PATCH document endpoint with name revert to original name"""
+    with patch("kiln_server.document_api.project_from_id") as mock_project_from_id:
+        mock_project_from_id.return_value = mock_project
+
+        original_name = mock_document["document"].original_file.filename
+
+        response = client.patch(
+            f"/api/projects/{mock_project.id}/documents/{mock_document['document'].id}",
+            json={"name_override": "modified name"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["friendly_name"] == "modified name"
+
+        response = client.patch(
+            f"/api/projects/{mock_project.id}/documents/{mock_document['document'].id}",
+            json={"name_override": ""},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["friendly_name"] == original_name
 
 
 def test_patch_document_invalid_tags_with_spaces(client, mock_project, mock_document):
@@ -3402,7 +3441,7 @@ def test_patch_document_partial_update_preserves_other_fields(
         # First update just the name
         response1 = client.patch(
             f"/api/projects/{mock_project.id}/documents/{mock_document['document'].id}",
-            json={"name": "Updated Name Only"},
+            json={"name_override": "Updated Name Only"},
         )
         assert response1.status_code == 200
 
@@ -3415,7 +3454,7 @@ def test_patch_document_partial_update_preserves_other_fields(
 
         data = response2.json()
         assert (
-            data["name"] == "Updated Name Only"
+            data["friendly_name"] == "Updated Name Only"
         )  # Should be preserved from first update
         assert data["description"] == "Updated Description Only"  # Should be updated
         assert data["tags"] == mock_document["document"].tags  # Should remain original


### PR DESCRIPTION
## What does this PR do?

1. Allow renaming and updating the description for documents. 
2. Sanitizing of filenames now replaces forbidden characters with spaces instead of underscores.

Implementation of renaming:
- the `Document.name` must be a valid filename because it goes into the folder name on the filesystem, so it cannot contain forbidden characters and cannot always be the same as the original filename.
- the design of the renaming adds a new field named `name_override` that can be any string
- add `friendly_name` computed field / property on the model, which uses `name_override` if set, and falls back on the `name` otherwise (backward compatibility and some safety)
- if the user updates a document with nothing, we revert back to the original filename (we set the attachment's original filename as `name_override`)

So the general idea is:
- `document.name`: immutable -> base model name, goes into fs naming; not displayed in the UI
- `document.name_override`: user-controlled -> the name the user can freely update, takes precedence over the `name`
- `document.friendly_name`: dynamic/computed -> virtual property, the name to display everywhere in the UI
- `document.original_file.filename`: immutable -> the original filename as it was uploaded, we don't display it, but use it as fallback if the user clears the name

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Documents now display a friendly name; you can edit it and revert to the original filename.
  - Library and document pages use the friendly name for display and sorting.
  - API: PATCH now accepts name_override; responses include friendly_name. Sending an empty string reverts to the original filename.
- Behavior Changes
  - Auto-generated document names now replace invalid characters with spaces (not underscores), affecting bulk uploads and default naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->