### PR TITLE
KIL-325: Refresh prompts when adding new run config in compare_run_configs

### DIFF
--- a/app/web_ui/src/lib/ui/run_config_component/run_config_summary.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/run_config_summary.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import type { TaskRunConfig } from "$lib/types"
-  import { model_info } from "$lib/stores"
+  import { model_info, get_task_composite_id } from "$lib/stores"
   import { getDetailedModelName } from "$lib/utils/run_config_formatters"
   import { getRunConfigPromptDisplayName } from "$lib/utils/run_config_formatters"
-  import { current_task_prompts } from "$lib/stores"
+  import { prompts_by_task_composite_id } from "$lib/stores/prompts_store"
   import RunConfigDetailsDialog from "./run_config_details_dialog.svelte"
 
   export let project_id: string
@@ -16,6 +16,10 @@
   function open_details_dialog() {
     details_dialog?.show()
   }
+
+  $: task_prompts =
+    $prompts_by_task_composite_id[get_task_composite_id(project_id, task_id)] ||
+    null
 
   $: tools_count =
     task_run_config.run_config_properties.tools_config?.tools?.length ?? 0
@@ -34,10 +38,7 @@
     Model: {getDetailedModelName(task_run_config, $model_info)}
   </div>
   <div>
-    Prompt: {getRunConfigPromptDisplayName(
-      task_run_config,
-      $current_task_prompts,
-    )}
+    Prompt: {getRunConfigPromptDisplayName(task_run_config, task_prompts)}
   </div>
   <div>
     Tools: {tools_count > 0 ? `${tools_count} available` : "None"}

--- a/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/evals/[project_id]/[task_id]/[eval_id]/compare_run_configs/+page.svelte
@@ -29,6 +29,7 @@
     load_task_run_configs,
     run_configs_by_task_composite_id,
   } from "$lib/stores/run_configs_store"
+  import { load_task_prompts } from "$lib/stores/prompts_store"
   import { set_current_eval_config } from "$lib/stores/evals_store"
   import Warning from "$lib/ui/warning.svelte"
   import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
@@ -727,6 +728,9 @@
     the highest scores on your eval dataset."
   {project_id}
   {task}
+  new_run_config_created={async () => {
+    await load_task_prompts(project_id, task_id, true)
+  }}
 />
 
 <Dialog


### PR DESCRIPTION
Fixes issue where prompt pretty names don't load after adding a new run configuration in the compare_run_configs page.

## Changes
- Updated  to use task-specific prompt store () instead of  for better robustness with URL links
- Added callback to  to refresh prompts when a new run config is created
- This ensures prompt pretty names display correctly after creating a new run config

## Testing
- All pre-commit checks passed
- No linting errors
- Type checking passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prompt data loading in run configuration views to use centralized data sources, ensuring accurate prompt display across the application.
  
* **Refactor**
  * Improved run configuration prompt handling by optimizing the data refresh mechanism after creating new configurations, ensuring users see the latest prompt updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->