### PR TITLE
Kiln server API client for use in the app

### DIFF
--- a/app/desktop/pyproject.toml
+++ b/app/desktop/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kiln-studio-desktop"
-version = "0.1.0"
+version = "0.23.0"
 description = "The Kiln Desktop App. Download from https://kiln.tech"
 requires-python = ">=3.10"
 dependencies = [
@@ -21,3 +21,9 @@ only-include = ["__init__.py"]
 
 [tool.uv.sources]
 kiln-server = { workspace = true }
+
+[tool.ruff]
+exclude = [
+    # Automatically generated code, so we don't lint it
+    "studio_server/api_client/kiln_ai_server_client",
+]

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/README.md
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/README.md
@@ -1,0 +1,106 @@
+# kiln-ai-server-client
+
+A client library for accessing Kiln AI FastAPI Service
+
+## Usage
+
+First, create a client (always use AuthenticatedClient):
+
+```python
+from kiln_ai_server_client import AuthenticatedClient
+
+client = AuthenticatedClient(base_url="https://api.kiln.tech", token="KILN_API_KEY")
+```
+
+Now call your endpoint and use your models:
+
+```python
+from kiln_ai_server_client.models import MyDataModel
+from kiln_ai_server_client.api.my_tag import get_my_data_model
+from kiln_ai_server_client.types import Response
+
+with client as client:
+    my_data: MyDataModel = get_my_data_model.sync(client=client)
+    # or if you need more info (e.g. status_code)
+    response: Response[MyDataModel] = get_my_data_model.sync_detailed(client=client)
+```
+
+Or do the same thing with an async version:
+
+```python
+from kiln_ai_server_client.models import MyDataModel
+from kiln_ai_server_client.api.my_tag import get_my_data_model
+from kiln_ai_server_client.types import Response
+
+async with client as client:
+    my_data: MyDataModel = await get_my_data_model.asyncio(client=client)
+    response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)
+```
+
+By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com",
+    token="SuperSecretToken",
+    verify_ssl="/path/to/certificate_bundle.pem",
+)
+```
+
+You can also disable certificate validation altogether, but beware that **this is a security risk**.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com",
+    token="SuperSecretToken",
+    verify_ssl=False
+)
+```
+
+Things to know:
+
+1. Every path/method combo becomes a Python module with four functions:
+
+   1. `sync`: Blocking request that returns parsed data (if successful) or `None`
+   1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
+   1. `asyncio`: Like `sync` but async instead of blocking
+   1. `asyncio_detailed`: Like `sync_detailed` but async instead of blocking
+
+1. All path/query params, and bodies become method arguments.
+1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
+1. Any endpoint which did not have a tag will be in `kiln_ai_server_client.api.default`
+
+## Advanced customizations
+
+There are more settings on the generated `Client` class which let you control more runtime behavior, check out the docstring on that class for more info. You can also customize the underlying `httpx.Client` or `httpx.AsyncClient` (depending on your use-case):
+
+```python
+from kiln_ai_server_client import Client
+
+def log_request(request):
+    print(f"Request event hook: {request.method} {request.url} - Waiting for response")
+
+def log_response(response):
+    request = response.request
+    print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
+
+client = Client(
+    base_url="https://api.example.com",
+    httpx_args={"event_hooks": {"request": [log_request], "response": [log_response]}},
+)
+
+# Or get the underlying httpx client to modify directly with client.get_httpx_client() or client.get_async_httpx_client()
+```
+
+You can even set the httpx client directly, but beware that this will override any existing settings (e.g., base_url):
+
+```python
+import httpx
+from kiln_ai_server_client import Client
+
+client = Client(
+    base_url="https://api.example.com",
+)
+# Note that base_url needs to be re-set, as would any shared cookies, headers, etc.
+client.set_httpx_client(httpx.Client(base_url="https://api.example.com", proxies="http://localhost:8030"))
+```

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/__init__.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing Kiln AI FastAPI Service"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/api/__init__.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/api/health/__init__.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/api/health/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/api/health/health_health_get.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/api/health/health_health_get.py
@@ -1,0 +1,157 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.health_health_get_response_health_health_get import (
+    HealthHealthGetResponseHealthHealthGet,
+)
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/health",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HealthHealthGetResponseHealthHealthGet | None:
+    if response.status_code == 200:
+        response_200 = HealthHealthGetResponseHealthHealthGet.from_dict(response.json())
+
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HealthHealthGetResponseHealthHealthGet]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HealthHealthGetResponseHealthHealthGet]:
+    r"""Health
+
+     Health check endpoint.
+
+    Returns the current health status of the service.
+
+    Returns:
+        dict: A dictionary containing the service status. {\"status\": \"ok\"} is expected.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HealthHealthGetResponseHealthHealthGet]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> HealthHealthGetResponseHealthHealthGet | None:
+    r"""Health
+
+     Health check endpoint.
+
+    Returns the current health status of the service.
+
+    Returns:
+        dict: A dictionary containing the service status. {\"status\": \"ok\"} is expected.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HealthHealthGetResponseHealthHealthGet
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HealthHealthGetResponseHealthHealthGet]:
+    r"""Health
+
+     Health check endpoint.
+
+    Returns the current health status of the service.
+
+    Returns:
+        dict: A dictionary containing the service status. {\"status\": \"ok\"} is expected.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HealthHealthGetResponseHealthHealthGet]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> HealthHealthGetResponseHealthHealthGet | None:
+    r"""Health
+
+     Health check endpoint.
+
+    Returns the current health status of the service.
+
+    Returns:
+        dict: A dictionary containing the service status. {\"status\": \"ok\"} is expected.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HealthHealthGetResponseHealthHealthGet
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/api/health/ping_ping_get.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/api/health/ping_ping_get.py
@@ -1,0 +1,157 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/ping",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> str | None:
+    if response.status_code == 200:
+        response_200 = response.text
+        return response_200
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[str]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[str]:
+    r"""Ping
+
+     Simple ping endpoint.
+
+    A lightweight endpoint that returns a simple \"pong\" response,
+    useful for basic connectivity testing and load balancer health checks.
+
+    Returns:
+        str: The string \"pong\"
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+) -> str | None:
+    r"""Ping
+
+     Simple ping endpoint.
+
+    A lightweight endpoint that returns a simple \"pong\" response,
+    useful for basic connectivity testing and load balancer health checks.
+
+    Returns:
+        str: The string \"pong\"
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[str]:
+    r"""Ping
+
+     Simple ping endpoint.
+
+    A lightweight endpoint that returns a simple \"pong\" response,
+    useful for basic connectivity testing and load balancer health checks.
+
+    Returns:
+        str: The string \"pong\"
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[str]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+) -> str | None:
+    r"""Ping
+
+     Simple ping endpoint.
+
+    A lightweight endpoint that returns a simple \"pong\" response,
+    useful for basic connectivity testing and load balancer health checks.
+
+    Returns:
+        str: The string \"pong\"
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        str
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/client.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/client.py
@@ -1,0 +1,282 @@
+import ssl
+from typing import Any
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(
+        default=True, kw_only=True, alias="verify_ssl"
+    )
+    _follow_redirects: bool = field(
+        default=False, kw_only=True, alias="follow_redirects"
+    )
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout configuration"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(
+        self, async_client: httpx.AsyncClient
+    ) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = (
+                f"{self.prefix} {self.token}" if self.prefix else self.token
+            )
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/errors.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/__init__.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/__init__.py
@@ -1,0 +1,7 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .health_health_get_response_health_health_get import (
+    HealthHealthGetResponseHealthHealthGet,
+)
+
+__all__ = ("HealthHealthGetResponseHealthHealthGet",)

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/health_health_get_response_health_health_get.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/health_health_get_response_health_health_get.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="HealthHealthGetResponseHealthHealthGet")
+
+
+@_attrs_define
+class HealthHealthGetResponseHealthHealthGet:
+    """ """
+
+    additional_properties: dict[str, str] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        health_health_get_response_health_health_get = cls()
+
+        health_health_get_response_health_health_get.additional_properties = d
+        return health_health_get_response_health_health_get
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/py.typed
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/types.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
+    # (filename, file (or bytes), content_type)
+    tuple[str | None, FileContent, str | None]
+    # (filename, file (or bytes), content_type, headers)
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: str | None = None
+    mime_type: str | None = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: T | None
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/app/desktop/studio_server/api_client/kiln_server_client.py
+++ b/app/desktop/studio_server/api_client/kiln_server_client.py
@@ -1,0 +1,30 @@
+import os
+from importlib.metadata import version
+
+from app.desktop.studio_server.api_client.kiln_ai_server_client.client import (
+    Client as KilnServerClient,
+)
+
+
+def _get_desktop_app_version() -> str:
+    """Get the version of the kiln-studio-desktop package."""
+    try:
+        return version("kiln-studio-desktop")
+    except Exception:
+        return "unknown"
+
+
+def get_kiln_server_client() -> KilnServerClient:
+    app_version = _get_desktop_app_version()
+    base_url = os.getenv("KILN_SERVER_BASE_URL", "https://api.kiln.tech")
+    return KilnServerClient(
+        base_url=base_url,
+        headers={
+            "User-Agent": f"KilnDesktopApp/{app_version}",
+            "Kiln-Desktop-App-Version": app_version,
+        },
+    )
+
+
+server_client = get_kiln_server_client()
+"""The default client for the Kiln server for reusability."""

