### PR TITLE
Increase MCP timeout to 30s

### DIFF
--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -173,7 +173,7 @@ class MCPSessionManager:
         try:
             async with stdio_client(server_params) as (read, write):
                 async with ClientSession(
-                    read, write, read_timeout_seconds=timedelta(seconds=8)
+                    read, write, read_timeout_seconds=timedelta(seconds=30)
                 ) as session:
                     await session.initialize()
                     yield session


### PR DESCRIPTION
## What does this PR do?

Increase MCP timeout to 30s. This includes install time on first run. 

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib
