### PR TITLE
Added available tools to run configs in eval pages

### DIFF
--- a/app/web_ui/src/lib/ui/tools_display.svelte
+++ b/app/web_ui/src/lib/ui/tools_display.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { get_tools_property_info } from "$lib/stores/tools_store"
+  import type { ToolSetApiDescription } from "$lib/types"
+
+  export let tool_ids: string[] = []
+  export let project_id: string
+  export let available_tools: Record<string, ToolSetApiDescription[]>
+  export let text_size: "xs" | "sm" = "sm"
+  export let center_text: boolean = false
+
+  $: tools_info = get_tools_property_info(tool_ids, project_id, available_tools)
+  $: text_size_class = text_size === "xs" ? "text-xs" : "text-sm"
+  $: badge_size_class = text_size === "xs" ? "badge-sm text-xs" : ""
+</script>
+
+<div class="text-gray-500 {text_size_class}">
+  {#if Array.isArray(tools_info.value) && tools_info.value.length > 0}
+    <div
+      class="flex flex-wrap items-center gap-1 {center_text
+        ? 'justify-center'
+        : ''}"
+    >
+      <span>Available Tools:</span>
+      {#each tools_info.value as tool_name, i}
+        {@const link = tools_info.links?.[i]}
+        {#if link}
+          <a href={link} class="badge badge-outline {badge_size_class}">
+            {tool_name}
+          </a>
+        {:else}
+          <span class="badge badge-outline {badge_size_class}">
+            {tool_name}
+          </span>
+        {/if}
+      {/each}
+    </div>
+  {:else}
+    <span class={center_text ? "block text-center" : ""}
+      >Available Tools: {tools_info.value}</span
+    >
+  {/if}
+</div>

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_configs/+page.svelte
@@ -21,6 +21,8 @@
     current_task_prompts,
     load_available_prompts,
     load_available_models,
+    load_available_tools,
+    available_tools,
     load_task,
     get_task_composite_id,
   } from "$lib/stores"
@@ -42,6 +44,7 @@
   import CreateNewRunConfigDialog from "$lib/ui/run_config_component/create_new_run_config_dialog.svelte"
   import { prompt_link } from "$lib/utils/link_builder"
   import type { UiProperty } from "$lib/ui/property_list"
+  import ToolsDisplay from "$lib/ui/tools_display.svelte"
 
   $: project_id = $page.params.project_id
   $: task_id = $page.params.task_id
@@ -95,6 +98,7 @@
       load_model_info(),
       load_available_prompts(),
       load_available_models(),
+      load_available_tools(project_id),
       get_task(),
     ])
     // Get the eval first (want it to set the current config id before the other two load)
@@ -605,6 +609,12 @@
                         />
                       {/if}
                     </div>
+                    <ToolsDisplay
+                      tool_ids={task_run_config.run_config_properties
+                        .tools_config?.tools ?? []}
+                      {project_id}
+                      available_tools={$available_tools}
+                    />
                   </td>
                   <td class="text-sm text-center">
                     {#if percent_complete < 1.0}

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/compare/+page.svelte
@@ -20,6 +20,8 @@
     load_available_models,
     get_task_composite_id,
     load_task,
+    load_available_tools,
+    available_tools,
   } from "$lib/stores"
   import {
     load_task_run_configs,
@@ -34,6 +36,7 @@
   import { prompt_link } from "$lib/utils/link_builder"
   import CreateNewRunConfigDialog from "$lib/ui/run_config_component/create_new_run_config_dialog.svelte"
   import SavedRunConfigurationsDropdown from "$lib/ui/run_config_component/saved_run_configs_dropdown.svelte"
+  import ToolsDisplay from "$lib/ui/tools_display.svelte"
 
   $: project_id = $page.params.project_id
   $: task_id = $page.params.task_id
@@ -142,6 +145,7 @@
       load_model_info(),
       load_available_prompts(),
       load_available_models(),
+      load_available_tools(project_id),
       get_task(),
     ])
     await get_task_run_configs()
@@ -617,6 +621,16 @@
                             no_pad={true}
                           />
                         {/if}
+                      </div>
+                      <div class="mt-1">
+                        <ToolsDisplay
+                          tool_ids={selectedConfig.run_config_properties
+                            .tools_config?.tools ?? []}
+                          {project_id}
+                          available_tools={$available_tools}
+                          text_size="xs"
+                          center_text={true}
+                        />
                       </div>
                     </div>
                   {/if}


### PR DESCRIPTION
<img width="796" height="204" alt="screenshot_2025-10-30_at_6 27 33___pm" src="https://github.com/user-attachments/assets/2b8d58c4-9a50-46c2-b8e5-38017170b28e" />
<img width="902" height="262" alt="Screenshot 2025-10-30 at 6 52 17 PM" src="https://github.com/user-attachments/assets/7f674ffb-f7a3-491c-8559-a76f51247d43" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a tools display feature to evaluation comparisons, enabling users to view all available tools associated with each run configuration and task configuration directly within the comparison interface.
  * Tools information is now accessible across multiple evaluation compare views with customizable text sizing and layout options for optimal visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->