### PR TITLE
Vertex AI: suggest global instead of us-central1 in connect providers

### DIFF
--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
@@ -130,7 +130,7 @@
         "Install the gcloud CLI, then run `gcloud auth application-default login` in the terminal. This will add Google Vertex credentials to your environment.",
         "Create a project in the console, enable Vertex AI for that project, and click 'Enable Recommended APIs' in the Vertex AI console.",
         "Add the project ID below. Be sure to use the project ID, not the project name.",
-        "Add a Google Cloud location, example: 'us-central1'. We suggest 'us-central1' as it has the widest model support.",
+        "Add a Google Cloud location, example: 'global'. We suggest 'global' as it has more recent Gemini models.",
         "Click connect.",
       ],
       api_key_fields: ["Project ID", "Project Location"],


### PR DESCRIPTION
## What does this PR do?
Google has rolled out a global region that has support for Gemini 3 models.

https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#global

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Google Vertex AI provider setup guidance to recommend using the global location instead of a regional location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->