### PR TITLE
Better Signup Flow, automatically create / saves API key

### DIFF
--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/api/auth/create_api_key_v1_create_api_key_post.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/api/auth/create_api_key_v1_create_api_key_post.py
@@ -1,0 +1,146 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.create_api_key_response import CreateApiKeyResponse
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/v1/create_api_key",
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, client: AuthenticatedClient | Client, response: httpx.Response) -> CreateApiKeyResponse | None:
+    if response.status_code == 201:
+        response_201 = CreateApiKeyResponse.from_dict(response.json())
+
+        return response_201
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[CreateApiKeyResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[CreateApiKeyResponse]:
+    """Create Api Key
+
+     Create a new API key for the authenticated user.
+
+    Requires a Kinde OAuth access token (not an API key).
+    Returns the raw API key which can then be used for subsequent API calls.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[CreateApiKeyResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+) -> CreateApiKeyResponse | None:
+    """Create Api Key
+
+     Create a new API key for the authenticated user.
+
+    Requires a Kinde OAuth access token (not an API key).
+    Returns the raw API key which can then be used for subsequent API calls.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        CreateApiKeyResponse
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+) -> Response[CreateApiKeyResponse]:
+    """Create Api Key
+
+     Create a new API key for the authenticated user.
+
+    Requires a Kinde OAuth access token (not an API key).
+    Returns the raw API key which can then be used for subsequent API calls.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[CreateApiKeyResponse]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+) -> CreateApiKeyResponse | None:
+    """Create Api Key
+
+     Create a new API key for the authenticated user.
+
+    Requires a Kinde OAuth access token (not an API key).
+    Returns the raw API key which can then be used for subsequent API calls.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        CreateApiKeyResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/__init__.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/__init__.py
@@ -13,6 +13,7 @@ from .check_entitlements_v1_check_entitlements_get_response_check_entitlements_v
 from .check_model_supported_response import CheckModelSupportedResponse
 from .clarify_spec_input import ClarifySpecInput
 from .clarify_spec_output import ClarifySpecOutput
+from .create_api_key_response import CreateApiKeyResponse
 from .examples_for_feedback_item import ExamplesForFeedbackItem
 from .examples_with_feedback_item import ExamplesWithFeedbackItem
 from .generate_batch_input import GenerateBatchInput
@@ -63,6 +64,7 @@ __all__ = (
     "CheckModelSupportedResponse",
     "ClarifySpecInput",
     "ClarifySpecOutput",
+    "CreateApiKeyResponse",
     "ExamplesForFeedbackItem",
     "ExamplesWithFeedbackItem",
     "GenerateBatchInput",

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/create_api_key_response.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/create_api_key_response.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="CreateApiKeyResponse")
+
+
+@_attrs_define
+class CreateApiKeyResponse:
+    """
+    Attributes:
+        api_key (str):
+    """
+
+    api_key: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        api_key = self.api_key
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "api_key": api_key,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        api_key = d.pop("api_key")
+
+        create_api_key_response = cls(
+            api_key=api_key,
+        )
+
+        create_api_key_response.additional_properties = d
+        return create_api_key_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/app/desktop/studio_server/api_client/kiln_server_client.py
+++ b/app/desktop/studio_server/api_client/kiln_server_client.py
@@ -50,5 +50,19 @@ def get_authenticated_client(api_key: str) -> AuthenticatedClient:
     )
 
 
+def get_oauth_authenticated_client(access_token: str) -> AuthenticatedClient:
+    """Get a client authenticated with a Kinde OAuth access token.
+
+    Used for pre-API-key flows like signup, where the user has authenticated
+    with Kinde but does not yet have a Kiln API key.
+    """
+    return AuthenticatedClient(
+        base_url=_get_base_url(),
+        token=access_token,
+        headers=_get_common_headers(),
+        timeout=httpx.Timeout(timeout=900.0, connect=30.0),
+    )
+
+
 server_client = get_kiln_server_client()
 """The default client for the Kiln server for reusability."""

--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -1,13 +1,21 @@
+import json
 import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from typing import Annotated, Any, Dict, List, Literal
 
 import httpx
 import litellm
 import openai
 import requests
