### PR TITLE
Tasks as tools link updates

### DIFF
--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/kiln_task/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/add_tools/kiln_task/+page.svelte
@@ -8,7 +8,7 @@
   title="Create Tool from Kiln Task"
   subtitle="Allow your tasks to call another Kiln task, as a tool call."
   sub_subtitle="Read the Docs"
-  sub_subtitle_link="https://docs.kiln.tech/docs/tools-and-mcp#connecting-kiln-tasks"
+  sub_subtitle_link="https://docs.kiln.tech/docs/agents#multi-actor-interaction-aka-subtasks"
   breadcrumbs={[
     {
       label: "Settings",

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/kiln_task/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/kiln_task/[tool_server_id]/+page.svelte
@@ -340,7 +340,7 @@
     title={"Kiln Task as Tool"}
     subtitle={`Name: ${tool_server?.name || ""}`}
     sub_subtitle="Read the Docs"
-    sub_subtitle_link="https://docs.kiln.tech/docs/agents#multi-actor-interaction-aka-sub-tasks"
+    sub_subtitle_link="https://docs.kiln.tech/docs/agents#multi-actor-interaction-aka-subtasks"
     breadcrumbs={[
       {
         label: "Settings",

--- a/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/kiln_task_tools/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_tools/[project_id]/kiln_task_tools/+page.svelte
@@ -66,7 +66,7 @@
     title="Manage Kiln Tasks as Tools"
     subtitle="Allow your tasks to call another Kiln task, as a tool call."
     sub_subtitle="Read the Docs"
-    sub_subtitle_link="https://docs.kiln.tech/docs/agents#multi-actor-interaction-aka-sub-tasks"
+    sub_subtitle_link="https://docs.kiln.tech/docs/agents#multi-actor-interaction-aka-subtasks"
     breadcrumbs={[
       {
         label: "Settings",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the “Read the Docs” link across Kiln Task Tool pages to point to the multi-actor interaction (subtasks) section.
  - Replaced outdated hyphenated anchors with the correct non-hyphenated variant, ensuring consistent and accurate documentation links.
  - Applied updates on Add Tool, Tool Settings, and Tool List pages; no changes to functionality or data behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->