### PR TITLE
refactor: remove unnecessary write locks

### DIFF
--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -1611,6 +1611,7 @@ def connect_document_api(app: FastAPI):
             filename=extraction.output.path.name,
         )
 
+    @no_write_lock
     @app.post(
         "/api/projects/{project_id}/documents/{document_id}/open_enclosing_folder",
         tags=["Documents"],
@@ -2410,6 +2411,7 @@ def connect_document_api(app: FastAPI):
         # the workflow runner handles locking
         return await run_rag_workflow_runner_with_status(runner_factory)
 
+    @no_write_lock
     @app.post(
         "/api/projects/{project_id}/rag_configs/progress",
         tags=["Documents"],
@@ -2443,6 +2445,7 @@ def connect_document_api(app: FastAPI):
         ] = await compute_current_progress_for_rag_configs(project, rag_configs)
         return progress_map
 
+    @no_write_lock
     @app.post(
         "/api/projects/{project_id}/rag_configs/{rag_config_id}/search",
         tags=["Documents"],

--- a/libs/server/kiln_server/test_document_api.py
+++ b/libs/server/kiln_server/test_document_api.py
@@ -5407,3 +5407,23 @@ def test_extract_file_has_no_write_lock(app):
 def test_run_rag_config_has_no_write_lock(app):
     endpoint = _find_endpoint_by_path(app, "/rag_configs/{rag_config_id}/run")
     assert getattr(endpoint, "_git_sync_no_write_lock", False) is True
+
+
+# --- Read-only POST endpoints must carry @no_write_lock ---
+
+
+def test_open_document_enclosing_folder_has_no_write_lock(app):
+    endpoint = _find_endpoint_by_path(
+        app, "/documents/{document_id}/open_enclosing_folder"
+    )
+    assert getattr(endpoint, "_git_sync_no_write_lock", False) is True
+
+
+def test_get_rag_config_progress_has_no_write_lock(app):
+    endpoint = _find_endpoint_by_path(app, "/rag_configs/progress")
+    assert getattr(endpoint, "_git_sync_no_write_lock", False) is True
+
+
+def test_search_rag_config_has_no_write_lock(app):
+    endpoint = _find_endpoint_by_path(app, "/rag_configs/{rag_config_id}/search")
+    assert getattr(endpoint, "_git_sync_no_write_lock", False) is True


### PR DESCRIPTION
## What does this PR do?

Some querying endpoints for RAGs take in various options and filters and are `POST` because they take in a body (nothing has changed recently with these endpoints beyond agent annotations); but they are not mutating endpoints and do not do writes. As such, they don't need write locks.

Changes:
- refactor: remove unnecessary write locks

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness for opening a document's enclosing folder, RAG configuration progress checks, and RAG configuration searches by adjusting request handling for these POST actions.

* **Tests**
  * Added unit tests to ensure these endpoints consistently bypass write-locking to maintain responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->