### PR TITLE
fix: increase file descriptor limits

### DIFF
--- a/app/desktop/desktop.py
+++ b/app/desktop/desktop.py
@@ -6,6 +6,7 @@ setup_certs()
 
 import contextlib
 import os
+import resource
 import sys
 import tkinter as tk
 import webbrowser
@@ -25,6 +26,11 @@ os.environ["LLAMA_INDEX_CACHE_DIR"] = os.path.join(
     Config.settings_dir(), "cache", "llama_index_cache"
 )
 os.environ["NLTK_DATA"] = os.path.join(Config.settings_dir(), "cache", "nltk_data")
+
+# Increase file descriptor limit
+soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+target_soft = max(soft, min(hard, 16384))
+resource.setrlimit(resource.RLIMIT_NOFILE, (target_soft, hard))
 
 
 class DesktopApp:

--- a/app/desktop/dev_server.py
+++ b/app/desktop/dev_server.py
@@ -2,6 +2,7 @@
 # - Auto-reload is enabled
 # - Extra logging (level+colors) is enabled
 import os
+import resource
 
 import uvicorn
 
@@ -9,6 +10,11 @@ from app.desktop.desktop_server import make_app
 
 # Skip remote model loading when running the dev server (unless explicitly set)
 os.environ.setdefault("KILN_SKIP_REMOTE_MODEL_LIST", "true")
+
+# Increase file descriptor limit
+soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+target_soft = max(soft, min(hard, 16384))
+resource.setrlimit(resource.RLIMIT_NOFILE, (target_soft, hard))
 
 # top level app object, as that's needed by auto-reload
 dev_app = make_app()

--- a/libs/server/kiln_server/server.py
+++ b/libs/server/kiln_server/server.py
@@ -1,4 +1,5 @@
 import argparse
+import resource
 from importlib.metadata import version
 from typing import Sequence
 
@@ -86,6 +87,10 @@ app = make_app()
 
 
 def main(argv: Sequence[str] | None = None) -> None:
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    target_soft = max(soft, min(hard, 16384))
+    resource.setrlimit(resource.RLIMIT_NOFILE, (target_soft, hard))
+
     parser = build_argument_parser()
     args = parser.parse_args(argv)
     uvicorn.run(


### PR DESCRIPTION
## What does this PR do?

Issue: we hit `Too many open files` when we send out too many concurrent requests or do too many file operations concurrently. The current limit is low, we can increase it.

This PR sets this limit on each entry point into the app (probably better than global that risks getting run implicitly into the lib on various hardware?).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system resource configuration across desktop and server components to support improved concurrent operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->