### PR TITLE
fix: show semantic-chunker specific properties in rag config detail page

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
@@ -489,22 +489,48 @@
                     rag_config.chunker_config.chunker_type,
                   ),
                 },
-                {
-                  name: "Chunk Size",
-                  value: rag_config.chunker_config.properties?.chunk_size
-                    ? `${String(rag_config.chunker_config.properties.chunk_size)} words`
-                    : "N/A",
-                  tooltip:
-                    "The approximate number of words to include in each chunk",
-                },
-                {
-                  name: "Overlap",
-                  value: rag_config.chunker_config.properties?.chunk_overlap
-                    ? `${String(rag_config.chunker_config.properties.chunk_overlap)} words`
-                    : "N/A",
-                  tooltip:
-                    "The approximate number of words to overlap between chunks",
-                },
+                ...(rag_config.chunker_config.chunker_type === "fixed_window"
+                  ? [
+                      {
+                        name: "Chunk Size",
+                        value: rag_config.chunker_config.properties?.chunk_size
+                          ? `${String(rag_config.chunker_config.properties.chunk_size)} words`
+                          : "N/A",
+                        tooltip:
+                          "The approximate number of words to include in each chunk",
+                      },
+                      {
+                        name: "Overlap",
+                        value: rag_config.chunker_config.properties
+                          ?.chunk_overlap
+                          ? `${String(rag_config.chunker_config.properties.chunk_overlap)} words`
+                          : "N/A",
+                        tooltip:
+                          "The approximate number of words to overlap between chunks",
+                      },
+                    ]
+                  : []),
+                ...(rag_config.chunker_config.chunker_type === "semantic"
+                  ? [
+                      {
+                        name: "Buffer Size",
+                        value: rag_config.chunker_config.properties?.buffer_size
+                          ? `${String(rag_config.chunker_config.properties.buffer_size)}`
+                          : "N/A",
+                        tooltip:
+                          "The number of sentences to group together when evaluating semantic similarity.",
+                      },
+                      {
+                        name: "Breakpoint Percentile",
+                        value: rag_config.chunker_config.properties
+                          ?.breakpoint_percentile_threshold
+                          ? `${String(rag_config.chunker_config.properties.breakpoint_percentile_threshold)}`
+                          : "N/A",
+                        tooltip:
+                          "The percentile of cosine dissimilarity that must be exceeded between a group of sentences and the next to create a breakpoint.",
+                      },
+                    ]
+                  : []),
               ]}
             />
 


### PR DESCRIPTION
## What does this PR do?

Issue: RAG Config detail page currently always showing the Fixed Window chunker properties; while the Semantic chunker has its own set of properties which are completely different.

Changes:
- fix: render the properties based on the chunker type on RAG Config detail page (`Search Tool (RAG)` page; http://localhost:5173/docs/rag_configs/XXX/YYY/rag_config)

Fixed Window case:
<img width="347" height="165" alt="image" src="https://github.com/user-attachments/assets/ada6e5f1-17d0-4d02-b36d-6c5a226037bd" />

Semantic case:
<img width="314" height="158" alt="image" src="https://github.com/user-attachments/assets/4595c7bd-a59c-46e6-8a66-78a12c27f59e" />

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * RAG configuration interface now displays chunker-specific settings based on the selected type. Fixed window chunker shows Chunk Size and Overlap options, while semantic chunker displays Buffer Size and Breakpoint Percentile settings. Irrelevant properties are hidden for a cleaner configuration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->