+from app.desktop.studio_server.api_client.kiln_ai_server_client.api.auth import (
+    create_api_key_v1_create_api_key_post,
+)
+from app.desktop.studio_server.api_client.kiln_server_client import (
+    get_authenticated_client,
+)
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import JSONResponse
 from kiln_ai.adapters.docker_model_runner_tools import (
@@ -237,6 +245,10 @@ class OpenAICompatibleProviderConfig(BaseModel):
     name: str = Field(description="Name for the OpenAI compatible provider.")
     base_url: str = Field(description="Base URL for the OpenAI compatible API.")
     api_key: str = Field(description="API key for authentication.")
+
+
+class CreateKilnCopilotApiKeyRequest(BaseModel):
+    access_token: str = Field(description="Kinde OAuth access token.")
 
 
 def connect_provider_api(app: FastAPI):
@@ -983,6 +995,56 @@ def connect_provider_api(app: FastAPI):
             status_code=200,
             content={"message": "Provider disconnected"},
         )
+
+    @app.post(
+        "/api/provider/create_kiln_copilot_api_key",
+        summary="Create Kiln Copilot API Key",
+        tags=["Providers & Models"],
+        openapi_extra=DENY_AGENT,
+    )
+    async def create_kiln_copilot_api_key(
+        payload: CreateKilnCopilotApiKeyRequest,
+    ) -> JSONResponse:
+        return await _create_kiln_copilot_api_key(payload.access_token)
+
+
+async def _create_kiln_copilot_api_key(access_token: str) -> JSONResponse:
+    if not access_token:
+        return JSONResponse(
+            status_code=400,
+            content={"message": "Access token is required"},
+        )
+
+    client = get_authenticated_client(access_token)
+    try:
+        response = await create_api_key_v1_create_api_key_post.asyncio_detailed(
+            client=client,
+        )
+    except httpx.RequestError as e:
+        return JSONResponse(
+            status_code=502,
+            content={"message": f"Failed to connect to Kiln server. Error: {e!s}"},
+        )
+
+    if response.status_code == HTTPStatus.CREATED and response.parsed is not None:
+        Config.shared().kiln_copilot_api_key = response.parsed.api_key
+        return JSONResponse(
+            status_code=200,
+            content={"message": "Connected to Kiln Copilot"},
+        )
+
+    try:
+        error_body = json.loads(response.content)
+        error_message = error_body.get(
+            "detail", f"Failed to create API key (HTTP {response.status_code.value})"
+        )
+    except Exception:
+        error_message = f"Failed to create API key (HTTP {response.status_code.value})"
+
+    return JSONResponse(
+        status_code=response.status_code.value,
+        content={"message": error_message},
+    )
 
 
 async def connect_openrouter(key: str):

--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -13,7 +13,7 @@ from app.desktop.studio_server.api_client.kiln_ai_server_client.api.auth import 
     create_api_key_v1_create_api_key_post,
 )
 from app.desktop.studio_server.api_client.kiln_server_client import (
-    get_authenticated_client,
+    get_oauth_authenticated_client,
 )
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import JSONResponse
@@ -1014,7 +1014,7 @@ async def _create_kiln_copilot_api_key(access_token: str) -> JSONResponse:
             content={"message": "Access token is required"},
         )
 
-    client = get_authenticated_client(access_token)
+    client = get_oauth_authenticated_client(access_token)
     try:
         response = await create_api_key_v1_create_api_key_post.asyncio_detailed(
             client=client,

--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -3,7 +3,6 @@ import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from http import HTTPStatus
 from typing import Annotated, Any, Dict, List, Literal
 
 import httpx
@@ -1026,7 +1025,7 @@ async def _create_kiln_copilot_api_key(access_token: str) -> JSONResponse:
             content={"message": f"Failed to connect to Kiln server. Error: {e!s}"},
         )
 
