### PR TITLE
Strip whitespace from descriptions of tools

### DIFF
--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -190,7 +190,7 @@ async def available_mcp_tools(
             ToolApiDescription(
                 id=f"{prefix}{server.id}::{tool.name}",
                 name=tool.name,
-                description=tool.description.strip() if tool.description else None,
+                description=tool.description,
             )
             for tool in tools_result.tools
         ]

--- a/app/web_ui/src/lib/ui/run_config_component/tools_selector.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/tools_selector.svelte
@@ -113,7 +113,9 @@
             ...tools.map((tool) => ({
               value: tool.id,
               label: tool.name,
-              description: tool.description || undefined,
+              description: tool.description
+                ? tool.description.trim()
+                : undefined,
             })),
           )
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool descriptions now display without leading or trailing whitespace.
  * Empty or missing descriptions are handled gracefully and no longer appear as blank or misleading entries.
  * Improves readability and consistency in tool listings for a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->