### PR TITLE
chore: exclude sdk folder from code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,4 @@ omit =
     **/test_*.py
     libs/core/kiln_ai/adapters/ml_model_list.py
     conftest.py
+    */kiln_ai_server_client/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,3 @@ extend-select = ["I","F401","RUF","FAST","TID"]
 
 [tool.pytest.ini_options]
  addopts="-n auto"
-
-[tool.coverage.run]
-omit = [
-    "app/desktop/studio_server/api_client/kiln_ai_server_client/**",
-]


### PR DESCRIPTION
## What does this PR do?

The server SDK codegen should be excluded from the code coverage report - otherwise every new endpoint codegened there counts towards coverage.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration for code coverage analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->