### PR TITLE
feat: agent can regex through Skill reference files

### DIFF
--- a/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
@@ -17,7 +17,10 @@ from kiln_ai.adapters.fine_tune.vertex_formatter import generate_vertex_gemini
 from kiln_ai.datamodel import DatasetSplit, TaskRun
 from kiln_ai.datamodel.datamodel_enums import THINKING_DATA_STRATEGIES, ChatStrategy
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
-from kiln_ai.datamodel.tool_id import SKILL_TOOL_ID_PREFIX
+from kiln_ai.datamodel.tool_id import (
+    SKILL_SEARCH_TOOL_ID_PREFIX,
+    SKILL_TOOL_ID_PREFIX,
+)
 from kiln_ai.tools.base_tool import ToolCallDefinition
 from kiln_ai.tools.tool_registry import tool_from_id
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
@@ -433,10 +436,16 @@ class DatasetFormatter:
         skill_tool_ids = [
             tid for tid in tools_config.tools if tid.startswith(SKILL_TOOL_ID_PREFIX)
         ]
+        skill_search_tool_ids = [
+            tid
+            for tid in tools_config.tools
+            if tid.startswith(SKILL_SEARCH_TOOL_ID_PREFIX)
+        ]
         non_skill_tool_ids = [
             tid
             for tid in tools_config.tools
             if not tid.startswith(SKILL_TOOL_ID_PREFIX)
+            and not tid.startswith(SKILL_SEARCH_TOOL_ID_PREFIX)
         ]
 
         for tool_id in non_skill_tool_ids:
@@ -474,5 +483,25 @@ class DatasetFormatter:
                     skill_def = await skill_tool.toolcall_definition()
                     self._tool_cache[cache_key] = skill_def
                     tool_definitions.append(skill_def)
+
+        if skill_search_tool_ids:
+            cache_key = "search::" + "::".join(sorted(skill_search_tool_ids))
+            if cache_key in self._tool_cache:
+                tool_definitions.append(self._tool_cache[cache_key])
+            else:
+                from kiln_ai.adapters.adapter_registry import (
+                    load_skills_from_tool_ids,
+                )
+                from kiln_ai.tools.skill_search_tool import SkillSearchTool
+
+                skills_dict = load_skills_from_tool_ids(task, skill_search_tool_ids)
+                if skills_dict:
+                    search_tool = SkillSearchTool(
+                        f"{SKILL_SEARCH_TOOL_ID_PREFIX}_combined",
+                        list(skills_dict.values()),
+                    )
+                    search_def = await search_tool.toolcall_definition()
+                    self._tool_cache[cache_key] = search_def
+                    tool_definitions.append(search_def)
 
         return tool_definitions if tool_definitions else None

--- a/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
@@ -51,7 +51,12 @@ from kiln_ai.datamodel.run_config import (
 )
 from kiln_ai.datamodel.skill import Skill
 from kiln_ai.datamodel.task import RunConfigProperties
-from kiln_ai.datamodel.tool_id import SKILL_TOOL_ID_PREFIX, skill_id_from_tool_id
+from kiln_ai.datamodel.tool_id import (
+    SKILL_SEARCH_TOOL_ID_PREFIX,
+    SKILL_TOOL_ID_PREFIX,
+    skill_id_from_skill_search_tool_id,
+    skill_id_from_tool_id,
+)
 
 # Import agent run context for run lifecycle management
 from kiln_ai.run_context import (
@@ -62,6 +67,7 @@ from kiln_ai.run_context import (
 )
 from kiln_ai.tools import KilnToolInterface
 from kiln_ai.tools.mcp_session_manager import MCPSessionManager
+from kiln_ai.tools.skill_search_tool import SkillSearchTool
 from kiln_ai.tools.skill_tool import SkillTool
 from kiln_ai.tools.tool_registry import tool_from_id
 from kiln_ai.utils.config import Config
@@ -158,6 +164,7 @@ class BaseAdapter(metaclass=ABCMeta):
             self.prompt_builder = None
         self._model_provider: KilnModelProvider | None = None
         self._resolved_skills: list[Skill] | None = None
+        self._resolved_skill_search_skills: list[Skill] | None = None
 
         self.output_schema = task.output_json_schema
         self.input_schema = task.input_json_schema
@@ -509,9 +516,13 @@ class BaseAdapter(metaclass=ABCMeta):
             == StructuredOutputMode.json_instruction_and_object
         )
 
+        skill_tool_skills = self._resolve_skills()
+        skill_search_skills = self._resolve_skill_search_tool_skills()
+        combined_skills = self._merge_skills(skill_tool_skills, skill_search_skills)
         return self.prompt_builder.build_prompt(
             include_json_instructions=add_json_instructions,
-            skills=self._resolve_skills(),
+            skills=combined_skills,
+            skill_search_enabled=bool(skill_search_skills),
         )
 
     def _resolve_skills(self) -> list[Skill]:
@@ -565,6 +576,73 @@ class BaseAdapter(metaclass=ABCMeta):
 
         self._resolved_skills = skills
         return self._resolved_skills
+
+    def _resolve_skill_search_tool_skills(self) -> list[Skill]:
+        """Resolve skills referenced by ``skill_search`` tool IDs.
+
+        Mirrors :meth:`_resolve_skills` but filters by
+        ``SKILL_SEARCH_TOOL_ID_PREFIX``. Cached separately so a run config that
+        enables both tools resolves each once.
+        """
+        if self._resolved_skill_search_skills is not None:
+            return self._resolved_skill_search_skills
+
+        if self.run_config.type != "kiln_agent":
+            self._resolved_skill_search_skills = []
+            return self._resolved_skill_search_skills
+
+        tool_config = as_kiln_agent_run_config(self.run_config).tools_config
+        if tool_config is None or tool_config.tools is None:
+            self._resolved_skill_search_skills = []
+            return self._resolved_skill_search_skills
+
+        search_tool_ids = [
+            tid
+            for tid in tool_config.tools
+            if tid.startswith(SKILL_SEARCH_TOOL_ID_PREFIX)
+        ]
+        if not search_tool_ids:
+            self._resolved_skill_search_skills = []
+            return self._resolved_skill_search_skills
+
+        injected = self.base_adapter_config.skills
+        if injected is None:
+            raise ValueError(
+                "Run config references skills but no skills dict was provided via "
+                "AdapterConfig(skills=...). Use load_skills_for_task() to pre-load "
+                "skills and pass them to the adapter."
+            )
+
+        skills: list[Skill] = []
+        seen: set[str] = set()
+        for tool_id in search_tool_ids:
+            sid = skill_id_from_skill_search_tool_id(tool_id)
+            if sid not in injected:
+                raise ValueError(
+                    f"Skill {sid} referenced in run config but not found in the "
+                    "injected skills dict."
+                )
+            if sid in seen:
+                continue
+            seen.add(sid)
+            skills.append(injected[sid])
+
+        self._resolved_skill_search_skills = skills
+        return self._resolved_skill_search_skills
+
+    @staticmethod
+    def _merge_skills(
+        skill_tool_skills: list[Skill], skill_search_skills: list[Skill]
+    ) -> list[Skill]:
+        """Union two skill lists, preserving order and de-duplicating by id."""
+        merged: list[Skill] = []
+        seen: set[str | None] = set()
+        for s in list(skill_tool_skills) + list(skill_search_skills):
+            if s.id in seen:
+                continue
+            seen.add(s.id)
+            merged.append(s)
+        return merged
 
     def build_chat_formatter(
         self,
@@ -734,7 +812,10 @@ class BaseAdapter(metaclass=ABCMeta):
             return []
 
         non_skill_tool_ids = [
-            tid for tid in tool_config.tools if not tid.startswith(SKILL_TOOL_ID_PREFIX)
+            tid
+            for tid in tool_config.tools
+            if not tid.startswith(SKILL_TOOL_ID_PREFIX)
+            and not tid.startswith(SKILL_SEARCH_TOOL_ID_PREFIX)
         ]
 
         tools: list[KilnToolInterface] = [
@@ -751,6 +832,21 @@ class BaseAdapter(metaclass=ABCMeta):
                     )
                 seen_names.add(skill.name)
             tools.append(SkillTool(f"{SKILL_TOOL_ID_PREFIX}_combined", skills))
+
+        search_skills = self._resolve_skill_search_tool_skills()
+        if search_skills:
+            seen_names = set()
+            for skill in search_skills:
+                if skill.name in seen_names:
+                    raise ValueError(
+                        f"Duplicate skill name '{skill.name}'. Each skill must have a unique name."
+                    )
+                seen_names.add(skill.name)
+            tools.append(
+                SkillSearchTool(
+                    f"{SKILL_SEARCH_TOOL_ID_PREFIX}_combined", search_skills
+                )
+            )
 
         tool_names = [await tool.name() for tool in tools]
         if len(tool_names) != len(set(tool_names)):

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -212,6 +212,7 @@ async def test_prompt_builder_json_instructions(
     mock_prompt_builder.build_prompt.assert_called_with(
         include_json_instructions=expected_json_instructions,
         skills=[],
+        skill_search_enabled=False,
     )
 
 
@@ -1770,3 +1771,155 @@ class TestResolveSkills:
     def test_build_prompt_no_skills_section_without_skills(self, adapter):
         prompt = adapter.build_prompt()
         assert "## Skills" not in prompt
+
+
+class TestResolveSkillSearchSkills:
+    @pytest.fixture
+    def _run_config_with_tools(self):
+        def _make(tools: list[str]) -> KilnAgentRunConfigProperties:
+            return KilnAgentRunConfigProperties(
+                model_name="test_model",
+                model_provider_name="openai",
+                prompt_id="simple_prompt_builder",
+                structured_output_mode="json_schema",
+                tools_config=ToolsRunConfig(tools=tools),
+            )
+
+        return _make
+
+    def test_returns_empty_for_non_kiln_agent(self, base_task):
+        from kiln_ai.datamodel.run_config import (
+            McpRunConfigProperties,
+            MCPToolReference,
+        )
+
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=McpRunConfigProperties(
+                tool_reference=MCPToolReference(tool_id="mcp::local::s::t"),
+            ),
+        )
+        assert adapter._resolve_skill_search_tool_skills() == []
+
+    def test_returns_empty_when_no_tools_config(self, adapter):
+        assert adapter._resolve_skill_search_tool_skills() == []
+
+    def test_returns_empty_when_no_search_ids(self, base_task, _run_config_with_tools):
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools(["kiln_tool::skill::skill_123"]),
+            config=AdapterConfig(skills={}),
+        )
+        assert adapter._resolve_skill_search_tool_skills() == []
+
+    def test_raises_when_skills_dict_not_provided(
+        self, base_task, _run_config_with_tools
+    ):
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools(["kiln_tool::skill_search::skill_123"]),
+        )
+        with pytest.raises(ValueError, match="no skills dict was provided"):
+            adapter._resolve_skill_search_tool_skills()
+
+    def test_raises_when_skill_missing_from_dict(
+        self, base_task, _run_config_with_tools
+    ):
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools(["kiln_tool::skill_search::skill_123"]),
+            config=AdapterConfig(skills={}),
+        )
+        with pytest.raises(ValueError, match="not found in the injected skills dict"):
+            adapter._resolve_skill_search_tool_skills()
+
+    def test_resolves_search_only_tool_config(self, base_task, _run_config_with_tools):
+        skill = Skill(name="my-skill", description="A skill")
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools([f"kiln_tool::skill_search::{skill.id}"]),
+            config=AdapterConfig(skills={skill.id: skill}),
+        )
+        result = adapter._resolve_skill_search_tool_skills()
+        assert len(result) == 1
+        assert result[0].name == "my-skill"
+
+    def test_resolves_both_prefixes_independently(
+        self, base_task, _run_config_with_tools
+    ):
+        skill = Skill(name="my-skill", description="A skill")
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools(
+                [
+                    f"kiln_tool::skill::{skill.id}",
+                    f"kiln_tool::skill_search::{skill.id}",
+                ]
+            ),
+            config=AdapterConfig(skills={skill.id: skill}),
+        )
+        skill_result = adapter._resolve_skills()
+        search_result = adapter._resolve_skill_search_tool_skills()
+        assert len(skill_result) == 1
+        assert len(search_result) == 1
+        assert skill_result[0].id == skill.id
+        assert search_result[0].id == skill.id
+
+    def test_deduplicates_search_ids(self, base_task, _run_config_with_tools):
+        skill = Skill(name="my-skill", description="A skill", body="do things")
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools(
+                [
+                    f"kiln_tool::skill_search::{skill.id}",
+                    f"kiln_tool::skill_search::{skill.id}",
+                ]
+            ),
+            config=AdapterConfig(skills={skill.id: skill}),
+        )
+        result = adapter._resolve_skill_search_tool_skills()
+        assert len(result) == 1
+        assert result[0].name == "my-skill"
+
+    def test_caches_result(self, base_task, _run_config_with_tools):
+        skill = Skill(name="my-skill", description="A skill")
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools([f"kiln_tool::skill_search::{skill.id}"]),
+            config=AdapterConfig(skills={skill.id: skill}),
+        )
+        r1 = adapter._resolve_skill_search_tool_skills()
+        r2 = adapter._resolve_skill_search_tool_skills()
+        assert r1 is r2
+
+    def test_build_prompt_mentions_skill_search_when_enabled(
+        self, base_task, _run_config_with_tools
+    ):
+        skill = Skill(name="my-skill", description="A test skill")
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools([f"kiln_tool::skill_search::{skill.id}"]),
+            config=AdapterConfig(skills={skill.id: skill}),
+        )
+        prompt = adapter.build_prompt()
+        assert "skill_search(name, pattern)" in prompt
+        assert "my-skill" in prompt
+
+    def test_build_prompt_omits_skill_search_when_only_skill_tool(
+        self, base_task, _run_config_with_tools
+    ):
+        skill = Skill(name="my-skill", description="A test skill")
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools([f"kiln_tool::skill::{skill.id}"]),
+            config=AdapterConfig(skills={skill.id: skill}),
+        )
+        prompt = adapter.build_prompt()
+        assert "skill_search(name, pattern)" not in prompt
+        assert "my-skill" in prompt
+
+    def test_merge_skills_dedups_overlapping_sets(self):
+        s1 = Skill(name="s1", description="d1")
+        s2 = Skill(name="s2", description="d2")
+        merged = BaseAdapter._merge_skills([s1, s2], [s2])
+        assert [s.id for s in merged] == [s1.id, s2.id]

