### PR TITLE
KIL-541 Persist last-used run config per task so it survives revisits

### DIFF
--- a/app/web_ui/package-lock.json
+++ b/app/web_ui/package-lock.json
@@ -382,7 +382,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -406,7 +405,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1357,7 +1355,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2381,7 +2378,6 @@
       "integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "@sveltejs/acorn-typescript": "^1.0.5",
@@ -2431,7 +2427,6 @@
       "integrity": "sha512-Txsm1tJvtiYeLUVRNqxZGKR/mI+CzuIQuc2gn+YCs9rMTowpNZ2Nqt53JdL8KF9bLhAf2ruR/dr9eZCwdTriRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^2.1.0",
         "debug": "^4.3.4",
@@ -2695,7 +2690,6 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -3016,7 +3010,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3060,7 +3053,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3339,7 +3331,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001587",
         "electron-to-chromium": "^1.4.668",
@@ -3687,7 +3678,6 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
       "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
       "hasInstallScript": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -4190,7 +4180,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5258,7 +5247,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5297,7 +5285,6 @@
       "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.5",
         "@asamuzakjp/dom-selector": "^7.0.6",
@@ -5364,7 +5351,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -5874,7 +5860,6 @@
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -6578,7 +6563,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -6804,7 +6788,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6951,7 +6934,6 @@
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6962,7 +6944,6 @@
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7704,7 +7685,6 @@
       "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",
@@ -7808,7 +7788,6 @@
       "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -8022,7 +8001,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.3.tgz",
       "integrity": "sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8295,7 +8273,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8413,7 +8390,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -8511,7 +8487,6 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",

--- a/app/web_ui/src/lib/stores/last_used_run_config_store.test.ts
+++ b/app/web_ui/src/lib/stores/last_used_run_config_store.test.ts
@@ -1,0 +1,84 @@
+import { get } from "svelte/store"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { get_task_composite_id } from "$lib/stores"
+import {
+  last_used_run_config_store,
+  get_last_used_run_config,
+  set_last_used_run_config,
+} from "./last_used_run_config_store"
+
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+}
+
+describe("last_used_run_config_store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal("window", { localStorage: localStorageMock })
+    localStorageMock.getItem.mockReturnValue(null)
+    localStorageMock.setItem.mockImplementation(() => {})
+    last_used_run_config_store.set({})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  const task_a = get_task_composite_id("p1", "t1")
+  const task_b = get_task_composite_id("p1", "t2")
+
+  describe("get_last_used_run_config", () => {
+    it("returns null when no value has been saved", () => {
+      expect(get_last_used_run_config(task_a)).toBeNull()
+    })
+
+    it("returns the saved value after set", () => {
+      set_last_used_run_config(task_a, "run-config-1")
+      expect(get_last_used_run_config(task_a)).toBe("run-config-1")
+    })
+
+    it("returns 'custom' when saved as custom", () => {
+      set_last_used_run_config(task_a, "custom")
+      expect(get_last_used_run_config(task_a)).toBe("custom")
+    })
+
+    it("keeps per-task values isolated", () => {
+      set_last_used_run_config(task_a, "run-config-1")
+      set_last_used_run_config(task_b, "custom")
+      expect(get_last_used_run_config(task_a)).toBe("run-config-1")
+      expect(get_last_used_run_config(task_b)).toBe("custom")
+    })
+  })
+
+  describe("set_last_used_run_config", () => {
+    it("overwrites the previous value for the same task", () => {
+      set_last_used_run_config(task_a, "run-config-1")
+      set_last_used_run_config(task_a, "run-config-2")
+      expect(get_last_used_run_config(task_a)).toBe("run-config-2")
+    })
+
+    it("removes the entry when value is null", () => {
+      set_last_used_run_config(task_a, "run-config-1")
+      set_last_used_run_config(task_a, null)
+      expect(get_last_used_run_config(task_a)).toBeNull()
+      expect(task_a in get(last_used_run_config_store)).toBe(false)
+    })
+
+    it("is a no-op when setting null for an unknown task", () => {
+      set_last_used_run_config(task_a, null)
+      expect(get(last_used_run_config_store)).toEqual({})
+    })
+
+    it("is a no-op when setting the same value again", () => {
+      set_last_used_run_config(task_a, "run-config-1")
+      const before = get(last_used_run_config_store)
+      set_last_used_run_config(task_a, "run-config-1")
+      const after = get(last_used_run_config_store)
+      expect(after).toBe(before)
+    })
+  })
+})

