### PR TITLE
chore: centralize warning suppression in pytest.ini

### DIFF
--- a/app/desktop/test_desktop.py
+++ b/app/desktop/test_desktop.py
@@ -10,13 +10,6 @@ from uvicorn import Config as UvicornConfig
 import app.desktop.desktop_server as desktop_server
 from app.desktop.desktop import DesktopApp, DesktopServer
 
-# Suppress third-party DeprecationWarnings from websockets during this test module
-pytestmark = pytest.mark.filterwarnings(
-    "ignore::DeprecationWarning:websockets\\.legacy",
-    "ignore::DeprecationWarning:websockets\\.server",
-    "ignore:.*WebSocketServerProtocol is deprecated:DeprecationWarning:uvicorn\\.protocols\\.websockets\\.websockets_impl",
-)
-
 
 @pytest.fixture(autouse=True)
 def mock_gui_modules():

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,9 @@ filterwarnings =
     ignore:File system does not support fine-grained timestamps
     ignore::pydantic.PydanticDeprecatedSince20
     ignore:Benchmark fixture was not used at all in this test
+    ignore::DeprecationWarning:websockets.legacy
+    ignore::DeprecationWarning:websockets.server
+    ignore:.*WebSocketServerProtocol is deprecated:DeprecationWarning:uvicorn.protocols.websockets.websockets_impl
 
 # Enable parallel testing. Disabled for now as single tests are much faster without it on. 
 # addopts = -n auto


### PR DESCRIPTION
## What does this PR do?

Move the warning suppression to `pytest.ini` (instead of scattered around)
