### PR TITLE
fix: broken test due to mock name

### DIFF
--- a/libs/server/kiln_server/test_document_api.py
+++ b/libs/server/kiln_server/test_document_api.py
@@ -3673,7 +3673,7 @@ async def test_build_rag_workflow_runner_ollama_extractor_concurrency_is_one(
     mock_project,
     mock_chunker_config,
     mock_embedding_config,
-    mock_vector_store_config,
+    mock_vector_store_config_fts,
 ):
     """Ensure extractor concurrency is 1 when provider is ollama."""
     # Create an extractor config that uses the ollama provider
@@ -3705,7 +3705,7 @@ async def test_build_rag_workflow_runner_ollama_extractor_concurrency_is_one(
         extractor_config_id=extractor_config_ollama.id,
         chunker_config_id=mock_chunker_config.id,
         embedding_config_id=mock_embedding_config.id,
-        vector_store_config_id=mock_vector_store_config.id,
+        vector_store_config_id=mock_vector_store_config_fts.id,
     )
     rag_config.save_to_file()
 
@@ -3745,7 +3745,7 @@ async def test_build_rag_workflow_runner_ollama_extractor_concurrency_is_one(
         mock_extractor_from_id.return_value = extractor_config_ollama
         mock_chunker_from_id.return_value = mock_chunker_config
         mock_embedding_from_id.return_value = mock_embedding_config
-        mock_vector_store_from_id.return_value = mock_vector_store_config
+        mock_vector_store_from_id.return_value = mock_vector_store_config_fts
 
         # Ensure __init__ behaves like a normal constructor
         mock_extract_runner_init.return_value = None


### PR DESCRIPTION
## What does this PR do?

Merging https://github.com/Kiln-AI/Kiln/pull/761 broke a test on prod - the test passed in the PR's CI, and `main`'s passed CI too, but the result of merging the two broke - in spite of there not being explicit merge conflicts.

Changes:
- fix: mock name changed (to be specific to its particular type - in this case, `fts`)

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for vector store handling in the RAG system tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->