### PR TITLE
KIL-269: Clean up Run Configuration Details modal

### DIFF
--- a/app/web_ui/src/lib/ui/run_config_component/run_config_details_dialog.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/run_config_details_dialog.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte"
   import Dialog from "$lib/ui/dialog.svelte"
   import PropertyList from "$lib/ui/property_list.svelte"
   import type { TaskRunConfig } from "$lib/types"
@@ -9,8 +8,6 @@
   import { get_task_composite_id } from "$lib/stores"
   import { getRunConfigUiProperties } from "$lib/utils/run_config_formatters"
 
-  const dispatch = createEventDispatcher()
-
   export let project_id: string
   export let task_id: string
   export let task_run_config: TaskRunConfig
@@ -19,10 +16,6 @@
 
   export function show() {
     dialog?.show()
-  }
-
-  function handle_close() {
-    dispatch("close")
   }
 
   $: task_prompts =
@@ -39,11 +32,6 @@
   )
 </script>
 
-<Dialog
-  bind:this={dialog}
-  title="Run Configuration Details"
-  width="wide"
-  on:close={handle_close}
->
+<Dialog bind:this={dialog} title="Run Configuration Details">
   <PropertyList {properties} />
 </Dialog>

--- a/app/web_ui/src/lib/ui/run_config_component/run_config_summary.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/run_config_summary.svelte
@@ -12,71 +12,47 @@
   export let is_default: boolean = false
 
   let details_dialog: RunConfigDetailsDialog | null = null
-  let clickable_element: HTMLDivElement | null = null
-  let opened_by_click = false
 
   function open_details_dialog() {
     details_dialog?.show()
-  }
-
-  function handle_dialog_close() {
-    // Blur if opened by click to prevent focus returning
-    if (opened_by_click && clickable_element) {
-      clickable_element.blur()
-    }
-    opened_by_click = false
   }
 
   $: tools_count =
     task_run_config.run_config_properties.tools_config?.tools?.length ?? 0
 </script>
 
-<div
-  bind:this={clickable_element}
-  class="rounded-md p-2 cursor-pointer hover:bg-base-200 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-base-300"
-  on:click={() => {
-    opened_by_click = true
-    open_details_dialog()
-  }}
-  on:keydown={(e) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault()
-      opened_by_click = false
-      open_details_dialog()
-    }
-  }}
-  role="button"
-  tabindex="0"
-  aria-label="Open run configuration details"
->
-  <div class="flex items-center gap-2">
-    <div class="font-medium">
-      {task_run_config.name}
-    </div>
-    {#if is_default}
-      <span class="badge badge-sm badge-primary badge-outline"> Default </span>
-    {/if}
+<div class="flex items-center gap-2">
+  <div class="font-medium">
+    {task_run_config.name}
   </div>
-  <div class="text-sm text-gray-500">
-    <div>
-      Model: {getDetailedModelName(task_run_config, $model_info)}
-    </div>
-    <div>
-      Prompt: {getRunConfigPromptDisplayName(
-        task_run_config,
-        $current_task_prompts,
-      )}
-    </div>
-    <div>
-      Tools: {tools_count > 0 ? `${tools_count} available` : "None"}
-    </div>
+  {#if is_default}
+    <span class="badge badge-sm badge-primary badge-outline"> Default </span>
+  {/if}
+</div>
+<div class="text-sm text-gray-500">
+  <div>
+    Model: {getDetailedModelName(task_run_config, $model_info)}
+  </div>
+  <div>
+    Prompt: {getRunConfigPromptDisplayName(
+      task_run_config,
+      $current_task_prompts,
+    )}
+  </div>
+  <div>
+    Tools: {tools_count > 0 ? `${tools_count} available` : "None"}
   </div>
 </div>
+<button
+  class="link text-sm text-gray-500 hover:text-gray-700 mt-1"
+  on:click={open_details_dialog}
+>
+  See Details
+</button>
 
 <RunConfigDetailsDialog
   bind:this={details_dialog}
   {task_run_config}
   {project_id}
   {task_id}
-  on:close={handle_dialog_close}
 />


### PR DESCRIPTION
## Summary
Addresses code review feedback on the Run Configuration Details modal.

## Changes
- **Removed `width="wide"`** from the details dialog - reduces whitespace, looks cleaner at standard width
- **Simplified `run_config_summary.svelte`** - removed complex blur state tracking (`opened_by_click`, `clickable_element`, `handle_dialog_close`)
- **Converted `div role="button"` to proper `<button>`** - better accessibility
- **Added 'See Details' link** - provides clear affordance that clicking opens details
- **Cleaned up `run_config_details_dialog.svelte`** - removed unused `createEventDispatcher` and close handler

## Testing
- Verified svelte-check passes
- Verified all web UI tests pass
- Manual testing: 'See Details' button is tabbable and responds to Enter key

Closes KIL-269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized run configuration summary layout with consolidated name and default badge display.
  * Moved detailed model, prompt, and tools information to a separate content column.
  * Added "See Details" button to access full configuration details dialog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->