### PR TITLE
KIL-271: Fix evals page showing empty state instead of error

### DIFF
--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/+page.svelte
@@ -130,10 +130,6 @@
     <div class="w-full min-h-[50vh] flex justify-center items-center">
       <div class="loading loading-spinner loading-lg"></div>
     </div>
-  {:else if is_empty}
-    <div class="flex flex-col items-center justify-center min-h-[60vh]">
-      <EmptyEvaluator {project_id} {task_id} />
-    </div>
   {:else if error}
     <div
       class="w-full min-h-[50vh] flex flex-col justify-center items-center gap-2"
@@ -142,6 +138,10 @@
       <div class="text-error text-sm">
         {error.getMessage() || "An unknown error occurred"}
       </div>
+    </div>
+  {:else if is_empty}
+    <div class="flex flex-col items-center justify-center min-h-[60vh]">
+      <EmptyEvaluator {project_id} {task_id} />
     </div>
   {:else if evals}
     <a href={`/evals/${project_id}/${task_id}/compare`} class="group">


### PR DESCRIPTION
## Summary

Fixes a bug where the evals home screen showed the new user empty state (EmptyEvaluator intro UI) instead of an error message when the /evals API errors.

## Problem

When the `/evals` API errors, the `evals` variable remains `null`, so `is_empty` (which is `!evals || evals.length == 0`) evaluates to `true`. The template conditionals were checking `is_empty` before `error`, causing the empty state to be shown instead of the error message.

## Solution

Reordered the template conditionals to check `error` before `is_empty`, matching the pattern used consistently in other pages (e.g., Models page, Tool server page, Run results page).

**Before:**
```svelte
{#if loading}
{:else if is_empty}    <!-- Ran first when evals is null -->
{:else if error}       <!-- Never reached on error -->
```

**After:**
```svelte
{#if loading}
{:else if error}       <!-- Now checked first -->
{:else if is_empty}
```

## Testing

- All 405 frontend tests pass
- Svelte check passes with 0 errors/warnings
- Manually verified the logic is correct

Closes KIL-271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error display priority in evaluation screens by ensuring error messages appear before empty state indicators, providing users with clearer feedback about issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->