### PR TITLE
fix: re-clamp chat sidebar width on window resize

### DIFF
--- a/app/web_ui/src/lib/chat/chat_bar_sizing.test.ts
+++ b/app/web_ui/src/lib/chat/chat_bar_sizing.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest"
+import {
+  CHAT_BAR_MIN_WIDTH,
+  CHAT_BAR_DEFAULT_WIDTH_LG,
+  CHAT_BAR_DEFAULT_WIDTH_2XL,
+  CHAT_BAR_BREAKPOINT_2XL,
+  getChatBarMaxWidth,
+  clampChatBarWidth,
+  getChatBarDefaultWidth,
+} from "./chat_bar_sizing"
+
+describe("chat_bar_sizing", () => {
+  describe("getChatBarMaxWidth", () => {
+    it("returns 30% of viewport width, floored", () => {
+      expect(getChatBarMaxWidth(1000)).toBe(300)
+      expect(getChatBarMaxWidth(1999)).toBe(599)
+      expect(getChatBarMaxWidth(2560)).toBe(768)
+    })
+  })
+
+  describe("clampChatBarWidth", () => {
+    it("clamps above max down to 30% of viewport", () => {
+      // On a 2560px monitor, 30% = 768. If stored at 768, then viewport
+      // shrinks to 1400px (30% = 420), the width should clamp to 420.
+      expect(clampChatBarWidth(768, 1400)).toBe(420)
+    })
+
+    it("clamps below minimum up to MIN_WIDTH", () => {
+      expect(clampChatBarWidth(100, 2000)).toBe(CHAT_BAR_MIN_WIDTH)
+    })
+
+    it("passes through values within range", () => {
+      expect(clampChatBarWidth(400, 2000)).toBe(400)
+    })
+
+    it("rounds fractional values", () => {
+      expect(clampChatBarWidth(400.7, 2000)).toBe(401)
+    })
+
+    it("respects min even when viewport is tiny", () => {
+      // Tiny viewport would make max < min; min wins.
+      expect(clampChatBarWidth(500, 600)).toBe(CHAT_BAR_MIN_WIDTH)
+    })
+  })
+
+  describe("getChatBarDefaultWidth", () => {
+    it("returns lg default below 2XL breakpoint", () => {
+      expect(getChatBarDefaultWidth(CHAT_BAR_BREAKPOINT_2XL - 1)).toBe(
+        CHAT_BAR_DEFAULT_WIDTH_LG,
+      )
+    })
+
+    it("returns 2xl default at or above 2XL breakpoint", () => {
+      expect(getChatBarDefaultWidth(CHAT_BAR_BREAKPOINT_2XL)).toBe(
+        CHAT_BAR_DEFAULT_WIDTH_2XL,
+      )
+      expect(getChatBarDefaultWidth(2560)).toBe(CHAT_BAR_DEFAULT_WIDTH_2XL)
+    })
+  })
+})

--- a/app/web_ui/src/lib/chat/chat_bar_sizing.ts
+++ b/app/web_ui/src/lib/chat/chat_bar_sizing.ts
@@ -1,0 +1,24 @@
+export const CHAT_BAR_MIN_WIDTH = 280
+export const CHAT_BAR_MAX_WIDTH_VW = 30
+export const CHAT_BAR_DEFAULT_WIDTH_LG = 320
+export const CHAT_BAR_DEFAULT_WIDTH_2XL = 380
+export const CHAT_BAR_BREAKPOINT_2XL = 1536
+
+export function getChatBarMaxWidth(viewportWidth: number): number {
+  return Math.floor(viewportWidth * (CHAT_BAR_MAX_WIDTH_VW / 100))
+}
+
+export function clampChatBarWidth(
+  width: number,
+  viewportWidth: number,
+): number {
+  const max = getChatBarMaxWidth(viewportWidth)
+  return Math.round(Math.max(CHAT_BAR_MIN_WIDTH, Math.min(width, max)))
+}
+
+export function getChatBarDefaultWidth(viewportWidth: number): number {
+  if (viewportWidth >= CHAT_BAR_BREAKPOINT_2XL) {
+    return CHAT_BAR_DEFAULT_WIDTH_2XL
+  }
+  return CHAT_BAR_DEFAULT_WIDTH_LG
+}

--- a/app/web_ui/src/routes/(app)/chat_bar.svelte
+++ b/app/web_ui/src/routes/(app)/chat_bar.svelte
@@ -141,6 +141,7 @@
     if (dragging) {
       onDragEnd()
     }
