### PR TITLE
fix: custom API key mutated into [hidden] incorrectly

### DIFF
--- a/libs/core/kiln_ai/utils/config.py
+++ b/libs/core/kiln_ai/utils/config.py
@@ -1,3 +1,4 @@
+import copy
 import getpass
 import os
 import threading
@@ -259,7 +260,7 @@ class Config:
         settings = {
             k: "[hidden]"
             if k in self._properties and self._properties[k].sensitive
-            else v
+            else copy.deepcopy(v)
             for k, v in self._settings.items()
         }
         # Hide sensitive keys in lists. Could generalize this if we every have more types, but right not it's only needed for root elements of lists

--- a/libs/core/kiln_ai/utils/test_config.py
+++ b/libs/core/kiln_ai/utils/test_config.py
@@ -281,6 +281,41 @@ async def test_openai_compatible_providers():
     ]
 
 
+async def test_openai_compatible_providers_not_mutated_by_hide_sensitive():
+    config = Config.shared()
+    assert config.openai_compatible_providers == []
+
+    new_settings = [
+        {
+            "name": "provider1",
+            "url": "https://provider1.com",
+            "api_key": "secret_key_123",
+        },
+        {
+            "name": "provider2",
+            "url": "https://provider2.com",
+            "api_key": "another_secret_key",
+        },
+    ]
+    config.save_setting("openai_compatible_providers", new_settings)
+    assert config.openai_compatible_providers == new_settings
+
+    hidden_settings = config.settings(hide_sensitive=True)
+    assert hidden_settings["openai_compatible_providers"] == [
+        {
+            "name": "provider1",
+            "url": "https://provider1.com",
+            "api_key": "[hidden]",
+        },
+        {"name": "provider2", "url": "https://provider2.com", "api_key": "[hidden]"},
+    ]
+
+    retrieved_providers = config.openai_compatible_providers
+    assert retrieved_providers == new_settings
+    assert retrieved_providers[0]["api_key"] == "secret_key_123"
+    assert retrieved_providers[1]["api_key"] == "another_secret_key"
+
+
 def test_yaml_persistence_structured_data(config_with_yaml, mock_yaml_file):
     # Set a value
     new_settings = [


### PR DESCRIPTION
## What does this PR do?

Bug:
- add custom provider
- go to `Run`, the list of models from the custom provider appears correctly in the model dropdown
- restart app
- the custom provider models are not there anymore
- logs show the provider is returning a `401`

Cause:
- we are calling `Config.shared().settings(hide_sensitive=True)` from the `GET /api/settings` endpoint
- the problem is that `Config.shared().settings(hide_sensitive=True)` mutates the original list of values and replaces the API keys with `[hidden]`
- when we retrieve the value later, we get `[hidden]` instead of the actual API key, causing a `401`

Fix:
- deep copy before mutating to replace with `[hidden]`

## Related Issues

https://github.com/Kiln-AI/Kiln/issues/891
https://github.com/Kiln-AI/Kiln/issues/720

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where configuration data could be unintentionally modified when masking sensitive fields.

* **Tests**
  * Added tests to verify that sensitive field masking preserves the integrity of underlying stored data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->