### PR TITLE
spec_id reactivity - re-load page when changes

### DIFF
--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
@@ -68,7 +68,7 @@
   let statusField: EditableStatusField | null = null
 
   let eval_progress: EvalProgress | null = null
-  let eval_progress_loading = true
+  let eval_progress_loading = false
   let eval_progress_error: KilnError | null = null
 
   let evaluator: Eval | null = null
@@ -203,6 +203,22 @@
     task = null
     score_summary = null
     eval_progress = null
+    current_tags = []
+    eval_state = "not_started"
+
+    spec_error = null
+    tags_error = null
+    eval_error = null
+    task_error = null
+    run_configs_error = null
+    score_summary_error = null
+    eval_progress_error = null
+
+    spec_loading = true
+    eval_loading = false
+    task_loading = false
+    run_configs_loading = false
+    eval_progress_loading = false
   }
   async function reload_all() {
     reset_spec_state()

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
@@ -2,7 +2,7 @@
   import PropertyList from "$lib/ui/property_list.svelte"
   import AppPage from "../../../../app_page.svelte"
   import { page } from "$app/stores"
-  import { onMount, tick } from "svelte"
+  import { tick } from "svelte"
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
   import EditablePriorityField from "../editable_priority_field.svelte"
   import EditableStatusField from "../editable_status_field.svelte"
@@ -197,10 +197,23 @@
   $: has_default_eval_config = evaluator && evaluator.current_config_id
   $: should_show_compare_table = has_eval && has_default_eval_config
 
-  onMount(async () => {
+  let load_token = 0
+  function reset_spec_state() {
+    spec = null
+    evaluator = null
+    task = null
+    score_summary = null
+    eval_progress = null
+  }
+  async function reload_all() {
+    const my_token = ++load_token
+    reset_spec_state()
+
     await tick()
+    if (my_token !== load_token) return
     load_model_info()
     await load_spec()
+    if (my_token !== load_token) return
     if (spec?.eval_id) {
       await Promise.all([
         load_eval_data(),
@@ -208,11 +221,16 @@
         load_run_configs_data(),
         get_eval_progress(),
       ])
+      if (my_token !== load_token) return
       if (evaluator?.current_config_id) {
         await load_score_summary()
       }
     }
-  })
+  }
+
+  $: if (project_id && task_id && spec_id) {
+    reload_all()
+  }
 
   async function load_spec() {
     try {

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
@@ -197,7 +197,6 @@
   $: has_default_eval_config = evaluator && evaluator.current_config_id
   $: should_show_compare_table = has_eval && has_default_eval_config
 
-  let load_token = 0
   function reset_spec_state() {
     spec = null
     evaluator = null
@@ -206,14 +205,10 @@
     eval_progress = null
   }
   async function reload_all() {
-    const my_token = ++load_token
     reset_spec_state()
-
     await tick()
-    if (my_token !== load_token) return
     load_model_info()
     await load_spec()
-    if (my_token !== load_token) return
     if (spec?.eval_id) {
       await Promise.all([
         load_eval_data(),
@@ -221,7 +216,6 @@
         load_run_configs_data(),
         get_eval_progress(),
       ])
-      if (my_token !== load_token) return
       if (evaluator?.current_config_id) {
         await load_score_summary()
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved data loading for specification pages so state is fully reset and refreshed when navigating between specs, ensuring consistent, up-to-date displays.
* **Bug Fix**
  * Adjusted initial loading behavior so progress indicators do not show incorrectly before evaluation progress is fetched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->