### PR TITLE
Reapply "chore: better logging config"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,18 @@ To run the API server, Studio server, and Studio Web UI with auto-reload for dev
 
 3. Open the app: http://localhost:5173/run
 
+
+### Logs
+
+The default log level for the development server is `INFO`. You may override the log level by setting the `KILN_LOG_LEVEL` environment variable.
+
+For example, to capture logs for the `DEBUG` level and up, run:
+```sh
+KILN_LOG_LEVEL=DEBUG uv run python -m app.desktop.dev_server
+```
+
+During development, logs go to stdout as well as into files prefixed with `dev_` in `~/.kiln_ai/logs/*.log`.
+
 ### Running and Building the Desktop App
 
 See the [desktop README](app/desktop/README.md) instructions for running the desktop app locally.

--- a/app/desktop/desktop_server.py
+++ b/app/desktop/desktop_server.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI
 from kiln_ai.adapters.remote_config import load_remote_models
 from kiln_ai.utils.logging import setup_litellm_logging
 
-from app.desktop.log_config import log_config
+from app.desktop.log_config import log_config, validate_log_level
 from app.desktop.studio_server.data_gen_api import connect_data_gen_api
 from app.desktop.studio_server.dev_tools import connect_dev_tools
 from app.desktop.studio_server.eval_api import connect_evals_api
@@ -49,8 +49,8 @@ async def lifespan(app: FastAPI):
     datamodel_strict_mode.set_strict_mode(original_strict_mode)
 
 
-def make_app(tk_root: tk.Tk | None = None):
-    setup_litellm_logging()
+def make_app(tk_root: tk.Tk | None = None, litellm_log_filename: str | None = None):
+    setup_litellm_logging(litellm_log_filename)
 
     load_remote_models(REMOTE_MODEL_LIST_URL)
 
@@ -73,11 +73,14 @@ def make_app(tk_root: tk.Tk | None = None):
 
 def server_config(port=8757, tk_root: tk.Tk | None = None):
     return uvicorn.Config(
-        make_app(tk_root=tk_root),
+        make_app(tk_root=tk_root, litellm_log_filename="model_calls.log"),
         host="127.0.0.1",
         port=port,
         use_colors=False,
-        log_config=log_config(),
+        log_config=log_config(
+            log_level=validate_log_level(os.getenv("KILN_LOG_LEVEL", "WARNING")),
+            log_file_name="kiln_desktop.log",
+        ),
     )
 
 

--- a/app/desktop/dev_server.py
+++ b/app/desktop/dev_server.py
@@ -6,12 +6,15 @@ import os
 import uvicorn
 
 from app.desktop.desktop_server import make_app
+from app.desktop.log_config import log_config, validate_log_level
 
 # Skip remote model loading when running the dev server (unless explicitly set)
 os.environ.setdefault("KILN_SKIP_REMOTE_MODEL_LIST", "true")
 
 # top level app object, as that's needed by auto-reload
-dev_app = make_app()
+dev_app = make_app(
+    litellm_log_filename="dev_model_calls.log",
+)
 
 os.environ["DEBUG_EVENT_LOOP"] = "true"
 
@@ -24,4 +27,9 @@ if __name__ == "__main__":
         reload=True,
         # Debounce when changing many files (changing branch)
         reload_delay=0.1,
+        use_colors=True,
+        log_config=log_config(
+            log_level=validate_log_level(os.getenv("KILN_LOG_LEVEL", "INFO")),
+            log_file_name="dev_kiln_desktop.log",
+        ),
     )

--- a/app/desktop/log_config.py
+++ b/app/desktop/log_config.py
@@ -1,8 +1,37 @@
+import json
+import logging
 import os
 from enum import Enum
-from typing import List
+from typing import List, Literal
 