-    if response.status_code == HTTPStatus.CREATED and response.parsed is not None:
+    if response.parsed is not None:
         Config.shared().kiln_copilot_api_key = response.parsed.api_key
         return JSONResponse(
             status_code=200,

--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -1038,7 +1038,7 @@ async def _create_kiln_copilot_api_key(access_token: str) -> JSONResponse:
         error_message = error_body.get(
             "detail", f"Failed to create API key (HTTP {response.status_code.value})"
         )
-    except Exception:
+    except json.JSONDecodeError:
         error_message = f"Failed to create API key (HTTP {response.status_code.value})"
 
     return JSONResponse(

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -1,12 +1,16 @@
 import json
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from unittest.mock import MagicMock, Mock, patch
 
 import httpx
 import litellm
 import openai
 import pytest
+from app.desktop.studio_server.api_client.kiln_ai_server_client.models.create_api_key_response import (
+    CreateApiKeyResponse,
+)
 from app.desktop.studio_server.provider_api import (
     AvailableModels,
     ModelDetails,
@@ -222,6 +226,76 @@ def test_connect_api_key_kiln_copilot_network_error(mock_httpx_get, client):
 
     assert response.status_code == 400
     assert "Failed to connect" in response.json()["message"]
+
+
+@patch("app.desktop.studio_server.provider_api.Config.shared")
+@patch(
+    "app.desktop.studio_server.provider_api.create_api_key_v1_create_api_key_post.asyncio_detailed"
+)
+def test_create_kiln_copilot_api_key_success(
+    mock_create_api_key, mock_config_shared, client
+):
+    mock_config = MagicMock()
+    mock_config_shared.return_value = mock_config
+
+    mock_response = MagicMock()
+    mock_response.status_code = HTTPStatus.CREATED
+    mock_response.parsed = CreateApiKeyResponse(api_key="new_test_key")
+    mock_create_api_key.return_value = mock_response
+
+    response = client.post(
+        "/api/provider/create_kiln_copilot_api_key",
+        json={"access_token": "kinde_oauth_token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Connected to Kiln Copilot"}
+    assert mock_config.kiln_copilot_api_key == "new_test_key"
+    mock_create_api_key.assert_called_once()
+
+
+def test_create_kiln_copilot_api_key_empty_token(client):
+    response = client.post(
+        "/api/provider/create_kiln_copilot_api_key",
+        json={"access_token": ""},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"message": "Access token is required"}
+
+
+@patch(
+    "app.desktop.studio_server.provider_api.create_api_key_v1_create_api_key_post.asyncio_detailed"
+)
+def test_create_kiln_copilot_api_key_server_error(mock_create_api_key, client):
+    mock_response = MagicMock()
+    mock_response.status_code = HTTPStatus.UNAUTHORIZED
+    mock_response.parsed = None
+    mock_response.content = b'{"detail": "Invalid token"}'
+    mock_create_api_key.return_value = mock_response
+
+    response = client.post(
+        "/api/provider/create_kiln_copilot_api_key",
+        json={"access_token": "bad_token"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"message": "Invalid token"}
+
+
+@patch(
+    "app.desktop.studio_server.provider_api.create_api_key_v1_create_api_key_post.asyncio_detailed"
+)
+def test_create_kiln_copilot_api_key_network_error(mock_create_api_key, client):
+    mock_create_api_key.side_effect = httpx.RequestError("Connection refused")
+
+    response = client.post(
+        "/api/provider/create_kiln_copilot_api_key",
+        json={"access_token": "kinde_oauth_token"},
+    )
+
+    assert response.status_code == 502
+    assert "Failed to connect to Kiln server" in response.json()["message"]
 
 
 @patch("app.desktop.studio_server.provider_api.requests.get")

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -1254,6 +1254,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/provider/create_kiln_copilot_api_key": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Kiln Copilot API Key */
+        post: operations["create_kiln_copilot_api_key_api_provider_create_kiln_copilot_api_key_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/projects/{project_id}/tasks/{task_id}/gen_prompt/{prompt_id}": {
         parameters: {
             query?: never;
@@ -3416,6 +3433,14 @@ export interface components {
             custom_thinking_instructions?: string | null;
             data_strategy: components["schemas"]["ChatStrategy"];
             run_config_properties?: components["schemas"]["KilnAgentRunConfigProperties"] | null;
+        };
+        /** CreateKilnCopilotApiKeyRequest */
+        CreateKilnCopilotApiKeyRequest: {
+            /**
+             * Access Token
+             * @description Kinde OAuth access token.
+             */
+            access_token: string;
         };
         /**
          * CreateMcpRunConfigRequest
@@ -11667,6 +11692,39 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_kiln_copilot_api_key_api_provider_create_kiln_copilot_api_key_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateKilnCopilotApiKeyRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
+++ b/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
@@ -25,6 +25,7 @@
       client_id: KINDE_ACCOUNT_CLIENT_ID,
       domain: KINDE_ACCOUNT_DOMAIN,
       redirect_uri: window.location.origin + window.location.pathname,
+      // Kinde SDK requires this callback; we handle the redirect ourselves in onMount
       on_redirect_callback: () => {},
     })
 
@@ -119,12 +120,12 @@
 <h1 class="text-xl font-medium flex-none text-center">Connect Kiln Copilot</h1>
 
 {#if showCheckmark}
-  <div class="flex justify-center py-4">
+  <div class="flex justify-center my-4">
     <img src="/images/circle-check.svg" class="size-8" alt="Connected" />
   </div>
 {:else if errorMessage}
-  <p class="text-error text-center pt-4 pb-2">{errorMessage}</p>
-  <div class="flex justify-center pb-4">
+  <p class="text-error text-center mx-8 my-4">{errorMessage}</p>
+  <div class="flex justify-center">
     <button
       class="btn min-w-[130px]"
       on:click={tokenExchangeFailed ? createApiKeyFromToken : openSignup}
@@ -135,7 +136,7 @@
   <p class="text-center text-gray-700 mx-8 my-4">
     Sign in or create an account to get started.
   </p>
-  <div class="flex justify-center pt-2">
+  <div class="flex justify-center">
     <button
       class="btn min-w-[130px]"
       on:click={openSignup}

--- a/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
+++ b/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
@@ -9,10 +9,9 @@
   export let showCheckmark = false
 
   let kindeClient: Awaited<ReturnType<typeof createKindeClient>> | null = null
-  let apiKey = ""
-  let apiKeyError = false
-  let apiKeyMessage: string | null = null
-  let submitting = false
+  let connecting = false
+  let errorMessage: string | null = null
+  let tokenExchangeFailed = false
 
   const KINDE_ACCOUNT_DOMAIN =
     env.PUBLIC_KINDE_ACCOUNT_DOMAIN || "https://account.kiln.tech"
@@ -36,168 +35,116 @@
     try {
       const kinde = await initKindeClient()
       if (!kinde) {
-        apiKeyError = true
-        apiKeyMessage = "Kinde configuration is missing"
+        errorMessage = "Kinde configuration is missing"
         return
       }
 
       await kinde.register()
     } catch (e) {
       console.error("openSignup error", e)
-      apiKeyError = true
-      apiKeyMessage = "Failed to open Kiln Copilot signup"
+      errorMessage = "Failed to open Kiln Copilot signup"
     }
   }
 
-  async function openSelfServePortal() {
+  async function createApiKeyFromToken() {
+    connecting = true
+    errorMessage = null
+    tokenExchangeFailed = false
+
     try {
       const kinde = await initKindeClient()
       if (!kinde) {
-        apiKeyError = true
-        apiKeyMessage = "Please sign up first"
+        errorMessage = "Failed to initialize authentication"
+        connecting = false
         return
       }
 
       const accessToken = await kinde.getToken()
       if (!accessToken) {
-        apiKeyError = true
-        apiKeyMessage = "Please sign up first before accessing the portal"
+        errorMessage =
+          "Failed to get access token. Please try signing in again."
+        connecting = false
         return
       }
 
-      const response = await fetch(
-        `${KINDE_ACCOUNT_DOMAIN}/account_api/v1/portal_link`,
+      tokenExchangeFailed = true
+
+      const res = await fetch(
+        base_url + "/api/provider/create_kiln_copilot_api_key",
         {
+          method: "POST",
           headers: {
-            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
           },
+          body: JSON.stringify({
+            access_token: accessToken,
+          }),
         },
       )
-
-      if (!response.ok) {
-        throw new Error("Failed to generate portal link")
-      }
-
-      const data = await response.json()
-      window.open(data.url, "_blank")
-    } catch (e) {
-      console.error("openSelfServePortal error", e)
-      apiKeyError = true
-      apiKeyMessage =
-        "Failed to open self-serve portal. Please try signing up first."
-    }
-  }
-
-  export async function submitApiKey() {
-    if (!apiKey.trim()) {
-      apiKeyError = true
-      return false
-    }
-
-    apiKeyError = false
-    apiKeyMessage = null
-    submitting = true
-
-    try {
-      const res = await fetch(base_url + "/api/provider/connect_api_key", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          provider: "kiln_copilot",
-          key_data: {
-            "API Key": apiKey,
-          },
-        }),
-      })
 
       const data = await res.json()
 
       if (!res.ok) {
-        apiKeyMessage =
-          data.message || data.detail || "Failed to connect to provider"
-        apiKeyError = true
-        return false
+        errorMessage = data.message || data.detail || "Failed to create API key"
+        connecting = false
+        return
       }
+
+      tokenExchangeFailed = false
+      window.history.replaceState({}, "", window.location.pathname)
 
       posthog.capture("connect_provider", {
         provider_id: "kiln_copilot",
       })
 
       onSuccess()
-      return true
     } catch (e) {
-      console.error("submitApiKey error", e)
-      apiKeyMessage = "Failed to connect to provider (Exception: " + e + ")"
-      apiKeyError = true
-      return false
+      console.error("createApiKeyFromToken error", e)
+      errorMessage = "Failed to connect to Kiln Copilot. Please try again."
     } finally {
-      submitting = false
+      connecting = false
     }
   }
 
   onMount(async () => {
-    if (
-      window.location.search.includes("code=") ||
-      window.location.search.includes("state=")
-    ) {
-      await initKindeClient()
+    const params = new URLSearchParams(window.location.search)
+    if (params.has("code")) {
+      await createApiKeyFromToken()
     }
   })
 </script>
 
-<h1 class="text-xl font-medium text-center mb-2">Connect Kiln Copilot</h1>
+<h1 class="text-xl font-medium flex-none text-center">Connect Kiln Copilot</h1>
 
-<ol class="mb-2 text-gray-700">
-  <li class="list-decimal pl-1 mx-8 mb-4">
-    <button class="link" on:click={openSignup}>Sign Up</button>
-    to create your Kiln Copilot account.
-  </li>
-  <li class="list-decimal pl-1 mx-8 my-4">
-    After registration,
-    <button class="link" on:click={openSelfServePortal}>
-      open the self-serve portal.
-    </button>
-    Go to 'API keys' section and create an API key.
-  </li>
-  <li class="list-decimal pl-1 mx-8 my-4">
-    Copy your API key, paste it below and click 'Connect'.
-  </li>
-</ol>
-
-{#if apiKeyMessage}
-  <p class="text-error text-center pb-4">{apiKeyMessage}</p>
-{/if}
-
-<div class="flex flex-row gap-4 items-center">
-  <div class="grow flex flex-col gap-2">
-    <input
-      type="text"
-      id="API Key"
-      placeholder="API Key"
-      class="input input-bordered w-full max-w-[300px] {apiKeyError
-        ? 'input-error'
-        : ''}"
-      bind:value={apiKey}
-      on:input={() => (apiKeyError = false)}
-    />
+{#if showCheckmark}
+  <div class="flex justify-center py-4">
+    <img src="/images/circle-check.svg" class="size-8" alt="Connected" />
   </div>
-  <button
-    class="btn min-w-[130px]"
-    on:click={submitApiKey}
-    disabled={submitting}
-  >
-    {#if submitting}
-      <div class="loading loading-spinner loading-md"></div>
-    {:else if showCheckmark}
-      <img
-        src="/images/circle-check.svg"
-        class="size-6 group-hover:hidden"
-        alt="Connected"
-      />
-    {:else}
-      Connect
-    {/if}
-  </button>
-</div>
+{:else}
+  <ol class="flex-none my-2 text-gray-700">
+    <li class="list-decimal pl-1 mx-8 my-4">
+      <button class="link underline" on:click={openSignup}>Sign Up</button>
+      to create your free Kiln Copilot account.
+    </li>
+    <li class="list-decimal pl-1 mx-8 my-4">
+      {#if connecting}
+        <span class="flex items-center gap-2">
+          <span class="loading loading-spinner loading-sm"></span>
+          Creating your API key...
+        </span>
+      {:else}
+        Your API key will be created automatically.
+      {/if}
+    </li>
+  </ol>
+  {#if errorMessage}
+    <p class="text-error text-center pb-2">{errorMessage}</p>
+    <div class="flex justify-center pb-4">
+      <button
+        class="btn min-w-[130px]"
+        on:click={tokenExchangeFailed ? createApiKeyFromToken : openSignup}
+        >Try Again</button
+      >
+    </div>
+  {/if}
+{/if}

--- a/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
+++ b/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
@@ -91,19 +91,21 @@
       }
 
       tokenExchangeFailed = false
-      window.history.replaceState({}, "", window.location.pathname)
-
-      posthog.capture("connect_provider", {
-        provider_id: "kiln_copilot",
-      })
-
-      onSuccess()
     } catch (e) {
       console.error("createApiKeyFromToken error", e)
       errorMessage = "Failed to connect to Kiln Copilot. Please try again."
+      return
     } finally {
       connecting = false
     }
+
+    window.history.replaceState({}, "", window.location.pathname)
+
+    posthog.capture("connect_provider", {
+      provider_id: "kiln_copilot",
+    })
+
+    onSuccess()
   }
 
   onMount(async () => {

--- a/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
+++ b/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
@@ -122,31 +122,30 @@
   <div class="flex justify-center py-4">
     <img src="/images/circle-check.svg" class="size-8" alt="Connected" />
   </div>
+{:else if errorMessage}
+  <p class="text-error text-center pt-4 pb-2">{errorMessage}</p>
+  <div class="flex justify-center pb-4">
+    <button
+      class="btn min-w-[130px]"
+      on:click={tokenExchangeFailed ? createApiKeyFromToken : openSignup}
+      >Try Again</button
+    >
+  </div>
 {:else}
-  <ol class="flex-none my-2 text-gray-700">
-    <li class="list-decimal pl-1 mx-8 my-4">
-      <button class="link underline" on:click={openSignup}>Sign Up</button>
-      to create your Kiln Copilot account.
-    </li>
-    <li class="list-decimal pl-1 mx-8 my-4">
+  <p class="text-center text-gray-700 mx-8 my-4">
+    Sign in or create an account to get started.
+  </p>
+  <div class="flex justify-center pt-2">
+    <button
+      class="btn min-w-[130px]"
+      on:click={openSignup}
+      disabled={connecting}
+    >
       {#if connecting}
-        <span class="flex items-center gap-2">
-          <span class="loading loading-spinner loading-sm"></span>
-          Creating your API key...
-        </span>
+        <div class="loading loading-spinner loading-md"></div>
       {:else}
-        Your API key will be created automatically.
+        Connect
       {/if}
-    </li>
-  </ol>
-  {#if errorMessage}
-    <p class="text-error text-center pb-2">{errorMessage}</p>
-    <div class="flex justify-center pb-4">
-      <button
-        class="btn min-w-[130px]"
-        on:click={tokenExchangeFailed ? createApiKeyFromToken : openSignup}
-        >Try Again</button
-      >
-    </div>
-  {/if}
+    </button>
+  </div>
 {/if}

--- a/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
+++ b/app/web_ui/src/lib/ui/kiln_copilot/connect_kiln_copilot_steps.svelte
@@ -124,7 +124,7 @@
   <ol class="flex-none my-2 text-gray-700">
     <li class="list-decimal pl-1 mx-8 my-4">
       <button class="link underline" on:click={openSignup}>Sign Up</button>
-      to create your free Kiln Copilot account.
+      to create your Kiln Copilot account.
     </li>
     <li class="list-decimal pl-1 mx-8 my-4">
       {#if connecting}

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_provider_create_kiln_copilot_api_key.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_provider_create_kiln_copilot_api_key.json
@@ -1,0 +1,8 @@
+{
+  "method": "post",
+  "path": "/api/provider/create_kiln_copilot_api_key",
+  "agent_policy": {
+    "permission": "deny",
+    "requires_approval": false
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Updated Kiln copilot sign up flow to skip the step of needing the user to manually copy the API key.

Backend server side has a new endpoint that does authentication (after sign in) and creates API key automatically. This PR adds the new api_client that contains that endpoint. 

**New in this PR:**
- Add new endpoint `create_kiln_copilot_api_key` to studio server. It accepts a Kinde OAuth token from web_ui and calls the backend server's new `create_api_key` end point.
- Simplified sign up flow to 2 steps. No more copy pasting. 

**Before:**
<img width="497" height="504" alt="image" src="https://github.com/user-attachments/assets/003455b1-412e-404a-bc4c-324876501bcc" />

**After:**
<img width="504" height="388" alt="image" src="https://github.com/user-attachments/assets/5ca811c3-d8a0-42a5-b218-a272d7b8a992" />

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kiln Copilot connection now auto-creates API keys via a token-based exchange for smoother setup.

* **API**
  * Added a server endpoint to accept an access token and create/persist a Kiln Copilot API key, with clear success and error responses.

* **UI**
  * Connection flow updated to show progress, connected checkmark, error messaging, and a “Try Again” retry action instead of manual API-key entry.

* **Tests**
  * Added tests for success, validation, authorization/error, and network-failure scenarios.

* **Chores**
  * Added a server-side policy rule governing POST requests to the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->