--- a/libs/core/kiln_ai/adapters/prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/prompt_builders.py
@@ -19,25 +19,37 @@ class PromptExample:
     output: str
 
 
-def build_skills_prompt_section(skills: list[Skill] | None) -> str | None:
+def build_skills_prompt_section(
+    skills: list[Skill] | None,
+    skill_search_enabled: bool = False,
+) -> str | None:
     """Build a system prompt section listing available skills.
 
     This is a standalone function so both the inference adapter and the
     fine-tune pipeline can include the same skills instructions in the
-    system prompt.
+    system prompt. When ``skill_search_enabled`` is True, the section also
+    points the agent at the ``skill_search`` tool for finding references
+    by content.
     """
     if not skills:
         return None
 
     skill_lines = "\n".join(f"- `{s.name}`\n  {s.description}" for s in skills)
 
-    return (
-        "# Skills\n\n"
-        "When a Skill is relevant, load it with `skill(name)` and follow its instructions.\n"
-        "Load additional Skill resources only if needed with `skill(name, resource)`.\n"
-        "## Available Skills\n\n"
-        f"{skill_lines}"
-    )
+    intro_lines = [
+        "When a Skill is relevant, load it with `skill(name)` and follow its instructions.",
+        "Load additional Skill resources with `skill(name, resource)`. "
+        "Pass a directory path (e.g. 'references/knowledge/') to see a listing with line counts.",
+    ]
+    if skill_search_enabled:
+        intro_lines.append(
+            "Use `skill_search(name, pattern)` to find references by content "
+            "when you don't know which file to read."
+        )
+
+    intro = "\n".join(intro_lines)
+
+    return "# Skills\n\n" + intro + "\n## Available Skills\n\n" + skill_lines
 
 
 class BasePromptBuilder(metaclass=ABCMeta):
@@ -66,6 +78,7 @@ class BasePromptBuilder(metaclass=ABCMeta):
         self,
         include_json_instructions: bool,
         skills: list[Skill] | None = None,
+        skill_search_enabled: bool = False,
     ) -> str:
         """Build and return the complete prompt string.
 
@@ -74,6 +87,8 @@ class BasePromptBuilder(metaclass=ABCMeta):
             skills: Optional list of skills to include in the prompt. When provided,
                 a skills instruction section is appended so the model knows which
                 skills are available.
+            skill_search_enabled: When True, the skills section additionally points
+                the agent at the ``skill_search`` tool for finding references by content.
 
         Returns:
             str: The constructed prompt.
@@ -86,7 +101,9 @@ class BasePromptBuilder(metaclass=ABCMeta):
                 + f"\n\n# Format Instructions\n\nReturn a JSON object conforming to the following schema:\n```\n{self.task.output_schema()}\n```"
             )
 
-        skills_section = build_skills_prompt_section(skills)
+        skills_section = build_skills_prompt_section(
+            skills, skill_search_enabled=skill_search_enabled
+        )
         if skills_section:
             prompt = prompt + "\n\n" + skills_section
 
@@ -109,18 +126,28 @@ class BasePromptBuilder(metaclass=ABCMeta):
         """
         return None
 
-    def build_prompt_for_ui(self, skills: list[Skill] | None = None) -> str:
+    def build_prompt_for_ui(
+        self,
+        skills: list[Skill] | None = None,
+        skill_search_enabled: bool = False,
+    ) -> str:
         """Build a prompt for the UI. It includes additional instructions (like chain of thought), even if they are passed to the model in stages.
 
         Designed for end-user consumption, not for model consumption.
 
         Args:
             skills: Optional list of skills to include in the prompt display.
+            skill_search_enabled: When True, the skills section points the agent at
+                the ``skill_search`` tool alongside ``skill``.
 
         Returns:
             str: The constructed prompt string.
         """
-        base_prompt = self.build_prompt(include_json_instructions=False, skills=skills)
+        base_prompt = self.build_prompt(
+            include_json_instructions=False,
+            skills=skills,
+            skill_search_enabled=skill_search_enabled,
+        )
         cot_prompt = self.chain_of_thought_prompt()
         if cot_prompt:
             base_prompt += "\n\n# Thinking Instructions\n\n" + cot_prompt

--- a/libs/core/kiln_ai/adapters/test_prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_builders.py
@@ -659,6 +659,23 @@ def test_build_skills_prompt_section_empty():
     assert build_skills_prompt_section(None) is None
 
 
+def test_build_skills_prompt_section_default_excludes_skill_search():
+    skills = [Skill(name="code-review", description="Reviews code for quality")]
+    section = build_skills_prompt_section(skills)
+    assert section is not None
+    assert "skill_search" not in section
+    assert "code-review" in section
+
+
+def test_build_skills_prompt_section_with_skill_search_enabled():
+    skills = [Skill(name="code-review", description="Reviews code for quality")]
+    section = build_skills_prompt_section(skills, skill_search_enabled=True)
+    assert section is not None
+    assert "skill_search(name, pattern)" in section
+    assert "code-review" in section
+    assert "Reviews code for quality" in section
+
+
 def test_build_prompt_with_skills(tmp_path):
     task = build_test_task(tmp_path)
     builder = SimplePromptBuilder(task=task)

--- a/libs/core/kiln_ai/datamodel/skill.py
+++ b/libs/core/kiln_ai/datamodel/skill.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Union
 
@@ -85,6 +86,57 @@ class Skill(KilnParentedModel):
     def read_asset(self, relative_path: str) -> str:
         """Read an asset file. Raises ValueError for path traversal, non-text, or if the path is a folder, FileNotFoundError if missing."""
         return self._read_resource(self.assets_dir(), relative_path)
+
+    def count_file_lines(self, resource_root: str, relative_path: str) -> int:
+        """Count lines in a resource file. resource_root is 'references' or 'assets'.
+        Reuses _read_resource for the traversal guard and decoding rules."""
+        if resource_root == "references":
+            base_dir = self.references_dir()
+        elif resource_root == "assets":
+            base_dir = self.assets_dir()
+        else:
+            raise ValueError(
+                f"Unknown resource root: {resource_root!r}. Expected 'references' or 'assets'."
+            )
+        text = self._read_resource(base_dir, relative_path)
+        if not text:
+            return 0
+        newlines = text.count("\n")
+        return newlines if text.endswith("\n") else newlines + 1
+
+    def iter_markdown_references(
+        self, prefix: str | None = None
+    ) -> Iterator[tuple[str, str]]:
+        """Yield (relative_path, text_content) for each .md file under references/,
+        optionally scoped by prefix (a subpath under references/). Files that fail
+        UTF-8 decode are skipped silently. Raises ValueError if prefix attempts path
+        traversal outside references/."""
+        base_dir = self.references_dir()
+        if not base_dir.exists():
+            return
+        base_resolved = base_dir.resolve()
+
+        if prefix:
+            target = (base_dir / prefix).resolve()
+            try:
+                target.relative_to(base_resolved)
+            except ValueError:
+                raise ValueError("Path traversal is not allowed") from None
+        else:
+            target = base_resolved
+
+        if not target.exists() or not target.is_dir():
+            return
+
+        for md_path in sorted(target.rglob("*.md")):
+            if not md_path.is_file():
+                continue
+            try:
+                content = md_path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                continue
+            rel = md_path.relative_to(base_resolved).as_posix()
+            yield (rel, content)
 
     def _read_resource(self, base_dir: Path, relative_path: str) -> str:
         """Read a resource file, validating it resolves within base_dir and is readable text."""