-from kiln_ai.utils.logging import get_default_formatter, get_log_file_path
+import uvicorn.logging
+from kiln_ai.utils.logging import get_default_log_file_formatter, get_log_file_path
+
+
+class PrettyPrintDictFormatter(uvicorn.logging.DefaultFormatter):
+    """Custom formatter that displays props data from extra logging parameters.
+
+    Usage:
+    logger.info("Hello there", extra={"dict": {"key": "value"}})
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        # format with uvicorn's colored formatter
+        formatted = super().format(record)
+
+        # check if record has any keys
+        dict_value = getattr(record, "dict", None)
+        if dict_value:
+            try:
+                if isinstance(dict_value, dict):
+                    dict_str = json.dumps(dict_value, ensure_ascii=False, indent=2)
+                else:
+                    dict_str = str(dict_value)
+            except Exception as e:  # never fail logging due to serialization
+                dict_str = f"<unserializable extra.dict: {e.__class__.__name__}>"
+            formatted += f"\n{dict_str}"
+
+        return formatted
 
 
 class LogDestination(Enum):
@@ -11,8 +40,21 @@ class LogDestination(Enum):
     ALL = "all"
 
 
-def get_log_level() -> str:
-    return os.getenv("KILN_LOG_LEVEL", "WARNING")
+class LogLevel(str, Enum):
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
+def validate_log_level(
+    log_level: str,
+) -> Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+    log_level_uppercase = log_level.upper()
+    if log_level_uppercase not in LogLevel.__members__:
+        raise ValueError(f"Invalid log level: {log_level}")
+    return LogLevel(log_level_uppercase).value
 
 
 def get_max_file_bytes() -> int:
@@ -43,41 +85,73 @@ def get_handlers() -> List[str]:
     return handlers[LogDestination(destination)]
 
 
-def log_config():
+def log_config(*, log_level: str, log_file_name: str):
     return {
         "version": 1,
         "disable_existing_loggers": False,
         "formatters": {
-            # uvicorn expects a "default" formatter
+            # uvicorn expects a "default" formatter with colors
             "default": {
-                "format": get_default_formatter(),
+                "()": "uvicorn.logging.DefaultFormatter",
+                "fmt": "%(levelprefix)s %(message)s",
+                "use_colors": None,
             },
-            # uvicorn expects an "access" formatter
+            # uvicorn expects an "access" formatter with colors for HTTP status codes
             "access": {
-                "format": get_default_formatter(),
+                "()": "uvicorn.logging.AccessFormatter",
+                "fmt": '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s',
             },
             "logformatter": {
-                "format": get_default_formatter(),
+                "()": "app.desktop.log_config.PrettyPrintDictFormatter",
+                "fmt": get_default_log_file_formatter(),
+                "use_colors": None,
             },
             "console": {
-                "format": "%(levelname)s: %(message)s",
+                "()": "app.desktop.log_config.PrettyPrintDictFormatter",
+                "fmt": "%(levelprefix)s %(message)s",
+                "use_colors": None,
             },
         },
         "handlers": {
             "logfile": {
                 "class": "logging.handlers.RotatingFileHandler",
-                "level": get_log_level(),
+                "level": log_level,
                 "formatter": "logformatter",
-                "filename": get_log_file_path("kiln_desktop.log"),
+                "filename": get_log_file_path(log_file_name),
                 "mode": "a",
                 "maxBytes": get_max_file_bytes(),
                 "backupCount": get_max_backup_count(),
             },
             "logconsole": {
                 "class": "logging.StreamHandler",
-                "level": get_log_level(),
+                "level": log_level,
                 "formatter": "console",
             },
+            "default": {
+                "class": "logging.StreamHandler",
+                "level": log_level,
+                "formatter": "default",
+            },
+            "access": {
+                "class": "logging.StreamHandler",
+                "level": log_level,
+                "formatter": "access",
+            },
         },
-        "root": {"level": get_log_level(), "handlers": get_handlers()},
+        "loggers": {
+            "uvicorn": {
+                "level": log_level,
+                "handlers": ["default", "logfile"],
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "level": log_level,
+                "handlers": ["access", "logfile"],
+                "propagate": False,
+            },
+        },
+        "root": {
+            "level": log_level,
+            "handlers": get_handlers(),
+        },
     }

--- a/app/desktop/test_log_config.py
+++ b/app/desktop/test_log_config.py
@@ -1,0 +1,41 @@
+import pytest
+
+from app.desktop.log_config import validate_log_level
+
+
+class TestValidateLogLevel:
+    """Tests for the validate_log_level function."""
+
+    @pytest.mark.parametrize(
+        "log_level,expected",
+        [
+            ("debug", "DEBUG"),
+            ("info", "INFO"),
+            ("warning", "WARNING"),
+            ("error", "ERROR"),
+            ("critical", "CRITICAL"),
+            ("DEBUG", "DEBUG"),
+            ("INFO", "INFO"),
+            ("WARNING", "WARNING"),
+            ("ERROR", "ERROR"),
+            ("CRITICAL", "CRITICAL"),
+            ("DebuG", "DEBUG"),
+            ("InfO", "INFO"),
+            ("WaRniNg", "WARNING"),
+            ("ErroR", "ERROR"),
+            ("CriTicaL", "CRITICAL"),
+        ],
+    )
+    def test_valid_log_levels(self, log_level, expected):
+        assert validate_log_level(log_level) == expected
+
+    def test_invalid_log_level_raises_value_error(self):
+        """Test that invalid log levels raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid log level: invalid"):
+            validate_log_level("invalid")
+
+        with pytest.raises(ValueError, match="Invalid log level: trace"):
+            validate_log_level("trace")
+
+        with pytest.raises(ValueError, match="Invalid log level: "):
+            validate_log_level("")

