### PR TITLE
add models (Minimax M2.1, Bytedance, Mistral)

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -216,6 +216,7 @@ class ModelName(str, Enum):
     hunyuan_a13b_no_thinking = "hunyuan_a13b_no_thinking"
     minimax_m1_80k = "minimax_m1_80k"
     minimax_m2 = "minimax_m2"
+    minimax_m2_1 = "minimax_m2_1"
     pangu_pro_moe_72b_a16b = "pangu_pro_moe_72b_a16b"
     bytedance_seed_oss_36b = "bytedance_seed_oss_36b"
     bytedance_seed_1_6 = "bytedance_seed_1_6"
@@ -5648,6 +5649,32 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
+    # Minimax M2.1
+    KilnModel(
+        family=ModelFamily.minimax,
+        name=ModelName.minimax_m2_1,
+        friendly_name="Minimax M2.1",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="minimax/minimax-m2.1",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                reasoning_capable=True,
+                supports_data_gen=True,
+                r1_openrouter_options=True,
+                require_openrouter_reasoning=True,
+                parser=ModelParserID.r1_thinking,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                model_id="accounts/fireworks/models/minimax-m2p1",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                reasoning_capable=True,
+                supports_data_gen=True,
+                reasoning_optional_for_structured_output=True,
+            ),
+        ],
+    ),
     # Minimax M2
     KilnModel(
         family=ModelFamily.minimax,
@@ -5668,6 +5695,14 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.siliconflow_cn,
                 model_id="MiniMaxAI/MiniMax-M2",
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                reasoning_capable=True,
+                supports_data_gen=True,
+                reasoning_optional_for_structured_output=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                model_id="accounts/fireworks/models/minimax-m2",
+                structured_output_mode=StructuredOutputMode.json_schema,
                 reasoning_capable=True,
                 supports_data_gen=True,
                 reasoning_optional_for_structured_output=True,


### PR DESCRIPTION
## What does this PR do?

Add models and providers:
- add Cerebras for GLM 4.7 and GLM 4.6
- add Minimax M2.1 on OpenRouter and Fireworks
- add ByteDance Seed series on OpenRouter: Seed 1.6 and Seed 1.6 Flash
- add Mistral 3 series: Mistral 3 Large 2512, Mistral Small Creative, Ministral 3 (14B, 8B, 3B)

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for 8 new AI models: Mistral 3 Large, Mistral Small Creative, Ministral 3 variants, Minimax M2.1, and ByteDance Seed models
  * Expanded provider availability for existing models through Cerebras and Fireworks AI integration
  * Enhanced structured output and reasoning capabilities across multiple model families

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->