### PR TITLE
Fixed link nav from compare screen

### DIFF
--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/compare/+page.svelte
@@ -704,14 +704,24 @@
                   <div class="px-6 py-4 text-center">
                     {#if section.has_default_eval_config === false}
                       <div>Select a default eval config to compare scores.</div>
-                      <a
-                        href={eval_templates_cache[section.eval_id] === "rag"
-                          ? `/evals/${project_id}/${task_id}/${section.eval_id}/compare_run_configs`
-                          : `/evals/${project_id}/${task_id}/${section.eval_id}/eval_configs`}
-                        class="btn btn-xs rounded-full"
-                      >
-                        Manage Eval Configs
-                      </a>
+                      {#if eval_templates_loading[section.eval_id]}
+                        <div class="mt-2">
+                          <div class="loading loading-spinner loading-xs"></div>
+                        </div>
+                      {:else if eval_templates_errors[section.eval_id]}
+                        <div class="mt-2 text-error text-xs">
+                          {eval_templates_errors[section.eval_id]}
+                        </div>
+                      {:else if eval_templates_cache[section.eval_id] !== undefined}
+                        <a
+                          href={eval_templates_cache[section.eval_id] === "rag"
+                            ? `/evals/${project_id}/${task_id}/${section.eval_id}/compare_run_configs`
+                            : `/evals/${project_id}/${task_id}/${section.eval_id}/eval_configs`}
+                          class="btn btn-xs rounded-full mt-2"
+                        >
+                          Manage Eval Configs
+                        </a>
+                      {/if}
                     {:else}
                       Unknown issue - no scores found
                     {/if}


### PR DESCRIPTION
This link was going to the compare judges screen which isn't supported for RAG. For RAG evals make the link go to the compare run configs screen which handles judge creation there!

<img width="720" height="665" alt="image_720" src="https://github.com/user-attachments/assets/cb8938f2-fee2-48d3-ba95-abb80058e205" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter "Manage Eval Configs" routing with dynamic navigation that shows loading or error states and routes based on template type (e.g., RAG vs. eval), improving workflow clarity.

* **Improvements**
  * Evaluation template caching and loading indicators to reduce redundant fetches, speed up responsiveness, and drive dynamic statuses in the eval comparison view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->