### PR TITLE
feat: add page numbers in chunks (RAG)

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -5084,6 +5084,11 @@ export interface components {
              * @description The score of the chunk, which depends on the similarity metric used.
              */
             similarity: number | null;
+            /**
+             * Page Number
+             * @description The page number (0-indexed) this chunk belongs to. Only set when the extraction has page_offsets.
+             */
+            page_number?: number | null;
         };
         /** SearchToolApiDescription */
         SearchToolApiDescription: {

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
@@ -55,6 +55,7 @@
     chunk_idx: number
     chunk_text: string
     similarity: number | null
+    page_number?: number | null
   }> = []
 
   onMount(async () => {
@@ -366,7 +367,8 @@
                           >
                             Document: {result.document_id}
                           </a>
-                          (Chunk #{result.chunk_idx})
+                          (Chunk #{result.chunk_idx} | Page: {result.page_number ??
+                            "N/A"})
                         </div>
                         <div>
                           Score: {result.similarity !== null

--- a/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/base_chunker.py
@@ -11,6 +11,10 @@ logger = logging.getLogger(__name__)
 
 class TextChunk(BaseModel):
     text: str = Field(description="The text of the chunk.")
+    page_number: int | None = Field(
+        default=None,
+        description="The page number (0-indexed) this chunk belongs to. Only set when page_offsets are provided.",
+    )
 
 
 class ChunkingResult(BaseModel):
@@ -27,15 +31,53 @@ class BaseChunker(ABC):
     def __init__(self, chunker_config: ChunkerConfig):
         self.chunker_config = chunker_config
 
-    async def chunk(self, text: str) -> ChunkingResult:
-        if not text:
+    async def chunk(
+        self, text: str, page_offsets: list[int] | None = None
+    ) -> ChunkingResult:
+        if not text or not clean_up_text(text):
             return ChunkingResult(chunks=[])
 
-        sanitized_text = clean_up_text(text)
-        if not sanitized_text:
-            return ChunkingResult(chunks=[])
+        chunking_result = await self._chunk(text)
 
-        return await self._chunk(sanitized_text)
+        if page_offsets is not None and len(page_offsets) > 0:
+            search_start = 0
+            for chunk in chunking_result.chunks:
+                chunk_start_offset = text.find(chunk.text, search_start)
+                if chunk_start_offset == -1:
+                    logger.warning(
+                        f"Chunk text not found in sanitized text starting from offset {search_start}. "
+                        "This may indicate an issue with the chunker implementation."
+                    )
+                    chunk.page_number = None
+                else:
+                    page_number = self._find_page_number(
+                        chunk_start_offset, page_offsets
+                    )
+                    chunk.page_number = page_number
+                    search_start = chunk_start_offset + 1
+
+        return chunking_result
+
+    def _find_page_number(
+        self, chunk_offset: int, page_offsets: list[int]
+    ) -> int | None:
+        """
+        Find the page number for a chunk at the given offset.
+
+        Returns the page number (0-indexed) that the chunk belongs to,
+        or None if the offset is before the first page.
+        """
+        if not page_offsets:
+            return None
+
+        if chunk_offset < page_offsets[0]:
+            return 0
+
+        for i in range(len(page_offsets) - 1, -1, -1):
+            if chunk_offset >= page_offsets[i]:
+                return i
+
+        return None
 
     @abstractmethod
     async def _chunk(self, text: str) -> ChunkingResult:

--- a/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
+++ b/libs/core/kiln_ai/adapters/chunkers/test_base_chunker.py
@@ -43,7 +43,8 @@ async def test_base_chunker_concrete_chunker(chunker: WhitespaceChunker):
     assert len(output.chunks) == 2
 
 
-async def test_base_chunker_calls_clean_up_text(chunker: WhitespaceChunker):
+async def test_base_chunker_checks_clean_up_text_for_empty(chunker: WhitespaceChunker):
+    """Test that clean_up_text is still called to check if text becomes empty."""
     with patch(
         "kiln_ai.adapters.chunkers.base_chunker.clean_up_text"
     ) as mock_clean_up_text:
@@ -58,10 +59,116 @@ async def test_base_chunker_empty_text(chunker: WhitespaceChunker):
 
 
 async def test_base_chunker_empty_text_after_clean_up(chunker: WhitespaceChunker):
-    with patch(
-        "kiln_ai.adapters.chunkers.base_chunker.clean_up_text"
-    ) as mock_clean_up_text:
-        mock_clean_up_text.side_effect = clean_up_text
-        chunks = await chunker.chunk("\n\n   ")
-        mock_clean_up_text.assert_called_once_with("\n\n   ")
-        assert chunks == ChunkingResult(chunks=[])
+    chunks = await chunker.chunk("\n\n   ")
+    assert chunks == ChunkingResult(chunks=[])
+
+
+async def test_base_chunker_page_number_without_offsets(chunker: WhitespaceChunker):
+    """Test that page_number is None when page_offsets are not provided."""
+    output = await chunker.chunk("Hello world test")
+    assert len(output.chunks) == 3
+    for chunk in output.chunks:
+        assert chunk.page_number is None
+
+
+async def test_base_chunker_page_number_with_offsets(chunker: WhitespaceChunker):
+    """Test that page_number is correctly assigned when page_offsets are provided."""
+    text = "Page0 content here Page1 content here Page2 content here"
+    page_offsets = [0, 20, 40]
+
+    output = await chunker.chunk(text, page_offsets=page_offsets)
+
+    assert len(output.chunks) == 9
+    assert output.chunks[0].text == "Page0"
+    assert output.chunks[0].page_number == 0
+
+    assert output.chunks[1].text == "content"
+    assert output.chunks[1].page_number == 0
+
+    assert output.chunks[2].text == "here"
+    assert output.chunks[2].page_number == 0
+
+
+async def test_base_chunker_page_number_multiple_pages(chunker: WhitespaceChunker):
+    """Test page number assignment across multiple pages."""
+    text = (
+        "Start of page 0. " * 10 + "Start of page 1. " * 10 + "Start of page 2. " * 10
+    )
+    page_offsets = [0, 160, 320]
+
+    output = await chunker.chunk(text, page_offsets=page_offsets)
+
+    assert len(output.chunks) > 0
+
+    search_start = 0
+    for chunk in output.chunks:
+        chunk_offset = text.find(chunk.text, search_start)
+        if chunk_offset == -1:
+            # Chunk text not found, skip validation
+            continue
+        search_start = chunk_offset + 1
+
+        if chunk_offset < 160:
+            assert chunk.page_number == 0, (
+                f"Chunk '{chunk.text}' at offset {chunk_offset} should be page 0"
+            )
+        elif chunk_offset < 320:
+            assert chunk.page_number == 1, (
+                f"Chunk '{chunk.text}' at offset {chunk_offset} should be page 1"
+            )
+        else:
+            assert chunk.page_number == 2, (
+                f"Chunk '{chunk.text}' at offset {chunk_offset} should be page 2"
+            )
+
+
+async def test_base_chunker_page_number_edge_cases(chunker: WhitespaceChunker):
+    """Test edge cases for page number calculation."""
+    text = "Test content"
+
+    # Empty page_offsets
+    output = await chunker.chunk(text, page_offsets=[])
+    for chunk in output.chunks:
+        assert chunk.page_number is None
+
+    # Single page
+    output = await chunker.chunk(text, page_offsets=[0])
+    for chunk in output.chunks:
+        assert chunk.page_number == 0
+
+    # Chunk at exact page boundary
+    text = "Page0" + " " * 15 + "Page1"
+    page_offsets = [0, 20]
+    output = await chunker.chunk(text, page_offsets=page_offsets)
+    for chunk in output.chunks:
+        chunk_offset = text.find(chunk.text)
+        if chunk_offset < 20:
+            assert chunk.page_number == 0
+        else:
+            assert chunk.page_number == 1
+
+
+async def test_find_page_number_method(chunker: WhitespaceChunker):
+    """Test the _find_page_number helper method directly."""
+    page_offsets = [0, 100, 200]
+
+    # Test various offsets
+    assert chunker._find_page_number(0, page_offsets) == 0
+    assert chunker._find_page_number(50, page_offsets) == 0
+    assert chunker._find_page_number(99, page_offsets) == 0
+    assert chunker._find_page_number(100, page_offsets) == 1
+    assert chunker._find_page_number(150, page_offsets) == 1
+    assert chunker._find_page_number(199, page_offsets) == 1
+    assert chunker._find_page_number(200, page_offsets) == 2
+    assert chunker._find_page_number(250, page_offsets) == 2
+
+    # Test edge cases
+    assert chunker._find_page_number(-10, page_offsets) == 0
+    assert chunker._find_page_number(1000, page_offsets) == 2
+
+    # Test empty offsets
+    assert chunker._find_page_number(50, []) is None
+
+    # Test single page
+    assert chunker._find_page_number(0, [0]) == 0
+    assert chunker._find_page_number(100, [0]) == 0

--- a/libs/core/kiln_ai/adapters/extractors/base_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/base_extractor.py
@@ -26,6 +26,10 @@ class ExtractionOutput(BaseModel):
         description="The format of the extracted data."
     )
     content: str = Field(description="The extracted data.")
+    page_offsets: list[int] | None = Field(
+        default=None,
+        description="Character offsets marking the start of each page. The int at index i is the char offset marking the start of page i (0-indexed).",
+    )
 
 
 class BaseExtractor(ABC):

--- a/libs/core/kiln_ai/adapters/extractors/extractor_runner.py
+++ b/libs/core/kiln_ai/adapters/extractors/extractor_runner.py
@@ -101,6 +101,7 @@ class ExtractorRunner:
                 source=ExtractionSource.PASSTHROUGH
                 if output.is_passthrough
                 else ExtractionSource.PROCESSED,
+                page_offsets=output.page_offsets,
             )
             extraction.save_to_file()
 

--- a/libs/core/kiln_ai/adapters/rag/rag_runners.py
+++ b/libs/core/kiln_ai/adapters/rag/rag_runners.py
@@ -157,6 +157,7 @@ async def execute_chunker_job(job: ChunkerJob, chunker: BaseChunker) -> bool:
 
     chunking_result = await chunker.chunk(
         extraction_output_content,
+        page_offsets=job.extraction.page_offsets,
     )
     if chunking_result is None:
         raise ValueError("Chunking result is not set")
@@ -170,6 +171,7 @@ async def execute_chunker_job(job: ChunkerJob, chunker: BaseChunker) -> bool:
                     data=chunk.text,
                     mime_type="text/plain",
                 ),
