### PR TITLE
Update MiniMax-M2.7 structured output and reasoning config

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -7036,10 +7036,11 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="MiniMaxAI/MiniMax-M2.7",
-                structured_output_mode=StructuredOutputMode.json_schema,
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 reasoning_capable=True,
                 supports_data_gen=True,
-                parser=ModelParserID.r1_thinking,
+                reasoning_optional_for_structured_output=True,
+                parser=ModelParserID.optional_r1_thinking,
             ),
         ],
     ),


### PR DESCRIPTION
## What does this PR do?

Updates the MiniMax-M2.7 model configuration to reflect its actual capabilities:
- Changes structured output mode from `json_schema` to `json_instruction_and_object` to match the model's supported output format
- Marks reasoning as optional for structured output by adding `reasoning_optional_for_structured_output=True`
- Updates the parser from `r1_thinking` to `optional_r1_thinking` to reflect that reasoning is not required

These changes ensure the model configuration accurately represents MiniMax-M2.7's behavior when generating structured outputs.

## Related Issues

<!-- Link to related issues if applicable -->

## Contributor License Agreement

I confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib

https://claude.ai/code/session_01F1L5ryuY5t2MxQXbNVjQGj