### PR TITLE
Capture MCP server stderr

### DIFF
--- a/app/web_ui/src/lib/utils/logs.ts
+++ b/app/web_ui/src/lib/utils/logs.ts
@@ -1,0 +1,20 @@
+import { client } from "$lib/api_client"
+
+/**
+ * Opens the application logs folder in the system file browser
+ */
+export async function view_logs(): Promise<void> {
+  try {
+    const { error } = await client.POST("/api/open_logs", {})
+    if (error) {
+      const errorMessage = (error as Record<string, unknown>)?.message
+      if (typeof errorMessage === "string") {
+        throw new Error(errorMessage)
+      } else {
+        throw new Error("Unknown error")
+      }
+    }
+  } catch (e) {
+    alert("Failed to open logs: " + e)
+  }
+}

--- a/app/web_ui/src/routes/(app)/settings/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/+page.svelte
@@ -1,24 +1,8 @@
 <script lang="ts">
   import AppPage from "../app_page.svelte"
   import { ui_state } from "$lib/stores"
-  import { client } from "$lib/api_client"
   import SettingsSection from "$lib/ui/settings_section.svelte"
-
-  async function view_logs() {
-    try {
-      const { error } = await client.POST("/api/open_logs", {})
-      if (error) {
-        const errorMessage = (error as Record<string, unknown>)?.message
-        if (typeof errorMessage === "string") {
-          throw new Error(errorMessage)
-        } else {
-          throw new Error("Unknown error")
-        }
-      }
-    } catch (e) {
-      alert("Failed to open logs: " + e)
-    }
-  }
+  import { view_logs } from "$lib/utils/logs"
 
   let sections = [
     {

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/edit_local_tool.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/edit_local_tool.svelte
@@ -12,6 +12,7 @@
   import { uncache_available_tools } from "$lib/stores"
   import type { ExternalToolServerApiDescription } from "$lib/types"
   import posthog from "posthog-js"
+  import { view_logs } from "$lib/utils/logs"
 
   // The existing tool server, if we're editing
   export let editing_tool_server: ExternalToolServerApiDescription | null = null
@@ -380,7 +381,15 @@
               {args}" runs in your terminal.
             </li>
             <li>Restart the Kiln App.</li>
-            <li>Check the application logs for additional error details.</li>
+            <li>
+              Check application logs for additional error details. <button
+                type="button"
+                class="link"
+                on:click={view_logs}
+              >
+                View Logs
+              </button>
+            </li>
           </ol>
         </div>
       {/if}

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/edit_local_tool.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/edit_local_tool.svelte
@@ -265,7 +265,6 @@
     <FormContainer
       submit_label={editing_tool_server ? "Save" : "Connect"}
       on:submit={save_or_connect}
-      bind:error
       bind:submitting
     >
       <FormElement
@@ -364,6 +363,27 @@
           </div>
         </div>
       </FormList>
+
+      {#if error}
+        <div class="mb-6 flex flex-col gap-2 text-center max-w-[600px] mx-auto">
+          <span class="text-lg text-error">Could Not Connect to MCP Server</span
+          >
+          {#each error.getErrorMessages() as error_line}
+            <div class="text-sm text-left whitespace-pre-line">
+              {error_line}
+            </div>
+          {/each}
+          <span class="text-lg text-center mt-6">Troubleshooting Steps:</span>
+          <ol class="text-sm list-decimal list-inside text-left">
+            <li>
+              Ensure your command "{command}
+              {args}" runs in your terminal.
+            </li>
+            <li>Restart the Kiln App.</li>
+            <li>Check the application logs for additional error details.</li>
+          </ol>
+        </div>
+      {/if}
     </FormContainer>
   </div>
 </div>

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/edit_local_tool.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/local_mcp/edit_local_tool.svelte
@@ -13,6 +13,7 @@
   import type { ExternalToolServerApiDescription } from "$lib/types"
   import posthog from "posthog-js"
   import { view_logs } from "$lib/utils/logs"
+  import Output from "../../../../../run/output.svelte"
 
   // The existing tool server, if we're editing
   export let editing_tool_server: ExternalToolServerApiDescription | null = null
@@ -366,31 +367,52 @@
       </FormList>
 
       {#if error}
-        <div class="mb-6 flex flex-col gap-2 text-center max-w-[600px] mx-auto">
-          <span class="text-lg text-error">Could Not Connect to MCP Server</span
+        <div
+          class="mb-6 flex flex-col gap-4 max-w-[600px] mx-auto border p-4 rounded-md"
+        >
+          <span class="font-bold text-error"
+            >Could Not Connect to MCP Server</span
           >
-          {#each error.getErrorMessages() as error_line}
-            <div class="text-sm text-left whitespace-pre-line">
-              {error_line}
-            </div>
-          {/each}
-          <span class="text-lg text-center mt-6">Troubleshooting Steps:</span>
-          <ol class="text-sm list-decimal list-inside text-left">
-            <li>
-              Ensure your command "{command}
-              {args}" runs in your terminal.
-            </li>
-            <li>Restart the Kiln App.</li>
-            <li>
-              Check application logs for additional error details. <button
-                type="button"
-                class="link"
-                on:click={view_logs}
-              >
-                View Logs
-              </button>
-            </li>
-          </ol>
+
+          <div class="flex flex-col gap-2">
+            <span class="font-medium">Troubleshooting Steps</span>
+            <ol
+              class="text-sm list-decimal list-outside pl-6 flex flex-col gap-2"
+            >
+              <li>
+                Check the Error Details below for information about the issue.
+              </li>
+              <li>
+                Check the server's documentation for the correct setup
+                (dependencies, etc.).
+              </li>
+              <li>
+                Ensure your command <span
+                  class="font-mono text-xs font-bold bg-base-200 p-1 rounded-sm"
+                  >{command}
+                  {args}</span
+                > runs in your terminal. If you had to install libraries or dependencies,
+                restart the Kiln app before trying again.
+              </li>
+              <li>
+                Check Kiln logs for additional details. <button
+                  type="button"
+                  class="link"
+                  on:click={view_logs}
+                >
+                  View Logs
+                </button>
+              </li>
+            </ol>
+          </div>
+          <div class="flex flex-col gap-2">
+            <span class="font-medium">Error Details</span>
+            <Output
+              raw_output={error.getErrorMessages().join("\n\n")}
+              hide_toggle={false}
+              max_height="120px"
+            />
+          </div>
         </div>
       {/if}
     </FormContainer>

--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -174,7 +174,8 @@ class MCPSessionManager:
         )
 
         # Create temporary file to capture MCP server stderr
-        err_log = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
+        # Use errors="replace" to handle non-UTF-8 bytes gracefully
+        err_log = tempfile.TemporaryFile(mode="w+", encoding="utf-8", errors="replace")
 
         try:
             async with stdio_client(server_params, errlog=err_log) as (

--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -20,7 +20,6 @@ from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 
 logger = logging.getLogger(__name__)
 
-# Error message constants for local MCP server failures
 LOCAL_MCP_ERROR_INSTRUCTION = "Please verify your command, arguments, and environment variables, and consult the server's documentation for the correct setup."
 
 


### PR DESCRIPTION
## What does this PR do?

Capture MCP server's stderr to provide more accurate error message to users when connecting to local mcp server fails. 

* Use tmp file for stdio client
* Log the error to Kiln log archive
* Update error UI for local mcp, add trouble shooting steps. 

## Checklists

- [x] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detailed error panel for local MCP connection failures with troubleshooting steps, displayed command/arguments, error details, and a "View Logs" action.

* **Bug Fixes**
  * Captures and surfaces MCP server stderr in error messages to provide fuller diagnostic details for local connection attempts (remote behavior unchanged).

* **Chores**
  * Centralized "View Logs" behavior so Application Logs consistently opens the logs.

* **Tests**
  * Updated tests to expect the centralized error instruction and new error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->