--- a/app/web_ui/src/lib/stores/last_used_run_config_store.ts
+++ b/app/web_ui/src/lib/stores/last_used_run_config_store.ts
@@ -1,0 +1,34 @@
+import type { Writable } from "svelte/store"
+import { get } from "svelte/store"
+import { localStorageStore } from "./local_storage_store"
+import type { TaskCompositeId } from "$lib/stores"
+
+export const last_used_run_config_store: Writable<
+  Record<TaskCompositeId, string>
+> = localStorageStore("last_used_run_config_store", {})
+
+export function get_last_used_run_config(
+  task_composite_id: TaskCompositeId,
+): string | null {
+  return get(last_used_run_config_store)[task_composite_id] ?? null
+}
+
+export function set_last_used_run_config(
+  task_composite_id: TaskCompositeId,
+  run_config_id: string | null,
+): void {
+  last_used_run_config_store.update((current) => {
+    if (run_config_id === null) {
+      if (!(task_composite_id in current)) {
+        return current
+      }
+      const next = { ...current }
+      delete next[task_composite_id]
+      return next
+    }
+    if (current[task_composite_id] === run_config_id) {
+      return current
+    }
+    return { ...current, [task_composite_id]: run_config_id }
+  })
+}

--- a/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
@@ -29,6 +29,10 @@
     run_configs_by_task_composite_id,
     update_task_default_run_config,
   } from "$lib/stores/run_configs_store"
+  import {
+    get_last_used_run_config,
+    set_last_used_run_config,
+  } from "$lib/stores/last_used_run_config_store"
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
   import Warning from "$lib/ui/warning.svelte"
 
@@ -62,32 +66,74 @@
     load_task_prompts(project_id, current_task.id)
   }
 
-  // Initialization of selected_run_config_id
+  // Initialization of selected_run_config_id.
   // Start with "custom" immediately (avoids showing "Select an option" while configs load),
