### PR TITLE
Remove Task Description field from create flow

### DIFF
--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -281,14 +281,17 @@
 
     <!-- Don't show these if onboarding, keep onboarding view as simple as possible -->
     {#if !onboarding}
-      <FormElement
-        label="Task Description"
-        inputType="textarea"
-        id="task_description"
-        description="A description for you and your team, not used by the model."
-        optional={true}
-        bind:value={task.description}
-      />
+      <!-- Don't show if Creating. Only on editing. -->
+      {#if !creating}
+        <FormElement
+          label="Task Description"
+          inputType="textarea"
+          id="task_description"
+          description="A description for you and your team, not used by the model."
+          optional={true}
+          bind:value={task.description}
+        />
+      {/if}
 
       <FormElement
         label="'Thinking' Instructions"


### PR DESCRIPTION
Fixes https://linear.app/kiln-ai/issue/KIL-206/remove-task-description-in-new-task. 

People are confusing description and prompt. Don't need it. Still there in edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task Description field now only displays when editing existing tasks, not during task creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->