### PR TITLE
Fix issue #815

### DIFF
--- a/app/desktop/studio_server/data_gen_api.py
+++ b/app/desktop/studio_server/data_gen_api.py
@@ -20,7 +20,7 @@ from kiln_ai.utils.open_ai_types import (
     ChatCompletionAssistantMessageParamWrapper,
     ChatCompletionMessageParam,
 )
-from kiln_ai.utils.project_utils import project_from_id
+from kiln_server.project_api import project_from_id
 from kiln_server.task_api import task_from_id
 from openai.types.chat import (
     ChatCompletionSystemMessageParam,
@@ -125,10 +125,13 @@ def connect_data_gen_api(app: FastAPI):
     async def generate_categories(
         project_id: str, task_id: str, input: DataGenCategoriesApiInput
     ) -> TaskRun:
+        project = project_from_id(project_id)
         task = task_from_id(project_id, task_id)
 
         categories_task = DataGenCategoriesTask(
-            gen_type=input.gen_type, guidance=input.guidance
+            gen_type=input.gen_type,
+            parent_project=project,
+            guidance=input.guidance,
         )
 
         task_input = DataGenCategoriesTaskInput.from_task(
@@ -153,10 +156,12 @@ def connect_data_gen_api(app: FastAPI):
     async def generate_samples(
         project_id: str, task_id: str, input: DataGenSampleApiInput
     ) -> TaskRun:
+        project = project_from_id(project_id)
         task = task_from_id(project_id, task_id)
         sample_task = DataGenSampleTask(
             target_task=task,
             gen_type=input.gen_type,
+            parent_project=project,
             guidance=input.guidance,
         )
 

--- a/app/web_ui/src/routes/(app)/settings/edit_project/[slug]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/edit_project/[slug]/+page.svelte
@@ -14,6 +14,7 @@
     title="Edit Project"
     subtitle={project?.name}
     breadcrumbs={[{ label: "Settings", href: "/settings" }]}
+    sub_subtitle={`ID: ${project_id || "Unknown"}`}
   >
     <EditProject {project} />
   </AppPage>

--- a/libs/core/kiln_ai/adapters/data_gen/data_gen_task.py
+++ b/libs/core/kiln_ai/adapters/data_gen/data_gen_task.py
@@ -76,15 +76,17 @@ class DataGenCategoriesTask(Task, parent_of={}):
     training data for model learning.
     """
 
-    def __init__(self, gen_type: Literal["training", "eval"], guidance: str | None):
-        # Keep the typechecker happy. We should make this optional.
-        tmp_project = Project(name="DataGen")
-
+    def __init__(
+        self,
+        gen_type: Literal["training", "eval"],
+        parent_project: Project,
+        guidance: str | None,
+    ):
         instruction = generate_topic_tree_prompt(gen_type=gen_type, guidance=guidance)
 
         super().__init__(
             name="DataGen",
-            parent=tmp_project,
+            parent=parent_project,
             description="A task which generates synthetic data categories, which in turn are used to generate training data for a model to learn from.",
             instruction=instruction,
             input_json_schema=json.dumps(
@@ -179,18 +181,16 @@ class DataGenSampleTask(Task, parent_of={}):
         self,
         target_task: Task,
         gen_type: Literal["training", "eval"],
+        parent_project: Project,
         guidance: str | None,
     ):
-        # Keep the typechecker happy. We should make this optional.
-        tmp_project = Project(name="DataGenSample")
-
         instruction = generate_sample_generation_prompt(
             gen_type=gen_type, guidance=guidance
         )
 
         super().__init__(
             name="DataGenSample",
-            parent=tmp_project,
+            parent=parent_project,
             description="A task which generates synthetic data samples for a given topic (and optional subtopic).",
             instruction=instruction,
             input_json_schema=json.dumps(DataGenSampleTaskInput.model_json_schema()),

--- a/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
+++ b/libs/core/kiln_ai/adapters/data_gen/test_data_gen_task.py
@@ -34,6 +34,15 @@ def base_task():
     )
 
 
+@pytest.fixture
+def test_project(tmp_path) -> Project:
+    project_path = tmp_path / "test_project" / "project.kiln"
+    project_path.parent.mkdir()
+    project = Project(name="Test Project", path=project_path)
+    project.save_to_file()
+    return project
+
+
 def test_data_gen_categories_task_input_initialization(base_task):
     # Arrange
     node_path = ["root", "branch", "leaf"]
@@ -62,9 +71,11 @@ def test_data_gen_categories_task_input_default_values(base_task):
     assert input_model.kiln_data_gen_topic_path == []
 
 
-def test_data_gen_categories_task_initialization():
+def test_data_gen_categories_task_initialization(test_project):
     # Act
-    task = DataGenCategoriesTask(gen_type="training", guidance="Test guidance")
+    task = DataGenCategoriesTask(
+        gen_type="training", guidance="Test guidance", parent_project=test_project
+    )
 
     # Assert
     assert task.name == "DataGen"
@@ -77,9 +88,11 @@ def test_data_gen_categories_task_initialization():
     assert "Test guidance" in task.instruction
 
 
-def test_data_gen_categories_task_schemas():
+def test_data_gen_categories_task_schemas(test_project):
     # Act
-    task = DataGenCategoriesTask(gen_type="eval", guidance="Test guidance")
+    task = DataGenCategoriesTask(
+        gen_type="eval", guidance="Test guidance", parent_project=test_project
+    )
 
     assert "I want to evaluate a large language model" in task.instruction
     assert "Test guidance" in task.instruction
@@ -165,10 +178,13 @@ def test_data_gen_sample_task_input_default_values(base_task):
     assert input_model.kiln_data_gen_topic_path == []
 
 
-def test_data_gen_sample_task_initialization(base_task):
+def test_data_gen_sample_task_initialization(base_task, test_project):
     # Act
     task = DataGenSampleTask(
-        target_task=base_task, gen_type="eval", guidance="Test guidance"
+        target_task=base_task,
+        gen_type="eval",
+        guidance="Test guidance",
+        parent_project=test_project,
     )
 
     # Assert


### PR DESCRIPTION
We need to pass a real project to Synth Data Gen tasks, as they may need tools associated with that project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project ID is now displayed in project settings for easy reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->