### PR TITLE
Adding haiku 4.5, and nominating sonnet 4.5 as recommended

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -1033,6 +1033,25 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
+    # Claude 4.5 Haiku
+    KilnModel(
+        family=ModelFamily.claude,
+        name=ModelName.claude_4_5_haiku,
+        friendly_name="Claude 4.5 Haiku",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="anthropic/claude-haiku-4.5",
+                structured_output_mode=StructuredOutputMode.function_calling,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.anthropic,
+                model_id="claude-haiku-4-5-20251001",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                temp_top_p_exclusive=True,
+            ),
+        ],
+    ),
     # Claude 3.5 Haiku
     KilnModel(
         family=ModelFamily.claude,
@@ -1053,25 +1072,6 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.vertex,
                 model_id="claude-3-5-haiku",
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
-            ),
-        ],
-    ),
-    # Claude 4.5 Haiku
-    KilnModel(
-        family=ModelFamily.claude,
-        name=ModelName.claude_4_5_haiku,
-        friendly_name="Claude 4.5 Haiku",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.openrouter,
-                model_id="anthropic/claude-haiku-4.5",
-                structured_output_mode=StructuredOutputMode.function_calling,
-            ),
-            KilnModelProvider(
-                name=ModelProviderName.anthropic,
-                model_id="claude-haiku-4-5-20251001",
-                structured_output_mode=StructuredOutputMode.json_schema,
-                temp_top_p_exclusive=True,
             ),
         ],
     ),


### PR DESCRIPTION

## What does this PR do?

- Adding Haiku 4.5
- bumping the recommendation from 4.0 to 4.5 for evals and data gen

## Checklists
- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib

Openrouter works with function calling only, and anthropic can handle json schema.
Haiku 4.5 on Anthropic did require the exclusive top P thing similar to sonnet 4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Claude 4.5 Haiku model, now selectable in the app.

* **Chores**
  * Marked Claude 4.5 Sonnet as recommended for data generation and evaluations.
  * Removed Claude 4 Sonnet from recommendations for data generation and evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->