### PR TITLE
fix: friendly name in config in reranker dropdown in RAG form

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/edit_rag_config_form.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/edit_rag_config_form.svelte
@@ -14,7 +14,10 @@
     VectorStoreConfig,
     RerankerConfig,
   } from "$lib/types"
-  import { load_available_embedding_models } from "$lib/stores"
+  import {
+    load_available_embedding_models,
+    load_available_reranker_models,
+  } from "$lib/stores"
   import Collapse from "$lib/ui/collapse.svelte"
   import {
     build_rag_config_sub_configs,
@@ -186,6 +189,7 @@
 
     await Promise.all([
       load_available_embedding_models(),
+      load_available_reranker_models(),
       loadExtractorConfigs(),
       loadChunkerConfigs(),
       loadEmbeddingConfigs(),

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/options_groups.ts
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/options_groups.ts
@@ -2,6 +2,7 @@ import {
   embedding_model_name,
   get_model_friendly_name,
   provider_name_from_id,
+  reranker_name,
 } from "$lib/stores"
 import type {
   ChunkerConfig,
@@ -169,7 +170,7 @@ export function build_vector_store_options(
 }
 
 function fmt_reranker_label(config: RerankerConfig) {
-  return `${get_model_friendly_name(config.model_name)} (${provider_name_from_id(config.model_provider_name)}) • ${config.top_n} results`
+  return `${reranker_name(config.model_name, config.model_provider_name)} (${provider_name_from_id(config.model_provider_name)}) • ${config.top_n} results`
 }
 
 export function build_reranker_options(reranker_configs: RerankerConfig[]) {


### PR DESCRIPTION
## What does this PR do?

Show friendly reranker name in the reranker config selection dropdown in rag config form:
<img width="2385" height="1824" alt="image" src="https://github.com/user-attachments/assets/5f3e849d-388e-42e3-a7f6-940f44c52c98" />

Before this PR, it looks like this:
<img width="1286" height="921" alt="image" src="https://github.com/user-attachments/assets/1d7bcdd5-9777-4c22-a039-331ad9004eaa" />

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reranker model selection capability to RAG configuration forms, allowing users to choose from available reranker models during setup.

* **Style**
  * Enhanced reranker option label formatting with improved display of provider information and result parameters for better clarity in configuration forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->