### PR TITLE
fix: Run not found flashing on arrow nav between runs

### DIFF
--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
@@ -407,6 +407,7 @@
     load_error = null
     run_id = new_run_id
     run = null
+    loading = true
     goto(`/dataset/${project_id}/${task_id}/${run_id}/run`, {
       state: { list_page: list_page },
     })

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
@@ -353,20 +353,25 @@
   })
 
   async function load_run() {
+    // Snapshot run_id so we can detect if it changes during the await
+    // (e.g. user hits arrow again) and discard this stale response.
+    const requested_run_id = run_id
     try {
       const { data, error } = await client.GET(
         "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}",
         {
           params: {
-            path: { project_id, task_id, run_id: run_id },
+            path: { project_id, task_id, run_id: requested_run_id },
           },
         },
       )
+      if (requested_run_id !== run_id) return
       if (error) {
         throw error
       }
       run = data
     } catch (error) {
+      if (requested_run_id !== run_id) return
       if (error instanceof Error && error.message.includes("Load failed")) {
         load_error = new KilnError(
           "Could not load run. It may belong to a project you don't have access to.",
@@ -376,7 +381,9 @@
         load_error = createKilnError(error)
       }
     } finally {
-      loading = false
+      if (requested_run_id === run_id) {
+        loading = false
+      }
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

The UI currently shows `Run not found` when navigating through TaskRuns in the dataset using the arrow buttons in the top right of the page.

Changes:
- fix: reset loading on every task run nav

Bug:
https://github.com/user-attachments/assets/d8622cd8-67d2-4f5c-b8ad-adef11880b03

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading state during dataset run navigation: the spinner now reliably appears when switching runs, and outdated responses are ignored so stale data or errors no longer overwrite the current run view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->