### PR TITLE
fix: react to query params change in synth data

### DIFF
--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
@@ -167,8 +167,7 @@
     load_initial_step()
   })
 
-  // if the user comes back through internal navigation + query params, onMount does not run, so we need
-  // to watch for query params changes and reload the state
+  // this page may redirect back to itself after finding state
   $: if ($page.url.searchParams && !is_setup) {
     load_initial_state()
     update_status()


### PR DESCRIPTION
## What does this PR do?

Bug:
- routing to synth data mode-specific page happens via query params
- when navigating through svelte navigation, `onMount` does not run, so initialization (including reading query params) does not react to query params changing

Fix:
- watch query params and reload if they change

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the synthesis generation UI could remain stale when arriving via URLs with query parameters; the page now reliably reloads its state, current step, and status on parameterized navigation so the interface reflects the correct content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->