### PR TITLE
Add titles to Create Rag screen

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/+page.svelte
@@ -36,6 +36,7 @@
   import { tool_name_validator } from "$lib/utils/input_validators"
   import posthog from "posthog-js"
   import { uncache_available_tools } from "$lib/stores"
+  import InfoTooltip from "$lib/ui/info_tooltip.svelte"
 
   $: project_id = $page.params.project_id
   const template_id = $page.url.searchParams.get("template_id")
@@ -647,6 +648,7 @@
         keyboard_submit={!modal_opened}
       >
         <!-- Search Tool Properties -->
+        <div class="text-xl font-bold">Part 1: Tool Properties</div>
         <FormElement
           label="Search Tool Name"
           description="A unique short tool name such as 'knowledge_base_search'. Be descriptive about what data this tool can search."
@@ -674,17 +676,23 @@
             on:change={(e) => (selected_tags = e.detail.selected_tags)}
           />
         </div>
+
+        <div>
+          <div class="text-xl font-bold mt-4">Part 2: Search Configuration</div>
+          <div class="text-xs text-gray-500 font-medium">
+            This configuration controls how the search tool will extract, index,
+            and search your documents.
+            {#if template && !customize_template_mode}
+              <InfoTooltip
+                no_pad={true}
+                tooltip_text="You selected a pre-configured search tool with these parameters."
+              />
+            {/if}
+          </div>
+        </div>
         {#if template && !customize_template_mode}
-          <div class="flex flex-col mt-4">
-            <FormElement
-              id="search_tool_configuration_header"
-              label="Search Configuration"
-              description="These parameters control how the search tool will extract, index, and search your documents."
-              info_description="You selected a pre-configured search tool with these parameters."
-              inputType="header_only"
-              value={null}
-            />
-            <div class="mt-2 mb-8">
+          <div class="flex flex-col">
+            <div class="mb-8">
               <PropertyList
                 properties={[
                   { name: "Template Name", value: template.name },


### PR DESCRIPTION
Fix for https://linear.app/kiln-ai/issue/KIL-42/section-titles-on-create-rag-screen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced “Part 2: Search Configuration” section in the Create Search Tool flow.
  * Added contextual InfoTooltip explaining pre-configured parameters when using a template.
  * Displayed a summary of template details (name, models, chunking, index, and notes) via a property list.
  * Added “Customize Configuration” button and an “Advanced” badge for deeper control.

* **Style**
  * Refined layout and spacing with a new flex column structure to improve readability and accommodate the new section without changing existing data behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->