### PR TITLE
fix: race on slow rating response causing repair UI to hide on response

### DIFF
--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -250,8 +250,23 @@
       },
     )
   }
-  // Load ratings anytime the run or rating requirements change
-  $: load_server_ratings(run, rating_requirements)
+  // Seed the ratings from the server run on navigation (new run.id), and once
+  // more when the task's rating options finish loading so requirement_ratings
+  // can be populated - we should not re-load on every Run mutation because if a
+  // PATCH is slow (as is the case for git-sync projects), it would reset the
+  // user's in progress input (e.g. Repair UI)
+  let seeded_ratings_for_run_id: string | null = null
+  let seeded_ratings_with_options = false
+  $: {
+    const options_loaded = !!$current_task_rating_options
+    const on_new_run = !!run?.id && run.id !== seeded_ratings_for_run_id
+    const options_just_loaded = options_loaded && !seeded_ratings_with_options
+    if (run?.id && (on_new_run || options_just_loaded)) {
+      load_server_ratings(run, rating_requirements)
+      seeded_ratings_for_run_id = run.id
+      seeded_ratings_with_options = options_loaded
+    }
+  }
 
   async function patch_run(
     patch_body: Record<string, unknown>,


### PR DESCRIPTION
## What does this PR do?

On git-sync projects, rating a TaskRun is quite slow - ~2s. If you rate it 1 star for example, it will cause the Repair UI to show; but it gets reset (hidden) when the response to the rating request comes in. 

Changes:
- fix: only seed ratings once (not on every mutation, otherwise the response causes a reset)

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized server ratings loading to prevent redundant refresh operations, enhancing app responsiveness during runtime interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->