+                page_number=chunk.page_number,
             )
             for chunk in chunking_result.chunks
         ],

--- a/libs/core/kiln_ai/adapters/rag/rag_runners.py
+++ b/libs/core/kiln_ai/adapters/rag/rag_runners.py
@@ -143,6 +143,7 @@ async def execute_extractor_job(job: ExtractorJob, extractor: BaseExtractor) -> 
         source=ExtractionSource.PASSTHROUGH
         if output.is_passthrough
         else ExtractionSource.PROCESSED,
+        page_offsets=output.page_offsets,
     )
     extraction.save_to_file()
 

--- a/libs/core/kiln_ai/adapters/vector_store/base_vector_store_adapter.py
+++ b/libs/core/kiln_ai/adapters/vector_store/base_vector_store_adapter.py
@@ -35,6 +35,10 @@ class SearchResult(BaseModel):
     similarity: float | None = Field(
         description="The score of the chunk, which depends on the similarity metric used."
     )
+    page_number: int | None = Field(
+        default=None,
+        description="The page number (0-indexed) this chunk belongs to. Only set when the extraction has page_offsets.",
+    )
 
 
 class VectorStoreQuery(BaseModel):

--- a/libs/core/kiln_ai/adapters/vector_store/lancedb_helpers.py
+++ b/libs/core/kiln_ai/adapters/vector_store/lancedb_helpers.py
@@ -50,31 +50,37 @@ def convert_to_llama_index_node(
     node_id: str,
     text: str,
     vector: List[float],
+    page_number: int | None = None,
 ) -> TextNode:
