### PR TITLE
Add simple session caching for remote mcp server

### DIFF
--- a/app/desktop/desktop_server.py
+++ b/app/desktop/desktop_server.py
@@ -11,6 +11,7 @@ import kiln_server.server as kiln_server
 import uvicorn
 from fastapi import FastAPI
 from kiln_ai.adapters.remote_config import load_remote_models
+from kiln_ai.tools.mcp_session_manager import MCPSessionManager
 from kiln_ai.utils.logging import setup_litellm_logging
 
 from app.desktop.log_config import log_config
@@ -44,6 +45,10 @@ async def lifespan(app: FastAPI):
     original_strict_mode = datamodel_strict_mode.strict_mode()
     datamodel_strict_mode.set_strict_mode(True)
     yield
+
+    # Close all MCP server sessions
+    await MCPSessionManager.shared()._session_cache.close_all()
+
     # Reset datamodel strict mode on shutdown
     datamodel_strict_mode.set_strict_mode(original_strict_mode)
 

--- a/app/desktop/studio_server/test_tool_api.py
+++ b/app/desktop/studio_server/test_tool_api.py
@@ -71,8 +71,9 @@ async def mock_mcp_success(tools=None):
     patch_obj, mock_client = create_mcp_session_manager_patch(mock_tools=tools)
 
     with patch_obj as mock_session_manager_shared:
-        mock_session_manager = Mock()
+        mock_session_manager = AsyncMock()
         mock_session_manager.mcp_client = mock_client
+        mock_session_manager.clear_shell_path_cache = Mock()
         mock_session_manager_shared.return_value = mock_session_manager
         yield
 
@@ -84,8 +85,9 @@ async def mock_mcp_connection_error(error_message="Connection failed"):
     patch_obj, mock_client = create_mcp_session_manager_patch(connection_error=error)
 
     with patch_obj as mock_session_manager_shared:
-        mock_session_manager = Mock()
+        mock_session_manager = AsyncMock()
         mock_session_manager.mcp_client = mock_client
+        mock_session_manager.clear_shell_path_cache = Mock()
         mock_session_manager_shared.return_value = mock_session_manager
         yield
 
@@ -97,8 +99,9 @@ async def mock_mcp_list_tools_error(error_message="list_tools failed"):
     patch_obj, mock_client = create_mcp_session_manager_patch(list_tools_error=error)
 
     with patch_obj as mock_session_manager_shared:
-        mock_session_manager = Mock()
+        mock_session_manager = AsyncMock()
         mock_session_manager.mcp_client = mock_client
+        mock_session_manager.clear_shell_path_cache = Mock()
         mock_session_manager_shared.return_value = mock_session_manager
         yield
 

--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -356,6 +356,9 @@ def connect_tool_servers_api(app: FastAPI):
         # Validate the tool server connectivity
         await validate_tool_server_connectivity(existing_tool_server)
 
+        # Remove cached session if any
+        await MCPSessionManager.shared().invalidate_session(tool_server_id)
+
         # Save the tool to file
         existing_tool_server.save_to_file()
 
@@ -415,6 +418,9 @@ def connect_tool_servers_api(app: FastAPI):
         MCPSessionManager.shared().clear_shell_path_cache()
         await validate_tool_server_connectivity(tool_server)
 
+        # Remove cached session if any
+        await MCPSessionManager.shared().invalidate_session(tool_server_id)
+
         # Save the tool to file
         tool_server.save_to_file()
 
@@ -433,6 +439,8 @@ def connect_tool_servers_api(app: FastAPI):
     @app.delete("/api/projects/{project_id}/tool_servers/{tool_server_id}")
     async def delete_tool_server(project_id: str, tool_server_id: str):
         tool_server = tool_server_from_id(project_id, tool_server_id)
+        # Close and remove the cached session
+        await MCPSessionManager.shared().invalidate_session(tool_server_id)
         # Delete the secrets from the settings
         tool_server.delete_secrets()
         # Delete the tool server from the file system

--- a/libs/core/kiln_ai/tools/mcp_session_cache.py
+++ b/libs/core/kiln_ai/tools/mcp_session_cache.py
@@ -1,0 +1,63 @@
+import asyncio
+
+from mcp.client.session import ClientSession
+
+from kiln_ai.utils.logging import logging
+
+logger = logging.getLogger(__name__)
+
+
+class MCPSessionCache:
+    """
+    Simple cache for MCP ClientSession by ExternalToolServer ID.
+
+    This cache provides manual lifecycle management - sessions must be
+    explicitly closed via close_session() or close_all(). Sessions remain alive until explicitly
+    removed or cleared.
+    """
+
+    def __init__(self):
+        self._sessions: dict[str, ClientSession] = {}
+        self._lock = asyncio.Lock()
+
+    async def _cleanup_session(self, session: ClientSession) -> None:
+        """Helper to clean up a session"""
+        try:
+            await session.__aexit__(None, None, None)
+        except Exception as e:
+            # Ignore errors during cleanup so we don't cause MCPSessionManager to throw
+            logger.error(f"Error cleaning up ClientSession: {e}")
+            pass
+
+    async def get(self, server_id: str) -> ClientSession | None:
+        async with self._lock:
+            return self._sessions.get(server_id)
+
+    async def set(self, server_id: str, session: ClientSession) -> None:
+        # Close old session if it exists to prevent memory leak
+        async with self._lock:
+            old_session = self._sessions.get(server_id)
+            self._sessions[server_id] = session
+
+        # Clean up old session, no lock needed
+        if old_session is not None:
+            await self._cleanup_session(old_session)
+
+    async def close_session(self, server_id: str) -> None:
+        """
+        Close and remove a specific session from the cache.
+        """
+        async with self._lock:
+            session = self._sessions.pop(server_id, None)
+
+        if session is not None:
+            await self._cleanup_session(session)
+
+    async def close_all(self) -> None:
+        """
+        Close all cached sessions and clear the cache.
+        """
+        # Get all server IDs first since close_session modifies the cache dictionary
+        server_ids = list(self._sessions.keys())
+        for server_id in server_ids:
+            await self.close_session(server_id)

