### PR TITLE
chore: wt config allow user layout

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -2,8 +2,8 @@
 deps = "uv sync && cd app/web_ui && npm install"
 claude = "utils/setup_claude.sh"
 
-[post-start]
+[pre-start]
 copy = "wt step copy-ignored"
 
 [pre-remove]
-session = "zellij delete-session {{ branch | sanitize }} 2>/dev/null || true"
+-session = "zellij delete-session {{ branch | sanitize }} 2>/dev/null || true"

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -6,4 +6,4 @@ claude = "utils/setup_claude.sh"
 copy = "wt step copy-ignored"
 
 [pre-remove]
--session = "zellij delete-session {{ branch | sanitize }} 2>/dev/null || true"
+session = "zellij delete-session {{ branch | sanitize }} 2>/dev/null || true"

--- a/.config/wt.toml.new
+++ b/.config/wt.toml.new
@@ -1,9 +1,0 @@
-[pre-start]
-deps = "uv sync && cd app/web_ui && npm install"
-claude = "utils/setup_claude.sh"
-
-[post-start]
-copy = "wt step copy-ignored"
-
-[pre-remove]
-session = "zellij delete-session {{ branch | sanitize }} 2>/dev/null || true"

--- a/.config/wt.toml.new
+++ b/.config/wt.toml.new
@@ -1,0 +1,9 @@
+[pre-start]
+deps = "uv sync && cd app/web_ui && npm install"
+claude = "utils/setup_claude.sh"
+
+[post-start]
+copy = "wt step copy-ignored"
+
+[pre-remove]
+session = "zellij delete-session {{ branch | sanitize }} 2>/dev/null || true"

--- a/.config/wt/README.md
+++ b/.config/wt/README.md
@@ -163,7 +163,11 @@ keybinds clear-defaults=true {
 
 - `.config/wt.toml` — project hooks: dependency install on create, Zellij session cleanup on remove
 - `.config/wt/start.sh` — launches a Zellij session with per-branch ports (via `hash_port`)
-- `.config/wt/layout.kdl` — Zellij layout: terminal, coding agent, backend server, frontend dev server
+- `.config/wt/layout.kdl` — default Zellij layout: terminal, coding agent, backend server, frontend dev server
+- `.config/wt/layout.user.kdl` — per-user layout override (gitignored); if present, takes priority over `layout.kdl`. Copy from `layout.user.kdl.example` to get started:
+  ```bash
+  cp .config/wt/layout.user.kdl.example .config/wt/layout.user.kdl
+  ```
 - `.config/wt/bin/web` — opens the worktree's web UI in a browser (type `web` in the terminal tab)
 - `.config/wt/user_settings.sh` — per-user overrides (gitignored); copy from `user_settings.sh.example`
 - `.config/wt/config.toml` — worktrunk user config (worktree path template)

--- a/.config/wt/layout.user.kdl.example
+++ b/.config/wt/layout.user.kdl.example
@@ -1,0 +1,36 @@
+// Per-user Zellij layout for the Kiln dev environment.
+// Copy this file to layout.user.kdl and customize:
+//   cp .config/wt/layout.user.kdl.example .config/wt/layout.user.kdl
+//
+// layout.user.kdl is gitignored — your changes stay local.
+// If present, it takes priority over the default layout.kdl.
+//
+// This example uses a single "dev" tab with 4 vertical splits, so all
+// panes are visible at once. Adjust pane sizes or add/remove panes to
+// suit your workflow.
+
+layout {
+    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="zellij:tab-bar"
+        }
+        children
+        pane size=2 borderless=true {
+            plugin location="zellij:status-bar"
+        }
+    }
+    tab name="dev" focus=true split_direction="vertical" {
+        pane size="40%" command="bash" start_suspended=false {
+            args "-c" "echo \"\nWeb UI: $KILN_WEB_URL\nBackend: http://localhost:$KILN_PORT\n\nType 'web' to open in browser.\n\"; exec $SHELL"
+        }
+        pane size="20%" command="bash" start_suspended=false {
+            args "-c" "$KILN_CODER_CMD"
+        }
+        pane size="20%" command="bash" start_suspended=false {
+            args "-c" "uv run python -m app.desktop.dev_server"
+        }
+        pane size="20%" cwd="app/web_ui" command="bash" start_suspended=false {
+            args "-c" "npm run dev -- --host --port $KILN_FRONTEND_PORT"
+        }
+    }
+}

--- a/.config/wt/start.sh
+++ b/.config/wt/start.sh
@@ -37,7 +37,10 @@ printf '\e]0;FEAT: %s\a' "$BRANCH"
 
 cd "$REPO_ROOT"
 
-LAYOUT="$REPO_ROOT/.config/wt/layout.kdl"
+LAYOUT="$REPO_ROOT/.config/wt/layout.user.kdl"
+if [ ! -f "$LAYOUT" ]; then
+    LAYOUT="$REPO_ROOT/.config/wt/layout.kdl"
+fi
 
 SESSION_STATUS=$(zellij list-sessions --no-formatting 2>/dev/null \
     | awk -v name="$SESSION_NAME" '{ n=$1; gsub(/[[:space:]]/, "", n); if (n == name) { print (/EXITED/ ? "exited" : "active"); exit } }') || true

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ test_output/
 
 .specs_skill_state/
 .config/wt/user_settings.sh
+.config/wt/layout.user.kdl
 .worktrees/
 

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,2 +1,3 @@
 .env
 .config/wt/user_settings.sh
+.config/wt/layout.user.kdl


### PR DESCRIPTION
## What does this PR do?

Let users override the layout with a custom `.config/wt/layout.user.kdl`

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-user terminal layout override so users can customize their development pane layout.

* **Documentation**
  * Clarified default layout behavior and added example and instructions for initializing a per-user layout.

* **Chores**
  * Adjusted when a setup step runs during startup.
  * Per-user layout is now ignored by version control and included in worktree tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->