### PR TITLE
Removed final "return to eval" step helper

### DIFF
--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
@@ -449,10 +449,6 @@
 
   function compare_run_configs() {
     let url = `/evals/${project_id}/${task_id}/${eval_id}/compare_run_configs`
-    show_progress_ui(
-      "When you're done comparing run configurations, ",
-      evaluator?.template === "rag" ? 3 : 5,
-    )
     goto(url)
   }
 


### PR DESCRIPTION
This UI didn't really do anything before because there were no action items on the Eval page. Removing it.
<img width="281" height="126" alt="Screenshot 2025-11-16 at 6 12 41 PM" src="https://github.com/user-attachments/assets/8c5007d1-f51c-47a8-bbdb-0abf2a94d009" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Removed progress UI when navigating to compare run configurations; users are now taken directly to the comparison page without an intermediate loading step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->