### PR TITLE
feat: project context dump endpoint for agent

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -60,6 +60,23 @@ export interface paths {
         patch: operations["update_project_api_projects__project_id__patch"];
         trace?: never;
     };
+    "/api/projects/{project_id}/context": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Project Context Dump */
+        get: operations["get_project_context_api_projects__project_id__context_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/import_project": {
         parameters: {
             query?: never;
@@ -4626,6 +4643,15 @@ export interface components {
             /** Models */
             models: components["schemas"]["EmbeddingModelDetails"][];
         };
+        /** EntitySummary */
+        EntitySummary: {
+            /** Id */
+            id: string | null;
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+        };
         /**
          * EphemeralSplitChunk
          * @description A single chunk from an ephemeral split.
@@ -5092,6 +5118,17 @@ export interface components {
             eval_config: components["schemas"]["EvalConfig"];
             /** @description The run config used. */
             run_config: components["schemas"]["TaskRunConfig"];
+        };
+        /** EvalSummary */
+        EvalSummary: {
+            /** Id */
+            id: string | null;
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /** Config Count */
+            config_count: number;
         };
         /**
          * EvalTemplateId
@@ -6899,6 +6936,35 @@ export interface components {
             description?: string | null;
             /** Model Type */
             readonly model_type: string;
+        };
+        /** ProjectContext */
+        ProjectContext: {
+            /** Id */
+            id: string | null;
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /** Tasks */
+            tasks: components["schemas"]["TaskSummary"][];
+            /** Skills */
+            skills: components["schemas"]["EntitySummary"][];
+            /** Documents */
+            documents: components["schemas"]["EntitySummary"][];
+            /** Extractor Configs */
+            extractor_configs: components["schemas"]["EntitySummary"][];
+            /** Chunker Configs */
+            chunker_configs: components["schemas"]["EntitySummary"][];
+            /** Embedding Configs */
+            embedding_configs: components["schemas"]["EntitySummary"][];
+            /** Rag Configs */
+            rag_configs: components["schemas"]["EntitySummary"][];
+            /** Vector Store Configs */
+            vector_store_configs: components["schemas"]["EntitySummary"][];
+            /** External Tool Servers */
+            external_tool_servers: components["schemas"]["EntitySummary"][];
+            /** Reranker Configs */
+            reranker_configs: components["schemas"]["EntitySummary"][];
         };
         /**
          * ProjectInfo
@@ -9116,6 +9182,31 @@ export interface components {
              */
             output: string;
         };
+        /** TaskSummary */
+        TaskSummary: {
+            /** Id */
+            id: string | null;
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /** Run Count */
+            run_count: number;
+            /** Evals */
+            evals: components["schemas"]["EvalSummary"][];
+            /** Prompts */
+            prompts: components["schemas"]["EntitySummary"][];
+            /** Finetunes */
+            finetunes: components["schemas"]["EntitySummary"][];
+            /** Run Configs */
+            run_configs: components["schemas"]["EntitySummary"][];
+            /** Dataset Splits */
+            dataset_splits: components["schemas"]["EntitySummary"][];
+            /** Prompt Optimization Jobs */
+            prompt_optimization_jobs: components["schemas"]["EntitySummary"][];
+            /** Specs */
+            specs: components["schemas"]["EntitySummary"][];
+        };
         /**
          * TaskToolCompatibility
          * @description Whether a task is compatible with a specific tool.
@@ -9772,6 +9863,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Project-Output"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_project_context_api_projects__project_id__context_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The unique identifier of the project. */
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectContext"];
                 };
             };
             /** @description Validation Error */

--- a/libs/server/kiln_server/project_api.py
+++ b/libs/server/kiln_server/project_api.py
@@ -12,11 +12,57 @@ from kiln_ai.utils.project_utils import (
 from kiln_ai.utils.project_utils import (
     project_from_id as project_from_id_core,
 )
+from pydantic import BaseModel
 
 from kiln_server.utils.agent_checks.policy import (
     ALLOW_AGENT,
     agent_policy_require_approval,
 )
+
+
+class EntitySummary(BaseModel):
+    id: str | None
+    name: str
+    description: str | None = None
+
+
+class EvalSummary(EntitySummary):
+    config_count: int
+
+
+class TaskSummary(EntitySummary):
+    run_count: int
+    evals: list[EvalSummary]
+    prompts: list[EntitySummary]
+    finetunes: list[EntitySummary]
+    run_configs: list[EntitySummary]
+    dataset_splits: list[EntitySummary]
+    prompt_optimization_jobs: list[EntitySummary]
+    specs: list[EntitySummary]
+
+
+class ProjectContext(BaseModel):
+    id: str | None
+    name: str
+    description: str | None = None
+    tasks: list[TaskSummary]
+    skills: list[EntitySummary]
+    documents: list[EntitySummary]
+    extractor_configs: list[EntitySummary]
+    chunker_configs: list[EntitySummary]
+    embedding_configs: list[EntitySummary]
+    rag_configs: list[EntitySummary]
+    vector_store_configs: list[EntitySummary]
+    external_tool_servers: list[EntitySummary]
+    reranker_configs: list[EntitySummary]
+
+
+def _summarize(item: Any) -> EntitySummary:
+    return EntitySummary(
+        id=item.id,
+        name=item.name,
+        description=getattr(item, "description", None),
+    )
 
 
 def default_project_path():
@@ -124,6 +170,78 @@ def connect_project_api(app: FastAPI):
         ],
     ) -> Project:
         return project_from_id(project_id)
