### PR TITLE
refactor: expose preload method on endpoint policy lookup

### DIFF
--- a/libs/server/kiln_server/utils/agent_checks/policy_lookup.py
+++ b/libs/server/kiln_server/utils/agent_checks/policy_lookup.py
@@ -13,7 +13,7 @@ class AgentPolicyLookup:
         self._annotations_dir = Path(annotations_dir)
         self._cache: dict[tuple[str, str], AgentPolicy] | None = None
 
-    def _load(self) -> None:
+    def preload(self) -> None:
         if not self._annotations_dir.is_dir():
             raise FileNotFoundError(
                 f"Annotations directory not found: {self._annotations_dir}"
@@ -28,9 +28,12 @@ class AgentPolicyLookup:
             if policy_data is not None:
                 self._cache[(method, path)] = AgentPolicy(**policy_data)
 
+    def _load(self) -> None:
+        self.preload()
+
     def get_policy(self, method: str, path: str) -> AgentPolicy:
         if self._cache is None:
-            self._load()
+            self.preload()
         assert self._cache is not None
         key = (method.lower(), path)
         if key not in self._cache:

--- a/libs/server/kiln_server/utils/agent_checks/policy_lookup.py
+++ b/libs/server/kiln_server/utils/agent_checks/policy_lookup.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from pathlib import Path
 
 from kiln_server.utils.agent_checks.policy import AgentPolicy
@@ -36,6 +37,7 @@ class AgentPolicyLookup:
             stacklevel=2,
         )
         self.preload()
+
     def get_policy(self, method: str, path: str) -> AgentPolicy:
         if self._cache is None:
             self.preload()

--- a/libs/server/kiln_server/utils/agent_checks/policy_lookup.py
+++ b/libs/server/kiln_server/utils/agent_checks/policy_lookup.py
@@ -29,8 +29,13 @@ class AgentPolicyLookup:
                 self._cache[(method, path)] = AgentPolicy(**policy_data)
 
     def _load(self) -> None:
+        warnings.warn(
+            "_load is deprecated and will be removed in a future version. "
+            "Please use preload() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.preload()
-
     def get_policy(self, method: str, path: str) -> AgentPolicy:
         if self._cache is None:
             self.preload()

--- a/libs/server/kiln_server/utils/agent_checks/test_policy_lookup.py
+++ b/libs/server/kiln_server/utils/agent_checks/test_policy_lookup.py
@@ -69,6 +69,24 @@ class TestGetPolicy:
         lookup.get_policy("get", "/api/projects")
         assert lookup._cache is not None
 
+    def test_preload_populates_cache(self, annotations_dir: Path) -> None:
+        _write_annotation(
+            annotations_dir,
+            "get",
+            "/api/projects",
+            {"permission": "allow", "requires_approval": False},
+        )
+        lookup = AgentPolicyLookup(annotations_dir)
+        assert lookup._cache is None
+        lookup.preload()
+        assert lookup._cache is not None
+        assert ("get", "/api/projects") in lookup._cache
+
+    def test_preload_missing_dir_raises(self, tmp_path: Path) -> None:
+        lookup = AgentPolicyLookup(tmp_path / "nonexistent")
+        with pytest.raises(FileNotFoundError, match="Annotations directory not found"):
+            lookup.preload()
+
     @pytest.mark.parametrize("method_input", ["GET", "Get", "get"])
     def test_method_case_insensitivity(
         self, annotations_dir: Path, method_input: str


### PR DESCRIPTION
## What does this PR do?

Endpoint policy lookup does file reads from filesystem; we have a `_load` method to populate the cache, but we should let the caller decide when to load this (instead of having to call the private `_load` or a fake endpoint just to trigger cache preload).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added an explicit policy-cache preload option and deprecated the older lazy loader with a deprecation warning, giving clearer control over when policy data is initialized and surfaced.

* **Tests**
  * Added tests verifying the preload behavior populates the policy cache correctly and that clear errors are raised when expected configuration directories are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->