### PR TITLE
Show copy-paste fallback when Git OAuth popups are blocked

### DIFF
--- a/app/web_ui/src/lib/components/import/step_credentials.svelte
+++ b/app/web_ui/src/lib/components/import/step_credentials.svelte
@@ -17,6 +17,7 @@
   } from "$lib/git_sync/api"
   import { createOAuthWithInstall } from "$lib/git_sync/oauth_with_install"
   import OAuthInstallStep from "$lib/git_sync/oauth_install_step.svelte"
+  import PopupBlockedFallback from "$lib/git_sync/popup_blocked_fallback.svelte"
   import { onDestroy } from "svelte"
 
   export let git_url: string
@@ -147,17 +148,31 @@
     {/if}
 
     {#if (oauth.oauth_starting || oauth.checking_access) && !oauth.oauth_error}
-      <div class="flex flex-col items-center py-8 gap-4">
-        <span class="loading loading-spinner loading-lg text-primary"></span>
-        <p class="text-sm text-gray-500">
-          {oauth.checking_access
-            ? "Verifying access..."
-            : "Waiting for GitHub authorization..."}
-        </p>
-        <button class="btn btn-sm btn-ghost mt-2" on:click={oauth_flow.reset}>
-          Cancel
-        </button>
-      </div>
+      {#if oauth.popup_blocked && oauth.authorize_url && !oauth.checking_access}
+        <div class="flex flex-col py-4 gap-3">
+          <PopupBlockedFallback
+            url={oauth.authorize_url}
+            message="Your browser blocked the GitHub popup. Copy the link below and open it manually in a new tab to continue."
+          />
+          <div class="text-center">
+            <button class="btn btn-sm btn-ghost" on:click={oauth_flow.reset}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      {:else}
+        <div class="flex flex-col items-center py-8 gap-4">
+          <span class="loading loading-spinner loading-lg text-primary"></span>
+          <p class="text-sm text-gray-500">
+            {oauth.checking_access
+              ? "Verifying access..."
+              : "Waiting for GitHub authorization..."}
+          </p>
+          <button class="btn btn-sm btn-ghost mt-2" on:click={oauth_flow.reset}>
+            Cancel
+          </button>
+        </div>
+      {/if}
     {:else}
       <button
         class="btn btn-primary w-full"

--- a/app/web_ui/src/lib/git_sync/git_sync_status.svelte
+++ b/app/web_ui/src/lib/git_sync/git_sync_status.svelte
@@ -21,6 +21,7 @@
     type OAuthWithInstallFlow,
   } from "$lib/git_sync/oauth_with_install"
   import OAuthInstallStep from "$lib/git_sync/oauth_install_step.svelte"
+  import PopupBlockedFallback from "$lib/git_sync/popup_blocked_fallback.svelte"
 
   type AuthFormMode = "oauth" | "pat"
 
@@ -228,21 +229,39 @@
             {/if}
 
             {#if (oauth.oauth_starting || oauth.checking_access) && !oauth.oauth_error}
-              <div class="flex flex-col items-center py-6 gap-3">
-                <span class="loading loading-spinner loading-md text-primary"
-                ></span>
-                <p class="text-sm text-gray-500">
-                  {oauth.checking_access
-                    ? "Verifying access..."
-                    : "Waiting for GitHub authorization..."}
-                </p>
-                <button
-                  class="btn btn-sm btn-ghost mt-1"
-                  on:click={oauth_flow.reset}
-                >
-                  Cancel
-                </button>
-              </div>
+              {#if oauth.popup_blocked && oauth.authorize_url && !oauth.checking_access}
+                <div class="flex flex-col py-2 gap-2">
+                  <PopupBlockedFallback
+                    url={oauth.authorize_url}
+                    message="Your browser blocked the GitHub popup. Copy the link below and open it manually in a new tab to continue."
+                    compact
+                  />
+                  <div class="text-center">
+                    <button
+                      class="btn btn-xs btn-ghost"
+                      on:click={oauth_flow.reset}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              {:else}
+                <div class="flex flex-col items-center py-6 gap-3">
+                  <span class="loading loading-spinner loading-md text-primary"
+                  ></span>
+                  <p class="text-sm text-gray-500">
+                    {oauth.checking_access
+                      ? "Verifying access..."
+                      : "Waiting for GitHub authorization..."}
+                  </p>
+                  <button
+                    class="btn btn-sm btn-ghost mt-1"
+                    on:click={oauth_flow.reset}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              {/if}
             {:else}
               <button
                 class="btn btn-primary btn-sm w-full"

--- a/app/web_ui/src/lib/git_sync/oauth_flow.test.ts
+++ b/app/web_ui/src/lib/git_sync/oauth_flow.test.ts
@@ -81,6 +81,8 @@ describe("startOAuthFlow", () => {
     expect(cbs.calls.onStarted).toHaveLength(1)
     expect(cbs.calls.onStarted[0]).toEqual({
       install_url: MOCK_START_RESPONSE.install_url,
+      authorize_url: MOCK_START_RESPONSE.authorize_url,
+      popup_blocked: false,
     })
     expect(cbs.calls.onPolling).toHaveLength(1)
     expect(window.open).toHaveBeenCalledWith("about:blank", "_blank")
@@ -226,19 +228,29 @@ describe("startOAuthFlow", () => {
     expect(popup.close).toHaveBeenCalled()
   })
 
-  it("calls onError when popup is blocked", async () => {
+  it("reports popup_blocked via onStarted when window.open returns null", async () => {
     const mockWindow = { open: vi.fn(() => null) }
     vi.stubGlobal("window", mockWindow)
     mockOauthStart.mockResolvedValue(MOCK_START_RESPONSE)
+    mockOauthStatus.mockResolvedValue({
+      complete: false,
+      oauth_token: null,
+      error: null,
+    })
 
     const cbs = makeCallbacks()
     startOAuthFlow("https://github.com/Kiln-AI/kiln.git", cbs)
 
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(cbs.calls.onError).toHaveLength(1)
-    expect(cbs.calls.onError[0]).toContain("Popup blocked")
-    expect(mockOauthStart).not.toHaveBeenCalled()
+    expect(cbs.calls.onError).toHaveLength(0)
+    expect(cbs.calls.onStarted).toHaveLength(1)
+    expect(cbs.calls.onStarted[0]).toEqual({
+      install_url: MOCK_START_RESPONSE.install_url,
+      authorize_url: MOCK_START_RESPONSE.authorize_url,
+      popup_blocked: true,
+    })
+    expect(cbs.calls.onPolling).toHaveLength(1)
   })
 
   it("retries polling on network error during status check", async () => {

--- a/app/web_ui/src/lib/git_sync/oauth_flow.ts
+++ b/app/web_ui/src/lib/git_sync/oauth_flow.ts
@@ -9,7 +9,11 @@ const TIMEOUT_MS = 300_000
 const MAX_CONSECUTIVE_POLL_FAILURES = 5
 
 export type OAuthFlowCallbacks = {
-  onStarted: (response: { install_url: string }) => void
+  onStarted: (response: {
+    install_url: string
+    authorize_url: string
+    popup_blocked: boolean
+  }) => void
   onPolling: () => void
   onSuccess: (token: string) => void
   onError: (error: string) => void
@@ -53,16 +57,7 @@ export function startOAuthFlow(
     if (popup === null) {
       popup = window.open("about:blank", "_blank")
     }
-
-    if (!popup) {
-      if (!cancelled) {
-        cleanup(false)
-        callbacks.onError(
-          "Popup blocked. Please allow popups for this site and try again.",
-        )
-      }
-      return
-    }
+    const popup_blocked = !popup
 
     let startResponse: OAuthStartResponse
     try {
@@ -82,13 +77,18 @@ export function startOAuthFlow(
       return
     }
 
-    // Provide the install_url so the caller can offer an "Install app" step
-    // if the token doesn't have access after authorization.
-    callbacks.onStarted({ install_url: startResponse.install_url })
+    callbacks.onStarted({
+      install_url: startResponse.install_url,
+      authorize_url: startResponse.authorize_url,
+      popup_blocked,
+    })
 
-    // Navigate the popup directly to the OAuth authorize URL.
-    // This is always a consistent flow regardless of app installation state.
-    popup.location.href = startResponse.authorize_url
+    // Navigate the popup directly to the OAuth authorize URL when the popup
+    // was opened. When blocked, the caller shows a copy-paste fallback and
+    // polling continues so manual completion is still detected.
+    if (popup) {
+      popup.location.href = startResponse.authorize_url
+    }
     callbacks.onPolling()
 
     const state = startResponse.state

--- a/app/web_ui/src/lib/git_sync/oauth_install_step.svelte
+++ b/app/web_ui/src/lib/git_sync/oauth_install_step.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Warning from "$lib/ui/warning.svelte"
   import type { OAuthWithInstallState } from "$lib/git_sync/oauth_with_install"
+  import PopupBlockedFallback from "$lib/git_sync/popup_blocked_fallback.svelte"
 
   export let state: OAuthWithInstallState
   export let open_install: () => void
@@ -51,22 +52,33 @@
       ? "Install the Kiln Sync GitHub App on the repository, then verify access."
       : "The Kiln Sync GitHub App needs to be installed on the repository to enable syncing. Click below to install it, then come back and verify."}
   </p>
+  {#if state.popup_blocked && state.install_url}
+    <div class="w-full {compact ? '' : 'max-w-sm'}">
+      <PopupBlockedFallback
+        url={state.install_url}
+        message="Your browser blocked the popup. Copy the link below and open it manually in a new tab to install the app."
+        {compact}
+      />
+    </div>
+  {:else}
+    <button
+      class="btn w-full {compact ? '' : 'max-w-sm'} {state.install_clicked
+        ? compact
+          ? 'btn-xs btn-ghost'
+          : 'btn-sm btn-ghost'
+        : compact
+          ? 'btn-primary btn-sm'
+          : 'btn-primary'}"
+      on:click={open_install}
+    >
+      {state.install_clicked
+        ? "Retry Install on GitHub"
+        : "Install Kiln Sync on GitHub"}
+    </button>
+  {/if}
   <button
-    class="btn w-full {compact ? '' : 'max-w-sm'} {state.install_clicked
-      ? compact
-        ? 'btn-xs btn-ghost'
-        : 'btn-sm btn-ghost'
-      : compact
-        ? 'btn-primary btn-sm'
-        : 'btn-primary'}"
-    on:click={open_install}
-  >
-    {state.install_clicked
-      ? "Retry Install on GitHub"
-      : "Install Kiln Sync on GitHub"}
-  </button>
-  <button
-    class="btn w-full {compact ? '' : 'max-w-sm'} {state.install_clicked
+    class="btn w-full {compact ? '' : 'max-w-sm'} {state.install_clicked ||
+    state.popup_blocked
       ? compact
         ? 'btn-primary btn-sm'
         : 'btn-primary'

--- a/app/web_ui/src/lib/git_sync/oauth_install_step.test.ts
+++ b/app/web_ui/src/lib/git_sync/oauth_install_step.test.ts
@@ -113,4 +113,24 @@ describe("OAuthInstallStep", () => {
     screen.getByText("Start over").click()
     expect(reset).toHaveBeenCalledOnce()
   })
+
+  it("shows popup-blocked copy fallback when popup_blocked is true", () => {
+    const { container } = render(OAuthInstallStep, {
+      props: {
+        state: make_state({
+          popup_blocked: true,
+          install_url: "https://github.com/apps/kiln/installations/new",
+        }),
+        open_install: noop,
+        verify_access: noop_async,
+        reset: noop,
+      },
+    })
+    const input = container.querySelector("input[readonly]") as HTMLInputElement
+    expect(input).not.toBeNull()
+    expect(input.value).toBe("https://github.com/apps/kiln/installations/new")
+    expect(screen.getByText("Copy")).not.toBeNull()
+    expect(screen.getByText(/blocked the popup/)).not.toBeNull()
+    expect(screen.queryByText("Install Kiln Sync on GitHub")).toBeNull()
+  })
 })

--- a/app/web_ui/src/lib/git_sync/oauth_with_install.test.ts
+++ b/app/web_ui/src/lib/git_sync/oauth_with_install.test.ts
@@ -55,6 +55,8 @@ describe("createOAuthWithInstall", () => {
     expect(state.needs_install).toBe(false)
     expect(state.install_url).toBeNull()
     expect(state.install_clicked).toBe(false)
+    expect(state.authorize_url).toBeNull()
+    expect(state.popup_blocked).toBe(false)
   })
 
   it("sets oauth_starting on start()", () => {
@@ -81,6 +83,8 @@ describe("createOAuthWithInstall", () => {
     flow.start()
     getCallbacks().onStarted({
       install_url: "https://github.com/apps/kiln/installations/new",
+      authorize_url: "https://github.com/login/oauth/authorize",
+      popup_blocked: false,
     })
     const state = get(flow.state)
     expect(state.oauth_starting).toBe(false)
@@ -181,7 +185,50 @@ describe("createOAuthWithInstall", () => {
     expect(state.install_url).toBeNull()
     expect(state.install_clicked).toBe(false)
     expect(state.checking_access).toBe(false)
+    expect(state.authorize_url).toBeNull()
+    expect(state.popup_blocked).toBe(false)
     expect(cancelFn).toHaveBeenCalled()
+  })
+
+  it("stores authorize_url and popup_blocked on onStarted", () => {
+    const { getCallbacks } = setupStartOAuthFlow()
+    const flow = createOAuthWithInstall({
+      git_url: "https://github.com/org/repo.git",
+      on_success: vi.fn(),
+    })
+    flow.start()
+    getCallbacks().onStarted({
+      install_url: "https://github.com/apps/kiln/installations/new",
+      authorize_url: "https://github.com/login/oauth/authorize?state=xyz",
+      popup_blocked: true,
+    })
+    const state = get(flow.state)
+    expect(state.popup_blocked).toBe(true)
+    expect(state.authorize_url).toBe(
+      "https://github.com/login/oauth/authorize?state=xyz",
+    )
+  })
+
+  it("open_install flags popup_blocked when window.open returns null", () => {
+    const { getCallbacks } = setupStartOAuthFlow()
+    const mockWindow = { open: vi.fn(() => null) }
+    vi.stubGlobal("window", mockWindow)
+
+    const flow = createOAuthWithInstall({
+      git_url: "https://github.com/org/repo.git",
+      on_success: vi.fn(),
+    })
+    flow.start()
+    getCallbacks().onStarted({
+      install_url: "https://github.com/apps/kiln/installations/new",
+      authorize_url: "https://github.com/login/oauth/authorize",
+      popup_blocked: false,
+    })
+
+    flow.open_install()
+    const state = get(flow.state)
+    expect(state.popup_blocked).toBe(true)
+    expect(state.install_clicked).toBe(false)
   })
 
   it("ignores stale callbacks after reset (generation tracking)", async () => {
@@ -241,6 +288,8 @@ describe("createOAuthWithInstall", () => {
     flow.start()
     getCallbacks().onStarted({
       install_url: "https://github.com/apps/kiln/installations/new",
+      authorize_url: "https://github.com/login/oauth/authorize",
+      popup_blocked: false,
     })
 
     flow.open_install()

--- a/app/web_ui/src/lib/git_sync/oauth_with_install.test.ts
+++ b/app/web_ui/src/lib/git_sync/oauth_with_install.test.ts
@@ -296,7 +296,6 @@ describe("createOAuthWithInstall", () => {
     expect(window.open).toHaveBeenCalledWith(
       "https://github.com/apps/kiln/installations/new",
       "_blank",
-      "noopener,noreferrer",
     )
     expect(get(flow.state).install_clicked).toBe(true)
   })

--- a/app/web_ui/src/lib/git_sync/oauth_with_install.ts
+++ b/app/web_ui/src/lib/git_sync/oauth_with_install.ts
@@ -135,11 +135,7 @@ export function createOAuthWithInstall(
   function open_install() {
     const current_install_url = get(state).install_url
     if (!current_install_url) return
-    const popup = window.open(
-      current_install_url,
-      "_blank",
-      "noopener,noreferrer",
-    )
+    const popup = window.open(current_install_url, "_blank")
     if (!popup) {
       update({ popup_blocked: true })
       return

--- a/app/web_ui/src/lib/git_sync/oauth_with_install.ts
+++ b/app/web_ui/src/lib/git_sync/oauth_with_install.ts
@@ -9,6 +9,8 @@ export type OAuthWithInstallState = {
   needs_install: boolean
   install_url: string | null
   install_clicked: boolean
+  authorize_url: string | null
+  popup_blocked: boolean
 }
 
 export const INITIAL_STATE: OAuthWithInstallState = {
@@ -18,6 +20,8 @@ export const INITIAL_STATE: OAuthWithInstallState = {
   needs_install: false,
   install_url: null,
   install_clicked: false,
+  authorize_url: null,
+  popup_blocked: false,
 }
 
 export type OAuthWithInstallOptions = {
@@ -97,18 +101,19 @@ export function createOAuthWithInstall(
     const this_generation = generation
 
     state.set({
+      ...INITIAL_STATE,
       oauth_starting: true,
-      oauth_error: null,
-      checking_access: false,
-      needs_install: false,
-      install_url: null,
-      install_clicked: false,
     })
 
     const callbacks: OAuthFlowCallbacks = {
       onStarted: (response) => {
         if (this_generation !== generation) return
-        update({ install_url: response.install_url, oauth_starting: false })
+        update({
+          install_url: response.install_url,
+          authorize_url: response.authorize_url,
+          popup_blocked: response.popup_blocked,
+          oauth_starting: false,
+        })
       },
       onPolling: () => {
         if (this_generation !== generation) return
@@ -130,8 +135,16 @@ export function createOAuthWithInstall(
   function open_install() {
     const current_install_url = get(state).install_url
     if (!current_install_url) return
-    window.open(current_install_url, "_blank", "noopener,noreferrer")
-    update({ install_clicked: true })
+    const popup = window.open(
+      current_install_url,
+      "_blank",
+      "noopener,noreferrer",
+    )
+    if (!popup) {
+      update({ popup_blocked: true })
+      return
+    }
+    update({ install_clicked: true, popup_blocked: false })
   }
 
   async function verify_access() {

--- a/app/web_ui/src/lib/git_sync/popup_blocked_fallback.svelte
+++ b/app/web_ui/src/lib/git_sync/popup_blocked_fallback.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { onDestroy } from "svelte"
+
+  export let url: string
+  export let message: string =
+    "Your browser blocked the popup. Copy the link below and open it manually in a new tab."
+  export let compact: boolean = false
+
+  let copied = false
+  let copy_timer: ReturnType<typeof setTimeout> | null = null
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(url)
+      copied = true
+      if (copy_timer) clearTimeout(copy_timer)
+      copy_timer = setTimeout(() => {
+        copied = false
+      }, 1500)
+    } catch {
+      // Clipboard API may be unavailable; users can still select the text.
+    }
+  }
+
+  onDestroy(() => {
+    if (copy_timer) clearTimeout(copy_timer)
+  })
+</script>
+
+<div
+  class="w-full border border-warning/40 bg-warning/5 rounded-lg {compact
+    ? 'p-3'
+    : 'p-4'} flex flex-col gap-2"
+>
+  <p class="{compact ? 'text-xs' : 'text-sm'} text-gray-700">
+    {message}
+  </p>
+  <div class="flex items-stretch gap-2">
+    <input
+      type="text"
+      readonly
+      value={url}
+      class="input input-bordered {compact
+        ? 'input-xs'
+        : 'input-sm'} flex-1 font-mono text-xs"
+      on:focus={(e) => e.currentTarget.select()}
+    />
+    <button
+      type="button"
+      class="btn {compact ? 'btn-xs' : 'btn-sm'} btn-primary"
+      on:click={copy}
+    >
+      {copied ? "Copied" : "Copy"}
+    </button>
+  </div>
+</div>


### PR DESCRIPTION
Safari persistently blocks window.open on the opener page after an OAuth popup navigates through a same-origin callback, leaving users stuck. Detect null popup returns on the authorize and install URLs, continue polling, and render a readonly URL + Copy button so users can complete the flow in a new tab manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fallback UI shows a manual authorization/install URL with a readonly input, Copy button and instructions when the browser blocks OAuth popups.

* **Bug Fixes**
  * OAuth flow no longer fails on blocked popups: verification continues via polling and users can complete auth manually instead of seeing an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->