### PR TITLE
fix: token check route is GET not POST

### DIFF
--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -1156,7 +1156,7 @@ async def connect_bedrock(key_data: dict):
 async def connect_kiln_copilot(key: str):
     base_url = os.environ.get("KILN_SERVER_BASE_URL", "https://api.kiln.tech")
     async with httpx.AsyncClient() as client:
-        response = await client.post(
+        response = await client.get(
             f"{base_url}/v1/verify_api_key",
             headers={"Authorization": f"Bearer {key}"},
             timeout=20,

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -135,7 +135,7 @@ def test_connect_api_key_siliconflow_success(mock_connect_siliconflow, client):
 
 
 @patch("app.desktop.studio_server.provider_api.Config.shared")
-@patch("app.desktop.studio_server.provider_api.httpx.AsyncClient.post")
+@patch("app.desktop.studio_server.provider_api.httpx.AsyncClient.get")
 def test_connect_api_key_kiln_copilot_success(
     mock_httpx_post, mock_config_shared, client
 ):


### PR DESCRIPTION
PR going into https://github.com/Kiln-AI/Kiln/pull/882

## What does this PR do?

The route called by the endpoint that verifies the Copilot token was `POST`, but server expects `GET`.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Kiln Copilot API verification now uses GET requests instead of POST requests
  * Validation determines key validity based on 200 status response from server

* **Tests**
  * Updated test cases to reflect API verification method changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->