### PR TITLE
KIL-246 add evaluate search tools entrypoint

### DIFF
--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/+page.svelte
@@ -17,6 +17,7 @@
     sortRagConfigs,
     getProjectRagStateStore,
   } from "$lib/stores/rag_progress_store"
+  import { ui_state } from "$lib/stores"
 
   $: projectStateStore = getProjectRagStateStore($page.params.project_id)
   $: progressState = $projectStateStore
@@ -35,6 +36,10 @@
   }
 
   $: project_id = $page.params.project_id
+  $: current_task_id = $ui_state.current_task_id
+  $: evals_href = current_task_id
+    ? `/evals/${project_id}/${current_task_id}/create_evaluator?template_id=rag`
+    : undefined
 
   onMount(async () => {
     // need to ensure the store is populated for friendly name resolution
@@ -102,6 +107,11 @@
     action_buttons={all_rag_configs && all_rag_configs.length == 0
       ? []
       : [
+          {
+            label: "Evaluate Search Tools",
+            href: evals_href,
+            disabled: !evals_href,
+          },
           {
             label: "Add Search Tool",
             primary: true,

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/create_evaluator/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/create_evaluator/+page.svelte
@@ -6,7 +6,10 @@
     EvalTemplateId,
     EvalDataType,
   } from "$lib/types"
-  import { type EvalTemplateResult } from "./eval_template"
+  import {
+    type EvalTemplateResult,
+    buildReferenceAnswerAccuracyTemplate,
+  } from "./eval_template"
   import FormContainer from "$lib/utils/form_container.svelte"
   import type { Task } from "$lib/types"
   import FormElement from "$lib/utils/form_element.svelte"
@@ -79,6 +82,11 @@
   let create_evaluator_loading: boolean = false
   // Used to not block the navigation once the evaluator is created
   let complete = false
+
+  $: template_id_param = $page.url.searchParams.get("template_id")
+  $: if (!selected_template && template_id_param === "rag") {
+    on_selected_template(buildReferenceAnswerAccuracyTemplate())
+  }
 
   async function create_evaluator() {
     create_evaluator_error = undefined

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/create_evaluator/eval_template.ts
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/create_evaluator/eval_template.ts
@@ -1,4 +1,5 @@
 import type { EvalOutputScore, EvalTemplateId, EvalDataType } from "$lib/types"
+import { generate_eval_tag } from "./eval_utils"
 
 export type EvalTemplateResult = {
   // Server IDs are EvalTemplateId. We have a custom "none" value for the UI.
@@ -10,4 +11,25 @@ export type EvalTemplateResult = {
   default_golden_tag: string | null
   template_properties: Record<string, string | number | boolean>
   evaluation_data_type: EvalDataType
+}
+
+export function buildReferenceAnswerAccuracyTemplate(): EvalTemplateResult {
+  return {
+    template_id: "rag",
+    name: "Reference Answer Accuracy",
+    description:
+      "Evaluate how well your task retrieves and answers queries using a Q&A dataset built from your documents.",
+    output_scores: [
+      {
+        name: "Reference Answer Accuracy",
+        type: "pass_fail",
+        instruction:
+          "Evaluate if the model's output is accurate as per the reference answer.",
+      },
+    ],
+    default_eval_tag: "qna_set_" + generate_eval_tag(""),
+    default_golden_tag: null,
+    template_properties: {},
+    evaluation_data_type: "reference_answer",
+  }
 }

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/create_evaluator/select_eval_template.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/create_evaluator/select_eval_template.svelte
@@ -15,6 +15,7 @@
   import FormContainer from "$lib/utils/form_container.svelte"
   import FormElement from "$lib/utils/form_element.svelte"
   import { generate_eval_tag } from "./eval_utils"
+  import { buildReferenceAnswerAccuracyTemplate } from "./eval_template"
   import KilnSection from "$lib/ui/kiln_section.svelte"
   import type { KilnSectionItem } from "$lib/ui/kiln_section_types"
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
@@ -86,24 +87,7 @@
               "Evaluate model accuracy against ground-truth Q&A pairs.",
             recommended: false,
             on_select: () =>
-              select_template("rag", {
-                template_id: "rag",
-                name: "Reference Answer Accuracy",
-                description:
-                  "Evaluate how well your task retrieves and answers queries using a Q&A dataset built from your documents.",
-                output_scores: [
-                  {
-                    name: "Reference Answer Accuracy",
-                    type: "pass_fail",
-                    instruction:
-                      "Evaluate if the model's output is accurate as per the reference answer.",
-                  },
-                ],
-                default_eval_tag: "qna_set_" + generate_eval_tag(""),
-                default_golden_tag: null,
-                template_properties: {},
-                evaluation_data_type: "reference_answer",
-              }),
+              select_template("rag", buildReferenceAnswerAccuracyTemplate()),
           },
         ],
       },


### PR DESCRIPTION
I know we are changing evals to specs but we might as well get this shipped in the time being! (Evaluate Search Tools button in Docs & Search)
<img width="1691" height="915" alt="Screenshot 2025-11-27 at 3 15 26 AM" src="https://github.com/user-attachments/assets/13a033ce-7fea-4a67-b560-829179b84388" />
The button goes directly to the RAG eval template form:
<img width="1165" height="1259" alt="Screenshot 2025-11-27 at 3 15 32 AM" src="https://github.com/user-attachments/assets/c89ced71-d001-4aab-ab1f-dcc2a87162e2" />

## Summary
- add secondary Evaluate Search Tools action on the Search Tools page
- auto-select the RAG evaluator template when the new link is used
- centralize the Reference Answer Accuracy template definition for reuse

## Testing
- ./checks.sh (fails only when calling pyright; uv run pyright . succeeds)
- uv run pyright .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Evaluate Search Tools" action button on the RAG Configs page.
  * Pre-populates "Reference Answer Accuracy" evaluation template when creating evaluators from RAG configurations, streamlining the evaluation setup workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->