### PR TITLE
Dialog link focus bug

### DIFF
--- a/app/web_ui/src/lib/ui/dialog.svelte
+++ b/app/web_ui/src/lib/ui/dialog.svelte
@@ -40,8 +40,11 @@
     // Clear the error, so the dialog can be used again
     error = null
     dispatch("show")
+    const dialogElement = document.getElementById(id)
     // @ts-expect-error showModal is not a method on HTMLElement
-    document.getElementById(id)?.showModal()
+    dialogElement?.showModal()
+    // Focus the dialog itself to prevent auto-focus on the first link
+    dialogElement?.focus()
   }
 
   export function close() {
@@ -73,7 +76,7 @@
   }
 </script>
 
-<dialog {id} class="modal" on:close={() => dispatch("close")}>
+<dialog {id} class="modal" tabindex="-1" on:close={() => dispatch("close")}>
   <div class="modal-box {width === 'wide' ? 'w-11/12 max-w-3xl' : ''}">
     <!-- Hidden div to force the compiler to find these classes -->
     <div class="hidden w-11/12 max-w-3xl"></div>


### PR DESCRIPTION
Fixed this
<img width="720" height="254" alt="screenshot_2025-11-17_at_2 21 47___pm_720" src="https://github.com/user-attachments/assets/6370c3be-ef6e-47b5-82d5-7f8e0df983cb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog focus management to ensure proper keyboard navigation when dialogs open, enhancing accessibility for users relying on keyboard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->