### PR TITLE
Simplify the onboarding user expereince: 

### DIFF
--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/[slug]/+page.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/[slug]/+page.svelte
@@ -19,7 +19,11 @@
 <div
   class="flex-none min-h-[50vh] py-8 px-4 h-full flex flex-col py-18 w-full max-w-[600px] mx-auto"
 >
-  <EditTask redirect_on_created="/" explicit_project_id={project_id} />
+  <EditTask
+    redirect_on_created="/"
+    explicit_project_id={project_id}
+    onboarding={true}
+  />
 </div>
 
 <div class="grow-[1.5]"></div>

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -22,6 +22,9 @@
   export let redirect_on_created: string | null = "/"
   export let hide_example_task: boolean = false
 
+  // Simplify the create view for onboarding
+  export let onboarding: boolean = false
+
   // @ts-expect-error This is a partial task, which is fine.
   export let task: Task = {
     name: "",
@@ -32,7 +35,7 @@
 
   $: creating = !task.id
   $: editing = !creating
-  $: show_requirements = editing || task.requirements.length > 0
+  $: show_requirements = !onboarding || task.requirements.length > 0
 
   // These have their own custom VM, which is translated back to the model on save
   let outputSchemaSection: SchemaSection
@@ -272,24 +275,27 @@
       bind:value={task.instruction}
     />
 
-    <FormElement
-      label="Task Description"
-      inputType="textarea"
-      id="task_description"
-      description="A description for you and your team, not used by the model."
-      optional={true}
-      bind:value={task.description}
-    />
+    <!-- Don't show these if onboarding, keep onboarding view as simple as possible -->
+    {#if !onboarding}
+      <FormElement
+        label="Task Description"
+        inputType="textarea"
+        id="task_description"
+        description="A description for you and your team, not used by the model."
+        optional={true}
+        bind:value={task.description}
+      />
 
-    <FormElement
-      label="'Thinking' Instructions"
-      inputType="textarea"
-      id="thinking_instructions"
-      optional={true}
-      description="Instructions for how the model should 'think' about the task prior to answering. Used for chain of thought style prompting."
-      info_description="Used when running a 'Chain of Thought' prompt. If left blank, a default 'think step by step' prompt will be used. Optionally customize this with your own instructions to better fit this task."
-      bind:value={task.thinking_instruction}
-    />
+      <FormElement
+        label="'Thinking' Instructions"
+        inputType="textarea"
+        id="thinking_instructions"
+        optional={true}
+        description="Instructions for how the model should 'think' about the task prior to answering. Used for chain of thought style prompting."
+        info_description="Used when running a 'Chain of Thought' prompt. If left blank, a default 'think step by step' prompt will be used. Optionally customize this with your own instructions to better fit this task."
+        bind:value={task.thinking_instruction}
+      />
+    {/if}
 
     {#if show_requirements}
       <div class="text-sm font-medium text-left pt-6 flex flex-col gap-1">


### PR DESCRIPTION
the team description and thinking fields are confusing folks. Leave them in edit, but not something we should make people think about on first run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an onboarding mode for creating tasks, providing a streamlined form with fewer fields for a faster first-time setup.

* **Improvements**
  * The Task Requirements section now shows only when appropriate: it appears if there are existing requirements or when not in onboarding.
  * Task Description and Thinking Instructions are hidden during onboarding to reduce complexity, while remaining available in the standard flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->