+    // onDestroy is called in SSR, while onMount isn't, so needs extra check
     if (browser) {
       window.removeEventListener("resize", onWindowResize)
       if (resizeFrame !== null) {

--- a/app/web_ui/src/routes/(app)/chat_bar.svelte
+++ b/app/web_ui/src/routes/(app)/chat_bar.svelte
@@ -9,6 +9,10 @@
     getChatBarWidth,
     setChatBarWidth,
   } from "$lib/chat/chat_ui_storage"
+  import {
+    clampChatBarWidth,
+    getChatBarDefaultWidth,
+  } from "$lib/chat/chat_bar_sizing"
   import { onDestroy, onMount } from "svelte"
   import { Section } from "$lib/ui/section"
   import { browser } from "$app/environment"
@@ -20,11 +24,6 @@
 
   export let section: Section = Section.None
 
-  const MIN_WIDTH = 280
-  const MAX_WIDTH_VW = 30
-  const DEFAULT_WIDTH_LG = 320
-  const DEFAULT_WIDTH_2XL = 380
-  const BREAKPOINT_2XL = 1536
   const RIGHT_MARGIN = 16
 
   let expanded = browser ? getChatBarExpanded() : true
@@ -32,6 +31,8 @@
   let dialogOpen = false
   let customWidth: number | null = browser ? getChatBarWidth() : null
   let dragging = false
+  let viewportWidth = browser ? window.innerWidth : 0
+  let resizeFrame: number | null = null
 
   type AnimState = "idle" | "collapsing" | "expanding"
   let animState: AnimState = "idle"
@@ -40,14 +41,7 @@
     return browser && window.matchMedia("(min-width: 1024px)").matches
   }
 
-  function getDefaultWidth(): number {
-    if (browser && window.innerWidth >= BREAKPOINT_2XL) {
-      return DEFAULT_WIDTH_2XL
-    }
-    return DEFAULT_WIDTH_LG
-  }
-
-  $: sidebarWidth = customWidth ?? getDefaultWidth()
+  $: sidebarWidth = customWidth ?? getChatBarDefaultWidth(viewportWidth)
 
   function toggle() {
     if (isLargeScreen() && animState === "idle") {
@@ -85,12 +79,8 @@
   $: iconHidden =
     expanded || animState === "collapsing" || animState === "expanding"
 
-  function getMaxWidth(): number {
-    return Math.floor(window.innerWidth * (MAX_WIDTH_VW / 100))
-  }
-
   function clampWidth(width: number): number {
-    return Math.round(Math.max(MIN_WIDTH, Math.min(width, getMaxWidth())))
+    return clampChatBarWidth(width, window.innerWidth)
   }
 
   function onDragStart(e: MouseEvent) {
@@ -121,9 +111,34 @@
     }
   }
 
+  function applyViewportResize() {
+    resizeFrame = null
+    if (dragging) return
+    viewportWidth = window.innerWidth
+    if (customWidth !== null) {
+      const clamped = clampChatBarWidth(customWidth, viewportWidth)
+      if (clamped !== customWidth) {
+        customWidth = clamped
+        setChatBarWidth(clamped)
+      }
+    }
+  }
+
+  function onWindowResize() {
+    if (resizeFrame !== null) return
+    resizeFrame = requestAnimationFrame(applyViewportResize)
+  }
+
   onDestroy(() => {
     if (dragging) {
       onDragEnd()
+    }
+    if (browser) {
+      window.removeEventListener("resize", onWindowResize)
+      if (resizeFrame !== null) {
+        cancelAnimationFrame(resizeFrame)
+        resizeFrame = null
+      }
     }
   })
 
@@ -139,6 +154,7 @@
 
   onMount(() => {
     initCopilotConnectionStore()
+    window.addEventListener("resize", onWindowResize)
   })
 
   $: copilot_chat_ready = $kilnCopilotConnected === true

--- a/app/web_ui/src/routes/(app)/chat_bar.svelte
+++ b/app/web_ui/src/routes/(app)/chat_bar.svelte
@@ -34,6 +34,14 @@
   let viewportWidth = browser ? window.innerWidth : 0
   let resizeFrame: number | null = null
 
+  if (browser && customWidth !== null) {
+    const clamped = clampChatBarWidth(customWidth, viewportWidth)
+    if (clamped !== customWidth) {
+      customWidth = clamped
+      setChatBarWidth(clamped)
+    }
+  }
+
   type AnimState = "idle" | "collapsing" | "expanding"
   let animState: AnimState = "idle"
 


### PR DESCRIPTION
## Summary
- Chat sidebar `customWidth` is persisted as absolute pixels, so shrinking the window (e.g. unplugging an external monitor) could leave the sidebar wider than the 30vw cap.
- Adds a `resize` listener coalesced via `requestAnimationFrame` that re-clamps `customWidth` and updates the default-width path across the 2XL breakpoint; skips when a drag is in progress.
- Extracts sizing math into `chat_bar_sizing.ts` as pure functions with unit tests.

## Test plan
- [ ] With sidebar at a custom width near 30vw on a wide monitor, resize the browser (or unplug the monitor) and confirm the sidebar shrinks to stay within the cap.
- [ ] Confirm default-width switches between `DEFAULT_WIDTH_LG` and `DEFAULT_WIDTH_2XL` when crossing `BREAKPOINT_2XL`.
- [ ] Start dragging the resize handle, then resize the window while still dragging — drag should not be yanked.
- [ ] Reload after an auto-clamp and confirm the persisted width is the new clamped value.
- [ ] `npm run test_run` — new `chat_bar_sizing.test.ts` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)