### PR TITLE
feat: more doc extractors and pdf to image pipeline

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/+page.svelte
@@ -280,7 +280,10 @@
 
     <div>
       <p>You can also install the models using the Ollama CLI:</p>
-      <pre>{selected_template?.required_commands?.join("\n")}</pre>
+      <pre
+        class="font-mono text-xs bg-base-200 p-2 rounded-md mt-1">{selected_template?.required_commands?.join(
+          "\n",
+        )}</pre>
     </div>
   </div>
 </Dialog>

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/rag_config_templates.ts
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/rag_config_templates.ts
@@ -15,7 +15,7 @@ import {
   default_extractor_audio_prompts,
 } from "../../../extractors/[project_id]/create_extractor/default_extractor_prompts"
 
-export type RequiredApiKeysSets = "Openai" | "Gemini"
+export type RequiredProvider = "Openai" | "Gemini" | "Ollama"
 
 type SubConfig = {
   config_name: string
@@ -43,7 +43,9 @@ export type RagConfigTemplate = {
   preview_description: string
   preview_subtitle: string
   preview_tooltip?: string
-  required_api_keys: RequiredApiKeysSets
+  required_provider: RequiredProvider
+  required_models?: string[]
+  required_commands?: string[]
   extractor: ExtractorSubConfig
   chunker: ChunkerSubConfig
   embedding: EmbeddingSubConfig
@@ -86,7 +88,7 @@ export const rag_config_templates: Record<string, RagConfigTemplate> = {
       "The best quality search configuration. Uses Gemini 2.5 Pro with hybrid search.",
     preview_tooltip:
       "Gemini 2.5 Pro extraction, Gemini embeddings 001 (3072 dimensions), and LanceDB hybrid search (vector + full-text).",
-    required_api_keys: "Gemini",
+    required_provider: "Gemini",
     extractor: {
       config_name: "Gemini 2p5 Pro w Default Prompts",
       description: "Gemini 2.5 Pro",
@@ -105,7 +107,7 @@ export const rag_config_templates: Record<string, RagConfigTemplate> = {
       "Great quality at a lower price. Uses Gemini 2.5 Flash with hybrid search.",
     preview_tooltip:
       "Gemini 2.5 Flash extraction, Gemini embeddings 001 (3072 dimensions), and LanceDB hybrid search (vector + full-text).",
-    required_api_keys: "Gemini",
+    required_provider: "Gemini",
     extractor: gemini_2_5_flash_extractor,
     chunker: default_chunker,
     embedding: default_embedding,
@@ -118,7 +120,12 @@ export const rag_config_templates: Record<string, RagConfigTemplate> = {
     preview_description: "Qwen 2.5 VL on your computer using Ollama.",
     preview_tooltip:
       "Qwen 2.5 VL 7B via Ollama for extraction and Qwen 3 Embedding 0.6B for embeddings.",
-    required_api_keys: "Gemini",
+    required_provider: "Ollama",
+    required_models: ["qwen2.5vl:7b", "qwen3-embedding:0.6b"],
+    required_commands: [
+      "ollama pull qwen2.5vl:7b",
+      "ollama pull qwen3-embedding:0.6b",
+    ],
     extractor: {
       config_name: "Qwen 2p5 VL 7B via Ollama",
       description: "Qwen 2.5 VL 7B via Ollama",
@@ -142,7 +149,7 @@ export const rag_config_templates: Record<string, RagConfigTemplate> = {
       "Use only vector search for semantic similarity, without keyword search.",
     preview_tooltip:
       "Gemini 2.5 Flash extraction, Gemini embeddings 001 (3072 dimensions), and LanceDB vector search (no full-text search).",
-    required_api_keys: "Gemini",
+    required_provider: "Gemini",
     extractor: gemini_2_5_flash_extractor,
     chunker: default_chunker,
     embedding: default_embedding,
@@ -161,7 +168,7 @@ export const rag_config_templates: Record<string, RagConfigTemplate> = {
       "We suggest Gemini, but if you need to use OpenAI try this template.",
     preview_tooltip:
       "GPT-5 extraction, OpenAI Embedding 3 Large (3072 dimensions), and LanceDB hybrid search (vector + full-text).",
-    required_api_keys: "Openai",
+    required_provider: "Openai",
     notice_text: "Does not support audio or video files.",
     notice_tooltip:
       "GPT 5 does not support extracting audio or video files. We suggest using Gemini if you require audio or video support.",

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/rag_config_templates.ts
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/rag_config_templates.ts
@@ -112,6 +112,29 @@ export const rag_config_templates: Record<string, RagConfigTemplate> = {
     vector_store: default_vector_store,
     rag_config_name: "Cost Optimized - Gemini Flash Hybrid Search",
   },
+  local_qwen: {
+    name: "All Local",
+    preview_subtitle: "Qwen 2.5 VL with Ollama",
+    preview_description: "Qwen 2.5 VL on your computer using Ollama.",
+    preview_tooltip:
+      "Qwen 2.5 VL 7B via Ollama for extraction and Qwen 3 Embedding 0.6B for embeddings.",
+    required_api_keys: "Gemini",
+    extractor: {
+      config_name: "Qwen 2p5 VL 7B via Ollama",
+      description: "Qwen 2.5 VL 7B via Ollama",
+      model_provider_name: "ollama",
+      model_name: "qwen_2p5_vl_7b",
+    },
+    chunker: default_chunker,
+    embedding: {
+      config_name: "Qwen 3 Embedding 0p6B (1024 dimensions)",
+      description: "Qwen 3 Embedding 0.6B (1024 dimensions)",
+      model_provider_name: "ollama",
+      model_name: "qwen_3_embedding_0p6b",
+    },
+    vector_store: default_vector_store,
+    rag_config_name: "Ollama - Qwen 2p5 VL",
+  },
   vector_only: {
     name: "Vector Only",
     preview_subtitle: "No Full-Text Search",

--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -170,7 +170,7 @@ class LitellmExtractor(BaseExtractor):
     async def convert_pdf_page_to_image_input(
         self, page_path: Path, page_number: int
     ) -> ExtractionInput:
-        image_paths = convert_pdf_to_images(page_path, page_path.parent)
+        image_paths = await convert_pdf_to_images(page_path, page_path.parent)
         if len(image_paths) != 1:
             raise ValueError(
                 f"Expected 1 image, got {len(image_paths)} for page {page_number} in {page_path}"

--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -23,7 +23,7 @@ from kiln_ai.datamodel.datamodel_enums import ModelProviderName
 from kiln_ai.datamodel.extraction import ExtractorConfig, ExtractorType, Kind
 from kiln_ai.utils.filesystem_cache import FilesystemCache
 from kiln_ai.utils.litellm import get_litellm_provider_info
-from kiln_ai.utils.pdf_utils import split_pdf_into_pages
+from kiln_ai.utils.pdf_utils import convert_pdf_to_images, split_pdf_into_pages
 
 logger = logging.getLogger(__name__)
 
@@ -167,13 +167,35 @@ class LitellmExtractor(BaseExtractor):
         logger.debug(f"Cache miss for page {page_number} of {pdf_path}")
         return None
 
+    async def convert_pdf_page_to_image_input(
+        self, page_path: Path, page_number: int
+    ) -> ExtractionInput:
+        image_paths = convert_pdf_to_images(page_path, page_path.parent)
+        if len(image_paths) != 1:
+            raise ValueError(
+                f"Expected 1 image, got {len(image_paths)} for page {page_number} in {page_path}"
+            )
+        image_path = image_paths[0]
+        page_input = ExtractionInput(path=str(image_path), mime_type="image/png")
+        return page_input
+
     async def _extract_single_pdf_page(
-        self, pdf_path: Path, page_path: Path, prompt: str, page_number: int
+        self,
+        pdf_path: Path,
+        page_path: Path,
+        prompt: str,
+        page_number: int,
     ) -> str:
         try:
-            page_input = ExtractionInput(
-                path=str(page_path), mime_type="application/pdf"
-            )
+            if self.model_provider.multimodal_requires_pdf_as_image:
+                page_input = await self.convert_pdf_page_to_image_input(
+                    page_path, page_number
+                )
+            else:
+                page_input = ExtractionInput(
+                    path=str(page_path), mime_type="application/pdf"
+                )
+
             completion_kwargs = self._build_completion_kwargs(prompt, page_input)
             response = await litellm.acompletion(**completion_kwargs)
         except Exception as e:
@@ -238,7 +260,9 @@ class LitellmExtractor(BaseExtractor):
                     continue
 
                 extract_page_jobs.append(
-                    self._extract_single_pdf_page(pdf_path, page_path, prompt, i)
+                    self._extract_single_pdf_page(
+                        pdf_path, page_path, prompt, page_number=i
+                    )
                 )
                 page_indices_for_jobs.append(i)
 

--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -219,11 +219,6 @@ class LitellmExtractor(BaseExtractor):
             )
 
         content = response.choices[0].message.content
-        if not content:
-            raise ValueError(
-                f"No text returned from extraction model when extracting page {page_number} for {page_path}"
-            )
-
         if self.filesystem_cache is not None:
             # we don't want to fail the whole extraction just because cache write fails
             # as that would block the whole flow

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -125,6 +125,10 @@ class ModelName(str, Enum):
     qwen_2p5_7b = "qwen_2p5_7b"
     qwen_2p5_14b = "qwen_2p5_14b"
     qwen_2p5_72b = "qwen_2p5_72b"
+    qwen_2p5_vl_3b = "qwen_2p5_vl_3b"
+    qwen_2p5_vl_7b = "qwen_2p5_vl_7b"
+    qwen_2p5_vl_32b = "qwen_2p5_vl_32b"
+    qwen_2p5_vl_72b = "qwen_2p5_vl_72b"
     qwq_32b = "qwq_32b"
     deepseek_3_1 = "deepseek_3_1"
     deepseek_3_1_terminus = "deepseek_3_1_terminus"
@@ -219,6 +223,7 @@ class KilnModelProvider(BaseModel):
         suggested_for_doc_extraction: Whether the model is suggested for document extraction
         multimodal_capable: Whether the model supports multimodal inputs (e.g. images, audio, video, PDFs, etc.)
         multimodal_mime_types: The mime types that the model supports for multimodal inputs (e.g. image/jpeg, video/mp4, application/pdf, etc.)
+        multimodal_requires_pdf_as_image: Whether the model requires PDFs to be processed as images
     """
 
     name: ModelProviderName
@@ -242,6 +247,7 @@ class KilnModelProvider(BaseModel):
     suggested_for_doc_extraction: bool = False
     multimodal_capable: bool = False
     multimodal_mime_types: List[str] | None = None
+    multimodal_requires_pdf_as_image: bool = False
 
     # We need a more generalized way to handle custom provider parameters.
     # Making them quite declarative here for now, isolating provider specific logic
@@ -2305,6 +2311,114 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.together_ai,
                 provider_finetune_id="Qwen/Qwen2.5-72B-Instruct",
             ),
+        ],
+    ),
+    # Qwen 2.5 VL 3B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_2p5_vl_3b,
+        friendly_name="Qwen 2.5 VL 3B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen2.5vl:3b",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+                max_parallel_requests=1,
+            ),
+            # openrouter has the model, but annotation format returned by this model is rejected
+            # by litellm internal validation
+        ],
+    ),
+    # Qwen 2.5 VL 7B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_2p5_vl_7b,
+        friendly_name="Qwen 2.5 VL 7B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen2.5vl:7b",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+                max_parallel_requests=1,
+            ),
+            # openrouter has the model, but annotation format returned by this model is rejected
+            # by litellm internal validation
+        ],
+    ),
+    # Qwen 2.5 VL 32B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_2p5_vl_32b,
+        friendly_name="Qwen 2.5 VL 32B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen2.5vl:32b",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+                max_parallel_requests=1,
+            ),
+            # openrouter has the model, but annotation format returned by this model is rejected
+            # by litellm internal validation
+        ],
+    ),
+    # Qwen 2.5 VL 72B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_2p5_vl_72b,
+        friendly_name="Qwen 2.5 VL 72B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen2.5vl:72b",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+                max_parallel_requests=1,
+            ),
+            # openrouter has the model, but annotation format returned by this model is rejected
+            # by litellm internal validation
         ],
     ),
     # Mistral Small 3

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -2248,109 +2248,16 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
-    # Qwen 2.5 7B
+    # Qwen 2.5 VL 72B
     KilnModel(
         family=ModelFamily.qwen,
-        name=ModelName.qwen_2p5_7b,
-        friendly_name="Qwen 2.5 7B",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.openrouter,
-                model_id="qwen/qwen-2.5-7b-instruct",
-                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
-                supports_function_calling=False,
-            ),
-            KilnModelProvider(
-                name=ModelProviderName.ollama,
-                model_id="qwen2.5",
-                supports_function_calling=False,
-            ),
-            KilnModelProvider(
-                name=ModelProviderName.docker_model_runner,
-                model_id="ai/qwen2.5:7B-Q4_K_M",
-                supports_function_calling=False,
-            ),
-        ],
-    ),
-    # Qwen 2.5 14B
-    KilnModel(
-        family=ModelFamily.qwen,
-        name=ModelName.qwen_2p5_14b,
-        friendly_name="Qwen 2.5 14B",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.together_ai,
-                provider_finetune_id="Qwen/Qwen2.5-14B-Instruct",
-            ),
-            KilnModelProvider(
-                name=ModelProviderName.ollama,
-                model_id="qwen2.5:14b",
-                supports_data_gen=False,
-                supports_function_calling=False,
-            ),
-        ],
-    ),
-    # Qwen 2.5 72B
-    KilnModel(
-        family=ModelFamily.qwen,
-        name=ModelName.qwen_2p5_72b,
-        friendly_name="Qwen 2.5 72B",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.openrouter,
-                model_id="qwen/qwen-2.5-72b-instruct",
-                # Not consistent with structure data. Works sometimes but not often
-                supports_structured_output=False,
-                supports_data_gen=False,
-                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
-            ),
-            KilnModelProvider(
-                name=ModelProviderName.ollama,
-                model_id="qwen2.5:72b",
-            ),
-            KilnModelProvider(
-                name=ModelProviderName.together_ai,
-                provider_finetune_id="Qwen/Qwen2.5-72B-Instruct",
-            ),
-        ],
-    ),
-    # Qwen 2.5 VL 3B
-    KilnModel(
-        family=ModelFamily.qwen,
-        name=ModelName.qwen_2p5_vl_3b,
-        friendly_name="Qwen 2.5 VL 3B",
+        name=ModelName.qwen_2p5_vl_72b,
+        friendly_name="Qwen 2.5 VL 72B",
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.ollama,
-                model_id="qwen2.5vl:3b",
-                supports_structured_output=False,
-                supports_function_calling=False,
-                supports_doc_extraction=True,
-                multimodal_capable=True,
-                multimodal_mime_types=[
-                    KilnMimeType.JPG,
-                    KilnMimeType.PNG,
-                    KilnMimeType.PDF,
-                    KilnMimeType.TXT,
-                    KilnMimeType.MD,
-                ],
-                multimodal_requires_pdf_as_image=True,
-                max_parallel_requests=1,
-            ),
-            # openrouter has the model, but annotation format returned by this model is rejected
-            # by litellm internal validation
-        ],
-    ),
-    # Qwen 2.5 VL 7B
-    KilnModel(
-        family=ModelFamily.qwen,
-        name=ModelName.qwen_2p5_vl_7b,
-        friendly_name="Qwen 2.5 VL 7B",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.ollama,
-                model_id="qwen2.5vl:7b",
-                supports_structured_output=False,
+                model_id="qwen2.5vl:72b",
+                structured_output_mode=StructuredOutputMode.json_schema,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
@@ -2366,8 +2273,8 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                model_id="qwen/qwen-2.5-vl-7b-instruct",
-                supports_structured_output=False,
+                model_id="qwen/qwen2.5-vl-72b-instruct",
+                structured_output_mode=StructuredOutputMode.json_schema,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
@@ -2382,8 +2289,8 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.siliconflow_cn,
-                model_id="Pro/Qwen/Qwen2.5-VL-7B-Instruct",
-                supports_structured_output=False,
+                model_id="Qwen/Qwen2.5-VL-72B-Instruct",
+                structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
@@ -2393,6 +2300,23 @@ built_in_models: List[KilnModel] = [
                     KilnMimeType.PDF,
                     KilnMimeType.TXT,
                     KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.together_ai,
+                model_id="Qwen/Qwen2.5-VL-72B-Instruct",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # supports video, but LiteLLM fails request validation
                 ],
                 multimodal_requires_pdf_as_image=True,
             ),
@@ -2471,16 +2395,16 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
-    # Qwen 2.5 VL 72B
+    # Qwen 2.5 VL 7B
     KilnModel(
         family=ModelFamily.qwen,
-        name=ModelName.qwen_2p5_vl_72b,
-        friendly_name="Qwen 2.5 VL 72B",
+        name=ModelName.qwen_2p5_vl_7b,
+        friendly_name="Qwen 2.5 VL 7B",
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.ollama,
-                model_id="qwen2.5vl:72b",
-                structured_output_mode=StructuredOutputMode.json_schema,
+                model_id="qwen2.5vl:7b",
+                supports_structured_output=False,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
@@ -2496,8 +2420,8 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                model_id="qwen/qwen2.5-vl-72b-instruct",
-                structured_output_mode=StructuredOutputMode.json_schema,
+                model_id="qwen/qwen-2.5-vl-7b-instruct",
+                supports_structured_output=False,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
@@ -2512,8 +2436,8 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.siliconflow_cn,
-                model_id="Qwen/Qwen2.5-VL-72B-Instruct",
-                structured_output_mode=StructuredOutputMode.json_instructions,
+                model_id="Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+                supports_structured_output=False,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
@@ -2526,10 +2450,18 @@ built_in_models: List[KilnModel] = [
                 ],
                 multimodal_requires_pdf_as_image=True,
             ),
+        ],
+    ),
+    # Qwen 2.5 VL 3B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_2p5_vl_3b,
+        friendly_name="Qwen 2.5 VL 3B",
+        providers=[
             KilnModelProvider(
-                name=ModelProviderName.together_ai,
-                model_id="Qwen/Qwen2.5-VL-72B-Instruct",
-                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                name=ModelProviderName.ollama,
+                model_id="qwen2.5vl:3b",
+                supports_structured_output=False,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
@@ -2539,9 +2471,75 @@ built_in_models: List[KilnModel] = [
                     KilnMimeType.PDF,
                     KilnMimeType.TXT,
                     KilnMimeType.MD,
-                    # supports video, but LiteLLM fails request validation
                 ],
                 multimodal_requires_pdf_as_image=True,
+                max_parallel_requests=1,
+            ),
+        ],
+    ),
+    # Qwen 2.5 72B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_2p5_72b,
+        friendly_name="Qwen 2.5 72B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen-2.5-72b-instruct",
+                # Not consistent with structure data. Works sometimes but not often
+                supports_structured_output=False,
+                supports_data_gen=False,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen2.5:72b",
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.together_ai,
+                provider_finetune_id="Qwen/Qwen2.5-72B-Instruct",
+            ),
+        ],
+    ),
+    # Qwen 2.5 14B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_2p5_14b,
+        friendly_name="Qwen 2.5 14B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.together_ai,
+                provider_finetune_id="Qwen/Qwen2.5-14B-Instruct",
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen2.5:14b",
+                supports_data_gen=False,
+                supports_function_calling=False,
+            ),
+        ],
+    ),
+    # Qwen 2.5 7B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_2p5_7b,
+        friendly_name="Qwen 2.5 7B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen-2.5-7b-instruct",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_function_calling=False,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.ollama,
+                model_id="qwen2.5",
+                supports_function_calling=False,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.docker_model_runner,
+                model_id="ai/qwen2.5:7B-Q4_K_M",
+                supports_function_calling=False,
             ),
         ],
     ),
@@ -3648,6 +3646,34 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
+    # Qwen 3 235B (22B Active) VL Instruct
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3_vl_235b_a22b_no_thinking,
+        friendly_name="Qwen 3 235B (22B Active) VL Instruct",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3-vl-235b-a22b-instruct",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                formatter=ModelFormatterID.qwen3_style_no_think,
+                supports_data_gen=False,
+                reasoning_capable=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+        ],
+    ),
     # Qwen 3 235B (22B Active) 2507 Version
     KilnModel(
         family=ModelFamily.qwen,
@@ -3822,34 +3848,6 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 siliconflow_enable_thinking=False,
                 supports_data_gen=True,
-            ),
-        ],
-    ),
-    # Qwen 3 235B (22B Active) VL Non-Thinking
-    KilnModel(
-        family=ModelFamily.qwen,
-        name=ModelName.qwen_3_vl_235b_a22b_no_thinking,
-        friendly_name="Qwen 3 235B (22B Active) VL Non-Thinking",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.openrouter,
-                model_id="qwen/qwen3-vl-235b-a22b-instruct",
-                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
-                formatter=ModelFormatterID.qwen3_style_no_think,
-                supports_data_gen=False,
-                reasoning_capable=False,
-                supports_doc_extraction=True,
-                multimodal_capable=True,
-                multimodal_mime_types=[
-                    # images
-                    KilnMimeType.JPG,
-                    KilnMimeType.PNG,
-                    # documents
-                    KilnMimeType.PDF,
-                    KilnMimeType.TXT,
-                    KilnMimeType.MD,
-                ],
-                multimodal_requires_pdf_as_image=True,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -170,6 +170,7 @@ class ModelName(str, Enum):
     qwen_3_235b_a22b = "qwen_3_235b_a22b"
     qwen_3_235b_a22b_2507_no_thinking = "qwen_3_235b_a22b_2507_no_thinking"
     qwen_3_235b_a22b_no_thinking = "qwen_3_235b_a22b_no_thinking"
+    qwen_3_vl_235b_a22b_no_thinking = "qwen_3_vl_235b_a22b_no_thinking"
     qwen_long_l1_32b = "qwen_long_l1_32b"
     kimi_k2 = "kimi_k2"
     kimi_k2_0905 = "kimi_k2_0905"
@@ -2322,7 +2323,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.ollama,
                 model_id="qwen2.5vl:3b",
-                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_structured_output=False,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
@@ -2349,7 +2350,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.ollama,
                 model_id="qwen2.5vl:7b",
-                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_structured_output=False,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
@@ -2363,8 +2364,38 @@ built_in_models: List[KilnModel] = [
                 multimodal_requires_pdf_as_image=True,
                 max_parallel_requests=1,
             ),
-            # openrouter has the model, but annotation format returned by this model is rejected
-            # by litellm internal validation
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen-2.5-vl-7b-instruct",
+                supports_structured_output=False,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.siliconflow_cn,
+                model_id="Pro/Qwen/Qwen2.5-VL-7B-Instruct",
+                supports_structured_output=False,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
         ],
     ),
     # Qwen 2.5 VL 32B
@@ -2390,8 +2421,54 @@ built_in_models: List[KilnModel] = [
                 multimodal_requires_pdf_as_image=True,
                 max_parallel_requests=1,
             ),
-            # openrouter has the model, but annotation format returned by this model is rejected
-            # by litellm internal validation
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen2.5-vl-32b-instruct",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.siliconflow_cn,
+                model_id="Qwen/Qwen2.5-VL-32B-Instruct",
+                structured_output_mode=StructuredOutputMode.json_instructions,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                model_id="accounts/fireworks/models/qwen2p5-vl-32b-instruct",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
         ],
     ),
     # Qwen 2.5 VL 72B
@@ -2417,8 +2494,55 @@ built_in_models: List[KilnModel] = [
                 multimodal_requires_pdf_as_image=True,
                 max_parallel_requests=1,
             ),
-            # openrouter has the model, but annotation format returned by this model is rejected
-            # by litellm internal validation
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen2.5-vl-72b-instruct",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.siliconflow_cn,
+                model_id="Qwen/Qwen2.5-VL-72B-Instruct",
+                structured_output_mode=StructuredOutputMode.json_instructions,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.together_ai,
+                model_id="Qwen/Qwen2.5-VL-72B-Instruct",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # supports video, but LiteLLM fails request validation
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
         ],
     ),
     # Mistral Small 3
@@ -3698,6 +3822,34 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 siliconflow_enable_thinking=False,
                 supports_data_gen=True,
+            ),
+        ],
+    ),
+    # Qwen 3 235B (22B Active) VL Non-Thinking
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3_vl_235b_a22b_no_thinking,
+        friendly_name="Qwen 3 235B (22B Active) VL Non-Thinking",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3-vl-235b-a22b-instruct",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                formatter=ModelFormatterID.qwen3_style_no_think,
+                supports_data_gen=False,
+                reasoning_capable=False,
+                supports_doc_extraction=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/utils/pdf_utils.py
+++ b/libs/core/kiln_ai/utils/pdf_utils.py
@@ -39,7 +39,7 @@ async def split_pdf_into_pages(pdf_path: Path) -> AsyncGenerator[list[Path], Non
         yield page_paths
 
 
-def convert_pdf_to_images(pdf_path: Path, output_dir: Path) -> list[Path]:
+async def convert_pdf_to_images(pdf_path: Path, output_dir: Path) -> list[Path]:
     image_paths = []
 
     # note: doing this in a thread causes a segfault - but this is slow and blocking
@@ -47,6 +47,7 @@ def convert_pdf_to_images(pdf_path: Path, output_dir: Path) -> list[Path]:
     pdf = pypdfium2.PdfDocument(pdf_path)
     try:
         for idx, page in enumerate(pdf):
+            await asyncio.sleep(0)
             # scale=2 is legible for ~A4 pages (research papers, etc.) - lower than this is blurry
             bitmap = page.render(scale=2).to_pil()
             target_path = output_dir / f"img-{pdf_path.name}-{idx}.png"

--- a/libs/core/kiln_ai/utils/test_pdf_utils.py
+++ b/libs/core/kiln_ai/utils/test_pdf_utils.py
@@ -80,7 +80,7 @@ async def test_convert_pdf_to_images(mock_file_factory):
     """Test that convert_pdf_to_images successfully converts a PDF into individual images."""
     test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
     with tempfile.TemporaryDirectory() as temp_dir:
-        images = convert_pdf_to_images(test_file, Path(temp_dir))
+        images = await convert_pdf_to_images(test_file, Path(temp_dir))
         assert len(images) == 2
         assert all(image.exists() for image in images)
         assert all(image.suffix == ".png" for image in images)

--- a/libs/core/kiln_ai/utils/test_pdf_utils.py
+++ b/libs/core/kiln_ai/utils/test_pdf_utils.py
@@ -1,8 +1,11 @@
+import tempfile
+from pathlib import Path
+
 import pytest
 from pypdf import PdfReader
 
 from conftest import MockFileFactoryMimeType
-from kiln_ai.utils.pdf_utils import split_pdf_into_pages
+from kiln_ai.utils.pdf_utils import convert_pdf_to_images, split_pdf_into_pages
 
 
 async def test_split_pdf_into_pages_success(mock_file_factory):
@@ -71,3 +74,13 @@ async def test_split_pdf_into_pages_temporary_directory_creation(mock_file_facto
     # Verify the temporary directory is cleaned up
     for temp_dir in captured_temp_dirs:
         assert not temp_dir.exists()
+
+
+async def test_convert_pdf_to_images(mock_file_factory):
+    """Test that convert_pdf_to_images successfully converts a PDF into individual images."""
+    test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        images = convert_pdf_to_images(test_file, Path(temp_dir))
+        assert len(images) == 2
+        assert all(image.exists() for image in images)
+        assert all(image.suffix == ".png" for image in images)

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
     "llama-index-vector-stores-lancedb>=0.3.3",
     "llama-index>=0.13.3",
     "anyio>=4.10.0",
+    "pypdfium2>=4.30.0",
+    "pillow>=11.1.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -1211,8 +1211,10 @@ dependencies = [
     { name = "llama-index-vector-stores-lancedb" },
     { name = "openai" },
     { name = "pdoc" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "pypdf" },
+    { name = "pypdfium2" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pyyaml" },
@@ -1246,8 +1248,10 @@ requires-dist = [
     { name = "llama-index-vector-stores-lancedb", specifier = ">=0.3.3" },
     { name = "openai", specifier = ">=1.53.0" },
     { name = "pdoc", specifier = ">=15.0.0" },
+    { name = "pillow", specifier = ">=11.1.0" },
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "pypdf", specifier = ">=6.0.0" },
+    { name = "pypdfium2", specifier = ">=4.30.0" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -2598,6 +2602,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/ac/a300a03c3b34967c050677ccb16e7a4b65607ee5df9d51e8b6d713de4098/pypdf-6.0.0.tar.gz", hash = "sha256:282a99d2cc94a84a3a3159f0d9358c0af53f85b4d28d76ea38b96e9e5ac2a08d", size = 5033827, upload-time = "2025-08-11T14:22:02.352Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/83/2cacc506eb322bb31b747bc06ccb82cc9aa03e19ee9c1245e538e49d52be/pypdf-6.0.0-py3-none-any.whl", hash = "sha256:56ea60100ce9f11fc3eec4f359da15e9aec3821b036c1f06d2b660d35683abb8", size = 310465, upload-time = "2025-08-11T14:22:00.481Z" },
+]
+
+[[package]]
+name = "pypdfium2"
+version = "4.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/14/838b3ba247a0ba92e4df5d23f2bea9478edcfd72b78a39d6ca36ccd84ad2/pypdfium2-4.30.0.tar.gz", hash = "sha256:48b5b7e5566665bc1015b9d69c1ebabe21f6aee468b509531c3c8318eeee2e16", size = 140239, upload-time = "2024-05-09T18:33:17.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9a/c8ff5cc352c1b60b0b97642ae734f51edbab6e28b45b4fcdfe5306ee3c83/pypdfium2-4.30.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:b33ceded0b6ff5b2b93bc1fe0ad4b71aa6b7e7bd5875f1ca0cdfb6ba6ac01aab", size = 2837254, upload-time = "2024-05-09T18:32:48.653Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8b/27d4d5409f3c76b985f4ee4afe147b606594411e15ac4dc1c3363c9a9810/pypdfium2-4.30.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4e55689f4b06e2d2406203e771f78789bd4f190731b5d57383d05cf611d829de", size = 2707624, upload-time = "2024-05-09T18:32:51.458Z" },
+    { url = "https://files.pythonhosted.org/packages/11/63/28a73ca17c24b41a205d658e177d68e198d7dde65a8c99c821d231b6ee3d/pypdfium2-4.30.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e6e50f5ce7f65a40a33d7c9edc39f23140c57e37144c2d6d9e9262a2a854854", size = 2793126, upload-time = "2024-05-09T18:32:53.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/53b3ebf0955edbd02ac6da16a818ecc65c939e98fdeb4e0958362bd385c8/pypdfium2-4.30.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3d0dd3ecaffd0b6dbda3da663220e705cb563918249bda26058c6036752ba3a2", size = 2591077, upload-time = "2024-05-09T18:32:55.99Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ee/0394e56e7cab8b5b21f744d988400948ef71a9a892cbeb0b200d324ab2c7/pypdfium2-4.30.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc3bf29b0db8c76cdfaac1ec1cde8edf211a7de7390fbf8934ad2aa9b4d6dfad", size = 2864431, upload-time = "2024-05-09T18:32:57.911Z" },
+    { url = "https://files.pythonhosted.org/packages/65/cd/3f1edf20a0ef4a212a5e20a5900e64942c5a374473671ac0780eaa08ea80/pypdfium2-4.30.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1f78d2189e0ddf9ac2b7a9b9bd4f0c66f54d1389ff6c17e9fd9dc034d06eb3f", size = 2812008, upload-time = "2024-05-09T18:32:59.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/91/2d517db61845698f41a2a974de90762e50faeb529201c6b3574935969045/pypdfium2-4.30.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5eda3641a2da7a7a0b2f4dbd71d706401a656fea521b6b6faa0675b15d31a163", size = 6181543, upload-time = "2024-05-09T18:33:02.597Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c4/ed1315143a7a84b2c7616569dfb472473968d628f17c231c39e29ae9d780/pypdfium2-4.30.0-py3-none-musllinux_1_1_i686.whl", hash = "sha256:0dfa61421b5eb68e1188b0b2231e7ba35735aef2d867d86e48ee6cab6975195e", size = 6175911, upload-time = "2024-05-09T18:33:05.376Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c4/9e62d03f414e0e3051c56d5943c3bf42aa9608ede4e19dc96438364e9e03/pypdfium2-4.30.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:f33bd79e7a09d5f7acca3b0b69ff6c8a488869a7fab48fdf400fec6e20b9c8be", size = 6267430, upload-time = "2024-05-09T18:33:08.067Z" },
+    { url = "https://files.pythonhosted.org/packages/90/47/eda4904f715fb98561e34012826e883816945934a851745570521ec89520/pypdfium2-4.30.0-py3-none-win32.whl", hash = "sha256:ee2410f15d576d976c2ab2558c93d392a25fb9f6635e8dd0a8a3a5241b275e0e", size = 2775951, upload-time = "2024-05-09T18:33:10.567Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bd/56d9ec6b9f0fc4e0d95288759f3179f0fcd34b1a1526b75673d2f6d5196f/pypdfium2-4.30.0-py3-none-win_amd64.whl", hash = "sha256:90dbb2ac07be53219f56be09961eb95cf2473f834d01a42d901d13ccfad64b4c", size = 2892098, upload-time = "2024-05-09T18:33:13.107Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7a/097801205b991bc3115e8af1edb850d30aeaf0118520b016354cf5ccd3f6/pypdfium2-4.30.0-py3-none-win_arm64.whl", hash = "sha256:119b2969a6d6b1e8d55e99caaf05290294f2d0fe49c12a3f17102d01c441bd29", size = 2752118, upload-time = "2024-05-09T18:33:15.489Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Add new extractor models across different providers. As some of the new extractor models (Qwen VL) do not support PDF natively, they first need to be converted into images first - we use `pypdfium2` for this - we do the normal page-by-page pipeline, but convert the page into an image before sending it to the model based on a new model provider property named `multimodal_requires_pdf_as_image`.

Also add a template for all local extraction + embedding with Ollama.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Provider-based setup for search tool templates (OpenAI, Google Gemini, Ollama) and unified provider checks.
  - Ollama flow with a dedicated dialog showing required local models/commands and guided navigation.
  - Added “Local Qwen” template for Ollama/local usage.
  - PDFs can be processed as images when a model requires image input.
  - Expanded model catalog with multiple Qwen VL variants (including a non-thinking option).

- **Tests**
  - Added tests for PDF→image conversion, per-page image-based extraction, caching, and error scenarios.

- **Chores**
  - Added runtime dependencies for PDF rendering and image processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->