### PR TITLE
fix: no upstream chunks allowed during embedding step

### DIFF
--- a/libs/core/kiln_ai/adapters/rag/rag_runners.py
+++ b/libs/core/kiln_ai/adapters/rag/rag_runners.py
@@ -181,10 +181,11 @@ async def execute_embedding_job(
     job: EmbeddingJob, embedding_adapter: BaseEmbeddingAdapter
 ) -> bool:
     chunks_text = await job.chunked_document.load_chunks_text()
+
+    # we do not raise because no chunks may be the legitimate result of the previous step
+    # e.g. an empty document; a document whose content was intentionally excluded by the extraction prompt
     if chunks_text is None or len(chunks_text) == 0:
-        raise ValueError(
-            f"Failed to load chunks for chunked document: {job.chunked_document.id}"
-        )
+        return True
 
     chunk_embedding_result = await embedding_adapter.generate_embeddings(
         input_texts=chunks_text

--- a/libs/core/kiln_ai/adapters/rag/test_rag_runners.py
+++ b/libs/core/kiln_ai/adapters/rag/test_rag_runners.py
@@ -474,10 +474,10 @@ class TestExecuteEmbeddingJob:
         )
         mock_embedding_adapter = MagicMock(spec=BaseEmbeddingAdapter)
 
-        with pytest.raises(
-            ValueError, match="Failed to load chunks for chunked document: 123"
-        ):
-            await execute_embedding_job(job, mock_embedding_adapter)
+        # we should not raise because no chunks may be the legitimate result of the previous step
+        # e.g. an empty document; a document whose content was intentionally excluded by the extraction prompt
+        result = await execute_embedding_job(job, mock_embedding_adapter)
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_execute_embedding_job_no_embedding_result_raises_error(


### PR DESCRIPTION
## What does this PR do?

Extraction can legitimately be empty - e.g. a blank page, a document extracted with a prompt that tells it to only extract X and Y information that happens to not be present in the doc. Such an extraction creates no chunks (which is valid), but then we raise during the embedding step while trying to embed these empty / non-existent chunks - this surfaces as a failure in the UI, while as far as the user is concerned, nothing actually failed - i.e. retrying would fail in the same way and would be correct behavior.

Changes:
- fix: mark the embedding job as successful if there is nothing to embed, instead of raising

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The RAG embedding process now gracefully handles documents with no extractable text chunks, completing successfully instead of raising an error. This improves system robustness when processing documents where content extraction yields empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->