### PR TITLE
feat: allow picking tags when uploading documents

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -437,6 +437,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/projects/{project_id}/documents/tag_counts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Document Tag Counts */
+        get: operations["get_document_tag_counts_api_projects__project_id__documents_tag_counts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/projects/{project_id}/documents/{document_id}": {
         parameters: {
             query?: never;
@@ -6081,6 +6098,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": string[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_document_tag_counts_api_projects__project_id__documents_tag_counts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: number;
+                    };
                 };
             };
             /** @description Validation Error */

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1986,6 +1986,8 @@ export interface components {
             files?: string[] | null;
             /** Names */
             names?: string[] | null;
+            /** Tags */
+            tags?: string[] | null;
         };
         /** Body_edit_tags_api_projects__project_id__documents_edit_tags_post */
         Body_edit_tags_api_projects__project_id__documents_edit_tags_post: {

--- a/app/web_ui/src/lib/stores/document_tag_store.ts
+++ b/app/web_ui/src/lib/stores/document_tag_store.ts
@@ -1,0 +1,83 @@
+import { writable } from "svelte/store"
+import { client } from "$lib/api_client"
+import { get } from "svelte/store"
+
+export type DocumentTagCounts = Record<string, number>
+
+export const document_tag_store_by_project_id = writable<
+  Record<string, DocumentTagCounts>
+>({})
+
+const loading_document_tags = writable<Record<string, boolean>>({})
+
+export async function load_document_tags(
+  project_id: string,
+): Promise<DocumentTagCounts> {
+  try {
+    // Return early if already loading
+    if (get(loading_document_tags)[project_id]) {
+      return {}
+    }
+    loading_document_tags.set({
+      ...get(loading_document_tags),
+      [project_id]: true,
+    })
+
+    // Check if tags are already loaded
+    const existing_tag_counts = get(document_tag_store_by_project_id)[
+      project_id
+    ]
+    if (existing_tag_counts) {
+      return existing_tag_counts
+    }
+    const { data, error } = await client.GET(
+      "/api/projects/{project_id}/documents/tag_counts",
+      {
+        params: {
+          path: { project_id },
+        },
+      },
+    )
+    if (error) {
+      console.error("Error loading document tags", error)
+      return {}
+    }
+    const tag_counts: DocumentTagCounts = data
+    document_tag_store_by_project_id.set({
+      ...get(document_tag_store_by_project_id),
+      [project_id]: tag_counts,
+    })
+    return tag_counts
+  } catch (error: unknown) {
+    console.error("Error loading document tags", error)
+    return {}
+  } finally {
+    loading_document_tags.set({
+      ...get(loading_document_tags),
+      [project_id]: false,
+    })
+  }
+}
+
+export function increment_document_tag(
+  project_id: string,
+  tag: string,
+): DocumentTagCounts {
+  const tag_counts = get(document_tag_store_by_project_id)[project_id]
+  if (!tag_counts) {
+    console.error(
+      "Attempted to increment a document tag, but no tag counts found for project",
+      project_id,
+    )
+    return {}
+  }
+
+  if (tag_counts) {
+    tag_counts[tag] = (tag_counts[tag] || 0) + 1
+  }
+  document_tag_store_by_project_id.set({
+    ...get(document_tag_store_by_project_id),
+    [project_id]: tag_counts,
+  })
+  return tag_counts
+}

--- a/app/web_ui/src/lib/ui/tag_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/tag_dropdown.svelte
@@ -4,8 +4,12 @@
     load_tags,
     tag_store_by_task_id,
     increment_tag as increment_task_tag,
-    type TagCounts,
   } from "$lib/stores/tag_store"
+  import {
+    load_document_tags,
+    document_tag_store_by_project_id,
+    increment_document_tag,
+  } from "$lib/stores/document_tag_store"
 
   export let project_id: string | null = null
   export let task_id: string | null = null
@@ -13,7 +17,8 @@
   export let on_select: (tag: string) => void = () => {}
   export let on_escape: () => void = () => {}
   export let focus_on_mount: boolean = false
