### PR TITLE
fix: remove stale warning about openrouter and embeddings

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/add_search_tool/+page.svelte
@@ -14,7 +14,6 @@
     type RequiredProvider,
     type RagConfigTemplate,
   } from "./rag_config_templates"
-  import Warning from "$lib/ui/warning.svelte"
   import posthog from "posthog-js"
 
   $: project_id = $page.params.project_id
@@ -43,13 +42,6 @@
   )
 
   let missing_provider: RequiredProvider | null = null
-  $: missing_provider_string = missing_provider
-    ? {
-        OpenaiOrOpenRouter: "OpenAI or OpenRouter",
-        GeminiOrOpenRouter: "Google Gemini or OpenRouter",
-        Ollama: "Ollama",
-      }[missing_provider]
-    : null
 
   function redirect_to_template(template_id: string) {
     // Go to the create search tool page with the template id
@@ -234,13 +226,6 @@
         API key.
       {/if}
     </p>
-    {#if settings && settings["open_router_api_key"]}
-      <Warning
-        warning_message="OpenRouter doesn't support embeddings yet. Please add a direct {missing_provider_string} API key for search tools."
-        warning_color="warning"
-        warning_icon="info"
-      />
-    {/if}
   </div>
 </Dialog>
 


### PR DESCRIPTION
## What does this PR do?

Follow up for https://github.com/Kiln-AI/Kiln/pull/789

Remove a stale UI warning (that does not show up anymore) about OpenRouter not supporting embeddings, since it now does and we already have support for it.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
