### PR TITLE
revert: reallow index creation on query

### DIFF
--- a/libs/core/kiln_ai/adapters/vector_store/vector_store_registry.py
+++ b/libs/core/kiln_ai/adapters/vector_store/vector_store_registry.py
@@ -46,16 +46,6 @@ async def vector_store_adapter_for_config(
                     rag_config,
                     vector_store_config,
                 )
-
-                # this flag is initially set to False in llama_index lancedb driver, it is used internally to lazy create the
-                # FTS index on query (hybrid or FTS), turning it on here means that:
-                # 1. An incoming query won't trigger reindexing
-                # 2. A write / add node will still create reindexing
-                #
-                # FTS reindexing is asynchronous and can take a while, and while it rebuilds, the previous index
-                # is deleted, so results are missing from the Top K, and that causes poorer results as well as unstable
-                # rankings, because a few minutes later, once indexing has completed, the FTS results will start changing
-                adapter.lancedb_vector_store._fts_index_ready = True
             case _:
                 raise_exhaustive_enum_error(vector_store_config.store_type)
 


### PR DESCRIPTION
## What does this PR do?

Daniel is getting this - which should not be possible if the config has docs and has been run to completion:
<img width="2998" height="1468" alt="image" src="https://github.com/user-attachments/assets/dc5de932-50e2-4972-97e9-906208c28e8c" />

Reallowing LlamaIndex to do its FTS reindex in the background on first load.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to vector store handling. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->