### PR TITLE
refactor: remove default tool name and description to force user to w…

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/edit_rag_config_form.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/edit_rag_config_form.svelte
@@ -456,16 +456,16 @@
       return
     }
 
-    if (!tool_name || !tool_name.trim()) {
-      throw new Error("Please provide a search tool name.")
-    }
-
-    if (!tool_description || !tool_description.trim()) {
-      throw new Error("Please provide a search tool description.")
-    }
-
     try {
       loading = true
+
+      if (!tool_name || !tool_name.trim()) {
+        throw new Error("Please provide a search tool name.")
+      }
+
+      if (!tool_description || !tool_description.trim()) {
+        throw new Error("Please provide a search tool description.")
+      }
 
       // Fetch or build the sub configs
       const {


### PR DESCRIPTION
## What does this PR do?

Tool name and description are important, we should not set a boilerplate default as users may keep it and have issues downstream with the model not calling the tool at the right time.

Changes:
- remove the default value in the create RAG Config / Search Tool form; for both `Tool name` and `Tool description`; use a placeholder instead

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added input placeholders to guide users when configuring RAG tool names and descriptions (examples for name and description).

* **Bug Fixes**
  * RAG tool configuration now requires users to explicitly provide non-empty custom names and descriptions; saves and template creation are blocked until provided.
  * Analytics events now consistently mark name and description as custom when submitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->