### PR TITLE
fix: QA only extract target tags docs

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -6729,7 +6729,9 @@ export interface operations {
     };
     run_extractor_config_api_projects__project_id__extractor_configs__extractor_config_id__run_extractor_config_get: {
         parameters: {
-            query?: never;
+            query?: {
+                tags?: string | null;
+            };
             header?: never;
             path: {
                 project_id: string;

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/+page.svelte
@@ -55,6 +55,7 @@
   $: qnaTotalCount = qna?.totalCount
   $: qnaGenerationErrors = qna?.generationErrors
   $: qnaStatus = qna?.status
+  $: qnaSelectedTags = qna?.selectedTags
 
   $: available_tags = derived(document_tag_store_by_project_id, ($store) => {
     const tag_counts = $store[project_id]
@@ -574,6 +575,7 @@
   />
 
   <Extractiondialog
+    target_tags={$qnaSelectedTags || []}
     keyboard_submit={current_dialog_type === "extraction"}
     bind:dialog={show_extraction_dialog}
     selected_extractor_id={$qnaExtractorId}

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/extraction_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/extraction_dialog.svelte
@@ -15,6 +15,7 @@
   export let dialog: Dialog | null = null
   export let keyboard_submit: boolean = false
   export let selected_extractor_id: string | null = null
+  export let target_tags: string[] = []
 
   let extractor_configs: ExtractorConfig[] = []
   let extractor_config_error: KilnError | null = null
@@ -126,7 +127,13 @@
         throw new Error("Please select an extractor")
       }
 
-      const url = `${base_url}/api/projects/${project_id}/${"extractor_configs"}/${selected_extractor_id}/run_extractor_config`
+      const url = new URL(
+        `${base_url}/api/projects/${project_id}/${"extractor_configs"}/${selected_extractor_id}/run_extractor_config`,
+      )
+
+      if (target_tags.length > 0) {
+        url.searchParams.set("tags", target_tags.join(","))
+      }
       // ensure only one live stream - we do not block the user while extraction is running, but we don't want the user to somehow
       // trigger parallel conflicting extraction runs
       es?.close()

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/qna_ui_store.ts
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/qna_ui_store.ts
@@ -5,13 +5,9 @@ import {
   type Readable,
   get,
 } from "svelte/store"
-import { client, base_url } from "$lib/api_client"
+import { client } from "$lib/api_client"
 import { indexedDBStore } from "$lib/stores/index_db_store"
-import type {
-  KilnDocument,
-  ModelProviderName,
-  RunConfigProperties,
-} from "$lib/types"
+import type { KilnDocument, RunConfigProperties } from "$lib/types"
 import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
 
 export type StepNumber = 1 | 2 | 3 | 4
@@ -99,6 +95,7 @@ export type QnaStore = {
   generationErrors: Readable<KilnError[]>
   currentStep: Readable<StepNumber>
   maxStep: Readable<StepNumber>
+  selectedTags: Readable<string[]>
   pendingSaveCount: Readable<number>
   saveAllStatus: Readable<{
     running: boolean
@@ -168,6 +165,7 @@ export function createQnaStore(projectId: string, taskId: string): QnaStore {
   const _generateErrors = writable<KilnError[]>([])
 
   // Generation config
+  const selectedTags = writable<string[]>([])
   const extractorId = writable<string | null>(null)
   const pairsPerPart = writable<number>(5)
   const guidance = writable<string>("")
@@ -203,6 +201,7 @@ export function createQnaStore(projectId: string, taskId: string): QnaStore {
     const initialValue = get(store)
     if (initialValue) {
       _state.set(initialValue)
+      selectedTags.set(initialValue.selected_tags)
       extractorId.set(initialValue.extractor_id)
       pairsPerPart.set(initialValue.generation_config.pairs_per_part)
       guidance.set(initialValue.generation_config.guidance)
@@ -269,6 +268,11 @@ export function createQnaStore(projectId: string, taskId: string): QnaStore {
             chunk_overlap_tokens: value,
           },
         }))
+      }),
+    )
+    configUnsubscribes.push(
+      selectedTags.subscribe((value) => {
+        _state.update((s) => ({ ...s, selected_tags: value }))
       }),
     )
   }
@@ -376,6 +380,7 @@ export function createQnaStore(projectId: string, taskId: string): QnaStore {
       }
     })
     manualStep.set(null)
+    selectedTags.set(tags)
   }
 
   function setExtractor(extractorConfigId: string): void {
@@ -981,6 +986,7 @@ export function createQnaStore(projectId: string, taskId: string): QnaStore {
     generationErrors: _generateErrors,
     currentStep,
     maxStep,
+    selectedTags,
     pendingSaveCount,
     saveAllStatus,
     targetType,


### PR DESCRIPTION
## What does this PR do?

Fix going into https://github.com/Kiln-AI/Kiln/pull/736 - currently extract stage extracts all docs regardless of tags

Changes:
- fix: extract stage in Q&A should only run extractor on the documents targeted by the selected tags (if no selected tags, then extract all docs)

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag-based filtering for extraction runs, allowing users to filter and extract documents by selected tags during the extraction process.
  * Enhanced the extraction interface to accept and apply tag selections from the QA workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->