--- a/libs/core/kiln_ai/tools/test_mcp_session_cache.py
+++ b/libs/core/kiln_ai/tools/test_mcp_session_cache.py
@@ -1,0 +1,133 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from kiln_ai.tools.mcp_session_cache import MCPSessionCache
+
+
+@pytest.fixture
+def cache():
+    return MCPSessionCache()
+
+
+def create_mock_session(close_side_effect=None):
+    """Create a mock ClientSession with optional close error."""
+    session = Mock()
+    session.__aexit__ = AsyncMock(side_effect=close_side_effect)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_cache_initialization(cache):
+    """Test that cache initializes empty."""
+    assert await cache.get("any-id") is None
+
+
+@pytest.mark.asyncio
+async def test_set_and_get(cache):
+    """Test storing and retrieving a session."""
+    session = create_mock_session()
+    await cache.set("test-server-1", session)
+    assert await cache.get("test-server-1") is session
+
+
+@pytest.mark.asyncio
+async def test_set_multiple_sessions(cache):
+    """Test storing multiple sessions."""
+    session1 = create_mock_session()
+    session2 = create_mock_session()
+
+    await cache.set("server-1", session1)
+    await cache.set("server-2", session2)
+
+    assert await cache.get("server-1") is session1
+    assert await cache.get("server-2") is session2
+
+
+@pytest.mark.asyncio
+async def test_set_overwrites_existing(cache):
+    """Test that setting a session with same ID overwrites and closes old session."""
+    server_id = "test-server"
+    session1 = create_mock_session()
+    session2 = create_mock_session()
+
+    await cache.set(server_id, session1)
+    await cache.set(server_id, session2)
+
+    assert await cache.get(server_id) is session2
+    # Old session should be closed to prevent memory leak
+    session1.__aexit__.assert_called_once_with(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_close_session(cache):
+    """Test closing a specific session."""
+    session = create_mock_session()
+    server_id = "test-server"
+
+    await cache.set(server_id, session)
+    await cache.close_session(server_id)
+
+    assert await cache.get(server_id) is None
+    session.__aexit__.assert_called_once_with(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_close_session_ignores_errors(cache):
+    """Test that close_session ignores errors during cleanup."""
+    session = create_mock_session(Exception("Close failed"))
+
+    server_id = "test-server"
+    await cache.set(server_id, session)
+
+    # Should not raise
+    await cache.close_session(server_id)
+
+    assert await cache.get(server_id) is None
+    session.__aexit__.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_close_all(cache):
+    """Test closing all sessions."""
+    session1 = create_mock_session()
+    session2 = create_mock_session()
+
+    await cache.set("server-1", session1)
+    await cache.set("server-2", session2)
+
+    await cache.close_all()
+
+    assert await cache.get("server-1") is None
+    assert await cache.get("server-2") is None
+    session1.__aexit__.assert_called_once()
+    session2.__aexit__.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_close_session_nonexistent(cache):
+    """Test closing a session that doesn't exist does nothing."""
+    # Should not raise
+    await cache.close_session("nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_operations_no_race_condition(cache):
+    """Test that concurrent operations don't cause race condition."""
+
+    async def mixed_operations(i: int):
+        # Mix of get, set, and close operations
+        session = create_mock_session()
+        await cache.set(f"server-{i}", session)
+        retrieved = await cache.get(f"server-{i}")
+        assert retrieved is session
+        return session
+
+    # Launch concurrent operations 10 times
+    tasks = [mixed_operations(i) for i in range(10)]
+    sessions = await asyncio.gather(*tasks)
+
+    # Verify final state is consistent
+    for i, session in enumerate(sessions):
+        assert await cache.get(f"server-{i}") is session

--- a/libs/core/kiln_ai/tools/test_mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/test_mcp_session_manager.py
@@ -104,6 +104,11 @@ def local_server_with_secret_keys():
 class TestMCPSessionManager:
     """Unit tests for MCPSessionManager."""
 
+    def setup_method(self):
+        """Reset the singleton before each test to ensure isolation."""
+        # Reset the singleton to ensure clean state for each test
+        MCPSessionManager._shared_instance = None
+
     def test_singleton_behavior(self):
         """Test that MCPSessionManager follows singleton pattern."""
         # Get two instances


### PR DESCRIPTION
## What does this PR do?

Add simple session caching for remote mcp server. This would prevent spawning new processes for every tool call. 

* Caching is only done for local mcp, remote mcp via http is ephemeral. 
* Currently we don't support TTL (time-to-live) cache or other self clean up mechanisms. Clients are required to manually clean up the sessions. It's done at the following places
   * app shutdown
   * delete / edit tool server

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib
