### PR TITLE
New idea for type discriminators

### DIFF
--- a/app/web_ui/src/lib/types.ts
+++ b/app/web_ui/src/lib/types.ts
@@ -90,3 +90,34 @@ export type ToolCallMessageParam =
   components["schemas"]["ChatCompletionMessageFunctionToolCallParam"]
 export type SearchToolApiDescription =
   components["schemas"]["SearchToolApiDescription"]
+
+// Type helpers for ExternalToolServerApiDescription properties
+
+type ToolPropsByType = {
+  remote_mcp: RemoteServerProperties
+  local_mcp: LocalServerProperties
+}
+
+export function toolIsType<T extends keyof ToolPropsByType>(
+  x: ExternalToolServerApiDescription,
+  t: T,
+): asserts x is ExternalToolServerApiDescription & {
+  type: T
+  properties: ToolPropsByType[T]
+} {
+  if (x.type !== t) {
+    throw new Error(`Tool type mismatch: ${x.type} !== ${t}`)
+  }
+}
+
+export function isToolType<T extends keyof ToolPropsByType>(
+  x: ExternalToolServerApiDescription,
+  t: T,
+): x is ExternalToolServerApiDescription & {
+  type: T
+  properties: ToolPropsByType[T]
+} {
+  // Throw an error if the tool is not of the given type
+  toolIsType(x, t)
+  return true
+}


### PR DESCRIPTION
Idea: discriminators in types.ts, which check the type the field is, and trusts the server is doing the right thing.

 - Saves us writing custom discriminators and running at runtime
 - Raises an exception instead of just not running if the type assertion is wrong
 - Two forms: one that just asserts type, the other that can be used in if blocks (nice for svelte)

Had to try a few things to find one that worked. This is all new to me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when viewing or editing tool server settings by validating remote vs. local configurations more strictly, reducing edge-case errors.
* **Refactor**
  * Consolidated tool type checks into shared helpers for consistent behavior across the app and simplified settings page logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->