### PR TITLE
fix: kiln tool interface run method change

### DIFF
--- a/libs/core/kiln_ai/tools/rag_tools.py
+++ b/libs/core/kiln_ai/tools/rag_tools.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TypedDict
 
 from pydantic import BaseModel
 
@@ -18,7 +18,7 @@ from kiln_ai.datamodel.project import Project
 from kiln_ai.datamodel.rag import RagConfig
 from kiln_ai.datamodel.tool_id import ToolId
 from kiln_ai.datamodel.vector_store import VectorStoreConfig, VectorStoreType
-from kiln_ai.tools.base_tool import KilnToolInterface
+from kiln_ai.tools.base_tool import KilnToolInterface, ToolCallContext
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 
 
@@ -44,6 +44,10 @@ def format_search_results(search_results: List[SearchResult]) -> str:
             )
         )
     return "\n=========\n".join([result.serialize() for result in results])
+
+
+class RagParams(TypedDict):
+    query: str
 
 
 class RagTool(KilnToolInterface):
@@ -126,7 +130,10 @@ class RagTool(KilnToolInterface):
             },
         }
 
-    async def run(self, query: str) -> str:
+    async def run(self, context: ToolCallContext | None = None, **kwargs) -> str:
+        kwargs = RagParams(**kwargs)
+        query = kwargs["query"]
+
         _, embedding_adapter = self.embedding
 
         vector_store_adapter = await self.vector_store()
@@ -152,6 +159,6 @@ class RagTool(KilnToolInterface):
             store_query.query_embedding = query_embedding_result.embeddings[0].vector
 
         search_results = await vector_store_adapter.search(store_query)
-        context = format_search_results(search_results)
+        search_results_as_text = format_search_results(search_results)
 
-        return context
+        return search_results_as_text


### PR DESCRIPTION
## What does this PR do?

Fix: broken `RagTool` implementation due to interface change that (silently) broke this class' `run` method. Details below - might want to figure out a way to trigger a typing error if the method prototype changes.

Compiler does not catch the invalid implementation / override because it is in `basic` mode (but `strict` causes a billion typing errors). The `"reportIncompatibleMethodOverride": "error",` option can be used, but causes some other errors elsewhere. Will do in another PR.

---

The `run` method in the `KilnToolInterface` changed from:
```py
@abstractmethod
async def run(self, **kwargs) -> Any:
    """Execute the tool with the given parameters."""
    pass
```

to:
```py
@abstractmethod
async def run(self, context: ToolCallContext | None = None, **kwargs) -> Any:
    """Execute the tool with the given parameters and calling context if provided."""
    pass
```

The `RagTool(KilnToolInterface)` implemented the interface as follows - and was not updated after the interface change:
```py
async def run(self, query: str) -> str:
    ...
```

This caused the function to be called with `RagTool.run(context=None, query=xxx)`, which then caused:
```
TypeError: RagTool.run() got multiple values for argument 'query'
```

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RAG tool supports optional context-aware execution for richer, tailored results.
  * Returns consolidated plain-text search results for easier consumption.

* **Refactor**
  * RAG tool API updated: callers should provide query as a named argument; positional-only usage may be impacted.
  * Improved input validation with clearer errors when query is missing.

* **Tests**
  * Added tests covering context handling and query validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->