### PR TITLE
implement half of translation support, the easy half

### DIFF
--- a/app/web_ui/src/routes/(app)/run/output.svelte
+++ b/app/web_ui/src/routes/(app)/run/output.svelte
@@ -87,7 +87,7 @@
   <link rel="stylesheet" href="/styles/highlightjs.min.css" />
 </head>
 
-<div class="relative">
+<div class="relative" translate="no">
   <div
     class="flex flex-row gap-2 bg-base-200 p-1 rounded-lg {no_padding
       ? ''


### PR DESCRIPTION
https://github.com/Kiln-AI/Kiln/issues/382

Just adding translate=no to our output view, which we use almost everywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated output section configuration to prevent automatic translation of content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->