### PR TITLE
fix: no enum in request schema to avoid remote_config conflict

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2535,8 +2535,11 @@ export interface components {
             description?: string | null;
             /** @description The provider of the embedding model */
             model_provider_name: components["schemas"]["ModelProviderName"];
-            /** @description The name of the embedding model */
-            model_name: components["schemas"]["EmbeddingModelName"];
+            /**
+             * Model Name
+             * @description The name of the embedding model
+             */
+            model_name: string;
             /** @description Properties to be used to execute the embedding config. */
             properties?: components["schemas"]["EmbeddingProperties"];
         };

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -10,7 +10,6 @@ from kiln_ai.adapters.chunkers.chunker_registry import chunker_adapter_from_type
 from kiln_ai.adapters.extractors.extractor_registry import extractor_adapter_from_type
 from kiln_ai.adapters.extractors.extractor_runner import ExtractorRunner
 from kiln_ai.adapters.ml_embedding_model_list import (
-    EmbeddingModelName,
     built_in_embedding_models_from_provider,
 )
 from kiln_ai.adapters.ml_model_list import built_in_models_from_provider
@@ -393,7 +392,7 @@ class CreateEmbeddingConfigRequest(BaseModel):
     model_provider_name: ModelProviderName = Field(
         description="The provider of the embedding model",
     )
-    model_name: EmbeddingModelName = Field(
+    model_name: str = Field(
         description="The name of the embedding model",
     )
     properties: EmbeddingProperties = Field(

--- a/libs/server/kiln_server/test_document_api.py
+++ b/libs/server/kiln_server/test_document_api.py
@@ -7,7 +7,10 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
-from kiln_ai.adapters.ml_embedding_model_list import EmbeddingModelName
+from kiln_ai.adapters.ml_embedding_model_list import (
+    EmbeddingModelName,
+    KilnEmbeddingModelProvider,
+)
 from kiln_ai.adapters.rag.progress import LogMessage, RagProgress
 from kiln_ai.adapters.vector_store.base_vector_store_adapter import SearchResult
 from kiln_ai.datamodel.basemodel import KilnAttachmentModel
@@ -1100,6 +1103,55 @@ async def test_create_embedding_config_success(
     assert result["description"] == "Test Embedding Config description"
     assert result["model_provider_name"] == model_provider_name
     assert result["model_name"] == model_name
+    assert result["properties"] == {}
+
+
+async def test_create_embedding_config_success_new_model_from_remote_config(
+    client,
+    mock_project,
+):
+    """
+    Some of the models available to users in the UI are not present in the ModelProviderName enum.
+    However, these models are included in the dynamically updated in-memory model list that comes from
+    the remote_config (over the internet) update.
+
+    If we use an enum type in the API request models, Pydantic will reject any request that uses a model
+    name not present in the enum, even if that model is present in the dynamically fetched model list.
+    So we must avoid using an enum for these model fields.
+    """
+    with (
+        patch("kiln_server.document_api.project_from_id") as mock_project_from_id,
+        patch(
+            "kiln_server.document_api.built_in_embedding_models_from_provider"
+        ) as mock_built_in_embedding_models_from_provider,
+    ):
+        mock_project_from_id.return_value = mock_project
+        mock_built_in_embedding_models_from_provider.return_value = KilnEmbeddingModelProvider(
+            name=ModelProviderName.openai,
+            model_id="model_not_in_enum_but_now_in_model_list_because_of_remote_config_update_ota",
+            n_dimensions=1536,
+        )
+        response = client.post(
+            f"/api/projects/{mock_project.id}/create_embedding_config",
+            json={
+                "name": "Test Embedding Config",
+                "description": "Test Embedding Config description",
+                "model_provider_name": ModelProviderName.openai,
+                "model_name": "model_not_in_enum_but_now_in_model_list_because_of_remote_config_update_ota",
+                "properties": {},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    result = response.json()
+    assert result["id"] is not None
+    assert result["name"] == "Test Embedding Config"
+    assert result["description"] == "Test Embedding Config description"
+    assert result["model_provider_name"] == "openai"
+    assert (
+        result["model_name"]
+        == "model_not_in_enum_but_now_in_model_list_because_of_remote_config_update_ota"
+    )
     assert result["properties"] == {}
 
 


### PR DESCRIPTION
## What does this PR do?

Fix:
- remove a model name enum from the request body schema for creating an EmbeddingConfig, because it conflicts with the models coming out of `remote_config` (they are in the model list, but not in the model enum)
- add test to check for this behavior

This problem happens as follows:
- model name enum: `model-a`, `model-b`, `model-c` (this enum never changes, comes packaged in the app release)
- remote_config: we add `model-x` and `model-y`
- the app fetches `remote_config.json`, sees the newly added `model-x` and `model-y` models and adds them to its `built_in_embedding_models` (in `ml_embedding_model_list.py`) in memory
- user can now see `model-x` and `model-y` in the dropdown menu when picking an embedding model to create a RAG Config
- the request goes to the local server, Pydantic checks the model is in the model name enum (if the enum is used in the request schema `BaseModel`); and it is not because the enum never changes

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
