### PR TITLE
fix: add gap-4 spacing between advanced run options form fields

### DIFF
--- a/app/web_ui/src/lib/ui/run_config_component/advanced_run_options.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/advanced_run_options.svelte
@@ -113,7 +113,7 @@
   ]
 </script>
 
-<div class="flex flex-col gap-2">
+<div class="flex flex-col gap-4">
   <FormElement
     id="temperature"
     label="Temperature"


### PR DESCRIPTION
## Summary
- Fixes spacing issue in Advanced Options collapse sections where form element labels were closer to the field above them than their own field
- Adds `flex flex-col gap-4` to the wrapper div in `advanced_run_options.svelte`

Fixes KIL-255

## Test plan
- [ ] Verify Advanced Options section in RunConfigComponent shows proper spacing between Temperature, Top P, and Structured Output fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the Advanced Run Options layout to use a column-based flex arrangement with increased gap spacing, resulting in cleaner spacing, improved visual alignment, and a more organized presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->