### PR TITLE
Tasks as tools links to Multi-Actor Interaction (aka sub-tasks) instead of general Agents page

### DIFF
--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/kiln_task/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/kiln_task/[tool_server_id]/+page.svelte
@@ -340,7 +340,7 @@
     title={"Kiln Task as Tool"}
     subtitle={`Name: ${tool_server?.name || ""}`}
     sub_subtitle="Read the Docs"
-    sub_subtitle_link="https://docs.kiln.tech/docs/agents"
+    sub_subtitle_link="https://docs.kiln.tech/docs/agents#multi-actor-interaction-aka-sub-tasks"
     breadcrumbs={[
       {
         label: "Settings",

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/kiln_task_tools/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/kiln_task_tools/+page.svelte
@@ -66,7 +66,7 @@
     title="Manage Kiln Tasks as Tools"
     subtitle="Allow your tasks to call another Kiln task, as a tool call."
     sub_subtitle="Read the Docs"
-    sub_subtitle_link="https://docs.kiln.tech/docs/agents"
+    sub_subtitle_link="https://docs.kiln.tech/docs/agents#multi-actor-interaction-aka-sub-tasks"
     breadcrumbs={[
       {
         label: "Settings",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - None

- Documentation
  - Updated in-app documentation links in Settings > Manage Tools for Kiln Task and Kiln Task Tools pages to point directly to the “Multi-actor interaction (aka sub-tasks)” section, improving navigation to relevant guidance.

- Chores
  - Minor URL fragment adjustments to documentation links; no functional changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->