### PR TITLE
KIL-323: Fix redirect after deleting eval to go to evals list instead of error page

### DIFF
--- a/app/web_ui/src/lib/ui/edit_dialog.svelte
+++ b/app/web_ui/src/lib/ui/edit_dialog.svelte
@@ -14,6 +14,7 @@
     // The parent page can override this, but reload the page by default
     window.location.reload()
   }
+  export let after_delete: (() => void) | undefined = undefined
 
   type EditField = {
     label: string
@@ -129,6 +130,6 @@
     bind:this={delete_dialog}
     {name}
     {delete_url}
-    after_delete={after_save}
+    after_delete={after_delete || after_save}
   />
 {/if}

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/+page.svelte
@@ -661,6 +661,9 @@
   name="Eval"
   patch_url={`/api/projects/${project_id}/tasks/${task_id}/eval/${eval_id}`}
   delete_url={`/api/projects/${project_id}/tasks/${task_id}/eval/${eval_id}`}
+  after_delete={() => {
+    goto(`/evals/${project_id}/${task_id}`)
+  }}
   fields={[
     {
       label: "Eval Name",

--- a/libs/core/kiln_ai/adapters/fine_tune/fireworks_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/fireworks_finetune.py
@@ -162,7 +162,7 @@ class FireworksFinetune(BaseFinetuneAdapter):
 
         # Only setup W&B if the base URL is None as FW doesn't support custom base URLs.
         if wandb_api_key and wandb_base_url is None:
-            # users may not have entity set. Try geting default entity from W&B.
+            # users may not have entity set. Try getting default entity from W&B.
             if not wandb_entity:
                 # Attempt to get their account default entity
                 default_entity = await get_wandb_default_entity(wandb_api_key, None)


### PR DESCRIPTION
Fixes issue where deleting an eval from the eval detail page would redirect back to the same page (which no longer exists), causing an error. Now redirects to the evals list page instead.

- Added optional  prop to  component
- Updated eval detail page to use custom  callback that redirects to evals list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation deletions now automatically redirect to the evaluations list for the current project and task.
  * The edit dialog component now supports customizable after-deletion callbacks that take precedence over default behavior.

* **Bug Fixes**
  * Minor comment correction in fine-tuning adapter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->