--- a/app/desktop/studio_server/api_client/test_kiln_server_client.py
+++ b/app/desktop/studio_server/api_client/test_kiln_server_client.py
@@ -1,0 +1,164 @@
+import os
+from importlib.metadata import version
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app.desktop.studio_server.api_client.kiln_ai_server_client.api.health import (
+    ping_ping_get,
+)
+from app.desktop.studio_server.api_client.kiln_server_client import (
+    KilnServerClient,
+    _get_desktop_app_version,
+    get_kiln_server_client,
+    server_client,
+)
+
+APP_VERSION = version("kiln-studio-desktop")
+
+
+class TestGetKilnServerClient:
+    """Tests for the get_kiln_server_client factory function."""
+
+    def test_default_kiln_server(self):
+        assert server_client is not None
+        assert isinstance(server_client, KilnServerClient)
+
+    def test_returns_client_with_correct_base_url_no_env_var(self):
+        """Verify the client is configured with the correct base URL."""
+        with patch.dict(os.environ, {}, clear=True):
+            client = get_kiln_server_client()
+            assert client._base_url == "https://api.kiln.tech"
+
+    def test_returns_client_with_correct_base_url_with_env_var(self):
+        """Verify the client is configured with the correct base URL."""
+        with patch.dict(
+            os.environ, {"KILN_SERVER_BASE_URL": "https://localhost:8000"}, clear=True
+        ):
+            client = get_kiln_server_client()
+            assert client._base_url == "https://localhost:8000"
+
+    def test_returns_client_with_correct_user_agent_header(self):
+        """Verify the client has the correct User-Agent header set."""
+        client = get_kiln_server_client()
+        assert client._headers["User-Agent"] == f"KilnDesktopApp/{APP_VERSION}"
+        assert client._headers["Kiln-Desktop-App-Version"] == APP_VERSION
+
+    def test_client_creates_httpx_client_with_correct_headers(self):
+        """Verify that when getting the httpx client, headers are properly passed."""
+        client = get_kiln_server_client()
+        httpx_client = client.get_httpx_client()
+
+        assert httpx_client.headers["User-Agent"] == f"KilnDesktopApp/{APP_VERSION}"
+        assert httpx_client.headers["Kiln-Desktop-App-Version"] == APP_VERSION
+
+    def test_fetching_version_from_metadata(self):
+        """Verify the client is configured with a valid version from metadata."""
+        version = _get_desktop_app_version()
+        assert APP_VERSION == version
+        assert version != "unknown"
+        assert "." in version
+        for digits in version.split("."):
+            assert digits.isdigit()
+
+
+class TestMockedPingRequest:
+    """Tests for ping request with mocked HTTP transport."""
+
+    def test_ping_sync(self):
+        """Verify ping request sends User-Agent header correctly."""
+        client = get_kiln_server_client()
+
+        mock_response = httpx.Response(
+            status_code=200,
+            content=b'"pong"',
+            headers={"content-type": "application/json"},
+        )
+
+        mock_httpx_client = MagicMock(spec=httpx.Client)
+        mock_httpx_client.request.return_value = mock_response
+
+        client.set_httpx_client(mock_httpx_client)
+
+        response = ping_ping_get.sync_detailed(client=client)
+
+        mock_httpx_client.request.assert_called_once_with(method="get", url="/ping")
+        assert response.status_code.value == 200
+        assert response.parsed == '"pong"'
+
+    def test_ping_returns_pong_using_sync_helper(self):
+        """Verify the sync helper returns the parsed pong response."""
+        client = get_kiln_server_client()
+
+        mock_response = httpx.Response(
+            status_code=200,
+            content=b"pong",
+            headers={"content-type": "text/plain"},
+        )
+
+        mock_httpx_client = MagicMock(spec=httpx.Client)
+        mock_httpx_client.request.return_value = mock_response
+
+        client.set_httpx_client(mock_httpx_client)
+
+        result = ping_ping_get.sync(client=client)
+
+        assert result == "pong"
+
+
+@pytest.mark.paid
+class TestRealPingRequest:
+    """
+    Tests for ping request against actual server.
+
+    Will fail if the server is not running so marked as paid.
+    """
+
+    def test_real_ping_request(self):
+        test_client = get_kiln_server_client()
+        response = ping_ping_get.sync(client=test_client)
+        assert response == "pong"
+
+    async def test_real_async_ping_request(self):
+        test_client = get_kiln_server_client()
+        response = await ping_ping_get.asyncio(client=test_client)
+        assert response == "pong"
+
+
+class TestAsyncPingRequest:
+    """Tests for async ping request."""
+
+    @pytest.fixture
+    def mock_async_transport(self):
+        """Create a mock async transport that returns pong for /ping requests."""
+
+        expected_user_agent = f"KilnDesktopApp/{APP_VERSION}"
+
+        async def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/ping":
+                assert request.headers["User-Agent"] == expected_user_agent
+                return httpx.Response(
+                    status_code=200,
+                    content=b"pong",
+                    headers={"content-type": "text/plain"},
+                )
+            return httpx.Response(status_code=404)
+
+        return httpx.MockTransport(handle_request)
+
+    @pytest.mark.asyncio
+    async def test_async_ping_request(self, mock_async_transport):
+        """Test async ping request returns pong."""
+        client = get_kiln_server_client()
+
+        async_httpx_client = httpx.AsyncClient(
+            base_url=client._base_url,
+            headers=client._headers,
+            transport=mock_async_transport,
+        )
+        client.set_async_httpx_client(async_httpx_client)
+
+        result = await ping_ping_get.asyncio(client=client)
+
+        assert result == "pong"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -1514,7 +1514,7 @@ dev = [
 
 [[package]]
 name = "kiln-studio-desktop"
-version = "0.1.0"
+version = "0.23.0"
 source = { editable = "app/desktop" }
 dependencies = [
     { name = "kiln-server" },


### PR DESCRIPTION
We don't need to merge yet, but ready for CR. Only the auto-generated code will change after this.

**Note to CR**: The `/api_client/kiln_ai_server_client` is auto-generated. Don't need to CR that.

Notes:
 - Autogenerated API client: app/desktop/studio_server/api_client/kiln_ai_server_client
 - Client wrapper that sets up headers, base url, etc: app/desktop/studio_server/api_client/kiln_server_client.py
 - Tests
 - Add our app version number to headers, so we can return custom errors to old clients



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API client for authenticated server communication with configurable headers and SSL verification options
  * Added health monitoring endpoints to verify server connectivity

* **Chores**
  * Updated project version to 0.23.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->