--- a/libs/core/kiln_ai/utils/logging.py
+++ b/libs/core/kiln_ai/utils/logging.py
@@ -11,7 +11,7 @@ from litellm.litellm_core_utils.litellm_logging import Logging
 from kiln_ai.utils.config import Config
 
 
-def get_default_formatter() -> str:
+def get_default_log_file_formatter() -> str:
     return "%(asctime)s.%(msecs)03d - %(levelname)s - %(name)s - %(message)s"
 
 
@@ -21,8 +21,7 @@ def get_log_file_path(filename: str) -> str:
     Returns:
         str: The path to the log file
     """
-    log_path_default = os.path.join(Config.settings_dir(), "logs", filename)
-    log_path = os.getenv("KILN_LOG_FILE", log_path_default)
+    log_path = os.path.join(Config.settings_dir(), "logs", filename)
 
     # Ensure the log directory exists
     os.makedirs(os.path.dirname(log_path), exist_ok=True)
@@ -133,7 +132,7 @@ class CustomLiteLLMLogger(CustomLogger):
         self.logger.info(f"LiteLLM Failure: {response_obj}")
 
 
-def setup_litellm_logging(filename: str = "model_calls.log"):
+def setup_litellm_logging(filename: str | None):
     # Check if we already have a custom litellm logger
     for callback in litellm.callbacks or []:
         if isinstance(callback, CustomLiteLLMLogger):
@@ -146,14 +145,14 @@ def setup_litellm_logging(filename: str = "model_calls.log"):
 
     # Create a logger that logs to files, with a max size of 5MB and 3 backup files
     handler = logging.handlers.RotatingFileHandler(
-        get_log_file_path(filename),
+        get_log_file_path(filename or "model_calls.log"),
         maxBytes=5 * 1024 * 1024,  # 5MB
         backupCount=3,
         encoding="utf-8",
     )
 
     # Set formatter to match the default formatting
-    formatter = logging.Formatter(get_default_formatter())
+    formatter = logging.Formatter(get_default_log_file_formatter())
     handler.setFormatter(formatter)
 
     # Create a new logger for model calls


### PR DESCRIPTION
This reverts commit 9d64b8222a754d56f6c2c1015a72e29cba2c2569. Double revert.

## What does this PR do?

Bring back logging config.

WIP:
- breaking on Windows, need to test there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logging levels now configurable via `KILN_LOG_LEVEL` environment variable (defaults to INFO).
  * Logs organized into separate files in `~/.kiln_ai/logs/` directory.
  * Improved log formatting with enhanced readability.

* **Documentation**
  * Added logging configuration details to CONTRIBUTING.md.

* **Tests**
  * Added validation tests for log level configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->