### PR TITLE
fix: turn off logprobs support for GPT models via OpenRouter

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -525,6 +525,7 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_doc_extraction=True,
                 supports_vision=True,
+                supports_logprobs=False,
                 multimodal_capable=True,
                 multimodal_mime_types=[
                     # documents
@@ -701,7 +702,11 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.openrouter,
                 model_id="openai/gpt-4.1",
                 structured_output_mode=StructuredOutputMode.json_schema,
-                supports_logprobs=True,
+                # OpenRouter does not return the logprobs for this model
+                supports_logprobs=False,
+                # logprobs_openrouter_options does not help this particular
+                # model at the moment
+                # logprobs_openrouter_options=True,
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
                 supports_doc_extraction=True,
@@ -754,7 +759,11 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.openrouter,
                 model_id="openai/gpt-4.1-mini",
                 structured_output_mode=StructuredOutputMode.json_schema,
-                supports_logprobs=True,
+                # OpenRouter does not return the logprobs for this model
+                supports_logprobs=False,
+                # logprobs_openrouter_options does not help this particular
+                # model at the moment
+                # logprobs_openrouter_options=True,
                 supports_doc_extraction=True,
                 supports_vision=True,
                 multimodal_capable=True,
@@ -803,7 +812,11 @@ built_in_models: List[KilnModel] = [
                 name=ModelProviderName.openrouter,
                 model_id="openai/gpt-4.1-nano",
                 structured_output_mode=StructuredOutputMode.json_schema,
-                supports_logprobs=True,
+                # OpenRouter does not return the logprobs for this model
+                supports_logprobs=False,
+                # logprobs_openrouter_options does not help this particular
+                # model at the moment
+                # logprobs_openrouter_options=True,
                 supports_doc_extraction=True,
                 supports_vision=True,
                 multimodal_capable=True,


### PR DESCRIPTION
## What does this PR do?

GPT 4.1 (and some other GPT models) are currently not returning logprobs via OpenRouter. This means we are showing `G-Eval` as a valid choice for evals using these judges as model but it fails when it runs. 

Double checked the models after GPT 4.1 too - and none of them supports logprobs (via OpenAI directly and via OpenRouter).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled log probabilities support for OpenRouter GPT-4.1 family models (gpt-4.1, gpt-4.1-mini, gpt-4.1-nano) to improve accuracy of capability reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->