### PR TITLE
Add gpt 5.2 family models to Openrouter + OpenAI

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -416,6 +416,24 @@ built_in_models: List[KilnModel] = [
         friendly_name="GPT-5.2 Chat",
         providers=[
             KilnModelProvider(
+                name=ModelProviderName.openai,
+                model_id="gpt-5.2-chat-latest",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                suggested_for_evals=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 model_id="openai/gpt-5.2-chat",
                 structured_output_mode=StructuredOutputMode.json_schema,


### PR DESCRIPTION
## What does this PR do?

Add gpt 5.2 family models to Openrouter + OpenAI.

The test failures from yesterday have been resolved by the following:
- Pro models were just mostly failing yesterday probably due to the new rollout. Some tests that consistently failed yesterday are consistently passing today.
- additionalProperties=False issues in tests were causing persistent failures, addressed here: https://github.com/Kiln-AI/Kiln/pull/892 + https://github.com/Kiln-AI/Kiln/pull/893 

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have 
<img width="307" height="846" alt="Screenshot 2025-12-12 at 10 34 04 AM" src="https://github.com/user-attachments/assets/1779c3cf-16ba-4703-aef6-673c5022bf45" />
been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.2 model family (Standard, Pro, and Chat) to available AI models.
  * Enabled multimodal support for the GPT-5.2 models with PDF, TXT, MD, JPG, and PNG file types.
  * Expanded provider availability for GPT-5.2 options, including integrations with OpenAI and OpenRouter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->