### PR TITLE
KIL-257: Fix tags not applied to synth data in subsequent generations

### DIFF
--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
@@ -671,7 +671,9 @@
   let root_node_component: GeneratedDataNode | null = null
 
   function get_random_split_tag() {
-    const splits = get(guidance_data.splits)
+    // Read splits from saved_state (the persisted source of truth) instead of
+    // guidance_data.splits to avoid sync issues between the two stores
+    const splits = get(saved_state).splits
     if (Object.keys(splits).length === 0) return undefined
 
     const random = Math.random()


### PR DESCRIPTION
## Summary

Fixes a bug where tags (split tags) were not being applied to synthetic data runs when generating more inputs/outputs after an initial save.

## Problem

When using the synthetic data generation flow:
1. Generate inputs/outputs, then `Save all` → tags applied correctly ✓
2. Go back to `Generate Inputs`, generate more, then `Generate Outputs`, then `Save all` → tags NOT applied ✗

## Root Cause

The `get_random_split_tag()` function was reading splits from `guidance_data.splits`, which is a separate store from `saved_state.splits`. These two stores are supposed to be synced via reactive statements, but the sync logic uses object reference comparison (`!==`) which fails when both stores reference the same object - causing the sync condition to always be false.

## Fix

Updated `get_random_split_tag()` to read splits directly from `saved_state.splits` (the persisted source of truth) instead of `guidance_data.splits`. This aligns with how the QnA page handles splits.

## Testing

- All existing tests pass
- Linting and type checking pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed random split selection to use persisted state instead of temporary storage, ensuring consistent behavior across sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->