### PR TITLE
KIL-543 Restore legacy repair UI alongside feedback UI

### DIFF
--- a/app/desktop/studio_server/repair_api.py
+++ b/app/desktop/studio_server/repair_api.py
@@ -112,7 +112,7 @@ def connect_repair_api(app: FastAPI):
             if top_p is not None and isinstance(top_p, float):
                 run_config_properties.top_p = top_p
 
-        except ValidationError as e:
+        except (ValidationError, ValueError) as e:
             raise HTTPException(
                 status_code=422,
                 detail=f"Invalid run config properties: {e}",

--- a/app/web_ui/src/routes/(app)/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/run/+page.svelte
@@ -238,7 +238,10 @@
           initial_run={response}
           task={$current_task}
           {project_id}
+          bind:model_name
+          bind:provider
           bind:run_complete
+          focus_repair_on_appear={true}
         />
       </div>
     {/if}

--- a/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
+++ b/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
@@ -30,6 +30,18 @@
   let post_repair_error: KilnError | null = null
   let post_repair_submitting = false
   async function handle_submit() {
+    if (!repair_run) {
+      post_repair_error = new KilnError("No repair to edit", null)
+      return
+    }
+    if (!task.id || !run.id) {
+      post_repair_error = new KilnError(
+        "This task run isn't saved. Enable Auto-save. You can't edit repairs for unsaved runs.",
+        null,
+      )
+      return
+    }
+
     repair_run = {
       ...repair_run,
       output: {
@@ -49,15 +61,6 @@
     post_repair_submitting = true
 
     try {
-      if (!repair_run) {
-        throw new KilnError("No repair to edit", null)
-      }
-      if (!task.id || !run.id) {
-        throw new KilnError(
-          "This task run isn't saved. Enable Auto-save. You can't edit repairs for unsaved runs.",
-          null,
-        )
-      }
       const {
         data, // only present if 2XX response
         error: fetch_error, // only present if 4XX or 5XX response

--- a/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
+++ b/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import FormElement from "$lib/utils/form_element.svelte"
+  import type { Task, TaskRun } from "$lib/types"
+  import FormContainer from "../../../lib/utils/form_container.svelte"
+  import { createKilnError, KilnError } from "../../../lib/utils/error_handlers"
+  import { client } from "../../../lib/api_client"
+
+  export let on_submit: (run: TaskRun) => void
+  export let on_cancel: () => void
+
+  export let project_id: string
+  export let task: Task
+  export let run: TaskRun
+  export let repair_run: TaskRun
+  export let repair_instructions: string
+
+  function prettify_output(text: string) {
+    if (task.output_json_schema) {
+      try {
+        return JSON.stringify(JSON.parse(text), null, 2)
+      } catch (_) {
+        return text
+      }
+    }
+    return text
+  }
+
+  let repair_output_edited = prettify_output(repair_run.output.output) || ""
+
+  let post_repair_error: KilnError | null = null
+  let post_repair_submitting = false
+  async function handle_submit() {
+    repair_run = {
+      ...repair_run,
+      output: {
+        ...repair_run.output,
+        output: repair_output_edited,
+        source: {
+          type: "human",
+          properties: {
+            // the user name will be replaced with the actual user name on the server side
+            created_by: "unknown",
+          },
+        },
+      },
+    }
+
+    post_repair_error = null
+    post_repair_submitting = true
+
+    try {
+      if (!repair_run) {
+        throw new KilnError("No repair to edit", null)
+      }
+      if (!task.id || !run.id) {
+        throw new KilnError(
+          "This task run isn't saved. Enable Auto-save. You can't edit repairs for unsaved runs.",
+          null,
+        )
+      }
+      const {
+        data, // only present if 2XX response
+        error: fetch_error, // only present if 4XX or 5XX response
+      } = await client.POST(
+        "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}/save_repair",
+        {
+          params: {
+            path: {
+              project_id: project_id,
+              task_id: task.id,
+              run_id: run.id,
+            },
+          },
+          body: {
+            repair_run: repair_run,
+            evaluator_feedback: repair_instructions || "",
+          },
+        },
+      )
+      if (fetch_error) {
+        throw fetch_error
+      }
+      on_submit(data)
+    } catch (err) {
+      post_repair_error = createKilnError(err)
+    } finally {
+      post_repair_submitting = false
+    }
+  }
+
+  function handle_cancel() {
+    on_cancel()
+  }
+</script>
+
+<div>
+  <FormContainer
+    submit_label="Save Repair (5 stars)"
+    on:submit={handle_submit}
+    submitting={post_repair_submitting}
+  >
+    <FormElement
+      id={"repair_manual_output"}
+      label="Manual Repair"
+      info_description="Provide a improvement or correction to the task's output"
+      inputType="textarea"
+      height="large"
+      bind:value={repair_output_edited}
+    />
+
+    {#if post_repair_error}
+      <p class="text-error font-medium text-sm">
+        Error Saving Repair<br />
+        <span class="text-error text-xs font-normal">
+          {post_repair_error.getMessage()}</span
+        >
+      </p>
+    {/if}
+
+    <button
+      class="link text-gray-500 text-sm text-right"
+      on:click={handle_cancel}>Cancel</button
+    >
+  </FormContainer>
+</div>

--- a/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
+++ b/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
@@ -118,6 +118,7 @@
     {/if}
 
     <button
+      type="button"
       class="link text-gray-500 text-sm text-right"
       on:click={handle_cancel}>Cancel</button
     >

--- a/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
+++ b/app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte
@@ -105,7 +105,7 @@
     <FormElement
       id={"repair_manual_output"}
       label="Manual Repair"
-      info_description="Provide a improvement or correction to the task's output"
+      info_description="Provide an improvement or correction to the task's output"
       inputType="textarea"
       height="large"
       bind:value={repair_output_edited}

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -173,6 +173,10 @@
   // note: this run is NOT the main run, but a repair run TaskRun
   let repair_run: TaskRun | null = null
   let repair_instructions: string | null = null
+  // Seed repair_instructions from the persisted run so tooltips/UI on historical repairs show the original feedback
+  $: if (run?.repair_instructions && repair_instructions === null) {
+    repair_instructions = run.repair_instructions
+  }
 
   $: rate_focus = run && overall_rating === null
   // True if this "Run" has everything we want: a rating and a repaired output (or 5-star rating and no repair is needed)
@@ -462,7 +466,6 @@
   }
 
   function handle_manual_edit_submit(repair_run_edited: TaskRun) {
-    repair_run = repair_run_edited
     repair_edit_mode = false
     updated_run = repair_run_edited
     repair_run = null

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -28,9 +28,9 @@
   import TraceComponent from "$lib/ui/trace/trace.svelte"
   import PropertyList from "$lib/ui/property_list.svelte"
   import TableActionMenu from "$lib/ui/table_action_menu.svelte"
-  import Warning from "../../../lib/ui/warning.svelte"
+  import Warning from "$lib/ui/warning.svelte"
   import OutputRepairEditForm from "./output_repair_edit_form.svelte"
-  import type { components } from "../../../lib/api_schema"
+  import type { components } from "$lib/api_schema"
 
   type SubtaskReference = {
     project_id: string
@@ -330,7 +330,8 @@
   async function attempt_repair() {
     try {
       repair_submitting = true
-      if (!repair_instructions) {
+      const trimmed_instructions = repair_instructions?.trim()
+      if (!trimmed_instructions) {
         throw new KilnError("Repair instructions are required", null)
       }
       if (!task.id || !run?.id) {
@@ -355,12 +356,12 @@
           body:
             model_name && provider
               ? {
-                  evaluator_feedback: repair_instructions,
+                  evaluator_feedback: trimmed_instructions,
                   model_name: model_name,
                   provider: provider,
                 }
               : {
-                  evaluator_feedback: repair_instructions,
+                  evaluator_feedback: trimmed_instructions,
                 },
         },
       )
@@ -433,7 +434,6 @@
       return
     }
     try {
-      repair_run = null
       delete_repair_error = null
       delete_repair_submitting = true
       let original_repair_instructions = run?.repair_instructions
@@ -442,6 +442,7 @@
         repaired_output: null,
       }
       updated_run = await patch_run(patch_body)
+      repair_run = null
 
       // Pull in the instructions from the original repair, so they can edit them if wanted
       if (!repair_instructions && original_repair_instructions) {

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -173,9 +173,12 @@
   // note: this run is NOT the main run, but a repair run TaskRun
   let repair_run: TaskRun | null = null
   let repair_instructions: string | null = null
-  // Seed repair_instructions from the persisted run so tooltips/UI on historical repairs show the original feedback
-  $: if (run?.repair_instructions && repair_instructions === null) {
-    repair_instructions = run.repair_instructions
+  // Seed repair_instructions from the persisted run so tooltips/UI on historical repairs show the original feedback.
+  // Track the last seeded run id so switching to a different run reseeds rather than leaking prior text.
+  let seeded_for_run_id: string | null = null
+  $: if (run?.id && run.id !== seeded_for_run_id) {
+    repair_instructions = run.repair_instructions ?? null
+    seeded_for_run_id = run.id
   }
 
   $: rate_focus = run && overall_rating === null

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -189,7 +189,7 @@
     overall_rating !== 5 &&
     !run?.repaired_output?.output && // model already repaired
     !repair_run // repair generated, should show repair evaluation instead
-  $: repair_review_available = !!repair_run && !run?.repaired_output
+  $: repair_review_available = !!repair_run && !run?.repaired_output?.output
   $: repair_complete = !!run?.repaired_output?.output
   $: repair_enabled_for_source = REPAIR_ENABLED_FOR_SOURCES.some(
     (s) => s === run?.output?.source?.type,
@@ -197,7 +197,10 @@
 
   $: repair_source =
     run?.repaired_output?.source?.type === "human"
-      ? { type: "user", name: run.repaired_output.source.properties.created_by }
+      ? {
+          type: "user",
+          name: run.repaired_output.source.properties?.created_by ?? "unknown",
+        }
       : run?.repaired_output?.source?.type === "synthetic"
         ? { type: "synthetic" }
         : null

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -28,6 +28,9 @@
   import TraceComponent from "$lib/ui/trace/trace.svelte"
   import PropertyList from "$lib/ui/property_list.svelte"
   import TableActionMenu from "$lib/ui/table_action_menu.svelte"
+  import Warning from "../../../lib/ui/warning.svelte"
+  import OutputRepairEditForm from "./output_repair_edit_form.svelte"
+  import type { components } from "../../../lib/api_schema"
 
   type SubtaskReference = {
     project_id: string
@@ -147,12 +150,19 @@
     }
   }
 
+  const REPAIR_ENABLED_FOR_SOURCES: Array<
+    components["schemas"]["DataSourceType"]
+  > = ["human", "synthetic"]
+
   export let project_id: string
   export let task: Task
   export let initial_run: TaskRun
   let updated_run: TaskRun | null = null
   $: run = updated_run || initial_run
+  export let model_name: string | null = null
+  export let provider: string | null = null
   export let run_complete: boolean = false
+  export let focus_repair_on_appear: boolean = false
 
   // Dynamic rating requirements based on tags
   $: rating_requirements = rating_options_for_sample(
@@ -160,8 +170,33 @@
     run?.tags || [],
   )
 
+  // note: this run is NOT the main run, but a repair run TaskRun
+  let repair_run: TaskRun | null = null
+  let repair_instructions: string | null = null
+
   $: rate_focus = run && overall_rating === null
-  $: run_complete = overall_rating !== null
+  // True if this "Run" has everything we want: a rating and a repaired output (or 5-star rating and no repair is needed)
+  $: run_complete = overall_rating === 5 || !!run?.repaired_output?.output
+
+  // Repair is available if the run has an overall rating but it's not 5 stars, and it doesn't yet have a repaired output
+  $: should_offer_repair =
+    run &&
+    overall_rating !== null &&
+    overall_rating !== 5 &&
+    !run?.repaired_output?.output && // model already repaired
+    !repair_run // repair generated, should show repair evaluation instead
+  $: repair_review_available = !!repair_run && !run?.repaired_output
+  $: repair_complete = !!run?.repaired_output?.output
+  $: repair_enabled_for_source = REPAIR_ENABLED_FOR_SOURCES.some(
+    (s) => s === run?.output?.source?.type,
+  )
+
+  $: repair_source =
+    run?.repaired_output?.source?.type === "human"
+      ? { type: "user", name: run.repaired_output.source.properties.created_by }
+      : run?.repaired_output?.source?.type === "synthetic"
+        ? { type: "synthetic" }
+        : null
 
   let show_raw_data = false
   let save_rating_error: KilnError | null = null
@@ -281,6 +316,156 @@
     } catch (err) {
       save_rating_error = createKilnError(err)
     }
+  }
+
+  let repair_submitting = false
+  let repair_error: KilnError | null = null
+  async function attempt_repair() {
+    try {
+      repair_submitting = true
+      if (!repair_instructions) {
+        throw new KilnError("Repair instructions are required", null)
+      }
+      if (!task.id || !run?.id) {
+        throw new KilnError(
+          "This task run isn't saved. Enable Auto-save. You can't repair unsaved runs.",
+          null,
+        )
+      }
+      const {
+        data: repair_data, // only present if 2XX response
+        error: fetch_error, // only present if 4XX or 5XX response
+      } = await client.POST(
+        "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}/generate_repair",
+        {
+          params: {
+            path: {
+              project_id: project_id,
+              task_id: task.id,
+              run_id: run?.id,
+            },
+          },
+          body:
+            model_name && provider
+              ? {
+                  evaluator_feedback: repair_instructions,
+                  model_name: model_name,
+                  provider: provider,
+                }
+              : {
+                  evaluator_feedback: repair_instructions,
+                },
+        },
+      )
+      if (fetch_error) {
+        throw fetch_error
+      }
+      repair_run = repair_data
+      repair_error = null
+    } catch (err) {
+      repair_error = createKilnError(err)
+    } finally {
+      repair_submitting = false
+    }
+  }
+
+  let accept_repair_error: KilnError | null = null
+  let accept_repair_submitting = false
+  async function accept_repair() {
+    try {
+      accept_repair_error = null
+      accept_repair_submitting = true
+      if (!repair_run) {
+        throw new KilnError("No repair to accept", null)
+      }
+      if (!task.id || !run?.id) {
+        throw new KilnError(
+          "This task run isn't saved. Enable Auto-save. You can't accept repairs for unsaved runs.",
+          null,
+        )
+      }
+      const {
+        data, // only present if 2XX response
+        error: fetch_error, // only present if 4XX or 5XX response
+      } = await client.POST(
+        "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}/save_repair",
+        {
+          params: {
+            path: {
+              project_id: project_id,
+              task_id: task.id,
+              run_id: run?.id,
+            },
+          },
+          body: {
+            repair_run: repair_run,
+            evaluator_feedback: repair_instructions || "",
+          },
+        },
+      )
+      if (fetch_error) {
+        throw fetch_error
+      }
+      updated_run = data
+      repair_run = null
+    } catch (err) {
+      accept_repair_error = createKilnError(err)
+    } finally {
+      accept_repair_submitting = false
+    }
+  }
+
+  let delete_repair_error: KilnError | null = null
+  let delete_repair_submitting = false
+  async function delete_repair() {
+    if (
+      !confirm(
+        "Are you sure you want to delete this repair?\n\nThis action cannot be undone.",
+      )
+    ) {
+      return
+    }
+    try {
+      repair_run = null
+      delete_repair_error = null
+      delete_repair_submitting = true
+      let original_repair_instructions = run?.repair_instructions
+      let patch_body = {
+        repair_instructions: null,
+        repaired_output: null,
+      }
+      updated_run = await patch_run(patch_body)
+
+      // Pull in the instructions from the original repair, so they can edit them if wanted
+      if (!repair_instructions && original_repair_instructions) {
+        repair_instructions = original_repair_instructions
+      }
+    } catch (err) {
+      delete_repair_error = createKilnError(err)
+    } finally {
+      delete_repair_submitting = false
+    }
+  }
+
+  function retry_repair() {
+    repair_run = null
+    accept_repair_error = null
+  }
+
+  let repair_edit_mode = false
+  function show_repair_edit() {
+    repair_edit_mode = true
+  }
+
+  function handle_manual_edit_cancel() {
+    repair_edit_mode = false
+  }
+
+  function handle_manual_edit_submit(repair_run_edited: TaskRun) {
+    repair_run = repair_run_edited
+    repair_edit_mode = false
+    updated_run = repair_run_edited
+    repair_run = null
   }
 
   function toggle_raw_data() {
@@ -573,6 +758,125 @@
           </div>
         </div>
       </div>
+
+      {#if !repair_enabled_for_source && (should_offer_repair || repair_review_available || repair_complete)}
+        <div class="grow mt-10">
+          <Warning
+            warning_message="Repair is not available for runs from {run.output
+              .source?.type || 'unknown'} sources."
+            warning_color="warning"
+            tight={true}
+          />
+        </div>
+      {/if}
+
+      {#if repair_enabled_for_source && (should_offer_repair || repair_review_available || repair_complete)}
+        <div class="grow mt-10">
+          <div class="text-xl font-bold mb-2">Repair Output</div>
+          {#if should_offer_repair}
+            <p class="text-sm text-gray-500 mb-4">
+              Since the output isn't 5-star, provide instructions for the model
+              on how to fix it.
+            </p>
+            <FormContainer
+              submit_label="Attempt Repair"
+              on:submit={attempt_repair}
+              bind:submitting={repair_submitting}
+              bind:error={repair_error}
+              focus_on_mount={focus_repair_on_appear}
+            >
+              <FormElement
+                id="repair_instructions"
+                label="Repair Instructions"
+                inputType="textarea"
+                bind:value={repair_instructions}
+              />
+            </FormContainer>
+          {:else if repair_edit_mode && repair_run}
+            <p class="text-sm text-gray-500 mb-4">
+              Manually improve or correct the response.
+            </p>
+            <OutputRepairEditForm
+              {task}
+              {run}
+              {repair_run}
+              {project_id}
+              repair_instructions={repair_instructions || ""}
+              on_submit={handle_manual_edit_submit}
+              on_cancel={handle_manual_edit_cancel}
+            />
+          {:else if repair_review_available}
+            <p class="text-sm text-gray-500 mb-4">
+              The model has attempted to fix the output given <span
+                class="tooltip link"
+                data-tip="The instructions you provided to the model: {repair_instructions ||
+                  'No instruction provided'}">your instructions</span
+              >. Review the result.
+            </p>
+            <Output raw_output={repair_run?.output.output || ""} />
+          {:else if repair_complete}
+            {#if repair_source?.type === "user"}
+              <p class="text-sm text-gray-500 mb-4">
+                This repaired output was provided by {repair_source.name}.
+              </p>
+            {:else}
+              <p class="text-sm text-gray-500 mb-4">
+                The model has fixed the output given <span
+                  class="tooltip link"
+                  data-tip="The instructions you provided to the model: {repair_instructions ||
+                    'No instruction provided'}">your instructions</span
+                >.
+              </p>
+            {/if}
+            <Output raw_output={run?.repaired_output?.output || ""} />
+            <div class="mt-2 text-xs text-gray-500 text-right">
+              {#if delete_repair_submitting}
+                <span class="loading loading-spinner loading-sm"></span>
+              {:else if delete_repair_error}
+                <p class="text-error">
+                  Error Deleting Repair:
+                  {delete_repair_error.getMessage()}
+                </p>
+              {:else}
+                <button class="link" on:click={delete_repair}
+                  >Delete Repair</button
+                >
+              {/if}
+            </div>
+          {/if}
+        </div>
+        {#if repair_review_available && !repair_edit_mode}
+          <div class="mt-4">
+            <div class="flex flex-row gap-4 justify-between">
+              <button class="btn" on:click={show_repair_edit}>Edit</button>
+              <div class="flex flex-row gap-4">
+                <button class="btn" on:click={retry_repair}>Retry Repair</button
+                >
+                <button
+                  class="btn btn-primary"
+                  on:click={accept_repair}
+                  disabled={accept_repair_submitting}
+                >
+                  {#if accept_repair_submitting}
+                    <span class="loading loading-spinner loading-sm"></span>
+                  {:else}
+                    Accept Repair (5 Stars)
+                  {/if}
+                </button>
+              </div>
+            </div>
+
+            {#if accept_repair_error}
+              <p class="mt-2 text-error font-medium text-sm">
+                Error Accepting Repair<br />
+                <span class="text-error text-xs font-normal">
+                  {accept_repair_error.getMessage()}</span
+                >
+              </p>
+            {/if}
+          </div>
+        {/if}
+      {/if}
     </div>
 
     <div class="w-72 2xl:w-96 flex-none">

--- a/libs/core/kiln_ai/adapters/repair/repair_task.py
+++ b/libs/core/kiln_ai/adapters/repair/repair_task.py
@@ -2,7 +2,11 @@ import json
 
 from pydantic import BaseModel, Field
 
-from kiln_ai.adapters.prompt_builders import BasePromptBuilder, prompt_builder_from_id
+from kiln_ai.adapters.prompt_builders import (
+    BasePromptBuilder,
+    SimplePromptBuilder,
+    prompt_builder_from_id,
+)
 from kiln_ai.datamodel import Priority, Project, Task, TaskRequirement, TaskRun
 
 
@@ -53,7 +57,9 @@ feedback describing what should be improved. Your job is to understand the evalu
             if isinstance(prompt_builder, BasePromptBuilder):
                 return prompt_builder.build_prompt(include_json_instructions=False)
 
-        raise ValueError(f"Prompt builder '{prompt_id}' is not a valid prompt builder")
+        # Fallback to simple prompt builder if prompt_id is missing (e.g. legacy runs)
+        fallback_builder = SimplePromptBuilder(task)
+        return fallback_builder.build_prompt(include_json_instructions=False)
 
     @classmethod
     def build_repair_task_input(

--- a/libs/core/kiln_ai/adapters/repair/repair_task.py
+++ b/libs/core/kiln_ai/adapters/repair/repair_task.py
@@ -45,19 +45,25 @@ feedback describing what should be improved. Your job is to understand the evalu
 
     @classmethod
     def _original_prompt(cls, run: TaskRun, task: Task) -> str:
-        if run.output.source is None or run.output.source.properties is None:
-            raise ValueError("No source properties found")
-
         # Get the prompt builder id. Need the second check because we used to store this in a prompt_builder_name field, so loading legacy runs will need this.
-        prompt_id = run.output.source.properties.get(
-            "prompt_id"
-        ) or run.output.source.properties.get("prompt_builder_name", None)
+        source_properties = (
+            run.output.source.properties
+            if run.output.source and run.output.source.properties
+            else {}
+        )
+        prompt_id = source_properties.get("prompt_id") or source_properties.get(
+            "prompt_builder_name", None
+        )
         if prompt_id is not None and isinstance(prompt_id, str):
-            prompt_builder = prompt_builder_from_id(prompt_id, task)
+            try:
+                prompt_builder = prompt_builder_from_id(prompt_id, task)
+            except ValueError:
+                # Unknown/legacy prompt_id — fall through to fallback below
+                prompt_builder = None
             if isinstance(prompt_builder, BasePromptBuilder):
                 return prompt_builder.build_prompt(include_json_instructions=False)
 
-        # Fallback to simple prompt builder if prompt_id is missing (e.g. legacy runs)
+        # Fallback to simple prompt builder if prompt_id is missing, unknown, or source/properties are absent (e.g. legacy runs)
         fallback_builder = SimplePromptBuilder(task)
         return fallback_builder.build_prompt(include_json_instructions=False)
 

--- a/libs/core/kiln_ai/adapters/repair/test_repair_task.py
+++ b/libs/core/kiln_ai/adapters/repair/test_repair_task.py
@@ -182,6 +182,41 @@ def test_build_repair_task_input_with_invalid_input(invalid_input):
         RepairTaskRun.build_repair_task_input(invalid_input)
 
 
+def test_build_repair_task_input_falls_back_when_prompt_id_unknown(
+    sample_task, sample_task_run
+):
+    # Simulate a legacy run whose prompt_id no longer resolves
+    assert sample_task_run.output.source is not None
+    assert sample_task_run.output.source.properties is not None
+    sample_task_run.output.source.properties["prompt_id"] = "no_such_prompt_builder_xyz"
+
+    result = RepairTaskRun.build_repair_task_input(
+        original_task=sample_task,
+        task_run=sample_task_run,
+        evaluator_feedback="Some feedback",
+    )
+
+    assert isinstance(result, RepairTaskInput)
+    # SimplePromptBuilder uses the task's instruction as the prompt
+    assert sample_task.instruction in result.original_prompt
+
+
+def test_build_repair_task_input_falls_back_when_source_missing(
+    sample_task, sample_task_run
+):
+    # Simulate a legacy run with no output source/properties at all
+    sample_task_run.output.source = None
+
+    result = RepairTaskRun.build_repair_task_input(
+        original_task=sample_task,
+        task_run=sample_task_run,
+        evaluator_feedback="Some feedback",
+    )
+
+    assert isinstance(result, RepairTaskInput)
+    assert sample_task.instruction in result.original_prompt
+
+
 @pytest.mark.paid
 async def test_live_run(sample_task, sample_task_run, sample_repair_data):
     if os.getenv("GROQ_API_KEY") is None:


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-543/feedback-follow-ups-legacy-repair

## Description

Follow-up from [KIL-537](https://linear.app/kiln-ai/issue/KIL-537/replace-repair-ui-with-feedback-ui). If a TaskRun has legacy `repair_instructions` text, it should either be displayed in the feedback UI or migrated to a Feedback child object. This ensures historical data is still visible after the repair UI removal.

## Summary

- Restores the legacy repair UI (generate / manual edit / review / accept / delete) on the run page, so runs persisted with `repair_instructions`/`repaired_output` are viewable and editable again.
- Leaves the new Feedback UI from KIL-537 fully intact — both systems coexist.
- Two small backend safety fixes to harden repair on legacy runs.

## Changes

- `app/web_ui/src/routes/(app)/run/output_repair_edit_form.svelte` — restored (was deleted in KIL-537).
- `app/web_ui/src/routes/(app)/run/run.svelte` — re-added repair imports, props, state, reactive expressions, `attempt_repair`/`accept_repair`/`delete_repair`/`retry_repair`/edit handlers, and the full repair UI template (form + edit + review/accept/delete + non-human-source warning). Feedback UI unchanged.
- `app/web_ui/src/routes/(app)/run/+page.svelte` — re-added `model_name`/`provider` bindings and `focus_repair_on_appear={true}` on the `Run` component.
- `app/desktop/studio_server/repair_api.py` — also catch `ValueError` when parsing run-config properties; pydantic validators surface as either `ValidationError` or `ValueError`, and the former was leaking as 500s.
- `libs/core/kiln_ai/adapters/repair/repair_task.py` — fall back to `SimplePromptBuilder` when a legacy run's `prompt_id` is missing or no longer resolvable, instead of raising. Unblocks repair on historical runs.

## Test plan

- [ ] Open a run with legacy `repair_instructions`/`repaired_output` and verify the repair output section renders.
- [ ] On an un-5-starred run, enter repair instructions and confirm **Attempt Repair** works (both with and without a selected model/provider).
- [ ] After a repair is generated, confirm **Edit**, **Retry Repair**, and **Accept Repair (5 Stars)** all work.
- [ ] Confirm **Delete Repair** works and restores the instructions into the form.
- [ ] Confirm the "Repair is not available for runs from X sources" warning renders on non-human / non-synthetic sources.
- [ ] Confirm the Feedback UI (add / view / delete) still works on the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive output repair workflow: generate, review, edit, accept, and delete repaired outputs.
  * Manual edit form for repaired output with validation, submit/cancel, and server persistence.
  * Model/provider values now propagate to the Run UI and an option auto-focuses the repair UI on appear.

* **Bug Fixes**
  * Broadened error handling to return consistent validation responses for additional failure cases.
  * Safer prompt-resolution fallback to avoid failures when run metadata is missing or legacy.

* **Tests**
  * Added tests covering fallback behavior when legacy or missing run metadata prevents prompt resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->