### PR TITLE
KIL-324: Fix SDG inputs not rendering when one topic fails

### DIFF
--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/generate_samples_modal.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/generate_samples_modal.svelte
@@ -48,6 +48,7 @@
   $: topics_failed_to_generate_count = topics_failed_to_generate.length
 
   export let on_completed: () => void
+  export let on_partial_complete: (() => void) | null = null
 
   function add_synthetic_samples(
     topic: SampleDataNode,
@@ -214,7 +215,13 @@
 
     sample_generating = false
 
-    // if every topic was generated successfully, move on
+    // Always trigger save/update so successfully generated samples are visible
+    // even if some topics failed
+    if (on_partial_complete) {
+      on_partial_complete()
+    }
+
+    // if every topic was generated successfully, close the modal
     // otherwise we stay here to show the user the errors
     if (topics_failed_to_generate_count === 0) {
       on_completed()

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/generated_data_node.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/generated_data_node.svelte
@@ -295,6 +295,14 @@
     )
   }
 
+  function handleGenerateSamplesPartialComplete() {
+    // Trigger reactivity
+    data = data
+
+    // Trigger save to localStorage
+    triggerSave()
+  }
+
   function handleGenerateSamplesCompleted() {
     // Trigger reactivity
     data = data
@@ -571,6 +579,7 @@
     {num_samples_to_generate}
     {custom_topics_string}
     on_completed={handleGenerateSamplesCompleted}
+    on_partial_complete={handleGenerateSamplesPartialComplete}
     cascade_mode={generate_samples_cascade_mode}
   />
 {/if}


### PR DESCRIPTION
Fixes issue where successfully generated inputs weren't displayed when generating inputs for multiple topics and one topic failed.

## Problem
When generating inputs for many topics, if one topic failed, none of the successfully generated inputs were displayed. The data was saved, but the UI didn't update to show them.

## Solution
- Added  callback to  that saves/updates state without closing the modal
- Always trigger state save/update after all workers complete, regardless of failures
- Only close the modal when all topics succeed (to show errors for failed topics)

This ensures successfully generated samples are always visible even when some topics fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sample generation now displays partial results as they complete, providing better visibility of progress even when some generation tasks encounter issues. Changes are automatically saved as results arrive.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->