### PR TITLE
taller input for plaintext

### DIFF
--- a/app/web_ui/src/routes/(app)/run/run_input_form.svelte
+++ b/app/web_ui/src/routes/(app)/run/run_input_form.svelte
@@ -90,6 +90,7 @@
   <FormElement
     label="Plaintext Input"
     inputType="textarea"
+    tall={true}
     {id}
     bind:value={plaintext_input}
   />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Increased the default height of the plaintext input area in the Run Input form to improve readability and comfort when entering longer text.
  - Reduces the need for manual resizing and excessive scrolling while typing.
  - No changes to data handling, validation, or interaction behavior; all existing workflows remain intact.
  - Layout and responsiveness are preserved across devices, ensuring a consistent appearance without affecting other UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->