### PR TITLE
Parallel tool calls. 

### DIFF
--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import json
 import logging
@@ -595,6 +596,7 @@ class LiteLlmAdapter(BaseAdapter):
 
         assistant_output_from_toolcall: str | None = None
         tool_call_response_messages: list[ChatCompletionToolMessageParamWrapper] = []
+        tool_run_coroutines = []
 
         for tool_call in tool_calls:
             # Kiln "task_response" tool is used for returning structured output via tool calls.
@@ -635,18 +637,24 @@ class LiteLlmAdapter(BaseAdapter):
             context = ToolCallContext(
                 allow_saving=self.base_adapter_config.allow_saving
             )
-            result = await tool.run(context, **parsed_args)
 
-            tool_call_response_messages.append(
-                ChatCompletionToolMessageParamWrapper(
+            async def run_tool_and_format(
+                t=tool, c=context, args=parsed_args, tc_id=tool_call.id
+            ):
+                result = await t.run(c, **args)
+                return ChatCompletionToolMessageParamWrapper(
                     role="tool",
-                    tool_call_id=tool_call.id,
+                    tool_call_id=tc_id,
                     content=result.output,
                     kiln_task_tool_data=result.kiln_task_tool_data
                     if isinstance(result, KilnTaskToolResult)
                     else None,
                 )
-            )
+
+            tool_run_coroutines.append(run_tool_and_format())
+
+        if tool_run_coroutines:
+            tool_call_response_messages = await asyncio.gather(*tool_run_coroutines)
 
         if (
             assistant_output_from_toolcall is not None


### PR DESCRIPTION
Fixes https://linear.app/kiln-ai/issue/KIL-303/tools-should-be-executed-in-parallel-if-a-model-has-requested-them-in

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Runs model-requested tool calls in parallel within the LiteLLM adapter for faster tool handling.
> 
> - **Adapters (LiteLLM)**:
>   - Parallelizes tool execution in `process_tool_calls` by batching coroutines and awaiting with `asyncio.gather`.
>   - Refactors per-tool run/format into an inner async helper to produce `ChatCompletionToolMessageParamWrapper`.
>   - Preserves special handling for `task_response` and existing validation/error checks.
> - **Misc**:
>   - Adds `asyncio` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 810ed7b623c1b8b0b830b669a446af4f88504636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tool execution performance through enhanced processing efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->