### PR TITLE
Openrouter determinism with provider routing, adding a preferred provider list

### DIFF
--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -435,9 +435,9 @@ class LiteLlmAdapter(BaseAdapter):
             # Require providers that support the reasoning parameter
             provider_options["require_parameters"] = True
             # Prefer R1 providers with reasonable perf/quants
-            provider_options["order"] = ["Fireworks", "Together"]
+            provider_options["order"] = ["fireworks", "together"]
             # R1 providers with unreasonable quants
-            provider_options["ignore"] = ["DeepInfra"]
+            provider_options["ignore"] = ["deepinfra"]
 
         # Only set of this request is to get logprobs.
         if (
@@ -447,7 +447,7 @@ class LiteLlmAdapter(BaseAdapter):
             # Don't let OpenRouter choose a provider that doesn't support logprobs.
             provider_options["require_parameters"] = True
             # DeepInfra silently fails to return logprobs consistently.
-            provider_options["ignore"] = ["DeepInfra"]
+            provider_options["ignore"] = ["deepinfra"]
 
         if provider.openrouter_skip_required_parameters:
             # Oddball case, R1 14/8/1.5B fail with this param, even though they support thinking params.

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -453,10 +453,10 @@ def test_build_extra_body_r1_overrides_default_order(config, mock_task):
     assert "provider" in extra_body
     assert "order" in extra_body["provider"]
     # R1 has a specific order that should override the default
-    assert extra_body["provider"]["order"] == ["Fireworks", "Together"]
+    assert extra_body["provider"]["order"] == ["fireworks", "together"]
     # R1 also sets require_parameters and ignore
     assert extra_body["provider"]["require_parameters"] is True
-    assert extra_body["provider"]["ignore"] == ["DeepInfra"]
+    assert extra_body["provider"]["ignore"] == ["deepinfra"]
 
 
 def test_build_extra_body_non_openrouter_no_provider_order(config, mock_task):


### PR DESCRIPTION
## What does this PR do?

Adding an order to the provider preferences taken from https://x.com/ArtificialAnlys/status/1955102409044398415 (simply used the list in the charts, roughly averaging rank of both equally).

here are the [docs](https://openrouter.ai/docs/features/provider-routing#ordering-specific-providers), which hint we should be using the slug (lowercase) rather than name (uppercase). which would imply a bug in previous routing preferences in this file (made that change in this PR as well)

and this is the endpoint with names/slugs: https://openrouter.ai/api/v1/providers
eg.
```
{"name":"Fireworks","slug":"fireworks","privacy_policy_url":"https://fireworks.ai/privacy-policy","terms_of_service_url":"https://fireworks.ai/terms-of-service","status_page_url":"https://status.fireworks.ai/"},{"name":"InferenceNet","slug":"inference-net","privacy_policy_url":"https://inference.net/privacy-policy","terms_of_service_url":"https://inference.net/terms-of-service","status_page_url":null},{"name":"DeepInfra","slug":"deepinfra","privacy_policy_url":"https://deepinfra.com/privacy","terms_of_service_url":"https://deepinfra.com/terms","status_page_url":"https://status.deepinfra.com/"},
```

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized provider routing preferences for OpenRouter model configurations.
  * Normalized provider ordering and exclusion settings across R1-related models for consistent fallback behavior.

* **Tests**
  * Added test coverage for OpenRouter provider routing configurations and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->