### PR TITLE
fix: synth data tags not deserialized correctly

### DIFF
--- a/app/web_ui/src/lib/utils/splits_util.ts
+++ b/app/web_ui/src/lib/utils/splits_util.ts
@@ -27,6 +27,12 @@ export function get_splits_from_url_param(splitsParam: string | null) {
   }
 }
 
+export function encode_splits_for_url(splits: Record<string, number>) {
+  return Object.entries(splits)
+    .map(([name, value]) => `${name}:${value}`)
+    .join(",")
+}
+
 export function get_splits_subtitle(splits: Record<string, number>) {
   if (Object.keys(splits).length === 0) return undefined
   return `Added data will be assigned the following tags: ${Object.entries(

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
@@ -32,7 +32,7 @@
     // Eval/Fine-tuning modes redirect to synth page - this is when we explicitly link back
     // to the synth page (e.g. via toast UI)
     if (reason_param === "eval" || reason_param === "fine_tune") {
-      const params = new URLSearchParams($page.url.searchParams)
+      const params = $page.url.searchParams
       await goto(
         `/generate/${project_id}/${task_id}/synth?${params.toString()}`,
       )

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/data_gen_intro.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/data_gen_intro.svelte
@@ -9,6 +9,7 @@
   import { goto } from "$app/navigation"
   import EvalIcon from "$lib/ui/icons/eval_icon.svelte"
   import FinetuneIcon from "$lib/ui/icons/finetune_icon.svelte"
+  import { encode_splits_for_url } from "$lib/utils/splits_util"
 
   export let generate_subtopics: () => void
   export let generate_samples: () => void
@@ -89,7 +90,7 @@
     }
 
     // .set will automatically URL encode
-    params.set("splits", JSON.stringify(splits))
+    params.set("splits", encode_splits_for_url(splits))
 
     goto(`/generate/${project_id}/${task_id}/synth?${params.toString()}`)
     evals_dialog?.close()
@@ -169,7 +170,7 @@
     params.set("template_id", "fine_tuning")
 
     // .set will automatically URL encode
-    params.set("splits", JSON.stringify(splits))
+    params.set("splits", encode_splits_for_url(splits))
 
     goto(`/generate/${project_id}/${task_id}/synth?${params.toString()}`)
     fine_tuning_dialog?.close()


### PR DESCRIPTION
## What does this PR do?

Fix:
- finetuning: the splits were not being deserialized correctly because they were encoded in JSON in the URL, while the page that reads them expected `k:v` CSVs

It was introduced when I moved the synth data page into `synth/`.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced URL parameter encoding and state management for improved navigation consistency across application sections.
  * Optimized serialization of configuration parameters for cleaner, more reliable URL formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->