### PR TITLE
fix: not cut stream when opening history dialog

### DIFF
--- a/app/web_ui/src/routes/(app)/chat/chat.svelte
+++ b/app/web_ui/src/routes/(app)/chat/chat.svelte
@@ -456,11 +456,7 @@
   <div
     class="flex flex-col flex-1 min-h-0 overflow-hidden w-full md:max-w-3xl mx-auto px-1"
   >
-    <ChatHistory
-      bind:this={chatHistory}
-      onBeforeOpen={stop}
-      on:apply={onChatHistoryApply}
-    />
+    <ChatHistory bind:this={chatHistory} on:apply={onChatHistoryApply} />
     <div
       bind:this={messagesContainer}
       class="chat-messages-scroll flex-1 min-h-0 flex flex-col gap-4 overflow-y-auto overflow-x-hidden"

--- a/app/web_ui/src/routes/(app)/chat/chat_history.svelte
+++ b/app/web_ui/src/routes/(app)/chat/chat_history.svelte
@@ -11,9 +11,6 @@
   import ChatIcon from "$lib/ui/icons/chat_icon.svelte"
   import TableActionMenu from "$lib/ui/table_action_menu.svelte"
 
-  /** Called before the modal opens (e.g. abort in-flight stream). */
-  export let onBeforeOpen: (() => void) | undefined = undefined
-
   const dispatch = createEventDispatcher<{
     apply: LoadedChatSessionDetail
   }>()
@@ -51,7 +48,6 @@
   }
 
   export function open() {
-    onBeforeOpen?.()
     historyDialog?.show()
     void loadSessionList()
   }


### PR DESCRIPTION
## What does this PR do?

While on the chat and the stream currently ongoing, clicking the `History` button opens the history dialog and terminates the stream.

Changes:
- fix: not cut the stream when opening history dialog; the stream gets cut off anyway if the user restores a past session from the dialog

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Simplified chat history opening interaction by removing pre-open event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->