### PR TITLE
KIL-322: Fix run config string loading to use task-specific prompts

### DIFF
--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/compare/+page.svelte
@@ -15,8 +15,6 @@
   import {
     model_info,
     load_model_info,
-    current_task_prompts,
-    load_available_prompts,
     load_available_models,
     get_task_composite_id,
     load_task,
@@ -25,6 +23,10 @@
     load_task_run_configs,
     run_configs_by_task_composite_id,
   } from "$lib/stores/run_configs_store"
+  import {
+    load_task_prompts,
+    prompts_by_task_composite_id,
+  } from "$lib/stores/prompts_store"
   import {
     getDetailedModelName,
     getRunConfigPromptDisplayName,
@@ -145,7 +147,7 @@
     // Load data needed for the page
     await Promise.all([
       load_model_info(),
-      load_available_prompts(),
+      load_task_prompts(project_id, task_id),
       load_available_models(),
       get_task(),
     ])
@@ -651,13 +653,17 @@
                           >
                             {getRunConfigPromptDisplayName(
                               selectedConfig,
-                              $current_task_prompts,
+                              $prompts_by_task_composite_id[
+                                get_task_composite_id(project_id, task_id)
+                              ] || null,
                             )}
                           </a>
                         {:else}
                           Prompt: {getRunConfigPromptDisplayName(
                             selectedConfig,
-                            $current_task_prompts,
+                            $prompts_by_task_composite_id[
+                              get_task_composite_id(project_id, task_id)
+                            ] || null,
                           )}
                         {/if}
                         {#if prompt_info_text}


### PR DESCRIPTION
Fixes issue where deep links to different projects/tasks would show ugly strings because the code was using `load_available_prompts()` which loads prompts for the current project/task instead of the specific task in the URL.

**Changes:**
- Changed from `load_available_prompts()` to `load_task_prompts(project_id, task_id)` to load prompts for the specific task
- Updated prompt display to use `prompts_by_task_composite_id` store instead of `current_task_prompts` to ensure task-specific prompts are used

This ensures that when opening a deep link to a different project/task, the prompts are correctly loaded for that specific task rather than assuming the current project/task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized prompt loading and management for the comparison view. Internal changes to how prompt data is fetched and referenced to improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->