### PR TITLE
fix: no path-specific page title

### DIFF
--- a/app/web_ui/src/routes/(app)/models/+page.svelte
+++ b/app/web_ui/src/routes/(app)/models/+page.svelte
@@ -588,10 +588,6 @@
   }
 </script>
 
-<svelte:head>
-  <title>Models - Kiln</title>
-</svelte:head>
-
 <div class="max-w-[1400px] overflow-x-hidden">
   <AppPage
     title="Model Library"


### PR DESCRIPTION
## What does this PR do?

Weird case where only the `/models` page as a Svelte title - and it persists intra-nav after visiting that page once. 

Changes:
- fix: remove page-specific title for the models page

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed page title customization from the Models page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->