### PR TITLE
KIL-522 Restore persisted model selection on Run page

### DIFF
--- a/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
@@ -63,11 +63,25 @@
   }
 
   // Initialization of selected_run_config_id
+  // Start with "custom" immediately (avoids showing "Select an option" while configs load),
+  // then upgrade to the default config once it's available in the loaded options.
   $: if (auto_select_default && selected_run_config_id === null) {
-    if (default_run_config_id) {
+    selected_run_config_id = run_page ? "custom" : null
+  }
+  $: if (
+    auto_select_default &&
+    run_page &&
+    selected_run_config_id === "custom" &&
+    default_run_config_id
+  ) {
+    const composite_key = get_task_composite_id(
+      project_id,
+      current_task.id ?? "",
+    )
+    const loaded_configs =
+      $run_configs_by_task_composite_id[composite_key] ?? []
+    if (loaded_configs.some((c) => c.id === default_run_config_id)) {
       selected_run_config_id = default_run_config_id
-    } else {
-      selected_run_config_id = run_page ? "custom" : null
     }
   }
 

--- a/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
@@ -65,10 +65,14 @@
   // Initialization of selected_run_config_id
   // Start with "custom" immediately (avoids showing "Select an option" while configs load),
   // then upgrade to the default config once it's available in the loaded options.
+  // Uses a one-shot guard so intentional later "Custom" selections aren't overridden.
+  let pending_default_upgrade = false
   $: if (auto_select_default && selected_run_config_id === null) {
     selected_run_config_id = run_page ? "custom" : null
+    pending_default_upgrade = run_page
   }
   $: if (
+    pending_default_upgrade &&
     auto_select_default &&
     run_page &&
     selected_run_config_id === "custom" &&
@@ -82,6 +86,7 @@
       $run_configs_by_task_composite_id[composite_key] ?? []
     if (loaded_configs.some((c) => c.id === default_run_config_id)) {
       selected_run_config_id = default_run_config_id
+      pending_default_upgrade = false
     }
   }
 

--- a/app/web_ui/src/routes/(app)/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/run/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import AppPage from "../app_page.svelte"
-  import { current_task, current_project } from "$lib/stores"
+  import { current_task, current_project, ui_state } from "$lib/stores"
   import { createKilnError } from "$lib/utils/error_handlers"
   import FormContainer from "$lib/utils/form_container.svelte"
   import { KilnError } from "$lib/utils/error_handlers"
@@ -26,7 +26,7 @@
   let selected_run_config_id: string | null = null
   // Some models have a model-specific suggested run config, such as fine-tuned models. If a model like that is selected, this will be set to the run config ID.
   let selected_model_specific_run_config_id: string | null = null
-  let model: string = ""
+  let model: string = $ui_state.selected_model || ""
 
   let run_config_component: RunConfigComponent
   let save_config_error: KilnError | null = null


### PR DESCRIPTION
Initialize model from ui_state store (localStorage) instead of empty string so the previously selected model is restored on page load. Also fix the saved-config dropdown to show "custom" immediately instead of "Select an option" while configs load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Run configuration auto-selection now waits for available configs and only applies a verified default, avoiding accidental overrides of custom selections.
  * Model field now retains the previously selected model from shared UI state so your selection persists across the run page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->