+
+    @app.get(
+        "/api/projects/{project_id}/context",
+        summary="Project Context Dump",
+        tags=["Projects"],
+        openapi_extra=ALLOW_AGENT,
+    )
+    async def get_project_context(
+        project_id: Annotated[
+            str, Path(description="The unique identifier of the project.")
+        ],
+    ) -> ProjectContext:
+        project = project_from_id(project_id)
+
+        tasks: list[TaskSummary] = []
+        for t in project.tasks(readonly=True):
+            evals = [
+                EvalSummary(
+                    id=e.id,
+                    name=e.name,
+                    description=getattr(e, "description", None),
+                    config_count=len(e.configs(readonly=True)),
+                )
+                for e in t.evals(readonly=True)
+            ]
+            tasks.append(
+                TaskSummary(
+                    id=t.id,
+                    name=t.name,
+                    description=getattr(t, "description", None),
+                    run_count=len(t.runs(readonly=True)),
+                    evals=evals,
+                    prompts=[_summarize(p) for p in t.prompts(readonly=True)],
+                    finetunes=[_summarize(f) for f in t.finetunes(readonly=True)],
+                    run_configs=[_summarize(rc) for rc in t.run_configs(readonly=True)],
+                    dataset_splits=[
+                        _summarize(d) for d in t.dataset_splits(readonly=True)
+                    ],
+                    prompt_optimization_jobs=[
+                        _summarize(j) for j in t.prompt_optimization_jobs(readonly=True)
+                    ],
+                    specs=[_summarize(s) for s in t.specs(readonly=True)],
+                )
+            )
+
+        return ProjectContext(
+            id=project.id,
+            name=project.name,
+            description=project.description,
+            tasks=tasks,
+            skills=[_summarize(s) for s in project.skills(readonly=True)],
+            documents=[_summarize(d) for d in project.documents(readonly=True)],
+            extractor_configs=[
+                _summarize(x) for x in project.extractor_configs(readonly=True)
+            ],
+            chunker_configs=[
+                _summarize(x) for x in project.chunker_configs(readonly=True)
+            ],
+            embedding_configs=[
+                _summarize(x) for x in project.embedding_configs(readonly=True)
+            ],
+            rag_configs=[_summarize(x) for x in project.rag_configs(readonly=True)],
+            vector_store_configs=[
+                _summarize(x) for x in project.vector_store_configs(readonly=True)
+            ],
+            external_tool_servers=[
+                _summarize(x) for x in project.external_tool_servers(readonly=True)
+            ],
+            reranker_configs=[
+                _summarize(x) for x in project.reranker_configs(readonly=True)
+            ],
+        )
 
     @app.post(
         "/api/import_project",

--- a/libs/server/kiln_server/test_project_api.py
+++ b/libs/server/kiln_server/test_project_api.py
@@ -7,6 +7,16 @@ from fastapi import FastAPI
 from fastapi.exceptions import HTTPException
 from fastapi.testclient import TestClient
 from kiln_ai.datamodel import Project
+from kiln_ai.datamodel.eval import (
+    Eval,
+    EvalConfig,
+    EvalConfigType,
+    EvalOutputScore,
+)
+from kiln_ai.datamodel.prompt import Prompt
+from kiln_ai.datamodel.task import Task
+from kiln_ai.datamodel.task_output import TaskOutput, TaskOutputRatingType
+from kiln_ai.datamodel.task_run import TaskRun
 from kiln_ai.utils.config import Config
 from kiln_ai.utils.project_utils import DuplicateProjectError
 
@@ -480,6 +490,165 @@ def test_update_project_not_found(client):
 
     assert response.status_code == 404
     assert response.json() == {"message": "Project not found. ID: non-existent-id"}
+
+
+def _build_project_with_entities(tmp_path):
+    project_path = tmp_path / "project" / "project.kiln"
+    project = Project(
+        name="Ctx Project", description="Context test project", path=project_path
+    )
+    project.save_to_file()
+
+    task1 = Task(
+        name="Task One",
+        description="First task",
+        instruction="Do thing one.",
+        parent=project,
+    )
+    task1.save_to_file()
+
+    task2 = Task(
+        name="Task Two",
+        description=None,
+        instruction="Do thing two.",
+        parent=project,
+    )
+    task2.save_to_file()
+
+    # Two runs on task1, zero on task2
+    for i in range(2):
+        TaskRun(
+            input=f"in-{i}",
+            output=TaskOutput(output=f"out-{i}"),
+            parent=task1,
+        ).save_to_file()
+
+    eval_ = Eval(
+        name="Accuracy Eval",
+        description="Measures accuracy",
+        eval_set_filter_id="tag::eval",
+        eval_configs_filter_id="tag::golden",
+        output_scores=[
+            EvalOutputScore(name="accuracy", type=TaskOutputRatingType.five_star)
+        ],
+        parent=task1,
+    )
+    eval_.save_to_file()
+
+    for i in range(2):
+        EvalConfig(
+            name=f"Config {i}",
+            config_type=EvalConfigType.g_eval,
+            properties={"eval_steps": ["step1", "step2"]},
+            model_name="gpt-4",
+            model_provider="openai",
+            parent=eval_,
+        ).save_to_file()
+
+    Prompt(
+        name="My Prompt",
+        description="A prompt",
+        prompt="You are helpful.",
+        parent=task1,
+    ).save_to_file()
+
+    return project, task1, task2, eval_
+
+
+def test_get_project_context_success(client, tmp_path):
+    project, task1, task2, eval_ = _build_project_with_entities(tmp_path)
+
+    with patch(
+        "kiln_server.project_api.project_from_id",
+        return_value=project,
+    ):
+        response = client.get(f"/api/projects/{project.id}/context")
+
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["id"] == project.id
+    assert body["name"] == "Ctx Project"
+    assert body["description"] == "Context test project"
+
+    # Top-level project-scoped buckets are present and empty for the untouched ones
+    for key in [
+        "skills",
+        "documents",
+        "extractor_configs",
+        "chunker_configs",
+        "embedding_configs",
+        "rag_configs",
+        "vector_store_configs",
+        "external_tool_servers",
+        "reranker_configs",
+    ]:
+        assert body[key] == [], f"expected empty list for {key}"
+
+    tasks_by_id = {t["id"]: t for t in body["tasks"]}
+    assert set(tasks_by_id.keys()) == {task1.id, task2.id}
+
+    t1 = tasks_by_id[task1.id]
+    assert t1["name"] == "Task One"
+    assert t1["description"] == "First task"
+    assert t1["run_count"] == 2
+    assert len(t1["evals"]) == 1
+    assert t1["evals"][0]["id"] == eval_.id
+    assert t1["evals"][0]["name"] == "Accuracy Eval"
+    assert t1["evals"][0]["description"] == "Measures accuracy"
+    assert t1["evals"][0]["config_count"] == 2
+    assert len(t1["prompts"]) == 1
+    assert t1["prompts"][0]["name"] == "My Prompt"
+    assert t1["finetunes"] == []
+    assert t1["run_configs"] == []
+    assert t1["dataset_splits"] == []
+    assert t1["prompt_optimization_jobs"] == []
+    assert t1["specs"] == []
+
+    t2 = tasks_by_id[task2.id]
+    assert t2["name"] == "Task Two"
+    assert t2["description"] is None
+    assert t2["run_count"] == 0
+    assert t2["evals"] == []
+
+
+def test_get_project_context_empty_project(client, tmp_path):
+    project_path = tmp_path / "empty" / "project.kiln"
+    project = Project(name="Empty", path=project_path)
+    project.save_to_file()
+
+    with patch(
+        "kiln_server.project_api.project_from_id",
+        return_value=project,
+    ):
+        response = client.get(f"/api/projects/{project.id}/context")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Empty"
+    assert body["tasks"] == []
+    assert body["skills"] == []
+    assert body["rag_configs"] == []
+
+
+def test_get_project_context_not_found(client):
+    with patch(
+        "kiln_server.project_api.project_from_id",
+        side_effect=HTTPException(status_code=404, detail="Project not found"),
+    ):
+        response = client.get("/api/projects/missing-id/context")
+
+    assert response.status_code == 404
+    assert response.json() == {"message": "Project not found"}
+
+
+def test_get_project_context_agent_policy(app):
+    schema = app.openapi()
+    path = schema["paths"]["/api/projects/{project_id}/context"]["get"]
+    assert path["x-agent-policy"] == {
+        "permission": "allow",
+        "requires_approval": False,
+    }
 
 
 @pytest.mark.filterwarnings("ignore")

--- a/libs/server/kiln_server/utils/agent_checks/annotations/get_api_projects_project_id_context.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/get_api_projects_project_id_context.json
@@ -1,0 +1,8 @@
+{
+  "method": "get",
+  "path": "/api/projects/{project_id}/context",
+  "agent_policy": {
+    "permission": "allow",
+    "requires_approval": false
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Add a basic context endpoints that dumps the hierarchy of the project (id, name, description) and some counts.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new project context API endpoint providing comprehensive access to project metadata, tasks, evaluations, prompts, configurations, and other related resources aggregated in a single structured response.

* **Tests**
  * Added extensive test coverage for the project context endpoint including response structure validation, correct aggregation counts, and edge case handling for empty and missing projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->