-  // then upgrade to the default config once it's available in the loaded options.
-  // Uses a one-shot guard so intentional later "Custom" selections aren't overridden.
-  let pending_default_upgrade = false
+  // then upgrade to the preferred config once it's available in the loaded options.
+  // Preference order: user's persisted last-used selection for this task, then the task default.
+  // Last-used wins so a "Custom" selection (and any sticky model tied to it) survives revisits
+  // even when the task has a default configured.
+  let pending_preferred_run_config_id: string | null = null
   $: if (auto_select_default && selected_run_config_id === null) {
-    selected_run_config_id = run_page ? "custom" : null
-    pending_default_upgrade = run_page
+    if (run_page) {
+      const composite_key = get_task_composite_id(
+        project_id,
+        current_task.id ?? "",
+      )
+      const last_used = get_last_used_run_config(composite_key)
+      selected_run_config_id = "custom"
+      if (last_used === "custom") {
+        pending_preferred_run_config_id = null
+      } else if (last_used) {
+        pending_preferred_run_config_id = last_used
+      } else if (default_run_config_id) {
+        pending_preferred_run_config_id = default_run_config_id
+      } else {
+        pending_preferred_run_config_id = null
+      }
+    } else {
+      selected_run_config_id = null
+    }
   }
   $: if (
-    pending_default_upgrade &&
+    pending_preferred_run_config_id &&
     auto_select_default &&
     run_page &&
-    selected_run_config_id === "custom" &&
-    default_run_config_id
+    selected_run_config_id === "custom"
   ) {
     const composite_key = get_task_composite_id(
       project_id,
       current_task.id ?? "",
     )
-    const loaded_configs =
-      $run_configs_by_task_composite_id[composite_key] ?? []
-    if (loaded_configs.some((c) => c.id === default_run_config_id)) {
-      selected_run_config_id = default_run_config_id
-      pending_default_upgrade = false
+    const loaded_configs = $run_configs_by_task_composite_id[composite_key]
+    if (loaded_configs !== undefined) {
+      if (
+        loaded_configs.some((c) => c.id === pending_preferred_run_config_id)
+      ) {
+        selected_run_config_id = pending_preferred_run_config_id
+      } else if (
+        default_run_config_id &&
+        loaded_configs.some((c) => c.id === default_run_config_id)
+      ) {
+        // Persisted last-used id no longer exists; fall back to the task default.
+        selected_run_config_id = default_run_config_id
+      }
+      pending_preferred_run_config_id = null
     }
+  }
+
+  // Persist the current selection so returning visits prefer it over the task default.
+  // Wait for init to settle (pending_preferred_run_config_id cleared) to avoid clobbering the
+  // persisted value with the transient "custom" placeholder used during loading.
+  $: if (
+    run_page &&
+    !pending_preferred_run_config_id &&
+    selected_run_config_id &&
+    current_task.id
+  ) {
+    set_last_used_run_config(
+      get_task_composite_id(project_id, current_task.id),
+      selected_run_config_id,
+    )
   }
 
   let cold_start_info_description =

--- a/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
@@ -73,14 +73,26 @@
   // Last-used wins so a "Custom" selection (and any sticky model tied to it) survives revisits
   // even when the task has a default configured.
   let pending_preferred_run_config_id: string | null = null
+  let initialized_for_task_id: string | null = null
+
+  // Reset selection when the task changes so init re-runs for the new task. The parent's
+  // bound selected_run_config_id survives task switches (dropdown remounts, parent does not),
+  // so without this we'd persist the old task's id against the new task's storage key.
+  $: if (
+    initialized_for_task_id !== null &&
+    initialized_for_task_id !== (current_task?.id ?? null)
+  ) {
+    selected_run_config_id = null
+    pending_preferred_run_config_id = null
+    initialized_for_task_id = null
+  }
+
   $: if (auto_select_default && selected_run_config_id === null) {
-    if (run_page) {
-      const composite_key = get_task_composite_id(
-        project_id,
-        current_task.id ?? "",
-      )
+    if (run_page && current_task?.id) {
+      const composite_key = get_task_composite_id(project_id, current_task.id)
       const last_used = get_last_used_run_config(composite_key)
       selected_run_config_id = "custom"
+      initialized_for_task_id = current_task.id
       if (last_used === "custom") {
         pending_preferred_run_config_id = null
       } else if (last_used) {
@@ -98,12 +110,10 @@
     pending_preferred_run_config_id &&
     auto_select_default &&
     run_page &&
-    selected_run_config_id === "custom"
+    selected_run_config_id === "custom" &&
+    current_task?.id
   ) {
-    const composite_key = get_task_composite_id(
-      project_id,
-      current_task.id ?? "",
-    )
+    const composite_key = get_task_composite_id(project_id, current_task.id)
     const loaded_configs = $run_configs_by_task_composite_id[composite_key]
     if (loaded_configs !== undefined) {
       if (
@@ -122,13 +132,14 @@
   }
 
   // Persist the current selection so returning visits prefer it over the task default.
-  // Wait for init to settle (pending_preferred_run_config_id cleared) to avoid clobbering the
-  // persisted value with the transient "custom" placeholder used during loading.
+  // Gate on initialized_for_task_id matching current_task.id so we never write a stale selection
+  // (e.g., leftover from a previous task) against the wrong storage key.
   $: if (
     run_page &&
     !pending_preferred_run_config_id &&
     selected_run_config_id &&
-    current_task.id
+    current_task?.id &&
+    initialized_for_task_id === current_task.id
   ) {
     set_last_used_run_config(
       get_task_composite_id(project_id, current_task.id),


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-541/custom-model-not-sticky

## Summary

- When a user returns to the Run page, the dropdown now prefers their last-used run config selection for that task over the task's configured default. Previously, the task default always won and clobbered the sticky model stored in `ui_state.selected_model`.
- Stores the last-used `selected_run_config_id` (either a saved config id or `"custom"`) per task in localStorage via a new `last_used_run_config_store`, mirroring the existing `localStorageStore` pattern used elsewhere.
- Falls back to the task default if the persisted last-used id no longer exists (e.g., the run config was deleted), and to `"custom"` if neither exists.

## Behavior matrix

| State | Before | After |
| --- | --- | --- |
| Task has default, user never selected custom | Task default | Task default (same) |
| Task has default, user picked "Custom" and returns | Snapped back to default | Stays "Custom" (sticky model applies) |
| Task has default, user picked a non-default saved config and returns | Snapped back to default | Stays on the saved config |
| Persisted last-used id no longer exists | — | Falls back to task default |
| No task default, no last-used | "Custom" | "Custom" (same) |

## Test plan

- [x] Unit tests for new store (`last_used_run_config_store.test.ts`)
- [x] `npm run check`, `npm run lint`, `npm run format_check`, `npm run test_run` pass
- [x] `uv run ./checks.sh --agent-mode` passes
- [ ] Manual: task with a default → pick Custom + different model → navigate away → return → Custom remains selected and the model is preserved
- [ ] Manual: pick a saved non-default run config → navigate away → return → that config remains selected
- [ ] Manual: clear `localStorage["last_used_run_config_store"]` → return to Run → task default is selected (first-visit behavior preserved)
- [ ] Manual: delete a run config that was last-used → return to Run → falls back to task default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-task run configuration is now persisted locally: the last selection is remembered and automatically restored when returning to the same task. Switching tasks resets selection to avoid cross-task leaks; literal "custom" selections are preserved.

* **Tests**
  * Added test coverage validating persistence, removal, no-op updates, and task isolation for the remembered run configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->