### PR TITLE
fix: use model_id or alias for ollama

### DIFF
--- a/libs/core/kiln_ai/utils/litellm.py
+++ b/libs/core/kiln_ai/utils/litellm.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from kiln_ai.adapters.ml_embedding_model_list import KilnEmbeddingModelProvider
 from kiln_ai.adapters.ml_model_list import KilnModelProvider
+from kiln_ai.adapters.ollama_tools import resolve_ollama_model_variant
 from kiln_ai.adapters.reranker_list import KilnRerankerModelProvider
 from kiln_ai.datamodel.datamodel_enums import ModelProviderName
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
@@ -90,8 +91,16 @@ def get_litellm_provider_info(
             f"Provider name could not lookup valid litellm provider ID {model_provider.model_id}"
         )
 
+    # for Ollama, we need to resolve which model slug is actually installed
+    resolved_model_id = model_provider.model_id
+    if model_provider.name == ModelProviderName.ollama:
+        resolved_model_id = resolve_ollama_model_variant(
+            model_provider.model_id,
+            getattr(model_provider, "ollama_model_aliases", None),
+        )
+
     return LitellmProviderInfo(
         provider_name=litellm_provider_name,
         is_custom=is_custom,
-        litellm_model_id=f"{litellm_provider_name}/{model_provider.model_id}",
+        litellm_model_id=f"{litellm_provider_name}/{resolved_model_id}",
     )


### PR DESCRIPTION
## What does this PR do?

The `ollama_model_alias` we define on the `ml_model_list` is currently only used to detect the model, but we always send the `model_id` in the actual LiteLLM request. If the user has the model via one of its aliases, the request that uses the `model_id` will fail due to it not matching the slug they actually have.

Changes:
- fix: when using an Ollama model, we first resolve the slug to use (`model_id`, or the first matching alias)

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Ollama integration with automatic detection of installed model variants, intelligently prioritizing the primary model and falling back to configured aliases when unavailable.
  * Enhanced model availability checking with graceful error handling to ensure reliable provider configuration across different installation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->