### PR TITLE
fix: git middleware breaks SSE disconnect handling

### DIFF
--- a/app/desktop/git_sync/middleware.py
+++ b/app/desktop/git_sync/middleware.py
@@ -10,6 +10,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import Match
+from starlette.types import Receive, Scope, Send
 
 from app.desktop.git_sync.config import get_git_sync_config, project_path_from_id
 from app.desktop.git_sync.errors import (
@@ -70,6 +71,65 @@ class GitSyncMiddleware(BaseHTTPMiddleware):
     For non-mutating requests and non-auto-sync routes,
     passes through without buffering (preserves streaming responses).
     """
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:  # type: ignore[override]
+        # BaseHTTPMiddleware wraps the request receive channel in its own anyio
+        # task group, which breaks disconnect propagation to StreamingResponse
+        # endpoints: the task-group-owned receive never delivers http.disconnect
+        # to the downstream generator, so SSE jobs (evals, extractions) can't
+        # detect a browser hard-refresh and keep running. For self-managed
+        # (@no_write_lock) endpoints we bypass BaseHTTPMiddleware entirely and
+        # hand the real ASGI receive/send to the endpoint.
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope)
+        endpoint = self._resolve_endpoint(request)
+        if endpoint is not None and getattr(endpoint, "_git_sync_no_write_lock", False):
+            await self._handle_self_managed(scope, receive, send, request)
+            return
+
+        await super().__call__(scope, receive, send)
+
+    async def _handle_self_managed(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        request: Request,
+    ) -> None:
+        """Pure-ASGI pass-through for @no_write_lock endpoints.
+
+        Mirrors the self-managed branch of dispatch() without going through
+        BaseHTTPMiddleware. Each self-managed endpoint builds its own
+        save_context per write inside its worker loop.
+        """
+        manager = self._get_manager_for_request(request)
+        if manager is None:
+            await self.app(scope, receive, send)
+            return
+
+        try:
+            await manager.ensure_fresh_for_read()
+        except GitSyncError as e:
+            status, message = self._map_error(e)
+            response = Response(
+                content=json.dumps({"detail": message}, ensure_ascii=False),
+                status_code=status,
+                media_type="application/json",
+            )
+            await response(scope, receive, send)
+            return
+
+        self._notify_background_sync(manager)
+        # Attach the manager via scope["state"] so build_save_context(request)
+        # can find it via request.state.git_sync_manager.
+        if "state" not in scope:
+            scope["state"] = {}
+        scope["state"]["git_sync_manager"] = manager
+
+        await self.app(scope, receive, send)
 
     async def dispatch(self, request: Request, call_next):  # type: ignore[override]
         manager = self._get_manager_for_request(request)

--- a/app/desktop/git_sync/test_middleware.py
+++ b/app/desktop/git_sync/test_middleware.py
@@ -945,3 +945,130 @@ def test_unresolved_endpoint_no_warning_in_prod_mode(git_repos, monkeypatch, cap
         if r.levelno == logging.WARNING and "could not resolve endpoint" in r.message
     ]
     assert len(warning_records) == 0
+
+
+# --- @no_write_lock pure-ASGI bypass ---
+
+
+def test_no_write_lock_bypasses_base_http_middleware_dispatch(git_repos, monkeypatch):
+    """@no_write_lock endpoints must skip BaseHTTPMiddleware.dispatch() so SSE
+    streams see the real ASGI receive/send and disconnects propagate.
+    """
+    local_path, _ = git_repos
+    config = _auto_config(str(local_path))
+
+    @no_write_lock
+    def bypass_endpoint():
+        return {"ok": True}
+
+    app = _build_app(get_endpoint=bypass_endpoint)
+
+    dispatch_called = False
+    original_dispatch = GitSyncMiddleware.dispatch
+
+    async def tracking_dispatch(self, request, call_next):
+        nonlocal dispatch_called
+        dispatch_called = True
+        return await original_dispatch(self, request, call_next)
+
+    monkeypatch.setattr(GitSyncMiddleware, "dispatch", tracking_dispatch)
+
+    with mock_git_sync_config(config):
+        client = TestClient(app)
+        resp = client.get(f"/api/projects/{PROJECT_ID}/items")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert dispatch_called is False, (
+        "dispatch() should not be called for @no_write_lock endpoints — "
+        "bypass must route around BaseHTTPMiddleware to preserve SSE disconnect "
+        "propagation."
+    )
+
+
+def test_no_write_lock_bypass_still_attaches_manager_to_state(git_repos):
+    """The bypass path must still attach the git sync manager to request.state
+    so build_save_context(request) can find it inside the endpoint.
+    """
+    local_path, _ = git_repos
+    config = _auto_config(str(local_path))
+
+    captured_manager = {}
+
+    @no_write_lock
+    def endpoint(request: FastAPIRequest):
+        captured_manager["value"] = getattr(
+            request.state, "git_sync_manager", "MISSING"
+        )
+        return {"ok": True}
+
+    app = _build_app(get_endpoint=endpoint)
+
+    with mock_git_sync_config(config):
+        client = TestClient(app)
+        resp = client.get(f"/api/projects/{PROJECT_ID}/items")
+
+    assert resp.status_code == 200
+    assert captured_manager["value"] != "MISSING"
+    assert captured_manager["value"] is not None
+
+
+@pytest.mark.asyncio
+async def test_no_write_lock_bypass_delivers_http_disconnect_to_endpoint(git_repos):
+    """The bypass must hand the real ASGI receive to the endpoint, so
+    http.disconnect messages reach the endpoint's receive channel directly.
+    Under the old BaseHTTPMiddleware path, the middleware's wrapped receive
+    masked disconnects, so the endpoint never saw them.
+    """
+    local_path, _ = git_repos
+    config = _auto_config(str(local_path))
+
+    observed = {"messages": []}
+
+    @no_write_lock
+    async def endpoint(request: FastAPIRequest):
+        # Consume the ASGI receive channel directly to prove the endpoint
+        # gets the real receive under the bypass.
+        for _ in range(2):
+            msg = await request.receive()
+            observed["messages"].append(msg["type"])
+            if msg["type"] == "http.disconnect":
+                break
+        return {"ok": True}
+
+    app = _build_app(get_endpoint=endpoint)
+
+    sent_request_once = {"done": False}
+
+    async def receive():
+        if not sent_request_once["done"]:
+            sent_request_once["done"] = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        return {"type": "http.disconnect"}
+
+    sent: list[dict] = []
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": f"/api/projects/{PROJECT_ID}/items",
+        "raw_path": f"/api/projects/{PROJECT_ID}/items".encode(),
+        "query_string": b"",
+        "headers": [],
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+        "http_version": "1.1",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("testclient", 12345),
+        "app": app,
+    }
+
+    with mock_git_sync_config(config):
+        await app(scope, receive, send)
+
+    # The endpoint must see the real http.disconnect — proving the bypass
+    # handed it the unwrapped ASGI receive channel.
+    assert "http.disconnect" in observed["messages"]

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 from collections import defaultdict
 from typing import Annotated, Any, Dict, List, Set, Tuple
@@ -31,6 +32,7 @@ from kiln_ai.datamodel.task import RunConfigProperties, TaskRunConfig
 from kiln_ai.datamodel.task_output import normalize_rating
 from kiln_ai.utils.name_generator import generate_memorable_name
 from kiln_server.git_sync_decorators import build_save_context, no_write_lock
+from kiln_server.sse import stream_with_heartbeat
 from kiln_server.task_api import task_from_id
 from kiln_server.utils.agent_checks.policy import (
     ALLOW_AGENT,
@@ -123,20 +125,37 @@ def task_run_config_from_id(
     )
 
 
-async def run_eval_runner_with_status(eval_runner: EvalRunner) -> StreamingResponse:
+def _format_progress_sse(progress) -> str:
+    data = {
+        "progress": progress.complete,
+        "total": progress.total,
+        "errors": progress.errors,
+    }
+    return f"data: {json.dumps(data)}\n\n"
+
+
+async def run_eval_runner_with_status(
+    eval_runner: EvalRunner, request: Request
+) -> StreamingResponse:
     # Yields async messages designed to be used with server sent events (SSE)
     # https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
     async def event_generator():
-        async for progress in eval_runner.run():
-            data = {
-                "progress": progress.complete,
-                "total": progress.total,
-                "errors": progress.errors,
-            }
-            yield f"data: {json.dumps(data)}\n\n"
-
-        # Send the final complete message the app expects, and uses to stop listening
-        yield "data: complete\n\n"
+        # aclosing ensures prompt cleanup: when event_generator is cancelled
+        # (client disconnect → Starlette aclose's the body iterator → GeneratorExit
+        # here), hb.aclose() fires, which runs stream_with_heartbeat's finally,
+        # which aclose's the runner, which runs AsyncJobRunner's finally and
+        # cancels its workers.
+        hb = stream_with_heartbeat(
+            eval_runner.run(),
+            _format_progress_sse,
+            is_disconnected=request.is_disconnected,
+        )
+        async with contextlib.aclosing(hb) as stream:
+            async for chunk in stream:
+                yield chunk
+        if not await request.is_disconnected():
+            # Send the final complete message the app expects, and uses to stop listening
+            yield "data: complete\n\n"
 
     return StreamingResponse(
         content=event_generator(),
@@ -939,7 +958,7 @@ def connect_evals_api(app: FastAPI):
             save_context=build_save_context(request),
         )
 
-        return await run_eval_runner_with_status(eval_runner)
+        return await run_eval_runner_with_status(eval_runner, request)
 
     @app.post(
         "/api/projects/{project_id}/tasks/{task_id}/evals/{eval_id}/set_current_eval_config/{eval_config_id}",
@@ -1017,7 +1036,7 @@ def connect_evals_api(app: FastAPI):
             save_context=build_save_context(request),
         )
 
-        return await run_eval_runner_with_status(eval_runner)
+        return await run_eval_runner_with_status(eval_runner, request)
 
     @app.get(
         "/api/projects/{project_id}/tasks/{task_id}/evals/{eval_id}/eval_config/{eval_config_id}/run_config/{run_config_id}/results",

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
@@ -3075,3 +3076,145 @@ async def test_eval_results_summary_dataset_ids_cached_per_filter(client):
 
     assert response.status_code == 200
     assert runs_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_eval_runner_with_status_cancels_on_client_disconnect():
+    """Regression: aclose() on the body iterator must propagate to the runner
+    so AsyncJobRunner's finally block cancels its workers.
+    """
+    from unittest.mock import AsyncMock
+
+    from app.desktop.studio_server.eval_api import run_eval_runner_with_status
+    from kiln_ai.utils.async_job_runner import Progress
+
+    inner_closed = False
+
+    async def fake_run():
+        nonlocal inner_closed
+        try:
+            for i in range(10):
+                yield Progress(complete=i, total=10, errors=0)
+        finally:
+            inner_closed = True
+
+    eval_runner = MagicMock()
+    eval_runner.run.return_value = fake_run()
+
+    request = MagicMock()
+    request.is_disconnected = AsyncMock(return_value=False)
+
+    response = await run_eval_runner_with_status(eval_runner, request)
+
+    body_iter = response.body_iterator
+    first = await body_iter.__anext__()
+    assert "data: " in (first if isinstance(first, str) else first.decode())
+
+    await body_iter.aclose()
+
+    assert inner_closed is True
+
+
+@pytest.mark.asyncio
+async def test_run_eval_runner_with_status_exits_when_is_disconnected():
+    """When is_disconnected() returns True, the stream must exit promptly and
+    the runner generator's finally must run (workers cancelled).
+    """
+    from app.desktop.studio_server.eval_api import run_eval_runner_with_status
+    from kiln_ai.utils.async_job_runner import Progress
+
+    inner_closed = False
+
+    async def fake_run():
+        nonlocal inner_closed
+        try:
+            for i in range(100):
+                yield Progress(complete=i, total=100, errors=0)
+        finally:
+            inner_closed = True
+
+    eval_runner = MagicMock()
+    eval_runner.run.return_value = fake_run()
+
+    poll_count = {"n": 0}
+
+    async def is_disconnected():
+        poll_count["n"] += 1
+        return poll_count["n"] >= 3
+
+    request = MagicMock()
+    request.is_disconnected = is_disconnected
+
+    response = await run_eval_runner_with_status(eval_runner, request)
+
+    chunks: list[str] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk if isinstance(chunk, str) else chunk.decode())
+
+    body = "".join(chunks)
+    assert inner_closed is True
+    assert "data: complete" not in body
+
+
+@pytest.mark.asyncio
+async def test_run_eval_runner_with_status_completes_when_connected():
+    """Happy path: progress events and a final 'complete' sentinel are emitted."""
+    from unittest.mock import AsyncMock
+
+    from app.desktop.studio_server.eval_api import run_eval_runner_with_status
+    from kiln_ai.utils.async_job_runner import Progress
+
+    async def fake_run():
+        for i in range(3):
+            yield Progress(complete=i, total=3, errors=0)
+
+    eval_runner = MagicMock()
+    eval_runner.run.return_value = fake_run()
+
+    request = MagicMock()
+    request.is_disconnected = AsyncMock(return_value=False)
+
+    response = await run_eval_runner_with_status(eval_runner, request)
+
+    chunks: list[bytes] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk if isinstance(chunk, bytes) else chunk.encode())
+
+    body = b"".join(chunks).decode()
+
+    assert body.count("data: ") == 4  # 3 progress + 1 complete
+    assert "data: complete" in body
+
+
+@pytest.mark.asyncio
+async def test_run_eval_runner_with_status_emits_heartbeat_when_idle():
+    """When the runner is silent, heartbeat comments must be emitted."""
+    from unittest.mock import AsyncMock
+
+    import kiln_server.sse as sse_mod
+    from app.desktop.studio_server.eval_api import run_eval_runner_with_status
+    from kiln_ai.utils.async_job_runner import Progress
+
+    async def slow_run():
+        await asyncio.sleep(0.25)
+        yield Progress(complete=1, total=1, errors=0)
+
+    eval_runner = MagicMock()
+    eval_runner.run.return_value = slow_run()
+
+    request = MagicMock()
+    request.is_disconnected = AsyncMock(return_value=False)
+
+    original = sse_mod.DEFAULT_HEARTBEAT_SECONDS
+    sse_mod.DEFAULT_HEARTBEAT_SECONDS = 0.05
+    try:
+        response = await run_eval_runner_with_status(eval_runner, request)
+        chunks: list[str] = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk if isinstance(chunk, str) else chunk.decode())
+    finally:
+        sse_mod.DEFAULT_HEARTBEAT_SECONDS = original
+
+    body = "".join(chunks)
+    assert ": keepalive" in body, f"expected heartbeat in body, got: {body!r}"
+    assert "data: complete" in body

--- a/libs/server/kiln_server/document_api.py
+++ b/libs/server/kiln_server/document_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import datetime
 import json
 import logging
@@ -92,6 +93,7 @@ from pydantic import BaseModel, Field, PositiveInt, model_validator
 
 from kiln_server.git_sync_decorators import build_save_context, no_write_lock
 from kiln_server.project_api import project_from_id
+from kiln_server.sse import stream_with_heartbeat
 from kiln_server.utils.agent_checks.policy import (
     ALLOW_AGENT,
     DENY_AGENT,
@@ -157,22 +159,33 @@ def get_rag_config_from_id(project: Project, rag_config_id: str) -> RagConfig:
     return rag_config
 
 
+def _format_extractor_progress_sse(progress) -> str:
+    data = {
+        "progress": progress.complete,
+        "total": progress.total,
+        "errors": progress.errors,
+    }
+    return f"data: {json.dumps(data)}\n\n"
+
+
 async def run_extractor_runner_with_status(
     extractor_runner: ExtractorRunner,
+    request: Request,
 ) -> StreamingResponse:
     # Yields async messages designed to be used with server sent events (SSE)
     # https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
     async def event_generator():
-        async for progress in extractor_runner.run():
-            data = {
-                "progress": progress.complete,
-                "total": progress.total,
-                "errors": progress.errors,
-            }
-            yield f"data: {json.dumps(data)}\n\n"
-
-        # Send the final complete message the app expects, and uses to stop listening
-        yield "data: complete\n\n"
+        hb = stream_with_heartbeat(
+            extractor_runner.run(),
+            _format_extractor_progress_sse,
+            is_disconnected=request.is_disconnected,
+        )
+        async with contextlib.aclosing(hb) as stream:
+            async for chunk in stream:
+                yield chunk
+        if not await request.is_disconnected():
+            # Send the final complete message the app expects, and uses to stop listening
+            yield "data: complete\n\n"
 
     return StreamingResponse(
         content=event_generator(),
@@ -182,6 +195,7 @@ async def run_extractor_runner_with_status(
 
 async def run_rag_workflow_runner_with_status(
     runner_factory: Callable[[], Awaitable[RagWorkflowRunner]],
+    request: Request,
 ) -> StreamingResponse:
     async def event_generator():
         latest_progress = RagProgress()
@@ -213,14 +227,23 @@ async def run_rag_workflow_runner_with_status(
             }
             return data
 
+        def format_rag_progress(progress: RagProgress) -> str:
+            nonlocal latest_progress
+            latest_progress = progress.model_copy()
+            return f"data: {json.dumps(serialize_progress(progress))}\n\n"
+
         try:
             # we initialize the runner inside the wrapper to surface errors to the frontend via logging UI
             # we do it via a factory to allow for easier mocking in tests
             runner = await runner_factory()
-            async for progress in runner.run():
-                latest_progress = progress.model_copy()
-                data = serialize_progress(progress)
-                yield f"data: {json.dumps(data)}\n\n"
+            hb = stream_with_heartbeat(
+                runner.run(),
+                format_rag_progress,
+                is_disconnected=request.is_disconnected,
+            )
+            async with contextlib.aclosing(hb) as stream:
+                async for chunk in stream:
+                    yield chunk
         except asyncio.TimeoutError:
             logger.info("RAG workflow runner cancelled")
             latest_progress.logs = [
@@ -245,8 +268,9 @@ async def run_rag_workflow_runner_with_status(
             data = serialize_progress(latest_progress)
             yield f"data: {json.dumps(data)}\n\n"
 
-        # Send the final complete message the app expects, and uses to stop listening
-        yield "data: complete\n\n"
+        if not await request.is_disconnected():
+            # Send the final complete message the app expects, and uses to stop listening
+            yield "data: complete\n\n"
 
     return StreamingResponse(
         content=event_generator(),
@@ -1445,7 +1469,7 @@ def connect_document_api(app: FastAPI):
                 save_context=save_context,
             )
 
-            return await run_extractor_runner_with_status(extractor_runner)
+            return await run_extractor_runner_with_status(extractor_runner, request)
 
     @app.get(
         "/api/projects/{project_id}/documents/{document_id}/extractions",
@@ -1797,7 +1821,7 @@ def connect_document_api(app: FastAPI):
             save_context=save_context,
         )
 
-        return await run_extractor_runner_with_status(extractor_runner)
+        return await run_extractor_runner_with_status(extractor_runner, request)
 
     @app.delete(
         "/api/projects/{project_id}/documents/{document_id}/extractions/{extraction_id}",
@@ -2409,7 +2433,7 @@ def connect_document_api(app: FastAPI):
             )
 
         # the workflow runner handles locking
-        return await run_rag_workflow_runner_with_status(runner_factory)
+        return await run_rag_workflow_runner_with_status(runner_factory, request)
 
     @no_write_lock
     @app.post(

--- a/libs/server/kiln_server/sse.py
+++ b/libs/server/kiln_server/sse.py
@@ -1,0 +1,90 @@
+import asyncio
+import contextlib
+import logging
+from typing import (
+    Any,
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    TypeVar,
+)
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# SSE comment lines start with ":" and are ignored by EventSource clients.
+# Emitting one forces Starlette to call send() on the ASGI channel, which
+# raises OSError (and in turn ClientDisconnect) when the client has gone away.
+HEARTBEAT_COMMENT = ": keepalive\n\n"
+
+DEFAULT_HEARTBEAT_SECONDS = 3.0
+
+
+async def stream_with_heartbeat(
+    source: AsyncIterable[T],
+    format_chunk: Callable[[T], str],
+    *,
+    heartbeat_seconds: float | None = None,
+    is_disconnected: Callable[[], Awaitable[bool]] | None = None,
+) -> AsyncGenerator[str, None]:
+    """Iterate `source`, yielding `format_chunk(item)` for each item.
+
+    Two disconnect-detection mechanisms run in parallel:
+
+    1. Heartbeat comments (`: keepalive\\n\\n`) are emitted every
+       `heartbeat_seconds` of idleness. Emitting forces Starlette to call
+       `send()`, which raises OSError/ClientDisconnect if the client is gone.
+    2. If `is_disconnected` is provided, it is polled at each iteration; when
+       it returns True, the generator returns immediately, triggering the
+       source's aclose via the `finally` block.
+
+    When the generator exits (for any reason), the underlying `source` has
+    `aclose()` called on it. That's the lever that propagates cancellation
+    to AsyncJobRunner's `finally` block and cancels its workers.
+    """
+    timeout = (
+        heartbeat_seconds
+        if heartbeat_seconds is not None
+        else DEFAULT_HEARTBEAT_SECONDS
+    )
+    it: AsyncIterator[T] = source.__aiter__()
+
+    async def next_item() -> T:
+        return await it.__anext__()
+
+    pending: asyncio.Task[T] | None = None
+    try:
+        while True:
+            if is_disconnected is not None and await is_disconnected():
+                logger.info("SSE stream: client disconnected, cancelling workers")
+                return
+
+            if pending is None:
+                pending = asyncio.create_task(next_item())
+            done, _ = await asyncio.wait({pending}, timeout=timeout)
+            if pending in done:
+                try:
+                    item = pending.result()
+                except StopAsyncIteration:
+                    return
+                pending = None
+                yield format_chunk(item)
+            else:
+                logger.debug("SSE stream: idle for %.1fs, emitting heartbeat", timeout)
+                yield HEARTBEAT_COMMENT
+    finally:
+        if pending is not None and not pending.done():
+            pending.cancel()
+            with contextlib.suppress(BaseException):
+                await pending
+        if hasattr(source, "aclose"):
+            with contextlib.suppress(BaseException):
+                await _call_aclose(source)
+
+
+async def _call_aclose(source: Any) -> None:
+    """Call source.aclose() — extracted so the call site is a single await."""
+    await source.aclose()

--- a/libs/server/kiln_server/test_document_api.py
+++ b/libs/server/kiln_server/test_document_api.py
@@ -2809,7 +2809,9 @@ async def test_run_rag_workflow_runner_with_status_success():
         return mock_runner
 
     # Call the function
-    response = await run_rag_workflow_runner_with_status(mock_factory)
+    mock_request = MagicMock()
+    mock_request.is_disconnected = AsyncMock(return_value=False)
+    response = await run_rag_workflow_runner_with_status(mock_factory, mock_request)
 
     # Verify response type
     assert isinstance(response, StreamingResponse)
@@ -2885,7 +2887,9 @@ async def test_run_rag_workflow_runner_with_status_no_logs(logs):
         return mock_runner
 
     # Call the function
-    response = await run_rag_workflow_runner_with_status(mock_factory)
+    mock_request = MagicMock()
+    mock_request.is_disconnected = AsyncMock(return_value=False)
+    response = await run_rag_workflow_runner_with_status(mock_factory, mock_request)
 
     # Read the streaming content
     content = ""
@@ -2946,7 +2950,9 @@ async def test_run_rag_workflow_runner_with_status_multiple_logs():
         return mock_runner
 
     # Call the function
-    response = await run_rag_workflow_runner_with_status(mock_factory)
+    mock_request = MagicMock()
+    mock_request.is_disconnected = AsyncMock(return_value=False)
+    response = await run_rag_workflow_runner_with_status(mock_factory, mock_request)
 
     # Read the streaming content
     content = ""
@@ -2997,7 +3003,9 @@ async def test_run_rag_workflow_runner_with_status_no_progress():
         return mock_runner
 
     # Call the function
-    response = await run_rag_workflow_runner_with_status(mock_factory)
+    mock_request = MagicMock()
+    mock_request.is_disconnected = AsyncMock(return_value=False)
+    response = await run_rag_workflow_runner_with_status(mock_factory, mock_request)
 
     # Read the streaming content
     content = ""
@@ -5427,3 +5435,154 @@ def test_get_rag_config_progress_has_no_write_lock(app):
 def test_search_rag_config_has_no_write_lock(app):
     endpoint = _find_endpoint_by_path(app, "/rag_configs/{rag_config_id}/search")
     assert getattr(endpoint, "_git_sync_no_write_lock", False) is True
+
+
+@pytest.mark.asyncio
+async def test_run_extractor_runner_with_status_cancels_on_client_disconnect():
+    """Regression: disconnect (body_iterator.aclose()) must propagate to the
+    runner so AsyncJobRunner's finally block cancels its workers.
+    """
+    from kiln_ai.utils.async_job_runner import Progress
+
+    from kiln_server.document_api import run_extractor_runner_with_status
+
+    inner_closed = False
+
+    async def fake_run():
+        nonlocal inner_closed
+        try:
+            for i in range(10):
+                yield Progress(complete=i, total=10, errors=0)
+        finally:
+            inner_closed = True
+
+    extractor_runner = MagicMock()
+    extractor_runner.run.return_value = fake_run()
+
+    request = MagicMock()
+    request.is_disconnected = AsyncMock(return_value=False)
+
+    response = await run_extractor_runner_with_status(extractor_runner, request)
+
+    body_iter = response.body_iterator
+    first = await body_iter.__anext__()
+    assert "data: " in (first if isinstance(first, str) else first.decode())
+
+    await body_iter.aclose()
+
+    assert inner_closed is True
+
+
+@pytest.mark.asyncio
+async def test_run_extractor_runner_with_status_exits_when_is_disconnected():
+    """Polling is_disconnected() returning True must exit the stream and close
+    the runner generator.
+    """
+    from kiln_ai.utils.async_job_runner import Progress
+
+    from kiln_server.document_api import run_extractor_runner_with_status
+
+    inner_closed = False
+
+    async def fake_run():
+        nonlocal inner_closed
+        try:
+            for i in range(100):
+                yield Progress(complete=i, total=100, errors=0)
+        finally:
+            inner_closed = True
+
+    extractor_runner = MagicMock()
+    extractor_runner.run.return_value = fake_run()
+
+    # Return True on the third poll.
+    poll_count = {"n": 0}
+
+    async def is_disconnected():
+        poll_count["n"] += 1
+        return poll_count["n"] >= 3
+
+    request = MagicMock()
+    request.is_disconnected = is_disconnected
+
+    response = await run_extractor_runner_with_status(extractor_runner, request)
+
+    chunks: list[str] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk if isinstance(chunk, str) else chunk.decode())
+
+    body = "".join(chunks)
+    assert inner_closed is True
+    assert "data: complete" not in body
+
+
+@pytest.mark.asyncio
+async def test_run_rag_workflow_runner_with_status_cancels_on_client_disconnect():
+    """Regression: same disconnect propagation guarantee for the RAG helper."""
+    from kiln_server.document_api import run_rag_workflow_runner_with_status
+
+    inner_closed = False
+
+    async def fake_run():
+        nonlocal inner_closed
+        try:
+            for _ in range(10):
+                yield RagProgress(total_document_count=10)
+        finally:
+            inner_closed = True
+
+    runner = MagicMock()
+    runner.run.return_value = fake_run()
+
+    async def runner_factory():
+        return runner
+
+    request = MagicMock()
+    request.is_disconnected = AsyncMock(return_value=False)
+
+    response = await run_rag_workflow_runner_with_status(runner_factory, request)
+
+    body_iter = response.body_iterator
+    first = await body_iter.__anext__()
+    assert "data: " in (first if isinstance(first, str) else first.decode())
+
+    await body_iter.aclose()
+
+    assert inner_closed is True
+
+
+@pytest.mark.asyncio
+async def test_run_extractor_runner_with_status_emits_heartbeat_when_idle():
+    """When the runner is silent, heartbeat comments must be emitted so
+    Starlette calls send() and can detect disconnects.
+    """
+    import asyncio
+
+    from kiln_ai.utils.async_job_runner import Progress
+
+    import kiln_server.sse as sse_mod
+    from kiln_server.document_api import run_extractor_runner_with_status
+
+    async def slow_run():
+        await asyncio.sleep(0.25)
+        yield Progress(complete=1, total=1, errors=0)
+
+    extractor_runner = MagicMock()
+    extractor_runner.run.return_value = slow_run()
+
+    request = MagicMock()
+    request.is_disconnected = AsyncMock(return_value=False)
+
+    original = sse_mod.DEFAULT_HEARTBEAT_SECONDS
+    sse_mod.DEFAULT_HEARTBEAT_SECONDS = 0.05
+    try:
+        response = await run_extractor_runner_with_status(extractor_runner, request)
+        chunks: list[str] = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk if isinstance(chunk, str) else chunk.decode())
+    finally:
+        sse_mod.DEFAULT_HEARTBEAT_SECONDS = original
+
+    body = "".join(chunks)
+    assert ": keepalive" in body, f"expected heartbeat in body, got: {body!r}"
+    assert "data: complete" in body

--- a/libs/server/kiln_server/test_sse.py
+++ b/libs/server/kiln_server/test_sse.py
@@ -1,0 +1,120 @@
+import asyncio
+
+import pytest
+
+from kiln_server import sse
+
+
+@pytest.mark.asyncio
+async def test_stream_with_heartbeat_forwards_items():
+    async def source():
+        yield 1
+        yield 2
+        yield 3
+
+    collected = []
+    async for chunk in sse.stream_with_heartbeat(source(), lambda i: f"item:{i}"):
+        collected.append(chunk)
+
+    assert collected == ["item:1", "item:2", "item:3"]
+
+
+@pytest.mark.asyncio
+async def test_stream_with_heartbeat_emits_heartbeat_on_idle():
+    """When the source is silent longer than heartbeat_seconds, emit keepalive."""
+
+    async def slow_source():
+        await asyncio.sleep(0.2)
+        yield "done"
+
+    collected = []
+    async for chunk in sse.stream_with_heartbeat(
+        slow_source(), lambda s: f"data:{s}", heartbeat_seconds=0.05
+    ):
+        collected.append(chunk)
+        if len(collected) > 20:  # safety
+            break
+
+    assert sse.HEARTBEAT_COMMENT in collected
+    assert collected[-1] == "data:done"
+
+
+@pytest.mark.asyncio
+async def test_stream_with_heartbeat_closes_source_on_normal_exit():
+    """Source aclose() must run in the wrapper's finally block so the source's
+    own finally (e.g. AsyncJobRunner's worker cancellation) runs.
+    """
+    closed = False
+
+    async def source():
+        nonlocal closed
+        try:
+            yield 1
+            yield 2
+        finally:
+            closed = True
+
+    async for _ in sse.stream_with_heartbeat(source(), lambda i: str(i)):
+        pass
+
+    assert closed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_with_heartbeat_closes_source_on_aclose():
+    """aclose() on the wrapper must also aclose the source."""
+    closed = False
+
+    async def source():
+        nonlocal closed
+        try:
+            while True:
+                await asyncio.sleep(10)
+                yield "never"
+        finally:
+            closed = True
+
+    wrapper = sse.stream_with_heartbeat(source(), lambda s: s, heartbeat_seconds=0.05)
+
+    # Pull one heartbeat to get the wrapper into its waiting state.
+    first = await wrapper.__anext__()
+    assert first == sse.HEARTBEAT_COMMENT
+
+    await wrapper.aclose()
+    assert closed is True
+
+
+@pytest.mark.asyncio
+async def test_stream_with_heartbeat_exits_when_is_disconnected():
+    """When the is_disconnected callable returns True, the wrapper exits and
+    closes the source — so AsyncJobRunner's finally block runs.
+    """
+    closed = False
+
+    async def source():
+        nonlocal closed
+        try:
+            while True:
+                await asyncio.sleep(0.01)
+                yield "tick"
+        finally:
+            closed = True
+
+    poll_count = {"n": 0}
+
+    async def is_disconnected():
+        poll_count["n"] += 1
+        return poll_count["n"] >= 2
+
+    collected = []
+    async for chunk in sse.stream_with_heartbeat(
+        source(),
+        lambda s: s,
+        heartbeat_seconds=0.05,
+        is_disconnected=is_disconnected,
+    ):
+        collected.append(chunk)
+        if len(collected) > 50:  # safety
+            break
+
+    assert closed is True


### PR DESCRIPTION
## What does this PR do?

Problem: a started Eval or Rag job does not terminate when the user refreshes their browser. The job continues running in the background - potentially at high concurrency.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

The cause is quite in the weeds, so do not understand all of it yet; but here is the slop breakdown:

# Fix: SSE runs (eval/extractor/RAG) don't cancel on browser hard-refresh

## The bug

Running an eval via `GET /api/projects/{p}/tasks/{t}/evals/{e}/eval_config/{c}/run_comparison`
and then hard-refreshing the browser left the eval running server-side indefinitely. New `EvalRun`
rows kept being created, LLM calls kept being made, and the app became unresponsive while the
worker pool continued to churn. Previously, refresh cancelled the in-flight eval; that behavior
regressed when git-sync (PR `a46ff424e`, "Phase 3: SSE endpoint wiring") landed.

Same bug applied to `run_extractor_config` and `run_rag_config` in `document_api.py` — all three
SSE endpoints share the same pattern.

## Root cause

The regression had two compounding problems, both caused by `GitSyncMiddleware` extending
`starlette.middleware.base.BaseHTTPMiddleware`:

### 1. `request.is_disconnected()` silently returned False under `BaseHTTPMiddleware`

`BaseHTTPMiddleware.__call__` replaces the ASGI `receive` callable with its own
`receive_or_disconnect`, which opens an `anyio.create_task_group` internally. `Request.is_disconnected()`
polls with a pre-cancelled `anyio.CancelScope`; under the middleware, the nested task group
unwinds before any message can be dequeued, so the method returned False even when the client
had disconnected. No disconnect signal ever reached the endpoint.

### 2. No other disconnect detection fired during long LLM calls

Starlette 0.52.1 (ASGI spec ≥ 2.4) removed `StreamingResponse.listen_for_disconnect`. Modern
Starlette only notices a disconnect when `await send(...)` raises `OSError`. Since our SSE
generator only called `send()` when `AsyncJobRunner` yielded a new progress event — which could
be 30+ seconds during a slow LLM call — the TCP close went undetected for the whole run.

### Why the worker pool then stayed alive

`AsyncJobRunner.run()` already has correct cancellation wiring: its `finally` block cancels all
worker tasks. But that `finally` only fires if the caller's `async for progress in runner.run():`
exits. Since nothing was exiting the outer SSE generator, that `finally` never ran. Workers kept
pulling new jobs off the queue → "keeps running new eval runs" as reported.

## The fix

Three layers, each addressing one link in the chain.

### 1. Bypass `BaseHTTPMiddleware` for `@no_write_lock` endpoints

`app/desktop/git_sync/middleware.py` — override `GitSyncMiddleware.__call__` so endpoints marked
`@no_write_lock` (the SSE ones) get a pure ASGI pass-through. The real `receive` and `send`
reach the endpoint directly; `request.is_disconnected()` now works. Other endpoints still use
the normal `BaseHTTPMiddleware.dispatch` path.

The bypass still does what the normal path did:
- resolves the git-sync manager for the project,
- calls `ensure_fresh_for_read()`,
- attaches the manager to `scope["state"]["git_sync_manager"]` so `build_save_context(request)`
  works inside the endpoint,
- notifies the background sync task.

It just skips the anyio task-group wrapping that breaks streaming.

### 2. Active disconnect polling in the SSE helper

`libs/server/kiln_server/sse.py` — new `stream_with_heartbeat()` helper wraps an async source
and:

- **polls `is_disconnected()` at each iteration** (default 3s). If it returns True, the
  generator returns, triggering the source's `aclose()` in its own `finally` block.
- **emits SSE keepalive comments** (`: keepalive\n\n`) after `heartbeat_seconds` of idleness.
  Keepalives force `send()` to fire, which raises `OSError` → `ClientDisconnect` if the
  connection is closed — belt-and-suspenders in case polling misses.
- **always `aclose()`s the source** in its `finally` block, regardless of exit reason.

Default heartbeat is 3s (`DEFAULT_HEARTBEAT_SECONDS`).

### 3. Prompt cleanup via `contextlib.aclosing`

Each SSE endpoint now wraps the heartbeat stream in `contextlib.aclosing(hb)`:

```python
async def event_generator():
    hb = stream_with_heartbeat(
        eval_runner.run(),
        _format_progress_sse,
        is_disconnected=request.is_disconnected,
    )
    async with contextlib.aclosing(hb) as stream:
        async for chunk in stream:
            yield chunk
    if not await request.is_disconnected():
        yield "data: complete\n\n"
```

Why `aclosing`: when Starlette cancels `event_generator` on client disconnect, a plain
`async for` does not automatically close the inner generator — cleanup would wait for GC,
leaving workers alive for an indeterminate time. `aclosing` guarantees `hb.aclose()` runs
synchronously, which in turn runs `stream_with_heartbeat`'s `finally`, which calls
`eval_runner.run().aclose()`, which fires `AsyncJobRunner`'s `finally` that cancels all workers.

## Cancellation chain (end to end)

1. Browser hard-refresh → TCP close.
2. uvicorn sends `{"type": "http.disconnect"}` on the receive channel.
3. Under the ASGI bypass, the endpoint's `request._receive` is the real channel (not the
   middleware's wrapped proxy), so on the next poll tick, `request.is_disconnected()` returns
   True.
4. `stream_with_heartbeat` returns; its `finally` runs `eval_runner.run().aclose()`.
5. `aclose()` raises `GeneratorExit` inside `AsyncJobRunner.run()` at its current yield point.
6. `AsyncJobRunner.run()`'s `finally` runs: `for w in workers: w.cancel()`.
7. Each worker's current `await run_job_fn(job)` raises `CancelledError`. `CancelledError`
   inherits from `BaseException` (not `Exception`), so the worker's `except Exception` clauses
   don't catch it. The worker coroutine unwinds and the task completes.
8. `asyncio.gather(*workers)` in `AsyncJobRunner.run()`'s `finally` completes.
9. `event_generator`'s `aclosing` block exits.
10. Response generator ends. The SSE connection is already closed client-side.

Worst-case latency is one heartbeat interval (3s) between refresh and all workers having
`cancel()` called.

## Files changed

- `app/desktop/git_sync/middleware.py` — ASGI bypass for `@no_write_lock`.
- `libs/server/kiln_server/sse.py` — new module with `stream_with_heartbeat`.
- `app/desktop/studio_server/eval_api.py` — use `stream_with_heartbeat` + `aclosing`.
- `libs/server/kiln_server/document_api.py` — same for extractor and RAG workflow helpers.

## Tests added

- `libs/server/kiln_server/test_sse.py` — unit tests for `stream_with_heartbeat` (forwards
  items, emits heartbeat on idle, closes source on normal exit / on `aclose` / on
  `is_disconnected=True`).
- `app/desktop/git_sync/test_middleware.py` — three new tests: bypass skips `dispatch()`,
  bypass still attaches `git_sync_manager` to `request.state`, and an ASGI-level test
  proving `http.disconnect` reaches the endpoint's receive channel under the bypass.
- `app/desktop/studio_server/test_eval_api.py` and
  `libs/server/kiln_server/test_document_api.py` — regression tests exercising disconnect
  (aclose), `is_disconnected=True` polling, the happy path, and idle-heartbeat emission.

All 297 touched-module tests pass; `./checks.sh --agent-mode` exits 0.

## Logging

When the disconnect path triggers, you'll see:

```
SSE stream: client disconnected, cancelling workers
```

at `INFO` level from the `kiln_server.sse` logger. Enable `DEBUG` on that logger if you want
to see heartbeat emissions (`SSE stream: idle for 3.0s, emitting heartbeat`).

## Open follow-ups (not in this fix)

- **UI reconnect-to-in-flight-eval.** After a refresh, the page has no way to rejoin an
  already-running eval — it starts from zero on the next click. Fixing this needs persistent
  server-side run state and a `GET …/current_run` endpoint. Separate PR.
- **Cancel button.** With the SSE stream gone, there's no user-facing way to abort a run that
  was started intentionally (e.g. accidental "Run All Evals"). A kill-switch endpoint keyed by
  eval/run id would be a small, robust addition.
- **Concurrency tuning.** Default is 25 workers; each eval-save serializes through the
  single-threaded git executor and a `threading.Lock`. Fine at small scale, but large eval
  sets may bottleneck on atomic_write. Worth profiling separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSE heartbeat support to maintain connections during long-running operations like evaluations and document processing.
  * Improved progress reporting with formatted status updates for streaming operations.

* **Bug Fixes**
  * Enhanced client disconnection handling to properly detect and respond when users disconnect from streaming endpoints.
  * Ensured proper cleanup of resources when streams are terminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->