### PR TITLE
Adopting openrouter exacto endpoints

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -917,7 +917,7 @@ built_in_models: List[KilnModel] = [
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                model_id="openai/gpt-oss-120b",
+                model_id="openai/gpt-oss-120b:exacto",
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
                 require_openrouter_reasoning=True,
@@ -2959,7 +2959,7 @@ built_in_models: List[KilnModel] = [
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                model_id="deepseek/deepseek-v3.1-terminus",
+                model_id="deepseek/deepseek-v3.1-terminus:exacto",
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=True,
             ),
@@ -4193,7 +4193,7 @@ built_in_models: List[KilnModel] = [
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                model_id="z-ai/glm-4.6",
+                model_id="z-ai/glm-4.6:exacto",
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
                 reasoning_optional_for_structured_output=True,
@@ -4368,7 +4368,7 @@ built_in_models: List[KilnModel] = [
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                model_id="moonshotai/kimi-k2-0905",
+                model_id="moonshotai/kimi-k2-0905:exacto",
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_data_gen=True,
                 suggested_for_evals=True,


### PR DESCRIPTION
## What does this PR do?

Adopting the better tool-use exacto endpoint providers from OpenRouter from announcement: https://openrouter.ai/announcements/provider-variance-introducing-exacto

This is a good change for tool reliability for these specific models as it reduces the provider list to less flakey ones.

Note: skipping the coding model since we didn't support it (Qwen3 Coder) before

## Checklists
- [X] Tests have been run locally and passed (ran the paid tests for these models. works)
- [X] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configurations for four AI models: GPT OSS 120B, DeepSeek 3.1 Terminus, GLM 4.6, and Kimi K2 Instruct 0905. These system updates improve integration, enable optimized operational modes, and ensure enhanced compatibility across the platform, delivering better performance and an improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->