### PR TITLE
refactor: gray trash can in add docs dialog

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/upload_file_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/upload_file_dialog.svelte
@@ -477,7 +477,7 @@
                   </div>
                   <button
                     type="button"
-                    class="ml-2 text-red-500 hover:text-red-700 h-4 w-4 flex-shrink-0"
+                    class="ml-2 text-gray-500 hover:text-gray-700 h-4 w-4 flex-shrink-0"
                     on:click={() => removeFile(index)}
                   >
                     <TrashIcon />


### PR DESCRIPTION
## What does this PR do?

Change the color of the trash can to gray (instead of red) in the `Add docs` dialog in RAG.

<img width="1305" height="1153" alt="image" src="https://github.com/user-attachments/assets/8f869c1b-a20b-4d0d-9982-5c247dd20ce0" />

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Trash button color from red to gray.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->