### PR TITLE
fix: extraction UI crashes if document is very long

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -634,6 +634,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/projects/{project_id}/documents/{document_id}/download_extraction/{extraction_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Download Extraction */
+        get: operations["download_extraction_api_projects__project_id__documents__document_id__download_extraction__extraction_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/projects/{project_id}/documents/{document_id}/open_enclosing_folder": {
         parameters: {
             query?: never;
@@ -3594,6 +3611,8 @@ export interface components {
             /** Output Content */
             output_content: string;
             extractor: components["schemas"]["ExtractorSummary"];
+            /** Output Content Truncated */
+            output_content_truncated: boolean;
         };
         /** ExtractorConfig */
         ExtractorConfig: {
@@ -7181,6 +7200,39 @@ export interface operations {
             path: {
                 project_id: string;
                 document_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    download_extraction_api_projects__project_id__documents__document_id__download_extraction__extraction_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                document_id: string;
+                extraction_id: string;
             };
             cookie?: never;
         };

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
@@ -18,6 +18,7 @@
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
   import TableButton from "../../../../generate/[project_id]/[task_id]/table_button.svelte"
   import EditDialog from "$lib/ui/edit_dialog.svelte"
+  import Warning from "$lib/ui/warning.svelte"
 
   let initial_document: KilnDocument | null = null
   let updated_document: KilnDocument | null = null
@@ -398,13 +399,43 @@
       label: "Close",
       isCancel: true,
     },
+    {
+      label: "Download",
+      isPrimary: true,
+      action: () => {
+        if (!dialog_extraction) {
+          return false
+        }
+        window.open(
+          `${base_url}/api/projects/${project_id}/documents/${document_id}/download_extraction/${dialog_extraction.id}`,
+          "_blank",
+        )
+        return false
+      },
+    },
   ]}
 >
   {#if dialog_extraction}
+    {#if dialog_extraction.output_content_truncated}
+      <div class="mb-4 flex flex-row gap-2">
+        <Warning
+          warning_message="The extraction output cannot be displayed in full because it is too long. To view the full output, please download the document."
+          warning_color="warning"
+          tight={true}
+          large_icon={false}
+          warning_icon="exclaim"
+        />
+      </div>
+    {/if}
     <div class="mb-2 text-sm text-gray-500">
       The extractor produced the following output:
     </div>
-    <Output raw_output={dialog_extraction.output_content} />
+    <Output
+      raw_output={dialog_extraction.output_content +
+        (dialog_extraction.output_content_truncated
+          ? "\n\n[EXTRACTION IS TOO LONG TO DISPLAY - DOWNLOAD TO VIEW FULL OUTPUT]"
+          : "")}
+    />
   {:else}
     <div class="text-sm text-gray-500">No extraction output found.</div>
   {/if}

--- a/libs/server/kiln_server/test_document_api.py
+++ b/libs/server/kiln_server/test_document_api.py
@@ -4984,3 +4984,187 @@ async def test_get_documents_filtered_with_document_no_tags(
     assert len(result) == 1
     assert result[0].id == document.id
     assert result[0].id == document.id
+
+
+async def test_download_extraction_success(
+    client, mock_document, mock_extractor_config
+):
+    """Test successfully downloading an extraction file"""
+    project = mock_document["project"]
+    document = mock_document["document"]
+    extractor_config = mock_extractor_config
+
+    extraction_output_data = b"extracted content"
+    extraction = Extraction(
+        parent=document,
+        source=ExtractionSource.PROCESSED,
+        extractor_config_id=extractor_config.id,
+        output=KilnAttachmentModel.from_data(extraction_output_data, "text/plain"),
+    )
+    extraction.save_to_file()
+
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+        patch(
+            "kiln_ai.datamodel.extraction.Document.from_id_and_parent_path"
+        ) as mock_document_from_id,
+        patch(
+            "kiln_ai.datamodel.extraction.Extraction.from_id_and_parent_path"
+        ) as mock_extraction_from_id,
+    ):
+        mock_project_from_id.return_value = project
+        mock_document_from_id.return_value = document
+        mock_extraction_from_id.return_value = extraction
+
+        response = client.get(
+            f"/api/projects/{project.id}/documents/{document.id}/download_extraction/{extraction.id}"
+        )
+
+    assert response.status_code == 200
+    assert response.content == extraction_output_data
+    assert extraction.output.path is not None
+    assert (
+        response.headers["content-disposition"]
+        == f'attachment; filename="{extraction.output.path.name}"'
+    )
+
+
+async def test_download_extraction_document_not_found(client, mock_project):
+    """Test downloading extraction when document is not found"""
+    project = mock_project
+
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+        patch(
+            "kiln_ai.datamodel.extraction.Document.from_id_and_parent_path"
+        ) as mock_document_from_id,
+    ):
+        mock_project_from_id.return_value = project
+        mock_document_from_id.return_value = None
+
+        response = client.get(
+            f"/api/projects/{project.id}/documents/fake_document_id/download_extraction/fake_extraction_id"
+        )
+
+    assert response.status_code == 404
+    assert "Document" in response.json()["message"]
+    assert "not found" in response.json()["message"]
+
+
+async def test_download_extraction_extraction_not_found(client, mock_document):
+    """Test downloading extraction when extraction is not found"""
+    project = mock_document["project"]
+    document = mock_document["document"]
+
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+        patch(
+            "kiln_ai.datamodel.extraction.Document.from_id_and_parent_path"
+        ) as mock_document_from_id,
+        patch(
+            "kiln_ai.datamodel.extraction.Extraction.from_id_and_parent_path"
+        ) as mock_extraction_from_id,
+    ):
+        mock_project_from_id.return_value = project
+        mock_document_from_id.return_value = document
+        mock_extraction_from_id.return_value = None
+
+        response = client.get(
+            f"/api/projects/{project.id}/documents/{document.id}/download_extraction/fake_extraction_id"
+        )
+
+    assert response.status_code == 404
+    assert "Extraction" in response.json()["message"]
+    assert "not found" in response.json()["message"]
+
+
+async def test_download_extraction_output_path_not_found(
+    client, mock_document, mock_extractor_config
+):
+    """Test downloading extraction when extraction output path is not found"""
+    project = mock_document["project"]
+    document = mock_document["document"]
+    extractor_config = mock_extractor_config
+
+    extraction = Extraction(
+        parent=document,
+        source=ExtractionSource.PROCESSED,
+        extractor_config_id=extractor_config.id,
+        output=KilnAttachmentModel.from_data(b"test output", "text/plain"),
+    )
+    extraction.save_to_file()
+
+    extraction_without_output_path = Extraction(
+        parent=document,
+        source=ExtractionSource.PROCESSED,
+        extractor_config_id=extractor_config.id,
+        output=KilnAttachmentModel.from_data(b"test output", "text/plain"),
+    )
+    extraction_without_output_path.path = extraction.path
+    extraction_without_output_path.output.path = None
+
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+        patch(
+            "kiln_ai.datamodel.extraction.Document.from_id_and_parent_path"
+        ) as mock_document_from_id,
+        patch(
+            "kiln_ai.datamodel.extraction.Extraction.from_id_and_parent_path"
+        ) as mock_extraction_from_id,
+    ):
+        mock_project_from_id.return_value = project
+        mock_document_from_id.return_value = document
+        mock_extraction_from_id.return_value = extraction_without_output_path
+
+        response = client.get(
+            f"/api/projects/{project.id}/documents/{document.id}/download_extraction/{extraction.id}"
+        )
+
+    assert response.status_code == 500
+    assert "Extraction output path not found" in response.json()["message"]
+
+
+async def test_download_extraction_path_not_found(
+    client, mock_document, mock_extractor_config
+):
+    """Test downloading extraction when extraction path is not found"""
+    project = mock_document["project"]
+    document = mock_document["document"]
+    extractor_config = mock_extractor_config
+
+    extraction = Extraction(
+        parent=document,
+        source=ExtractionSource.PROCESSED,
+        extractor_config_id=extractor_config.id,
+        output=KilnAttachmentModel.from_data(b"test output", "text/plain"),
+    )
+    extraction.save_to_file()
+
+    extraction_without_path = Extraction(
+        parent=document,
+        source=ExtractionSource.PROCESSED,
+        extractor_config_id=extractor_config.id,
+        output=KilnAttachmentModel.from_data(b"test output", "text/plain"),
+    )
+    extraction_without_path.save_to_file()
+    extraction_without_path.path = None
+
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+        patch(
+            "kiln_ai.datamodel.extraction.Document.from_id_and_parent_path"
+        ) as mock_document_from_id,
+        patch(
+            "kiln_ai.datamodel.extraction.Extraction.from_id_and_parent_path"
+        ) as mock_extraction_from_id,
+    ):
+        mock_project_from_id.return_value = project
+        mock_document_from_id.return_value = document
+        mock_extraction_from_id.return_value = extraction_without_path
+
+        response = client.get(
+            f"/api/projects/{project.id}/documents/{document.id}/download_extraction/{extraction.id}"
+        )
+
+    assert response.status_code == 500
+    assert "Extraction path not found" in response.json()["message"]


### PR DESCRIPTION
## What does this PR do?

UI detailed page for a document crashes when the extraction is extremely long - which happens if the document is also very long.

Changes:
- cap extraction displayed in UI to 100,000 chars
- display a warning when the output is truncated
- add a button to download the full extraction

<img width="3322" height="1965" alt="image" src="https://github.com/user-attachments/assets/fea7b23f-cf32-4a7d-9428-00c9c1356776" />

<img width="1446" height="703" alt="image" src="https://github.com/user-attachments/assets/9815a0f7-9120-4554-ab54-1ce83b33fc21" />

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Download extraction output directly to your device
  * Large extraction outputs now display a truncation warning in the UI
  * Download button available in the extraction output dialog for complete content access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->