### PR TITLE
Missing Add a Judge Page breadcrumbs

### DIFF
--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/create_eval_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/create_eval_config/+page.svelte
@@ -307,6 +307,39 @@
         "G-Eval requires logprobs which do not work with this model or provider.",
     }
   }
+
+  type Breadcrumb = {
+    label: string
+    href: string
+  }
+
+  $: breadcrumbs = (() => {
+    const next_page = $page.url.searchParams.get("next_page")
+    const crumbs: Breadcrumb[] = [
+      {
+        label: "Evals",
+        href: `/evals/${$page.params.project_id}/${$page.params.task_id}`,
+      },
+      {
+        label: evaluator?.name || "Eval",
+        href: `/evals/${$page.params.project_id}/${$page.params.task_id}/${$page.params.eval_id}`,
+      },
+    ]
+
+    if (next_page === "eval_configs") {
+      crumbs.push({
+        label: "Compare Judges",
+        href: `/evals/${$page.params.project_id}/${$page.params.task_id}/${$page.params.eval_id}/eval_configs`,
+      })
+    } else if (next_page === "compare_run_configs") {
+      crumbs.push({
+        label: "Compare Run Configurations",
+        href: `/evals/${$page.params.project_id}/${$page.params.task_id}/${$page.params.eval_id}/compare_run_configs`,
+      })
+    }
+
+    return crumbs
+  })()
 </script>
 
 <div class="max-w-[1400px]">
@@ -315,6 +348,7 @@
     subtitle="A judge evaluates task outputs with a model, evaluation prompt, and algorithm."
     sub_subtitle="Read the Docs"
     sub_subtitle_link="https://docs.kiln.tech/docs/evaluations#finding-the-ideal-eval-method"
+    {breadcrumbs}
   >
     {#if loading}
       <div class="w-full min-h-[50vh] flex justify-center items-center">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb navigation to the evaluation configuration workflow. Breadcrumbs now display your current evaluation and intelligently adapt based on your selected comparison type—whether comparing judges or run configurations. This enhancement makes it easier to maintain context and navigate through the evaluation creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->