--- a/libs/core/kiln_ai/datamodel/test_skill.py
+++ b/libs/core/kiln_ai/datamodel/test_skill.py
@@ -467,3 +467,133 @@ class TestAssets:
         skill = make_skill()
         with pytest.raises(ValueError, match="Skill must be saved"):
             skill.assets_dir()
+
+
+class TestCountFileLines:
+    @pytest.mark.parametrize(
+        "content,expected",
+        [
+            ("", 0),
+            ("one line", 1),
+            ("one line\n", 1),
+            ("first\nsecond", 2),
+            ("first\nsecond\n", 2),
+            ("a\nb\nc\nd\n", 4),
+            ("a\n\nc", 3),
+            ("\n", 1),
+            ("\n\n\n", 3),
+        ],
+    )
+    def test_count_file_lines(self, mock_project, content, expected):
+        skill = save_skill_with_body(mock_project)
+        (skill.references_dir() / "f.md").write_text(content, encoding="utf-8")
+        assert skill.count_file_lines("references", "f.md") == expected
+
+    def test_count_file_lines_assets_root(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        (skill.assets_dir() / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+        assert skill.count_file_lines("assets", "data.csv") == 2
+
+    def test_count_file_lines_unknown_root(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        with pytest.raises(ValueError, match="Unknown resource root"):
+            skill.count_file_lines("secrets", "f.md")
+
+    def test_count_file_lines_path_traversal(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        with pytest.raises(ValueError, match="Path traversal"):
+            skill.count_file_lines("references", "../../etc/passwd")
+
+    def test_count_file_lines_missing_file(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        with pytest.raises(FileNotFoundError, match="Resource file not found"):
+            skill.count_file_lines("references", "missing.md")
+
+    def test_count_file_lines_binary_rejected(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        (skill.references_dir() / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00")
+        with pytest.raises(ValueError, match="not a readable text file"):
+            skill.count_file_lines("references", "image.png")
+
+
+class TestIterMarkdownReferences:
+    def test_yields_markdown_only(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        ref_dir = skill.references_dir()
+        (ref_dir / "a.md").write_text("A\n", encoding="utf-8")
+        (ref_dir / "b.txt").write_text("not md", encoding="utf-8")
+        (ref_dir / "c.md").write_text("C\n", encoding="utf-8")
+        results = list(skill.iter_markdown_references())
+        rel_paths = [rel for rel, _ in results]
+        assert rel_paths == ["a.md", "c.md"]
+        assert dict(results)["a.md"] == "A\n"
+
+    def test_recurses_into_subdirectories(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        ref_dir = skill.references_dir()
+        (ref_dir / "top.md").write_text("top", encoding="utf-8")
+        sub = ref_dir / "knowledge" / "nested"
+        sub.mkdir(parents=True)
+        (sub / "deep.md").write_text("deep", encoding="utf-8")
+        rel_paths = [rel for rel, _ in skill.iter_markdown_references()]
+        assert "top.md" in rel_paths
+        assert "knowledge/nested/deep.md" in rel_paths
+
+    def test_scoped_by_prefix(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        ref_dir = skill.references_dir()
+        (ref_dir / "top.md").write_text("top", encoding="utf-8")
+        (ref_dir / "knowledge").mkdir()
+        (ref_dir / "knowledge" / "rag.md").write_text("rag", encoding="utf-8")
+        rel_paths = [rel for rel, _ in skill.iter_markdown_references("knowledge")]
+        assert rel_paths == ["knowledge/rag.md"]
+
+    def test_scoped_by_prefix_trailing_slash(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        (skill.references_dir() / "knowledge").mkdir()
+        (skill.references_dir() / "knowledge" / "x.md").write_text(
+            "x", encoding="utf-8"
+        )
+        rel_paths = [rel for rel, _ in skill.iter_markdown_references("knowledge/")]
+        assert rel_paths == ["knowledge/x.md"]
+
+    def test_path_traversal_rejected(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        with pytest.raises(ValueError, match="Path traversal"):
+            list(skill.iter_markdown_references("../../etc"))
+
+    def test_missing_prefix_yields_empty(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        assert list(skill.iter_markdown_references("does_not_exist")) == []
+
+    def test_prefix_points_to_file_yields_empty(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        (skill.references_dir() / "a.md").write_text("A", encoding="utf-8")
+        assert list(skill.iter_markdown_references("a.md")) == []
+
+    def test_skips_bad_utf8(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        ref_dir = skill.references_dir()
+        (ref_dir / "ok.md").write_text("ok", encoding="utf-8")
+        (ref_dir / "bad.md").write_bytes(b"\xff\xfe\xff\xbad utf8")
+        rel_paths = [rel for rel, _ in skill.iter_markdown_references()]
+        assert rel_paths == ["ok.md"]
+
+    def test_empty_references_yields_nothing(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        assert list(skill.iter_markdown_references()) == []
+
+    def test_no_references_dir_yields_nothing(self, mock_project):
+        skill = make_skill(parent=mock_project)
+        skill.save_to_file()
+        # references_dir() returns a Path but dir is not created until save_skill_md
+        assert not skill.references_dir().exists()
+        assert list(skill.iter_markdown_references()) == []
+
+    def test_yields_sorted(self, mock_project):
+        skill = save_skill_with_body(mock_project)
+        ref_dir = skill.references_dir()
+        for name in ("zeta.md", "alpha.md", "mid.md"):
+            (ref_dir / name).write_text(name, encoding="utf-8")
+        rel_paths = [rel for rel, _ in skill.iter_markdown_references()]
+        assert rel_paths == ["alpha.md", "mid.md", "zeta.md"]

--- a/libs/core/kiln_ai/datamodel/test_tool_id.py
+++ b/libs/core/kiln_ai/datamodel/test_tool_id.py
@@ -5,14 +5,17 @@ from kiln_ai.datamodel.tool_id import (
     MCP_LOCAL_TOOL_ID_PREFIX,
     MCP_REMOTE_TOOL_ID_PREFIX,
     RAG_TOOL_ID_PREFIX,
+    SKILL_SEARCH_TOOL_ID_PREFIX,
     KilnBuiltInToolId,
     ToolId,
     _check_tool_id,
     build_kiln_unmanaged_tool_id,
+    build_skill_search_tool_id,
     kiln_task_server_id_from_tool_id,
     kiln_unmanaged_tool_slug_from_id,
     mcp_server_and_tool_name_from_id,
     rag_config_id_from_id,
+    skill_id_from_skill_search_tool_id,
 )
 
 
@@ -182,6 +185,90 @@ class TestCheckToolId:
         # This tests the case where kiln_task_server_id_from_tool_id returns empty string which should raise an error
         with pytest.raises(ValueError, match="Invalid Kiln task tool ID"):
             _check_tool_id("kiln_task::")
+
+
+class TestSkillSearchToolIds:
+    """kiln_tool::skill_search::<skill_id> for SkillSearchTool."""
+
+    @pytest.mark.parametrize(
+        "tool_id",
+        [
+            "kiln_tool::skill_search::abc123",
+            "kiln_tool::skill_search::my_skill",
+            "kiln_tool::skill_search::1",
+            "kiln_tool::skill_search::408910145779",
+        ],
+    )
+    def test_valid_skill_search_tool_ids(self, tool_id: str):
+        assert _check_tool_id(tool_id) == tool_id
+
+    @pytest.mark.parametrize(
+        "tool_id",
+        [
+            "kiln_tool::skill_search::",
+            "kiln_tool::skill_search::a::b",
+            "kiln_tool::skill_search::a::b::c",
+        ],
+    )
+    def test_invalid_skill_search_tool_ids(self, tool_id: str):
+        with pytest.raises(ValueError, match="Invalid skill search tool ID"):
+            _check_tool_id(tool_id)
+
+    def test_skill_id_from_skill_search_tool_id(self):
+        assert (
+            skill_id_from_skill_search_tool_id("kiln_tool::skill_search::xyz789")
+            == "xyz789"
+        )
+
+    @pytest.mark.parametrize(
+        "tool_id",
+        [
+            "kiln_tool::skill::xyz789",
+            "kiln_tool::skill_search::a::b",
+            "wrong::skill_search::xyz",
+            "",
+            "kiln_tool::skill_search",
+        ],
+    )
+    def test_skill_id_from_skill_search_tool_id_rejects_malformed(self, tool_id: str):
+        with pytest.raises(ValueError, match="Invalid skill search tool ID"):
+            skill_id_from_skill_search_tool_id(tool_id)
+
+    def test_build_skill_search_tool_id(self):
+        assert build_skill_search_tool_id("abc123") == "kiln_tool::skill_search::abc123"
+
+    def test_round_trip(self):
+        skill_id = "408910145779"
+        built = build_skill_search_tool_id(skill_id)
+        assert _check_tool_id(built) == built
+        assert skill_id_from_skill_search_tool_id(built) == skill_id
+
+    def test_prefix_constant(self):
+        assert SKILL_SEARCH_TOOL_ID_PREFIX == "kiln_tool::skill_search::"
+
+    def test_pydantic_validation_accepts_skill_search_id(self):
+        class _M(BaseModel):
+            tool_id: ToolId
+
+        model = _M(tool_id="kiln_tool::skill_search::xyz")
+        assert model.tool_id == "kiln_tool::skill_search::xyz"
+
+    def test_pydantic_validation_rejects_missing_skill_id_segment(self):
+        class _M(BaseModel):
+            tool_id: ToolId
+
+        with pytest.raises(ValidationError):
+            _M(tool_id="kiln_tool::skill_search::")
+
+    def test_skill_and_skill_search_prefixes_do_not_collide(self):
+        """Ensures skill_search IDs are not validated as skill IDs and vice versa."""
+        search_id = "kiln_tool::skill_search::s1"
+        skill_id = "kiln_tool::skill::s1"
+        assert _check_tool_id(search_id) == search_id
+        assert _check_tool_id(skill_id) == skill_id
+        # and parsers only accept their own prefix
+        with pytest.raises(ValueError):
+            skill_id_from_skill_search_tool_id(skill_id)
 
 
 class TestKilnUnmanagedToolIds:

--- a/libs/core/kiln_ai/datamodel/tool_id.py
+++ b/libs/core/kiln_ai/datamodel/tool_id.py
@@ -17,6 +17,8 @@ Tool IDs can be one of:
 - A remote MCP tool: mcp::remote::<server_id>::<tool_name>
 - A local MCP tool: mcp::local::<server_id>::<tool_name>
 - A Kiln task tool: kiln_task::<server_id>
+- A Kiln skill tool: kiln_tool::skill::<skill_id>
+- A Kiln skill search tool: kiln_tool::skill_search::<skill_id>
 - An SDK / adapter-injected unmanaged tool: kiln_unmanaged::<id> (single slug, not from the registry)
 - More coming soon like kiln_project_tool::rag::RAG_CONFIG_ID
 """
@@ -37,6 +39,7 @@ RAG_TOOL_ID_PREFIX = "kiln_tool::rag::"
 MCP_LOCAL_TOOL_ID_PREFIX = "mcp::local::"
 KILN_TASK_TOOL_ID_PREFIX = "kiln_task::"
 SKILL_TOOL_ID_PREFIX = "kiln_tool::skill::"
+SKILL_SEARCH_TOOL_ID_PREFIX = "kiln_tool::skill_search::"
 KILN_UNMANAGED_TOOL_ID_PREFIX = "kiln_unmanaged::"
 
 
@@ -115,6 +118,15 @@ def _check_tool_id(id: str) -> str:
             )
         return id
 
+    # Skill search tools must have format: kiln_tool::skill_search::<skill_id>
+    if id.startswith(SKILL_SEARCH_TOOL_ID_PREFIX):
+        skill_id = skill_id_from_skill_search_tool_id(id)
+        if not skill_id:
+            raise ValueError(
+                f"Invalid skill search tool ID: {id}. Expected format: 'kiln_tool::skill_search::<skill_id>'."
+            )
+        return id
+
     # Skill tools must have format: kiln_tool::skill::<skill_id>
     if id.startswith(SKILL_TOOL_ID_PREFIX):
         skill_id = skill_id_from_tool_id(id)
@@ -190,6 +202,21 @@ def skill_id_from_tool_id(id: str) -> str:
 def build_skill_tool_id(skill_id: str) -> str:
     """Construct the tool ID for a skill."""
     return f"{SKILL_TOOL_ID_PREFIX}{skill_id}"
+
+
+def skill_id_from_skill_search_tool_id(id: str) -> str:
+    """Get the skill ID from a skill search tool ID."""
+    parts = id.split("::")
+    if not id.startswith(SKILL_SEARCH_TOOL_ID_PREFIX) or len(parts) != 3:
+        raise ValueError(
+            f"Invalid skill search tool ID: {id}. Expected format: 'kiln_tool::skill_search::<skill_id>'."
+        )
+    return parts[2]
+
+
+def build_skill_search_tool_id(skill_id: str) -> str:
+    """Construct the tool ID for a skill search tool."""
+    return f"{SKILL_SEARCH_TOOL_ID_PREFIX}{skill_id}"
 
 
 def kiln_task_server_id_from_tool_id(tool_id: str) -> str:

--- a/libs/core/kiln_ai/tools/skill_search_tool.py
+++ b/libs/core/kiln_ai/tools/skill_search_tool.py
@@ -1,0 +1,455 @@
+import re
+from dataclasses import dataclass, field
+
+import yaml
+
+from kiln_ai.datamodel.skill import Skill
+from kiln_ai.datamodel.tool_id import ToolId
+from kiln_ai.tools.base_tool import (
+    KilnToolInterface,
+    ToolCallContext,
+    ToolCallDefinition,
+    ToolCallResult,
+)
+
+REFERENCES_PREFIX = "references/"
+
+DEFAULT_CONTEXT = 0
+DEFAULT_MAX_MATCHES_PER_FILE = 10
+DEFAULT_MAX_FILES = 20
+DEFAULT_MAX_LINE_LENGTH = 240
+
+CONTEXT_RANGE = (0, 10)
+MAX_MATCHES_PER_FILE_RANGE = (1, 100)
+MAX_FILES_RANGE = (1, 100)
+MAX_LINE_LENGTH_RANGE = (40, 1000)
+
+_H1_SEARCH_LINES = 10
+
+
+@dataclass
+class _Hunk:
+    start: int
+    end: int
+    match_lines: set[int] = field(default_factory=set)
+
+
+class SkillSearchTool(KilnToolInterface):
+    """Regex search across a skill's markdown references.
+
+    The agent calls ``skill_search(name, pattern)`` to find candidate files
+    by content before reading any of them in full via ``skill(name, resource=...)``.
+    Matches are case-insensitive and line-by-line. Only markdown files
+    under ``references/`` are searched; assets are not indexed.
+    """
+
+    def __init__(self, tool_id: str, skills: list[Skill]):
+        self._tool_id = tool_id
+        self._skills = {s.name: s for s in skills}
+
+    @property
+    def skills(self) -> list[Skill]:
+        return list(self._skills.values())
+
+    async def id(self) -> ToolId:
+        return self._tool_id
+
+    async def name(self) -> str:
+        return "skill_search"
+
+    async def description(self) -> str:
+        return (
+            "Search a skill's markdown reference files with a regex pattern. "
+            "Use this when you don't know which reference file discusses a given concept — "
+            "it returns matching lines grouped by file so you can then open specific files "
+            "with skill(name, resource=...). Matches are case-insensitive and line-by-line. "
+            "Scope the search with 'path_prefix' (e.g. 'references/knowledge/') or target one "
+            "file with 'resource'. Use 'context_before'/'context_after' (or the 'context_lines' "
+            "shorthand) to see surrounding lines."
+        )
+
+    async def toolcall_definition(self) -> ToolCallDefinition:
+        return {
+            "type": "function",
+            "function": {
+                "name": await self.name(),
+                "description": await self.description(),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "The name of the skill to search.",
+                        },
+                        "pattern": {
+                            "type": "string",
+                            "description": "Python regex, matched line-by-line with re.IGNORECASE.",
+                        },
+                        "resource": {
+                            "type": "string",
+                            "description": (
+                                "Optional. Search only inside this single markdown file "
+                                "(e.g. 'references/modes/improve_task.md'). Mutually exclusive "
+                                "with 'path_prefix'. Must start with 'references/' and end with '.md'."
+                            ),
+                        },
+                        "path_prefix": {
+                            "type": "string",
+                            "description": (
+                                "Optional. Subdirectory scope (e.g. 'references/knowledge/'). "
+                                "Mutually exclusive with 'resource'. Must start with 'references/'. "
+                                "Defaults to the whole references tree."
+                            ),
+                        },
+                        "context_before": {
+                            "type": "integer",
+                            "description": (
+                                f"Optional. Context lines before each match. Default {DEFAULT_CONTEXT}. "
+                                f"Clamped to [{CONTEXT_RANGE[0]}, {CONTEXT_RANGE[1]}]."
+                            ),
+                        },
+                        "context_after": {
+                            "type": "integer",
+                            "description": (
+                                f"Optional. Context lines after each match. Default {DEFAULT_CONTEXT}. "
+                                f"Clamped to [{CONTEXT_RANGE[0]}, {CONTEXT_RANGE[1]}]."
+                            ),
+                        },
+                        "context_lines": {
+                            "type": "integer",
+                            "description": (
+                                "Optional shorthand. Sets both context_before and context_after. "
+                                "Mutually exclusive with either of those. "
+                                f"Clamped to [{CONTEXT_RANGE[0]}, {CONTEXT_RANGE[1]}]."
+                            ),
+                        },
+                        "max_matches_per_file": {
+                            "type": "integer",
+                            "description": (
+                                f"Optional. Default {DEFAULT_MAX_MATCHES_PER_FILE}. "
+                                f"Clamped to [{MAX_MATCHES_PER_FILE_RANGE[0]}, {MAX_MATCHES_PER_FILE_RANGE[1]}]."
+                            ),
+                        },
+                        "max_files": {
+                            "type": "integer",
+                            "description": (
+                                f"Optional. Overall result cap. Default {DEFAULT_MAX_FILES}. "
+                                f"Clamped to [{MAX_FILES_RANGE[0]}, {MAX_FILES_RANGE[1]}]."
+                            ),
+                        },
+                        "max_line_length": {
+                            "type": "integer",
+                            "description": (
+                                f"Optional. Per-line truncation. Default {DEFAULT_MAX_LINE_LENGTH}. "
+                                f"Clamped to [{MAX_LINE_LENGTH_RANGE[0]}, {MAX_LINE_LENGTH_RANGE[1]}]."
+                            ),
+                        },
+                    },
+                    "required": ["name", "pattern"],
+                },
+            },
+        }
+
+    async def run(
+        self, context: ToolCallContext | None = None, **kwargs
+    ) -> ToolCallResult:
+        skill_name = kwargs.get("name")
+        pattern = kwargs.get("pattern")
+        resource = kwargs.get("resource")
+        path_prefix = kwargs.get("path_prefix")
+        context_lines_arg = kwargs.get("context_lines")
+        context_before_arg = kwargs.get("context_before")
+        context_after_arg = kwargs.get("context_after")
+        max_matches_per_file_arg = kwargs.get("max_matches_per_file")
+        max_files_arg = kwargs.get("max_files")
+        max_line_length_arg = kwargs.get("max_line_length")
+
+        if not isinstance(skill_name, str) or not skill_name:
+            return ToolCallResult(output="Error: 'name' parameter is required.")
+
+        skill = self._skills.get(skill_name)
+        if skill is None:
+            available = ", ".join(self._skills.keys())
+            return ToolCallResult(
+                output=f"Error: Skill '{skill_name}' not found. Available skills: {available}"
+            )
+
+        if not isinstance(pattern, str) or not pattern:
+            return ToolCallResult(output="Error: 'pattern' parameter is required.")
+
+        try:
+            regex = re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            return ToolCallResult(output=f"Error: Invalid regex: {e}")
+
+        if resource and path_prefix:
+            return ToolCallResult(
+                output="Error: Provide either 'resource' or 'path_prefix', not both."
+            )
+
+        if context_lines_arg is not None and (
+            context_before_arg is not None or context_after_arg is not None
+        ):
+            return ToolCallResult(
+                output="Error: Use either 'context_lines' or 'context_before'/'context_after', not both."
+            )
+
+        if context_lines_arg is not None:
+            before = self._resolve_int(
+                context_lines_arg, DEFAULT_CONTEXT, CONTEXT_RANGE
+            )
+            after = before
+        else:
+            before = self._resolve_int(
+                context_before_arg, DEFAULT_CONTEXT, CONTEXT_RANGE
+            )
+            after = self._resolve_int(context_after_arg, DEFAULT_CONTEXT, CONTEXT_RANGE)
+
+        max_matches_per_file = self._resolve_int(
+            max_matches_per_file_arg,
+            DEFAULT_MAX_MATCHES_PER_FILE,
+            MAX_MATCHES_PER_FILE_RANGE,
+        )
+        max_files = self._resolve_int(max_files_arg, DEFAULT_MAX_FILES, MAX_FILES_RANGE)
+        max_line_length = self._resolve_int(
+            max_line_length_arg, DEFAULT_MAX_LINE_LENGTH, MAX_LINE_LENGTH_RANGE
+        )
+
+        corpus: list[tuple[str, str]]
+        scope_label: str | None
+
+        if resource is not None:
+            if not isinstance(resource, str) or not resource.startswith(
+                REFERENCES_PREFIX
+            ):
+                return ToolCallResult(
+                    output="Error: 'resource' must start with 'references/'"
+                )
+            if not resource.endswith(".md"):
+                return ToolCallResult(
+                    output="Error: Only markdown files (.md) are searchable"
+                )
+            rel = resource[len(REFERENCES_PREFIX) :]
+            if not rel:
+                return ToolCallResult(
+                    output="Error: 'resource' must be a file path. Use 'path_prefix' to search a directory."
+                )
+            base_dir = skill.references_dir()
+            try:
+                base_resolved = base_dir.resolve()
+                target = (base_dir / rel).resolve()
+                target.relative_to(base_resolved)
+            except ValueError:
+                return ToolCallResult(output="Error: Path traversal is not allowed")
+            if not target.exists():
+                return ToolCallResult(output=f"Error: Resource not found: {resource}")
+            if target.is_dir():
+                return ToolCallResult(
+                    output="Error: 'resource' must be a file path. Use 'path_prefix' to search a directory."
+                )
+            try:
+                content = skill.read_reference(rel)
+            except FileNotFoundError:
+                return ToolCallResult(output=f"Error: Resource not found: {resource}")
+            except ValueError as e:
+                return ToolCallResult(output=f"Error: {e}")
+            corpus = [(rel, content)]
+            scope_label = resource
+        else:
+            if path_prefix is not None:
+                if not isinstance(path_prefix, str) or not path_prefix.startswith(
+                    REFERENCES_PREFIX
+                ):
+                    return ToolCallResult(
+                        output="Error: 'path_prefix' must start with 'references/'"
+                    )
+                prefix_rel = path_prefix[len(REFERENCES_PREFIX) :].rstrip("/") or None
+                scope_label = path_prefix
+            else:
+                prefix_rel = None
+                scope_label = None
+            try:
+                corpus = list(skill.iter_markdown_references(prefix=prefix_rel))
+            except ValueError as e:
+                return ToolCallResult(output=f"Error: {e}")
+
+        file_blocks: list[str] = []
+        files_matched = 0
+        truncated_files = 0
+        total_matches_shown = 0
+
+        for rel_path, text in corpus:
+            lines = text.splitlines()
+            match_indices = [i for i, line in enumerate(lines) if regex.search(line)]
+            if not match_indices:
+                continue
+
+            files_matched += 1
+
+            if len(file_blocks) >= max_files:
+                truncated_files += 1
+                continue
+
+            truncated_per_file = max(0, len(match_indices) - max_matches_per_file)
+            shown_match_indices = match_indices[:max_matches_per_file]
+            hunks = self._merge_hunks(shown_match_indices, before, after, len(lines))
+            frontmatter = self._parse_frontmatter(text)
+            block = self._render_file_block(
+                rel_path=rel_path,
+                lines=lines,
+                hunks=hunks,
+                frontmatter=frontmatter,
+                raw_text=text,
+                max_line_length=max_line_length,
+                truncated_per_file=truncated_per_file,
+            )
+            file_blocks.append(block)
+            total_matches_shown += len(shown_match_indices)
+
+        if files_matched == 0:
+            return ToolCallResult(
+                output=self._no_match_message(pattern, skill_name, scope_label)
+            )
+
+        footer = self._build_footer(
+            skill_name=skill_name,
+            files_shown=len(file_blocks),
+            truncated_files=truncated_files,
+            total_matches_shown=total_matches_shown,
+        )
+        return ToolCallResult(output="\n\n".join(file_blocks) + "\n\n" + footer)
+
+    @staticmethod
+    def _resolve_int(value: object, default: int, clamp_range: tuple[int, int]) -> int:
+        lo, hi = clamp_range
+        if value is None:
+            v = default
+        else:
+            try:
+                v = int(value)  # type: ignore[call-overload]
+            except (TypeError, ValueError):
+                v = default
+        return max(lo, min(hi, v))
+
+    @staticmethod
+    def _merge_hunks(
+        match_indices: list[int], before: int, after: int, total: int
+    ) -> list[_Hunk]:
+        if not match_indices or total == 0:
+            return []
+        hunks: list[_Hunk] = []
+        for m in match_indices:
+            start = max(0, m - before)
+            end = min(total - 1, m + after)
+            if hunks and start <= hunks[-1].end + 1:
+                prev = hunks[-1]
+                prev.end = max(prev.end, end)
+                prev.match_lines.add(m)
+            else:
+                hunks.append(_Hunk(start=start, end=end, match_lines={m}))
+        return hunks
+
+    @staticmethod
+    def _parse_frontmatter(text: str) -> dict[str, str]:
+        if not text.startswith("---\n"):
+            return {}
+        try:
+            end_idx = text.index("\n---\n", 3)
+        except ValueError:
+            return {}
+        fm_text = text[4:end_idx]
+        try:
+            data = yaml.safe_load(fm_text)
+        except yaml.YAMLError:
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        result: dict[str, str] = {}
+        for key in ("name", "description"):
+            value = data.get(key)
+            if value is None:
+                continue
+            result[key] = " ".join(str(value).split())
+        return result
+
+    @staticmethod
+    def _extract_first_h1(raw_text: str) -> str | None:
+        body = raw_text
+        if body.startswith("---\n"):
+            try:
+                end_idx = body.index("\n---\n", 3)
+                body = body[end_idx + 5 :]
+            except ValueError:
+                pass
+        body = body.lstrip("\n")
+        for i, line in enumerate(body.splitlines()):
+            if i >= _H1_SEARCH_LINES:
+                break
+            if line.startswith("# "):
+                return line
+        return None
+
+    @staticmethod
+    def _render_file_block(
+        rel_path: str,
+        lines: list[str],
+        hunks: list[_Hunk],
+        frontmatter: dict[str, str],
+        raw_text: str,
+        max_line_length: int,
+        truncated_per_file: int,
+    ) -> str:
+        out: list[str] = [f"=== references/{rel_path} ({len(lines)} lines) ==="]
+
+        if "name" in frontmatter:
+            out.append(f"name: {frontmatter['name']}")
+        if "description" in frontmatter:
+            out.append(f"description: {frontmatter['description']}")
+
+        if not frontmatter:
+            h1 = SkillSearchTool._extract_first_h1(raw_text)
+            if h1:
+                out.append(h1)
+
+        for hi, hunk in enumerate(hunks):
+            if hi > 0:
+                out.append("")
+            for i in range(hunk.start, hunk.end + 1):
+                sep = ":" if i in hunk.match_lines else "-"
+                line_str = lines[i] if i < len(lines) else ""
+                if len(line_str) > max_line_length:
+                    line_str = line_str[: max_line_length - 1] + "…"
+                out.append(f"  {i + 1}{sep} {line_str}")
+
+        if truncated_per_file > 0:
+            out.append(
+                f"  ... (truncated: {truncated_per_file} more matches in this file)"
+            )
+
+        return "\n".join(out)
+
+    @staticmethod
+    def _build_footer(
+        skill_name: str,
+        files_shown: int,
+        truncated_files: int,
+        total_matches_shown: int,
+    ) -> str:
+        file_part = f"Found {files_shown} files"
+        if truncated_files > 0:
+            file_part += f" (+{truncated_files} more truncated)"
+        return (
+            f"{file_part}, {total_matches_shown} matches shown. "
+            f'Read a full file with skill(name="{skill_name}", resource="references/...").'
+        )
+
+    @staticmethod
+    def _no_match_message(
+        pattern: str, skill_name: str, scope_label: str | None
+    ) -> str:
+        if scope_label:
+            return (
+                f"No matches for pattern '{pattern}' in skill '{skill_name}' "
+                f"under '{scope_label}'."
+            )
+        return f"No matches for pattern '{pattern}' in skill '{skill_name}'."

--- a/libs/core/kiln_ai/tools/skill_tool.py
+++ b/libs/core/kiln_ai/tools/skill_tool.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from kiln_ai.datamodel.skill import Skill
 from kiln_ai.datamodel.tool_id import ToolId
 from kiln_ai.tools.base_tool import (
@@ -8,6 +10,7 @@ from kiln_ai.tools.base_tool import (
 )
 
 ALLOWED_RESOURCE_PREFIXES = ("references/", "assets/")
+_RESOURCE_ROOTS = ("references", "assets")
 
 
 class SkillTool(KilnToolInterface):
@@ -15,7 +18,8 @@ class SkillTool(KilnToolInterface):
 
     Available skills and their descriptions are listed in the system prompt.
     The agent calls this tool with a skill name to retrieve its full body.
-    Optionally, the agent can request a specific resource file within the skill.
+    Optionally, the agent can request a specific resource file within the skill,
+    or list a resource directory's contents.
     """
 
     def __init__(self, tool_id: str, skills: list[Skill]):
@@ -38,7 +42,8 @@ class SkillTool(KilnToolInterface):
             "may help solve the user's task. Calling the tool with a skill name loads that skill's "
             "full instructions. If the skill references additional files "
             "relevant to the task, load them by passing a 'resource' path "
-            "(e.g. 'references/guide.md', 'references/subdir/notes.txt', or 'assets/template.csv')."
+            "(e.g. 'references/guide.md', 'references/subdir/notes.txt', or 'assets/template.csv'). "
+            "Pass a directory path ('references/', 'references/subdir', 'assets/') to list its contents with line counts."
         )
 
     async def toolcall_definition(self) -> ToolCallDefinition:
@@ -56,7 +61,7 @@ class SkillTool(KilnToolInterface):
                         },
                         "resource": {
                             "type": "string",
-                            "description": "Optional. Path to a specific resource file within the skill (e.g. 'references/guide.md', 'assets/data.csv'). If omitted, returns the skill's main instructions.",
+                            "description": "Optional. Path to a resource within the skill. A file path (e.g. 'references/guide.md', 'assets/data.csv') returns the file contents. A directory path (e.g. 'references/', 'references/subdir', 'assets/') returns a tree listing with line counts. If omitted, returns the skill's main instructions.",
                         },
                     },
                     "required": ["name"],
@@ -92,31 +97,113 @@ class SkillTool(KilnToolInterface):
         return ToolCallResult(output=body)
 
     def _load_resource(self, skill: Skill, resource: str) -> ToolCallResult:
-        """Load a resource file from an allowed subdirectory (references/ or assets/)."""
-        if not any(resource.startswith(p) for p in ALLOWED_RESOURCE_PREFIXES):
+        """Load a file or render a directory listing under references/ or assets/."""
+        root, rest = self._split_resource(resource)
+        if root not in _RESOURCE_ROOTS:
             return ToolCallResult(
                 output=f"Error: Resource path must start with one of: {', '.join(ALLOWED_RESOURCE_PREFIXES)}"
             )
 
-        parts = resource.split("/", 1)
-        if len(parts) != 2 or not parts[1]:
-            return ToolCallResult(
-                output="Error: Resource path must include a filename after the directory prefix."
-            )
-
-        prefix, relative_path = parts
+        base_dir = (
+            skill.references_dir() if root == "references" else skill.assets_dir()
+        )
 
         try:
-            if prefix == "references":
-                content = skill.read_reference(relative_path)
-            elif prefix == "assets":
-                content = skill.read_asset(relative_path)
+            base_resolved = base_dir.resolve()
+            target = (base_dir / rest).resolve() if rest else base_resolved
+            target.relative_to(base_resolved)
+        except ValueError:
+            return ToolCallResult(output="Error: Path traversal is not allowed")
+
+        if not target.exists():
+            return ToolCallResult(output=f"Error: Resource not found: {resource}")
+
+        if target.is_dir():
+            return ToolCallResult(
+                output=self._render_directory_listing(skill, root, target)
+            )
+
+        try:
+            if root == "references":
+                content = skill.read_reference(rest)
             else:
-                return ToolCallResult(
-                    output=f"Error: Unknown resource directory: {prefix}"
-                )
+                content = skill.read_asset(rest)
             return ToolCallResult(output=content)
         except FileNotFoundError:
             return ToolCallResult(output=f"Error: Resource not found: {resource}")
         except ValueError as e:
             return ToolCallResult(output=f"Error: {e}")
+
+    @staticmethod
+    def _split_resource(resource: str) -> tuple[str, str]:
+        parts = resource.split("/", 1)
+        root = parts[0]
+        rest = parts[1] if len(parts) > 1 else ""
+        return root, rest
+
+    @staticmethod
+    def _render_directory_listing(skill: Skill, root: str, dir_path: Path) -> str:
+        """Render a tree listing of dir_path with per-markdown-file line counts.
+
+        root: 'references' or 'assets'.
+        dir_path: resolved absolute path to the directory being listed.
+        """
+        base_dir = (
+            skill.references_dir() if root == "references" else skill.assets_dir()
+        ).resolve()
+        rel_dir = dir_path.relative_to(base_dir)
+        display_root = (
+            f"{root}/" if rel_dir == Path(".") else f"{root}/{rel_dir.as_posix()}/"
+        )
+
+        top_entries = sorted(
+            dir_path.iterdir(), key=lambda e: (not e.is_dir(), e.name.lower())
+        )
+        if not top_entries:
+            return f"Directory: {display_root}\n\n(empty)\nTotal: 0 files, 0 lines."
+
+        tree_lines: list[str] = []
+        totals = {"md_files": 0, "md_lines": 0}
+
+        def walk(path: Path, prefix: str) -> None:
+            entries = sorted(
+                path.iterdir(), key=lambda e: (not e.is_dir(), e.name.lower())
+            )
+            for i, entry in enumerate(entries):
+                is_last = i == len(entries) - 1
+                connector = "└── " if is_last else "├── "
+                child_prefix = prefix + ("    " if is_last else "│   ")
+                if entry.is_dir():
+                    file_count = sum(1 for p in entry.rglob("*") if p.is_file())
+                    tree_lines.append(
+                        f"{prefix}{connector}{entry.name}/ ({file_count} files)"
+                    )
+                    walk(entry, child_prefix)
+                elif entry.suffix == ".md":
+                    rel = entry.relative_to(base_dir).as_posix()
+                    try:
+                        line_count = skill.count_file_lines(root, rel)
+                        tree_lines.append(
+                            f"{prefix}{connector}{entry.name} ({line_count} lines)"
+                        )
+                        totals["md_files"] += 1
+                        totals["md_lines"] += line_count
+                    except (ValueError, OSError, UnicodeDecodeError):
+                        tree_lines.append(f"{prefix}{connector}{entry.name}")
+                else:
+                    tree_lines.append(f"{prefix}{connector}{entry.name}")
+
+        walk(dir_path, "")
+
+        output = [
+            f"Directory: {display_root}",
+            "",
+            display_root,
+            *tree_lines,
+            "",
+            f"Total: {totals['md_files']} markdown files, {totals['md_lines']} lines.",
+            "",
+            f'Tip: read a file with skill(name="{skill.name}", resource="{root}/..."). '
+            f'Search with skill_search(name="{skill.name}", pattern="...").',
+        ]
+        return "\n".join(output)

--- a/libs/core/kiln_ai/tools/test_skill_search_tool.py
+++ b/libs/core/kiln_ai/tools/test_skill_search_tool.py
@@ -1,0 +1,635 @@
+import pytest
+
+from kiln_ai.datamodel.project import Project
+from kiln_ai.datamodel.skill import Skill
+from kiln_ai.tools.skill_search_tool import (
+    DEFAULT_MAX_FILES,
+    DEFAULT_MAX_LINE_LENGTH,
+    DEFAULT_MAX_MATCHES_PER_FILE,
+    SkillSearchTool,
+    _Hunk,
+)
+
+
+def _make_saved_skill(project, name, description, body):
+    skill = Skill(name=name, description=description, parent=project)
+    skill.save_to_file()
+    skill.save_skill_md(body)
+    return skill
+
+
+def _seed_refs(skill: Skill, files: dict[str, str]) -> None:
+    """Write each {rel_path: content} under the skill's references/ dir."""
+    ref_dir = skill.references_dir()
+    ref_dir.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        path = ref_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture
+def mock_project(tmp_path):
+    project_path = tmp_path / "test_project" / "project.kiln"
+    project_path.parent.mkdir()
+    project = Project(name="Test Project", path=project_path)
+    project.save_to_file()
+    return project
+
+
+@pytest.fixture
+def sample_skill(mock_project) -> Skill:
+    return _make_saved_skill(
+        mock_project,
+        "kiln-chat",
+        "Chat skill for kiln",
+        "## kiln-chat\nMain body.",
+    )
+
+
+@pytest.fixture
+def sample_skills(mock_project) -> list[Skill]:
+    return [
+        _make_saved_skill(
+            mock_project, "kiln-chat", "Chat skill", "## kiln-chat\nbody"
+        ),
+        _make_saved_skill(mock_project, "other-skill", "Other skill", "## other\nbody"),
+    ]
+
+
+@pytest.fixture
+def search_tool(sample_skills: list[Skill]) -> SkillSearchTool:
+    return SkillSearchTool("kiln_tool::skill_search::abc", sample_skills)
+
+
+class TestSkillSearchToolDefinition:
+    async def test_name(self, search_tool: SkillSearchTool):
+        assert await search_tool.name() == "skill_search"
+
+    async def test_id(self, search_tool: SkillSearchTool):
+        assert await search_tool.id() == "kiln_tool::skill_search::abc"
+
+    async def test_description_not_empty(self, search_tool: SkillSearchTool):
+        desc = await search_tool.description()
+        assert "regex" in desc.lower()
+        assert "skill" in desc.lower()
+        assert len(desc) <= 1024
+
+    async def test_toolcall_definition_schema(self, search_tool: SkillSearchTool):
+        defn = await search_tool.toolcall_definition()
+        assert defn["type"] == "function"
+        assert defn["function"]["name"] == "skill_search"
+        params = defn["function"]["parameters"]
+        assert params["required"] == ["name", "pattern"]
+        props = params["properties"]
+        for key in (
+            "name",
+            "pattern",
+            "resource",
+            "path_prefix",
+            "context_before",
+            "context_after",
+            "context_lines",
+            "max_matches_per_file",
+            "max_files",
+            "max_line_length",
+        ):
+            assert key in props, f"missing property: {key}"
+        assert props["pattern"]["type"] == "string"
+        assert props["max_files"]["type"] == "integer"
+
+    async def test_skills_property(self, search_tool: SkillSearchTool):
+        assert {s.name for s in search_tool.skills} == {"kiln-chat", "other-skill"}
+
+
+class TestSkillSearchToolValidation:
+    async def test_missing_name(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(pattern="foo")
+        assert "Error" in result.output
+        assert "'name' parameter is required" in result.output
+
+    async def test_empty_name(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(name="", pattern="foo")
+        assert "'name' parameter is required" in result.output
+
+    async def test_unknown_skill(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(name="nonexistent", pattern="foo")
+        assert "not found" in result.output
+        assert "kiln-chat" in result.output
+        assert "other-skill" in result.output
+
+    async def test_missing_pattern(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(name="kiln-chat")
+        assert "'pattern' parameter is required" in result.output
+
+    async def test_empty_pattern(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(name="kiln-chat", pattern="")
+        assert "'pattern' parameter is required" in result.output
+
+    async def test_invalid_regex(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(name="kiln-chat", pattern="[")
+        assert "Invalid regex" in result.output
+
+    async def test_resource_and_path_prefix_mutex(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(
+            name="kiln-chat",
+            pattern="foo",
+            resource="references/a.md",
+            path_prefix="references/docs",
+        )
+        assert "either 'resource' or 'path_prefix'" in result.output
+
+    async def test_context_lines_and_context_before_mutex(
+        self, search_tool: SkillSearchTool
+    ):
+        result = await search_tool.run(
+            name="kiln-chat", pattern="foo", context_lines=2, context_before=1
+        )
+        assert "either 'context_lines' or 'context_before'" in result.output
+
+    async def test_context_lines_and_context_after_mutex(
+        self, search_tool: SkillSearchTool
+    ):
+        result = await search_tool.run(
+            name="kiln-chat", pattern="foo", context_lines=2, context_after=1
+        )
+        assert "either 'context_lines' or 'context_before'" in result.output
+
+    async def test_bad_resource_prefix(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(
+            name="kiln-chat", pattern="foo", resource="assets/data.md"
+        )
+        assert "'references/'" in result.output
+
+    async def test_bad_path_prefix(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(
+            name="kiln-chat", pattern="foo", path_prefix="assets/"
+        )
+        assert "'references/'" in result.output
+
+    async def test_resource_traversal_blocked(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"ok.md": "hello"})
+        result = await search_tool.run(
+            name="kiln-chat",
+            pattern="foo",
+            resource="references/../../etc/passwd.md",
+        )
+        assert "Path traversal" in result.output
+
+    async def test_path_prefix_traversal_blocked(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"ok.md": "hello"})
+        result = await search_tool.run(
+            name="kiln-chat",
+            pattern="foo",
+            path_prefix="references/../..",
+        )
+        assert "Path traversal" in result.output or "Error" in result.output
+
+    async def test_resource_not_markdown(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(
+            name="kiln-chat", pattern="foo", resource="references/data.json"
+        )
+        assert "Only markdown files" in result.output
+
+    async def test_resource_is_a_directory(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        ref_dir = sample_skills[0].references_dir()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        sub = ref_dir / "dir.md"
+        sub.mkdir()
+        result = await search_tool.run(
+            name="kiln-chat", pattern="foo", resource="references/dir.md"
+        )
+        assert "Error" in result.output
+
+    async def test_resource_missing_file(self, search_tool: SkillSearchTool):
+        result = await search_tool.run(
+            name="kiln-chat", pattern="foo", resource="references/missing.md"
+        )
+        assert "not found" in result.output.lower()
+
+    async def test_clamps_context_lines_high(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(
+            sample_skills[0], {"a.md": "\n".join(f"line {i}" for i in range(50))}
+        )
+        result = await search_tool.run(
+            name="kiln-chat", pattern="line 25", context_lines=999
+        )
+        # Not an error; the huge context value is clamped to 10
+        assert "Error" not in result.output.splitlines()[0]
+        assert "line 25" in result.output
+
+    async def test_clamps_context_lines_negative(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"a.md": "alpha\nbeta\ngamma\n"})
+        result = await search_tool.run(
+            name="kiln-chat", pattern="beta", context_lines=-5
+        )
+        # Negative clamps to 0 — no context lines
+        out = result.output
+        assert "  2: beta" in out
+        assert "  1- alpha" not in out
+        assert "  3- gamma" not in out
+
+
+class TestSkillSearchToolMatching:
+    async def test_zero_matches(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"a.md": "alpha\nbeta\n"})
+        result = await search_tool.run(name="kiln-chat", pattern="nonexistent")
+        assert "No matches for pattern 'nonexistent'" in result.output
+        assert "kiln-chat" in result.output
+
+    async def test_zero_matches_with_scope(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"docs/a.md": "alpha\n"})
+        result = await search_tool.run(
+            name="kiln-chat", pattern="nonexistent", path_prefix="references/docs"
+        )
+        assert "under 'references/docs'" in result.output
+
+    async def test_single_match(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"a.md": "alpha\nbeta\ngamma\n"})
+        result = await search_tool.run(name="kiln-chat", pattern="beta")
+        out = result.output
+        assert "=== references/a.md" in out
+        assert "  2: beta" in out
+        assert "Found 1 files" in out
+
+    async def test_multi_match_ordering_within_file(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(
+            sample_skills[0],
+            {"a.md": "alpha\nbeta\ngamma\nbeta again\n"},
+        )
+        result = await search_tool.run(name="kiln-chat", pattern="beta")
+        out = result.output
+        assert out.index("  2: beta") < out.index("  4: beta again")
+
+    async def test_ordering_across_files(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(
+            sample_skills[0],
+            {
+                "z_last.md": "match here\n",
+                "a_first.md": "match here\n",
+                "m_middle.md": "match here\n",
+            },
+        )
+        result = await search_tool.run(name="kiln-chat", pattern="match")
+        out = result.output
+        assert (
+            out.index("a_first.md") < out.index("m_middle.md") < out.index("z_last.md")
+        )
+
+    async def test_case_insensitive(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"a.md": "Hello World\n"})
+        result = await search_tool.run(name="kiln-chat", pattern="hello")
+        assert "Hello World" in result.output
+
+    async def test_regex_character_class(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"a.md": "cat\ndog\nbird\n"})
+        result = await search_tool.run(name="kiln-chat", pattern=r"^(cat|dog)$")
+        out = result.output
+        assert "  1: cat" in out
+        assert "  2: dog" in out
+        assert "  3: bird" not in out
+
+    async def test_resource_scoped_search(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(
+            sample_skills[0],
+            {"a.md": "match in a\n", "b.md": "match in b\n"},
+        )
+        result = await search_tool.run(
+            name="kiln-chat", pattern="match", resource="references/a.md"
+        )
+        out = result.output
+        assert "references/a.md" in out
+        assert "b.md" not in out
+        assert "Found 1 files" in out
+
+    async def test_path_prefix_scoped_search(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(
+            sample_skills[0],
+            {
+                "docs/a.md": "match in docs\n",
+                "knowledge/b.md": "match in knowledge\n",
+            },
+        )
+        result = await search_tool.run(
+            name="kiln-chat", pattern="match", path_prefix="references/docs"
+        )
+        out = result.output
+        assert "docs/a.md" in out
+        assert "knowledge/b.md" not in out
+
+    async def test_whole_tree_default(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(
+            sample_skills[0],
+            {"docs/a.md": "match\n", "knowledge/b.md": "match\n"},
+        )
+        result = await search_tool.run(name="kiln-chat", pattern="match")
+        out = result.output
+        assert "docs/a.md" in out
+        assert "knowledge/b.md" in out
+
+
+class TestSkillSearchToolOutput:
+    async def test_header_includes_path_and_total_lines(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"a.md": "line1\nmatchme\nline3\nline4\n"})
+        result = await search_tool.run(name="kiln-chat", pattern="matchme")
+        assert "=== references/a.md (4 lines) ===" in result.output
+
+    async def test_frontmatter_surfaces_name_and_description(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        content = "---\nname: my-ref\ndescription: A short note.\n---\n\nhello world\n"
+        _seed_refs(sample_skills[0], {"a.md": content})
+        result = await search_tool.run(name="kiln-chat", pattern="hello")
+        out = result.output
+        assert "name: my-ref" in out
+        assert "description: A short note." in out
+
+    async def test_frontmatter_block_scalar_flattened(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        content = (
+            "---\n"
+            "name: doc\n"
+            "description: |\n"
+            "  This is a long\n"
+            "  description that\n"
+            "  spans multiple lines.\n"
+            "---\n\n"
+            "hello\n"
+        )
+        _seed_refs(sample_skills[0], {"a.md": content})
+        result = await search_tool.run(name="kiln-chat", pattern="hello")
+        out = result.output
+        assert (
+            "description: This is a long description that spans multiple lines." in out
+        )
+
+    async def test_h1_fallback_when_no_frontmatter(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        content = "# Big Title\n\nsome body\nmatchme here\n"
+        _seed_refs(sample_skills[0], {"a.md": content})
+        result = await search_tool.run(name="kiln-chat", pattern="matchme")
+        out = result.output
+        assert "# Big Title" in out
+        assert "name:" not in out
+        assert "description:" not in out
+
+    async def test_no_metadata_line_when_neither(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        content = "plain text\nmatchme\n"
+        _seed_refs(sample_skills[0], {"a.md": content})
+        result = await search_tool.run(name="kiln-chat", pattern="matchme")
+        out = result.output
+        # header then directly the hunk lines, no name:/description:/# line between
+        header_idx = out.index("=== references/a.md")
+        match_idx = out.index("  2: matchme")
+        between = out[header_idx:match_idx]
+        assert "name:" not in between
+        assert "description:" not in between
+        assert "# " not in between
+
+    async def test_match_line_uses_colon_separator(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"a.md": "match\n"})
+        result = await search_tool.run(name="kiln-chat", pattern="match")
+        assert "  1: match" in result.output
+
+    async def test_context_line_uses_dash_separator(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"a.md": "line1\nmatch\nline3\n"})
+        result = await search_tool.run(
+            name="kiln-chat", pattern="match", context_lines=1
+        )
+        out = result.output
+        assert "  1- line1" in out
+        assert "  2: match" in out
+        assert "  3- line3" in out
+
+    async def test_hunks_separated_by_blank_line(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        body = "\n".join(f"line {i}" for i in range(20)) + "\nmatch A\n"
+        body2 = body + "\n".join(f"mid {i}" for i in range(20)) + "\nmatch B\n"
+        _seed_refs(sample_skills[0], {"a.md": body2})
+        result = await search_tool.run(
+            name="kiln-chat", pattern="match", context_lines=0
+        )
+        out = result.output
+        lines = out.splitlines()
+        match_a_idx = next(i for i, ln in enumerate(lines) if "match A" in ln)
+        match_b_idx = next(i for i, ln in enumerate(lines) if "match B" in ln)
+        # there must be at least one blank line between the two hunks
+        assert "" in lines[match_a_idx + 1 : match_b_idx]
+
+    async def test_max_matches_per_file_truncation(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        body = "\n".join("match" for _ in range(15)) + "\n"
+        _seed_refs(sample_skills[0], {"a.md": body})
+        result = await search_tool.run(
+            name="kiln-chat", pattern="match", max_matches_per_file=5
+        )
+        out = result.output
+        assert "truncated: 10 more matches in this file" in out
+
+    async def test_max_files_truncation_in_footer(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        files = {f"f{i:02d}.md": "match\n" for i in range(5)}
+        _seed_refs(sample_skills[0], files)
+        result = await search_tool.run(name="kiln-chat", pattern="match", max_files=3)
+        out = result.output
+        assert "Found 3 files (+2 more truncated)" in out
+
+    async def test_long_line_truncated_with_ellipsis(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        long_line = "x" * 500 + " match " + "y" * 200 + "\n"
+        _seed_refs(sample_skills[0], {"a.md": long_line})
+        result = await search_tool.run(
+            name="kiln-chat", pattern="match", max_line_length=60
+        )
+        out = result.output
+        assert "…" in out
+        # Find the rendered match line (starts with "  1: ")
+        rendered = next(ln for ln in out.splitlines() if ln.startswith("  1: "))
+        body = rendered[len("  1: ") :]
+        assert len(body) == 60
+
+    async def test_footer_includes_skill_name_and_tip(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        _seed_refs(sample_skills[0], {"a.md": "match\n"})
+        result = await search_tool.run(name="kiln-chat", pattern="match")
+        out = result.output
+        assert 'skill(name="kiln-chat"' in out
+        assert 'resource="references/..."' in out
+
+
+class TestSkillSearchToolMergedHunks:
+    def test_overlapping_windows_merge(self):
+        hunks = SkillSearchTool._merge_hunks([5, 7], before=2, after=2, total=100)
+        assert len(hunks) == 1
+        assert hunks[0].start == 3
+        assert hunks[0].end == 9
+        assert hunks[0].match_lines == {5, 7}
+
+    def test_non_overlapping_windows_stay_separate(self):
+        hunks = SkillSearchTool._merge_hunks([5, 50], before=2, after=2, total=100)
+        assert len(hunks) == 2
+        assert hunks[0].match_lines == {5}
+        assert hunks[1].match_lines == {50}
+
+    def test_adjacent_windows_merge(self):
+        # match at 5 with after=2 ends at 7; match at 8 with before=2 starts at 6.
+        # 6 <= 7 + 1 → merge.
+        hunks = SkillSearchTool._merge_hunks([5, 8], before=2, after=2, total=100)
+        assert len(hunks) == 1
+        assert hunks[0].match_lines == {5, 8}
+
+    def test_touching_windows_merge(self):
+        # match at 5 ends at 5 (after=0); match at 6 starts at 6; 6 <= 5+1 → merge.
+        hunks = SkillSearchTool._merge_hunks([5, 6], before=0, after=0, total=100)
+        assert len(hunks) == 1
+        assert hunks[0].start == 5
+        assert hunks[0].end == 6
+
+    def test_match_at_line_0_with_before_context(self):
+        hunks = SkillSearchTool._merge_hunks([0], before=3, after=0, total=10)
+        assert len(hunks) == 1
+        assert hunks[0].start == 0
+        assert hunks[0].end == 0
+
+    def test_match_at_last_line_with_after_context(self):
+        hunks = SkillSearchTool._merge_hunks([9], before=0, after=3, total=10)
+        assert len(hunks) == 1
+        assert hunks[0].start == 9
+        assert hunks[0].end == 9
+
+    def test_empty_matches_returns_empty(self):
+        assert SkillSearchTool._merge_hunks([], 1, 1, 10) == []
+
+    def test_hunk_dataclass_default(self):
+        h = _Hunk(start=0, end=1)
+        assert h.match_lines == set()
+
+
+class TestSkillSearchToolFileHandling:
+    async def test_invalid_utf8_file_is_skipped(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        ref_dir = sample_skills[0].references_dir()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        (ref_dir / "bad.md").write_bytes(b"\xff\xfe\xfdnot utf8\n")
+        (ref_dir / "good.md").write_text("match here\n", encoding="utf-8")
+        result = await search_tool.run(name="kiln-chat", pattern="match")
+        out = result.output
+        assert "good.md" in out
+        assert "bad.md" not in out
+
+    async def test_empty_frontmatter_does_not_error(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        content = "---\n---\n\nmatch me\n"
+        _seed_refs(sample_skills[0], {"a.md": content})
+        result = await search_tool.run(name="kiln-chat", pattern="match")
+        assert "match me" in result.output
+        # no name:/description: emitted
+        out = result.output
+        assert "name:" not in out.split("=== references/a.md")[1].split("match me")[0]
+
+    async def test_missing_name_in_frontmatter(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        content = "---\ndescription: Only description.\n---\n\nmatch here\n"
+        _seed_refs(sample_skills[0], {"a.md": content})
+        result = await search_tool.run(name="kiln-chat", pattern="match")
+        out = result.output
+        assert "description: Only description." in out
+        assert (
+            "name:" not in out.split("description:")[0].split("=== references/a.md")[1]
+        )
+
+    async def test_malformed_yaml_frontmatter_falls_back(
+        self, search_tool: SkillSearchTool, sample_skills: list[Skill]
+    ):
+        content = "---\nname: [unclosed\n---\n\n# A Title\n\nmatch here\n"
+        _seed_refs(sample_skills[0], {"a.md": content})
+        result = await search_tool.run(name="kiln-chat", pattern="match")
+        out = result.output
+        # Frontmatter invalid → parsed as empty → H1 fallback kicks in
+        assert "# A Title" in out
+
+
+class TestSkillSearchToolDefaults:
+    def test_default_exposed_constants(self):
+        assert DEFAULT_MAX_MATCHES_PER_FILE == 10
+        assert DEFAULT_MAX_FILES == 20
+        assert DEFAULT_MAX_LINE_LENGTH == 240
+
+    def test_resolve_int_clamp(self):
+        assert SkillSearchTool._resolve_int(999, default=5, clamp_range=(0, 10)) == 10
+        assert SkillSearchTool._resolve_int(-5, default=5, clamp_range=(0, 10)) == 0
+        assert SkillSearchTool._resolve_int(None, default=5, clamp_range=(0, 10)) == 5
+        assert SkillSearchTool._resolve_int("abc", default=5, clamp_range=(0, 10)) == 5
+        assert SkillSearchTool._resolve_int(7, default=5, clamp_range=(0, 10)) == 7
+
+
+class TestSkillSearchToolFrontmatter:
+    def test_parse_frontmatter_returns_empty_when_no_block(self):
+        assert SkillSearchTool._parse_frontmatter("hello\nworld\n") == {}
+
+    def test_parse_frontmatter_valid_block(self):
+        text = "---\nname: foo\ndescription: bar\n---\n\nbody\n"
+        result = SkillSearchTool._parse_frontmatter(text)
+        assert result == {"name": "foo", "description": "bar"}
+
+    def test_parse_frontmatter_flattens_whitespace(self):
+        text = "---\ndescription: |\n  line1\n  line2\n---\n\nbody\n"
+        result = SkillSearchTool._parse_frontmatter(text)
+        assert result == {"description": "line1 line2"}
+
+    def test_parse_frontmatter_unclosed_returns_empty(self):
+        text = "---\nname: foo\n\nbody\n"
+        assert SkillSearchTool._parse_frontmatter(text) == {}
+
+    def test_parse_frontmatter_ignores_extra_fields(self):
+        text = "---\nname: foo\nother: baz\n---\n\nbody\n"
+        result = SkillSearchTool._parse_frontmatter(text)
+        assert result == {"name": "foo"}

--- a/libs/core/kiln_ai/tools/test_skill_tool.py
+++ b/libs/core/kiln_ai/tools/test_skill_tool.py
@@ -201,10 +201,6 @@ class TestSkillToolResource:
         assert "Error" in result.output
         assert "not found" in result.output.lower()
 
-    async def test_no_filename_after_prefix(self, skill_tool: SkillTool):
-        result = await skill_tool.run(name="code-review", resource="references/")
-        assert "Error" in result.output
-
     async def test_without_resource_returns_body(self, skill_tool: SkillTool):
         result = await skill_tool.run(name="code-review")
         assert result.output == "## Code Review\nCheck for bugs."
@@ -220,6 +216,132 @@ class TestSkillToolResource:
         )
         assert "Error" in result.output
         assert "not a readable text file" in result.output
+
+
+class TestSkillToolDirectoryListing:
+    def _seed_refs(self, skill: Skill) -> None:
+        ref_dir = skill.references_dir()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        (ref_dir / "guide.md").write_text("# Guide\nline2\nline3\n", encoding="utf-8")
+        (ref_dir / "notes.txt").write_text("plain text", encoding="utf-8")
+        sub = ref_dir / "knowledge"
+        sub.mkdir()
+        (sub / "rag.md").write_text("# RAG\nbody\n", encoding="utf-8")
+        (sub / "tools.md").write_text("# Tools\na\nb\nc\n", encoding="utf-8")
+
+    async def test_references_with_trailing_slash_returns_listing(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        self._seed_refs(sample_skills[0])
+        result = await skill_tool.run(name="code-review", resource="references/")
+        out = result.output
+        assert out.startswith("Directory: references/")
+        assert "references/\n" in out
+        assert "guide.md (3 lines)" in out
+        assert "notes.txt" in out
+        assert "knowledge/ (2 files)" in out
+        assert "rag.md (2 lines)" in out
+        assert "tools.md (4 lines)" in out
+        assert "Total: 3 markdown files, 9 lines." in out
+        assert "Tip: read a file with skill(" in out
+        assert 'skill_search(name="code-review"' in out
+
+    async def test_references_no_slash_returns_listing(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        self._seed_refs(sample_skills[0])
+        result = await skill_tool.run(name="code-review", resource="references")
+        assert "Directory: references/" in result.output
+        assert "guide.md (3 lines)" in result.output
+
+    async def test_subdirectory_listing(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        self._seed_refs(sample_skills[0])
+        result = await skill_tool.run(
+            name="code-review", resource="references/knowledge"
+        )
+        out = result.output
+        assert out.startswith("Directory: references/knowledge/")
+        assert "rag.md (2 lines)" in out
+        assert "tools.md (4 lines)" in out
+        assert "guide.md" not in out  # top-level file excluded
+        assert "Total: 2 markdown files, 6 lines." in out
+
+    async def test_subdirectory_listing_trailing_slash(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        self._seed_refs(sample_skills[0])
+        result = await skill_tool.run(
+            name="code-review", resource="references/knowledge/"
+        )
+        assert "Directory: references/knowledge/" in result.output
+
+    async def test_empty_directory_returns_empty_marker(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        result = await skill_tool.run(name="code-review", resource="references/")
+        out = result.output
+        assert out == ("Directory: references/\n\n(empty)\nTotal: 0 files, 0 lines.")
+
+    async def test_non_markdown_files_have_no_line_count(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        ref_dir = sample_skills[0].references_dir()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        (ref_dir / "data.json").write_text('{"k": 1}', encoding="utf-8")
+        result = await skill_tool.run(name="code-review", resource="references/")
+        out = result.output
+        assert "data.json" in out
+        assert "data.json (" not in out  # no annotation for non-md
+        assert "Total: 0 markdown files, 0 lines." in out
+
+    async def test_assets_listing(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        assets_dir = sample_skills[0].assets_dir()
+        assets_dir.mkdir(parents=True, exist_ok=True)
+        (assets_dir / "prices.csv").write_text(
+            "item,price\nwidget,9.99", encoding="utf-8"
+        )
+        result = await skill_tool.run(name="code-review", resource="assets/")
+        out = result.output
+        assert out.startswith("Directory: assets/")
+        assert "prices.csv" in out
+        assert "Tip: read a file with skill(" in out
+
+    async def test_single_file_read_still_works(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        ref_dir = sample_skills[0].references_dir()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        (ref_dir / "guide.md").write_text(
+            "# Guide\nReference content.", encoding="utf-8"
+        )
+        result = await skill_tool.run(
+            name="code-review", resource="references/guide.md"
+        )
+        assert result.output == "# Guide\nReference content."
+
+    async def test_path_traversal_on_directory_blocked(self, skill_tool: SkillTool):
+        result = await skill_tool.run(name="code-review", resource="references/..")
+        assert "Error" in result.output
+        assert "Path traversal" in result.output
+
+    async def test_nested_directory_count_is_recursive(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        ref_dir = sample_skills[0].references_dir()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        nested = ref_dir / "outer" / "inner"
+        nested.mkdir(parents=True)
+        (nested / "deep.md").write_text("one\ntwo\n", encoding="utf-8")
+        (ref_dir / "outer" / "sibling.md").write_text("a\n", encoding="utf-8")
+        result = await skill_tool.run(name="code-review", resource="references/")
+        out = result.output
+        assert "outer/ (2 files)" in out
+        assert "inner/ (1 files)" in out
+        assert "Total: 2 markdown files, 3 lines." in out
 
 
 class TestSkillToolId:


### PR DESCRIPTION
## What does this PR do?

WIP prototype for letting agent regex through Skill reference files.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
