### PR TITLE
Add basic markdown support to tooltips: links and bold

### DIFF
--- a/app/web_ui/src/lib/ui/info_tooltip.svelte
+++ b/app/web_ui/src/lib/ui/info_tooltip.svelte
@@ -18,6 +18,52 @@
   let isVisible = false
   let cleanupAutoUpdate: (() => void) | null = null
 
+  type Segment =
+    | { type: "text"; content: string }
+    | { type: "bold"; content: string }
+    | { type: "link"; text: string; url: string }
+
+  // Parse a line of text into segments for safe rendering
+  function parseLineToSegments(text: string): Segment[] {
+    const segments: Segment[] = []
+    // Combined regex to match links or bold text
+    const pattern = /\[([^\]]+)\]\(([^)]+)\)|\*\*([^*]+)\*\*/g
+    let lastIndex = 0
+    let match
+
+    while ((match = pattern.exec(text)) !== null) {
+      // Add plain text before this match
+      if (match.index > lastIndex) {
+        segments.push({
+          type: "text",
+          content: text.slice(lastIndex, match.index),
+        })
+      }
+
+      if (match[1] !== undefined && match[2] !== undefined) {
+        // Link: [text](url) - match[1] is text, match[2] is url
+        segments.push({ type: "link", text: match[1], url: match[2] })
+      } else if (match[3] !== undefined) {
+        // Bold: **text** - match[3] is the bold content
+        segments.push({ type: "bold", content: match[3] })
+      }
+
+      lastIndex = pattern.lastIndex
+    }
+
+    // Add remaining plain text
+    if (lastIndex < text.length) {
+      segments.push({ type: "text", content: text.slice(lastIndex) })
+    }
+
+    // If no segments were added, return the whole text as plain
+    if (segments.length === 0) {
+      segments.push({ type: "text", content: text })
+    }
+
+    return segments
+  }
+
   function showTooltip() {
     if (!triggerElement || !tooltipElement) return
 
@@ -95,12 +141,31 @@
 <!-- Custom Floating Tooltip -->
 <div
   bind:this={tooltipElement}
-  class="fixed z-[50] px-3 py-2 text-sm text-base-content bg-stone-200 rounded-md shadow-lg w-72 whitespace-normal pointer-events-none text-center flex flex-col gap-1 {isVisible
+  class="fixed z-[50] px-3 py-2 text-sm text-base-content bg-stone-200 rounded-md shadow-lg w-72 whitespace-normal text-center flex flex-col gap-1 {isVisible
     ? ''
     : 'hidden'}"
   role="tooltip"
+  on:mouseenter={showTooltip}
+  on:mouseleave={hideTooltip}
 >
   {#each tooltip_text.split("\n") as line}
-    <p>{line}</p>
+    <p>
+      {#each parseLineToSegments(line) as segment}
+        {#if segment.type === "text"}
+          {segment.content}
+        {:else if segment.type === "bold"}
+          <strong>{segment.content}</strong>
+        {:else if segment.type === "link"}
+          <a
+            href={segment.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="link"
+          >
+            {segment.text}
+          </a>
+        {/if}
+      {/each}
+    </p>
   {/each}
 </div>

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
@@ -524,7 +524,7 @@
           <PromptTypeSelector
             bind:prompt_method={system_prompt_method}
             description="The system message to use for fine-tuning. Choose the prompt you want to use with your fine-tuned model."
-            info_description="There are tradeoffs to consider when choosing a system prompt for fine-tuning. Read more: https://platform.openai.com/docs/guides/fine-tuning/#crafting-prompts"
+            info_description="There are tradeoffs to consider when choosing a system prompt for fine-tuning. Read more: [OpenAI Docs](https://platform.openai.com/docs/guides/fine-tuning/#crafting-prompts)."
             exclude_cot={true}
             custom_prompt_name="Custom Fine Tuning Prompt"
           />
@@ -533,7 +533,7 @@
               <FormElement
                 label="Custom System Prompt"
                 description="Enter a custom system prompt to use during fine-tuning."
-                info_description="There are tradeoffs to consider when choosing a system prompt for fine-tuning. Read more: https://platform.openai.com/docs/guides/fine-tuning/#crafting-prompts"
+                info_description="There are tradeoffs to consider when choosing a system prompt for fine-tuning. Read more: [OpenAI Docs](https://platform.openai.com/docs/guides/fine-tuning/#crafting-prompts)."
                 inputType="textarea"
                 id="finetune_custom_system_prompt"
                 bind:value={finetune_custom_system_prompt}


### PR DESCRIPTION
Fixes https://linear.app/kiln-ai/issue/KIL-318/fine-tune-custom-prompt-tool-tip-cant-properly-render-url


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tooltips now support markdown-like formatting, including bold text and hyperlinks.
* **Documentation**
  * Updated documentation references to display as formatted clickable hyperlinks instead of plain URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->