### PR TITLE
Fix broken link: the add fine-tuning link

### DIFF
--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/select_finetune_dataset.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/select_finetune_dataset.svelte
@@ -211,7 +211,7 @@
       step_count: 4,
       current_step: 2,
     })
-    let link = `/dataset/${project_id}/${task_id}/add_data?reason=fine_tune&splits=fine_tune_data:1.0&finetune_link=${encodeURIComponent(
+    let link = `/dataset/${project_id}/${task_id}/add_data?reason=fine_tune&template_id=fine_tuning&splits=fine_tune_data:1.0&finetune_link=${encodeURIComponent(
       `/fine_tune/${project_id}/${task_id}/create_finetune`,
     )}`
     goto(link)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the “Add Data” link in the fine-tuning setup to include a context parameter, directing users to the dataset creation page with the fine-tuning context applied. Navigation behavior remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->