### PR TITLE
Upgrade MacOS builder images for our MacOS Intel Builds

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -10,11 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-latest is for arm64 build, macos-13 is for x86_64
         include:
           - os: windows-latest
           - os: macos-latest # arm64 macOS
-          - os: macos-13 # x86_64 macOS
+          - os: macos-15-intel # x86_64 macOS
           - os: ubuntu-22.04 # x86_64 linux, oldest available GH runner. Older libc for maximal compatibility
           - os: ubuntu-22.04-arm # arm linux build
 


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/13046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build infrastructure to use newer Intel-based runner for x86_64 architecture builds, replacing the previous configuration while maintaining ARM64 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->