### PR TITLE
KIL-519 Align spec builder button verbs

### DIFF
--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/+page.svelte
@@ -324,7 +324,7 @@
     current_state = "review"
   }
 
-  // Handler for "Analyze with Copilot" button
+  // Handler for "Create with Copilot" button
   async function handle_analyze_with_copilot() {
     error = null
 

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/+page.svelte
@@ -325,7 +325,7 @@
   }
 
   // Handler for "Create with Copilot" button
-  async function handle_analyze_with_copilot() {
+  async function handle_create_with_copilot() {
     error = null
 
     try {
@@ -876,7 +876,7 @@
         {task_id}
         bind:few_shot_example
         bind:has_unsaved_manual_entry
-        on:analyze_with_copilot={handle_analyze_with_copilot}
+        on:create_with_copilot={handle_create_with_copilot}
         on:create_without_copilot={handle_create_spec_without_copilot}
       />
     {:else if current_state === "analyzing_for_review"}

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_form.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_form.svelte
@@ -69,7 +69,7 @@
 
 <FormContainer
   bind:this={form_container}
-  submit_label={copilot_enabled ? "Analyze with Copilot" : "Create Spec"}
+  submit_label={copilot_enabled ? "Create with Copilot" : "Create Spec"}
   on:submit={handle_submit}
   bind:error
   bind:submitting
@@ -140,7 +140,7 @@
       disabled={submitting}
       on:click={handle_secondary_click}
     >
-      Create without Copilot
+      Create manually
     </button>
   </div>
 {/if}

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_form.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_form.svelte
@@ -29,7 +29,7 @@
   let form_container: FormContainer
 
   const dispatch = createEventDispatcher<{
-    analyze_with_copilot: void
+    create_with_copilot: void
     create_without_copilot: void
   }>()
 
@@ -54,7 +54,7 @@
 
   function handle_submit() {
     if (copilot_enabled) {
-      dispatch("analyze_with_copilot")
+      dispatch("create_with_copilot")
     } else {
       dispatch("create_without_copilot")
     }


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-519/align-verbs

## Description

Align the verbs on spec builder entry point buttons so both use "create":
- "Analyze with Copilot" → "Create with Copilot"
- "Create without Copilot" → "Create manually"

Later copilot flow buttons (e.g. "Analyze Refined Spec") are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated spec builder wording and action labels to emphasize "Create" workflows.
  * When Copilot is enabled the primary action now reads "Create with Copilot" and the secondary option reads "Create manually"; when disabled the primary remains "Create Spec".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->