-  export let example_tag_set: "task_run" | "doc" = "task_run"
+  type ExampleTagSet = "task_run" | "doc"
+  export let example_tag_set: ExampleTagSet = "task_run"
   let error: string | null = null
   let id = crypto.randomUUID()
   let datalist_id = `${id}_options`
@@ -32,14 +37,14 @@
     } else if (tag.includes(" ")) {
       error = "Tags cannot contain spaces. Use underscores."
     } else {
-      increment_tag_set(task_id, tag)
+      increment_tag_set(tag)
       on_select(tag)
       error = null
     }
   }
 
   // Update the in memory set dynamically, as reloading requires full scan of project.
-  function increment_tag_set(task_id: string | null, tag: string) {
+  function increment_tag_set(tag: string) {
     switch (example_tag_set) {
       case "task_run": {
         if (task_id) {
@@ -51,9 +56,16 @@
         }
         break
       }
-      case "doc":
-        // No tracking yet
+      case "doc": {
+        if (project_id) {
+          increment_document_tag(project_id, tag)
+        } else {
+          console.error(
+            "Attempted to increment a tag set for document, but not project_id provided",
+          )
+        }
         break
+      }
       default: {
         // Check we don't miss a new case
         const _: never = example_tag_set
@@ -65,58 +77,89 @@
     if (focus_on_mount) {
       document.getElementById(id)?.focus()
     }
-    // Load task tasks, if we're rendering task tags
-    if (example_tag_set === "task_run") {
-      if (!project_id || !task_id) {
-        console.error(
-          "Requested to load tags for a task, without setting project ID and task ID",
-        )
-      } else {
-        await load_tags(project_id, task_id)
+
+    switch (example_tag_set) {
+      case "task_run": {
+        if (!project_id || !task_id) {
+          console.error(
+            "Requested to load tags for a task, without setting project ID and task ID",
+          )
+        } else {
+          await load_tags(project_id, task_id)
+        }
+        break
+      }
+      case "doc": {
+        if (!project_id) {
+          console.error(
+            "Requested to load tags for documents, without setting project ID",
+          )
+        } else {
+          await load_document_tags(project_id)
+        }
+        break
+      }
+      default: {
+        // typecheck error if we miss a case
+        const _: never = example_tag_set
       }
     }
   })
 
-  const DEFAULT_TAGS = ["eval_set", "golden", "fine_tune_data", "needs_rating"]
+  const DEFAULT_TASK_TAGS = [
+    "eval_set",
+    "golden",
+    "fine_tune_data",
+    "needs_rating",
+  ]
+  const DEFAULT_DOC_TAGS = ["knowledge_base", "faq", "policies", "research"]
 
-  $: sorted_tag_counts = get_sorted_tag_counts($tag_store_by_task_id, task_id)
+  $: task_tag_counts = $tag_store_by_task_id
+  $: document_tag_counts = $document_tag_store_by_project_id
 
-  function get_sorted_tag_counts(
-    task_tag_connts: Record<string, TagCounts>,
-    task_id: string | null,
-  ): string[] {
+  $: sorted_tag_counts = (() => {
+    let current_tag_counts: Record<string, number> = {}
+    let default_tags: string[] = []
+
     switch (example_tag_set) {
-      case "doc":
-        // Hard coded sample tags for doc library
-        return ["knowledge_base", "faq", "policies", "research"]
+      case "doc": {
+        if (project_id !== null) {
+          current_tag_counts = document_tag_counts[project_id] || {}
+        }
+        default_tags = DEFAULT_DOC_TAGS
+        break
+      }
       case "task_run": {
-        let sorted_tag_counts: string[] = []
-        if (task_id === null) {
-          console.error(
-            "task_id is null, but example_tag_set is task_run. Can't load the task tags.",
-          )
-        } else {
-          const tag_counts = task_tag_connts[task_id]
-          sorted_tag_counts = Object.entries(tag_counts || {})
-            .sort((a, b) => b[1] - a[1])
-            .map(([tag, _]) => tag)
+        if (task_id !== null) {
+          current_tag_counts = task_tag_counts[task_id] || {}
         }
-
-        // Add default tags to the bottom of the list, unless they are naturally already in the list
-        for (const tag of DEFAULT_TAGS) {
-          if (!sorted_tag_counts.includes(tag)) {
-            sorted_tag_counts.push(tag)
-          }
-        }
-
-        return sorted_tag_counts
+        default_tags = DEFAULT_TASK_TAGS
+        break
       }
       default: {
-        // Compiler check we never miss a case
         const _: never = example_tag_set
-        return []
       }
     }
+
+    return sort_tags_by_frequency(current_tag_counts, default_tags)
+  })()
+
+  function sort_tags_by_frequency(
+    tag_counts: Record<string, number>,
+    default_tags: string[],
+  ): string[] {
+    let sorted_tag_counts: string[] = Object.entries(tag_counts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([tag, _]) => tag)
+
+    // Add default tags to the bottom of the list, unless they are naturally already in the list
+    for (const tag of default_tags) {
+      if (!sorted_tag_counts.includes(tag)) {
+        sorted_tag_counts.push(tag)
+      }
+    }
+
+    return sorted_tag_counts
   }
 </script>
 

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
@@ -472,6 +472,7 @@
     } finally {
       // Reload UI, even on failure, as partial delete is possible
       selected_runs = new Set()
+      add_tags = new Set()
       select_mode = false
       await get_runs()
     }

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
@@ -469,6 +469,7 @@
     } finally {
       // Reload UI, even on failure, as partial delete is possible
       selected_documents = new Set()
+      add_tags = new Set()
       select_mode = false
       await get_documents()
     }
@@ -762,6 +763,8 @@
       >
         <TagDropdown
           bind:tag={current_tag}
+          {project_id}
+          example_tag_set="doc"
           on_select={(tag) => {
             add_tags.add(tag)
             add_tags = add_tags
@@ -769,7 +772,6 @@
             current_tag = ""
           }}
           on_escape={() => (show_add_tag_dropdown = false)}
-          example_tag_set="doc"
           focus_on_mount={true}
         />
         <div class="flex-none">

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
@@ -397,10 +397,10 @@
             >
               <TagDropdown
                 {project_id}
+                example_tag_set="doc"
                 on_select={(tag) => add_tags([tag])}
                 on_escape={() => (show_create_tag = false)}
                 focus_on_mount={true}
-                example_tag_set="doc"
               />
               <div class="flex-none">
                 <button

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -685,6 +685,18 @@ def connect_document_api(app: FastAPI):
                 all_tags.update(document.tags)
         return sorted(list(all_tags))
 
+    @app.get("/api/projects/{project_id}/documents/tag_counts")
+    async def get_document_tag_counts(project_id: str) -> dict[str, int]:
+        tags_count = {}
+        project = project_from_id(project_id)
+        # Not particularly efficient, but projects are memory cached after first load so re-compute is fairly cheap
+        # We also cache the result client side
+        for document in project.documents(readonly=True):
+            if document.tags:
+                for tag in document.tags:
+                    tags_count[tag] = tags_count.get(tag, 0) + 1
+        return tags_count
+
     @app.get("/api/projects/{project_id}/documents/{document_id}")
     async def get_document(
         project_id: str,

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -582,6 +582,7 @@ def connect_document_api(app: FastAPI):
         project_id: str,
         files: Annotated[List[UploadFile] | None, File()] = None,
         names: Annotated[List[str] | None, Form()] = None,
+        tags: Annotated[List[str] | None, Form()] = None,
     ) -> BulkCreateDocumentsResponse:
         project = project_from_id(project_id)
 
@@ -636,6 +637,7 @@ def connect_document_api(app: FastAPI):
                     name_override=document_name,
                     description="",  # No description support in bulk upload
                     kind=kind,
+                    tags=tags if tags else [],
                     original_file=FileInfo(
                         filename=file.filename,
                         mime_type=mime_type,


### PR DESCRIPTION
## What does this PR do?

Allow picking tags for documents in the upload dialog.

Changes:
- pick tag in upload dialog
- fix: tags were not clearing correctly in both the TaskRun / Dataset tagging and in the Documents table view - the last entered tag was shown as if it were selected and removable on every subsequent tagging dialog (until cleared)
- fix: add general upload failure error in the document upload dialog (we had specific ones for partial failures, but no unexpected error kind of handler)

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
