### PR TITLE
fix: show plus button even when no tags at all

### DIFF
--- a/app/web_ui/src/lib/ui/tag_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/tag_dropdown.svelte
@@ -183,7 +183,7 @@
       class="btn btn-sm {tag && tag.length > 0
         ? 'btn-primary'
         : 'btn-disabled'} btn-circle text-xl font-medium"
-      on:click={() => add_tag()}>+</button
+      on:click={() => add_tag()}>＋</button
     >
   </div>
   <datalist id={datalist_id}>

--- a/app/web_ui/src/lib/ui/tag_picker.svelte
+++ b/app/web_ui/src/lib/ui/tag_picker.svelte
@@ -79,30 +79,28 @@
 </script>
 
 <div class="w-full">
-  {#if tags.length > 0}
-    <div class="flex flex-row flex-wrap gap-2 mb-2">
-      {#each (tags ?? []).slice().sort() as tag (tag)}
-        <div class="badge bg-gray-200 text-gray-500 py-3 px-3 max-w-full">
-          <span class="truncate">{tag}</span>
-          <button
-            class="pl-3 font-medium shrink-0"
-            on:click={() => handle_remove_tag(tag)}
-            {disabled}>✕</button
-          >
-        </div>
-      {/each}
-
-      {#if !show_dropdown}
+  <div class="flex flex-row flex-wrap gap-2 mb-2">
+    {#each tags.slice().sort() as tag (tag)}
+      <div class="badge bg-gray-200 text-gray-500 py-3 px-3 max-w-full">
+        <span class="truncate">{tag}</span>
         <button
-          class="badge bg-gray-200 text-gray-500 p-3 font-medium {disabled
-            ? 'opacity-50'
-            : ''}"
-          on:click={toggle_dropdown}
-          {disabled}>+</button
+          class="pl-3 font-medium shrink-0"
+          on:click={() => handle_remove_tag(tag)}
+          {disabled}>✕</button
         >
-      {/if}
-    </div>
-  {/if}
+      </div>
+    {/each}
+
+    {#if !show_dropdown}
+      <button
+        class="badge bg-gray-200 text-gray-500 p-3 font-medium {disabled
+          ? 'opacity-50'
+          : ''}"
+        on:click={toggle_dropdown}
+        {disabled}>＋</button
+      >
+    {/if}
+  </div>
 
   {#if show_dropdown}
     <div class="flex flex-row gap-2 items-center">


### PR DESCRIPTION
## What does this PR do?

TagPicker is not showing the `plus` button when there are no tags at all.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tags always render and are displayed in sorted order for clearer organization.
  * Per-tag removal simplified with a direct delete (✕) button on each tag.
  * Add-tag control updated to a fullwidth plus (＋); toggle behavior preserved and presented as a separate dropdown toggle button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->