### PR TITLE
more additionalProperties issues: Fix test schema validation for GPT-5.2 strict mode

### DIFF
--- a/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_structured_output.py
@@ -64,13 +64,15 @@ async def test_mock_unstructred_response(tmp_path):
     task = build_structured_output_test_task(tmp_path)
 
     # don't error on valid response
-    adapter = MockAdapter(task, response={"setup": "asdf", "punchline": "asdf"})
+    adapter = MockAdapter(
+        task, response={"setup": "asdf", "punchline": "asdf", "rating": None}
+    )
     run = await adapter.invoke("You are a mock, send me the response!")
     answer = json.loads(run.output.output)
     assert answer["setup"] == "asdf"
     assert answer["punchline"] == "asdf"
 
-    # error on response that doesn't match schema
+    # error on response that doesn't match schema (missing required fields)
     adapter = MockAdapter(task, response={"setup": "asdf"})
     with pytest.raises(Exception):
         answer = await adapter.invoke("You are a mock, send me the response!")

--- a/libs/core/kiln_ai/datamodel/test_json_schema.py
+++ b/libs/core/kiln_ai/datamodel/test_json_schema.py
@@ -46,8 +46,10 @@ json_joke_schema = """{
   },
   "required": [
     "setup",
-    "punchline"
-  ]
+    "punchline",
+    "rating"
+  ],
+  "additionalProperties": false
 }
 """
 
@@ -57,7 +59,7 @@ def test_json_schema():
     parsed_schema = schema_from_json_str(o.x_schema)
     assert parsed_schema is not None
     assert parsed_schema["type"] == "object"
-    assert parsed_schema["required"] == ["setup", "punchline"]
+    assert parsed_schema["required"] == ["setup", "punchline", "rating"]
     assert parsed_schema["properties"]["setup"]["type"] == "string"
     assert parsed_schema["properties"]["punchline"]["type"] == "string"
     assert parsed_schema["properties"]["rating"] is not None
@@ -77,7 +79,7 @@ def test_validate_schema_content():
     o = {"setup": "asdf"}
     with pytest.raises(jsonschema.exceptions.ValidationError):
         validate_schema(0, json_joke_schema)
-    o = {"setup": "asdf", "punchline": "asdf"}
+    o = {"setup": "asdf", "punchline": "asdf", "rating": None}
     validate_schema(o, json_joke_schema)
     o = {"setup": "asdf", "punchline": "asdf", "rating": "1"}
     with pytest.raises(jsonschema.exceptions.ValidationError):
@@ -92,7 +94,7 @@ def test_validate_schema_content_with_value_error():
         ValueError, match="PREFIX The error from the schema check was: "
     ):
         validate_schema_with_value_error(0, json_joke_schema, "PREFIX")
-    o = {"setup": "asdf", "punchline": "asdf"}
+    o = {"setup": "asdf", "punchline": "asdf", "rating": None}
     validate_schema_with_value_error(o, json_joke_schema, "PREFIX")
     o = {"setup": "asdf", "punchline": "asdf", "rating": "1"}
     with pytest.raises(


### PR DESCRIPTION
## What does this PR do?

**Summary**
Updates json_joke_schema in test files to comply with GPT-5.2's stricter JSON schema validation requirements. Not sure if the preferred way is to drop `rating` as a field or to make it required. But optionals seem to cause a lot of problems. As it is now the GPT5.2 tests fail without these changes. Can confirm GPT 4.1 mini passes with these changes NP so no regression issues. 

**Problem**
After adding GPT-5.2 models to the model list, test_all_built_in_models_structured_output started failing:

`litellm.exceptions.BadRequestError: OpenrouterException - {  "error": {    "message": "Invalid schema for response_format 'task_response': In context=(), 'required' is required     to be supplied and to be an array including every key in properties. Missing 'rating'.",    "type": "invalid_request_error",    "param": "text.format.schema",    "code": "invalid_json_schema"  }}`

GPT-5.2 requires all properties to be in the required array, even those with default values or nullable types. This is stricter than standard JSON Schema behavior.

**Solution**
Updated json_joke_schema in test_json_schema.py:
- Added "rating" to the required array
- Added "additionalProperties": false to the schema

The rating field can still be null because it's defined as "anyOf": [{"type": "integer"}, {"type": "null"}], so making it "required" only means it must be present in the response (but can be null).

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests & Validation**
  * Expanded test coverage for structured response validation with enhanced schema enforcement to ensure improved data quality and consistency
  * Updated validation tests to ensure responses comply with stricter property requirements and proper field handling in all scenarios
  * Improved schema validation with additional enforcement rules for response objects and stricter validation of all supported properties

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->