### PR TITLE
refactor: add flag to hide tool selection in run config component

### DIFF
--- a/app/web_ui/src/lib/ui/run_config_component/run_config_component.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/run_config_component.svelte
@@ -40,6 +40,7 @@
   export let set_default_error: KilnError | null = null
   export let hide_create_kiln_task_tool_button: boolean = false
   export let hide_prompt_selector: boolean = false
+  export let hide_tools_selector: boolean = false
   export let show_tools_selector_in_advanced: boolean = false
   export let requires_structured_output: boolean = false
 
@@ -270,12 +271,14 @@
     />
   {/if}
   {#if !show_tools_selector_in_advanced}
-    <ToolsSelector
-      bind:tools
-      {project_id}
-      task_id={current_task?.id ?? null}
-      {hide_create_kiln_task_tool_button}
-    />
+    {#if !hide_tools_selector}
+      <ToolsSelector
+        bind:tools
+        {project_id}
+        task_id={current_task?.id ?? null}
+        {hide_create_kiln_task_tool_button}
+      />
+    {/if}
     <Collapse title="Advanced Options">
       <AdvancedRunOptions
         bind:temperature
@@ -287,12 +290,14 @@
   {:else}
     <Collapse title="Advanced Options">
       <div class="flex flex-col gap-0">
-        <ToolsSelector
-          bind:tools
-          {project_id}
-          task_id={current_task?.id ?? null}
-          {hide_create_kiln_task_tool_button}
-        />
+        {#if !hide_tools_selector}
+          <ToolsSelector
+            bind:tools
+            {project_id}
+            task_id={current_task?.id ?? null}
+            {hide_create_kiln_task_tool_button}
+          />
+        {/if}
         <AdvancedRunOptions
           bind:temperature
           bind:top_p


### PR DESCRIPTION
## What does this PR do?

Add a prop to optionally hide the Tool selector in the `RunConfigComponent`.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to hide the tools selector in the run configuration UI. By default the selector remains visible, but a new option lets the selector be suppressed in both advanced and simplified views, giving more control over interface appearance and reducing visual clutter when tools selection is not needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->