+    metadata: Dict[str, Any] = {
+        # metadata is populated by some internal llama_index logic
+        # that uses for example the source_node relationship
+        "kiln_doc_id": document_id,
+        "kiln_chunk_idx": chunk_idx,
+        #
+        # llama_index lancedb vector store automatically sets these metadata:
+        # "doc_id": "UUID node_id of the Source Node relationship",
+        # "document_id": "UUID node_id of the Source Node relationship",
+        # "ref_doc_id": "UUID node_id of the Source Node relationship"
+        #
+        # llama_index file loaders set these metadata, which would be useful to also support:
+        # "creation_date": "2025-09-03",
+        # "file_name": "file.pdf",
+        # "file_path": "/absolute/path/to/the/file.pdf",
+        # "file_size": 395154,
+        # "file_type": "application\/pdf",
+        # "last_modified_date": "2025-09-03",
+        # "page_label": "1",
+    }
+
+    if page_number is not None:
+        metadata["kiln_page_number"] = page_number
+
     return TextNode(
         id_=node_id,
         text=text,
         embedding=vector,
-        metadata={
-            # metadata is populated by some internal llama_index logic
-            # that uses for example the source_node relationship
-            "kiln_doc_id": document_id,
-            "kiln_chunk_idx": chunk_idx,
-            #
-            # llama_index lancedb vector store automatically sets these metadata:
-            # "doc_id": "UUID node_id of the Source Node relationship",
-            # "document_id": "UUID node_id of the Source Node relationship",
-            # "ref_doc_id": "UUID node_id of the Source Node relationship"
-            #
-            # llama_index file loaders set these metadata, which would be useful to also support:
-            # "creation_date": "2025-09-03",
-            # "file_name": "file.pdf",
-            # "file_path": "/absolute/path/to/the/file.pdf",
-            # "file_size": 395154,
-            # "file_type": "application\/pdf",
-            # "last_modified_date": "2025-09-03",
-            # "page_label": "1",
-        },
+        metadata=metadata,
         relationships={
             # when using the llama_index loaders, llama_index groups Nodes under Documents
             # and relationships point to the Document (which is also a Node), which confusingly

--- a/libs/core/kiln_ai/adapters/vector_store/test_lancedb_helpers.py
+++ b/libs/core/kiln_ai/adapters/vector_store/test_lancedb_helpers.py
@@ -152,6 +152,7 @@ def test_convert_to_llama_index_node_builds_expected_structure():
     assert node.embedding == [0.1, 0.2]
     assert node.metadata["kiln_doc_id"] == "doc-123"
     assert node.metadata["kiln_chunk_idx"] == 0
+    assert "kiln_page_number" not in node.metadata
 
     # relationship exists and points to the source document id
     from llama_index.core.schema import NodeRelationship, RelatedNodeInfo
@@ -162,6 +163,36 @@ def test_convert_to_llama_index_node_builds_expected_structure():
     assert related.node_id == "doc-123"
     assert related.node_type == "1"
     assert isinstance(related.metadata, dict)
+
+
+def test_convert_to_llama_index_node_with_page_number():
+    node = convert_to_llama_index_node(
+        document_id="doc-123",
+        chunk_idx=0,
+        node_id="11111111-1111-5111-8111-111111111111",
+        text="hello",
+        vector=[0.1, 0.2],
+        page_number=5,
+    )
+
+    assert node.metadata["kiln_doc_id"] == "doc-123"
+    assert node.metadata["kiln_chunk_idx"] == 0
+    assert node.metadata["kiln_page_number"] == 5
+
+
+def test_convert_to_llama_index_node_with_page_number_none():
+    node = convert_to_llama_index_node(
+        document_id="doc-123",
+        chunk_idx=0,
+        node_id="11111111-1111-5111-8111-111111111111",
+        text="hello",
+        vector=[0.1, 0.2],
+        page_number=None,
+    )
+
+    assert node.metadata["kiln_doc_id"] == "doc-123"
+    assert node.metadata["kiln_chunk_idx"] == 0
+    assert "kiln_page_number" not in node.metadata
 
 
 def test_deterministic_chunk_id_uses_uuid_v5_namespace():

--- a/libs/core/kiln_ai/adapters/vector_store_loaders/vector_store_loader.py
+++ b/libs/core/kiln_ai/adapters/vector_store_loaders/vector_store_loader.py
@@ -84,6 +84,7 @@ class VectorStoreLoader:
                         for chunk_idx, (chunk_text, chunk_embeddings) in enumerate(
                             zip(chunks_text, embeddings)
                         ):
+                            chunk = chunked_document.chunks[chunk_idx]
                             batch.append(
                                 convert_to_llama_index_node(
                                     document_id=document_id,
@@ -93,6 +94,7 @@ class VectorStoreLoader:
                                     ),
                                     text=chunk_text,
                                     vector=chunk_embeddings.vector,
+                                    page_number=chunk.page_number,
                                 )
                             )
 

--- a/libs/core/kiln_ai/datamodel/chunk.py
+++ b/libs/core/kiln_ai/datamodel/chunk.py
@@ -172,6 +172,10 @@ class Chunk(BaseModel):
     content: KilnAttachmentModel = Field(
         description="The content of the chunk, stored as an attachment."
     )
+    page_number: int | None = Field(
+        default=None,
+        description="The page number (0-indexed) this chunk belongs to. Only set when the extraction has page_offsets.",
+    )
 
     @field_serializer("content")
     def serialize_content(

--- a/libs/core/kiln_ai/datamodel/extraction.py
+++ b/libs/core/kiln_ai/datamodel/extraction.py
@@ -95,6 +95,10 @@ class Extraction(
     output: KilnAttachmentModel = Field(
         description="The extraction output.",
     )
+    page_offsets: list[int] | None = Field(
+        default=None,
+        description="Character offsets marking the start of each page. The int at index i is the char offset marking the start of page i (0-indexed). Only set for PDF extractions.",
+    )
 
     def parent_document(self) -> Union["Document", None]:
         if self.parent is None or self.parent.__class__.__name__ != "Document":

--- a/libs/core/kiln_ai/datamodel/test_chunk_models.py
+++ b/libs/core/kiln_ai/datamodel/test_chunk_models.py
@@ -423,6 +423,39 @@ class TestChunk:
             with pytest.raises(ValueError):
                 Chunk(content=None)  # type: ignore[arg-type]
 
+    def test_page_number_defaults_to_none(self):
+        """Test that page_number defaults to None when not provided."""
+        with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
+            tmp_file.write(b"test content")
+            tmp_path = Path(tmp_file.name)
+
+            attachment = KilnAttachmentModel.from_file(tmp_path)
+            chunk = Chunk(content=attachment)
+            assert chunk.page_number is None
+
+    def test_page_number_can_be_set(self):
+        """Test that page_number can be set to an integer."""
+        with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
+            tmp_file.write(b"test content")
+            tmp_path = Path(tmp_file.name)
+
+            attachment = KilnAttachmentModel.from_file(tmp_path)
+            chunk = Chunk(content=attachment, page_number=0)
+            assert chunk.page_number == 0
+
+            chunk = Chunk(content=attachment, page_number=5)
+            assert chunk.page_number == 5
+
+    def test_page_number_can_be_none_explicitly(self):
+        """Test that page_number can be explicitly set to None."""
+        with tempfile.NamedTemporaryFile(delete=True) as tmp_file:
+            tmp_file.write(b"test content")
+            tmp_path = Path(tmp_file.name)
+
+            attachment = KilnAttachmentModel.from_file(tmp_path)
+            chunk = Chunk(content=attachment, page_number=None)
+            assert chunk.page_number is None
+
 
 class TestPropertiesNotMatchingChunkerType:
     """Test that properties are not matching the chunker type."""

--- a/libs/core/kiln_ai/tools/rag_tools.py
+++ b/libs/core/kiln_ai/tools/rag_tools.py
@@ -46,12 +46,15 @@ class ChunkContext(BaseModel):
 def format_search_results(search_results: List[SearchResult]) -> str:
     results: List[ChunkContext] = []
     for search_result in search_results:
+        metadata = {
+            "document_id": search_result.document_id,
+            "chunk_idx": search_result.chunk_idx,
+        }
+        if search_result.page_number is not None:
+            metadata["page_number"] = search_result.page_number
         results.append(
             ChunkContext(
-                metadata={
-                    "document_id": search_result.document_id,
-                    "chunk_idx": search_result.chunk_idx,
-                },
+                metadata=metadata,
                 text=search_result.chunk_text,
             )
         )


### PR DESCRIPTION
## What does this PR do?

This adds page numbers into chunks in RAG - this allows the caller of the `RagTool` to format citations that points to a specific page. 

Page number is nullable. It is `None` for non-PDF (or non-page) documents.

Getting the page number in an existing `Search Tool` requires reindexing - delete `~/.kiln_ai/rag_indexes/`

The entire flow is:
1. Extract -> extract each page, and as we materialize the extraction datamodel to disk as a single unit, add an array of char offsets marking the start of each page
2. Chunking -> do the chunks off the entire extraction, then map back each chunk to their location in the entire extraction and find the char offset range each chunk falls in to map back to the corresponding page
3. Indexing -> add the `kiln_page_number` as metadata in the record (alongside `kiln_doc_id` and chunk id
4. Retrieval -> in the `RagTool`, add the page number in the chunk metadata
5. UI -> Surface the page number

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PDF extractions now track page numbers for each chunk, enabling better content attribution in search results and improved visibility into source document structure.
  * Search results display page information when chunks originate from multi-page documents, helping users quickly identify document location.
  * RAG configuration UI now shows page numbers alongside chunk indices for enhanced document context.

* **Tests**
  * Expanded test coverage for page number tracking across extraction, chunking, vector storage, and search components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->