### PR TITLE
Fix Manage Projects table scrolling at narrow widths

### DIFF
--- a/app/web_ui/src/routes/(app)/settings/manage_projects/+page.svelte
+++ b/app/web_ui/src/routes/(app)/settings/manage_projects/+page.svelte
@@ -116,7 +116,7 @@
   {:else if $projects.projects.length == 0}
     <div class="p-16">No projects found</div>
   {:else}
-    <div class="rounded-lg border">
+    <div class="overflow-x-auto rounded-lg border">
       <table class="table">
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- Manage Projects table now scrolls horizontally at narrow widths instead of wrapping/cramming cell content
- Adds `overflow-x-auto` to the table wrapper, matching the pattern used by the datasets page and other tables in the app

## Test plan
- [ ] Visit `/settings/manage_projects` at a narrow viewport width and confirm the table scrolls horizontally cleanly
- [ ] Confirm no visual regression at normal widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table overflow in Manage Projects page with horizontal scrolling support when content exceeds available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->