### PR TITLE
fix: retry os.rename on Windows to avoid transient PermissionError

### DIFF
--- a/app/desktop/git_sync/clone.py
+++ b/app/desktop/git_sync/clone.py
@@ -3,7 +3,9 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -266,6 +268,10 @@ def compute_temp_clone_path(base_dir: Path) -> Path:
     return Path(tempfile.mkdtemp(prefix="kiln_clone_", dir=base_dir))
 
 
+_WINDOWS_RENAME_MAX_RETRIES = 5
+_WINDOWS_RENAME_BASE_DELAY = 0.5
+
+
 def rename_clone_to_final_path(
     current_path: Path,
     final_path: Path,
@@ -275,6 +281,9 @@ def rename_clone_to_final_path(
     The caller is responsible for computing final_path (via compute_clone_path)
     and validating it before calling this function.
 
+    On Windows, retries with exponential backoff when PermissionError occurs
+    (commonly caused by antivirus or lingering file handles from the clone).
+
     Returns the final path.
 
     Raises ValueError if current_path does not exist.
@@ -283,9 +292,37 @@ def rename_clone_to_final_path(
         raise ValueError(f"Clone path does not exist: {current_path}")
 
     final_path.parent.mkdir(parents=True, exist_ok=True)
-    os.rename(current_path, final_path)
+
+    if sys.platform == "win32":
+        _rename_with_retry(current_path, final_path)
+    else:
+        os.rename(current_path, final_path)
 
     return final_path
+
+
+def _rename_with_retry(current_path: Path, final_path: Path) -> None:
+    """Rename with retry and exponential backoff for Windows PermissionError.
+
+    Windows Defender and other processes can briefly lock files in a freshly
+    cloned git repository, causing os.rename to fail with PermissionError.
+    A short retry loop resolves this in the vast majority of cases.
+    """
+    for attempt in range(_WINDOWS_RENAME_MAX_RETRIES):
+        try:
+            os.rename(current_path, final_path)
+            return
+        except PermissionError:
+            if attempt == _WINDOWS_RENAME_MAX_RETRIES - 1:
+                raise
+            delay = _WINDOWS_RENAME_BASE_DELAY * (2**attempt)
+            logger.info(
+                "Rename attempt %d/%d failed with PermissionError, retrying in %.1fs",
+                attempt + 1,
+                _WINDOWS_RENAME_MAX_RETRIES,
+                delay,
+            )
+            time.sleep(delay)
 
 
 def clone_repo(

--- a/app/desktop/git_sync/clone.py
+++ b/app/desktop/git_sync/clone.py
@@ -3,9 +3,7 @@ import logging
 import os
 import re
 import shutil
-import sys
 import tempfile
-import time
 from pathlib import Path
 from typing import Any
 
@@ -268,10 +266,6 @@ def compute_temp_clone_path(base_dir: Path) -> Path:
     return Path(tempfile.mkdtemp(prefix="kiln_clone_", dir=base_dir))
 
 
-_WINDOWS_RENAME_MAX_RETRIES = 5
-_WINDOWS_RENAME_BASE_DELAY = 0.5
-
-
 def rename_clone_to_final_path(
     current_path: Path,
     final_path: Path,
@@ -281,9 +275,6 @@ def rename_clone_to_final_path(
     The caller is responsible for computing final_path (via compute_clone_path)
     and validating it before calling this function.
 
-    On Windows, retries with exponential backoff when PermissionError occurs
-    (commonly caused by antivirus or lingering file handles from the clone).
-
     Returns the final path.
 
     Raises ValueError if current_path does not exist.
@@ -292,37 +283,9 @@ def rename_clone_to_final_path(
         raise ValueError(f"Clone path does not exist: {current_path}")
 
     final_path.parent.mkdir(parents=True, exist_ok=True)
-
-    if sys.platform == "win32":
-        _rename_with_retry(current_path, final_path)
-    else:
-        os.rename(current_path, final_path)
+    os.rename(current_path, final_path)
 
     return final_path
-
-
-def _rename_with_retry(current_path: Path, final_path: Path) -> None:
-    """Rename with retry and exponential backoff for Windows PermissionError.
-
-    Windows Defender and other processes can briefly lock files in a freshly
-    cloned git repository, causing os.rename to fail with PermissionError.
-    A short retry loop resolves this in the vast majority of cases.
-    """
-    for attempt in range(_WINDOWS_RENAME_MAX_RETRIES):
-        try:
-            os.rename(current_path, final_path)
-            return
-        except PermissionError:
-            if attempt == _WINDOWS_RENAME_MAX_RETRIES - 1:
-                raise
-            delay = _WINDOWS_RENAME_BASE_DELAY * (2**attempt)
-            logger.info(
-                "Rename attempt %d/%d failed with PermissionError, retrying in %.1fs",
-                attempt + 1,
-                _WINDOWS_RENAME_MAX_RETRIES,
-                delay,
-            )
-            time.sleep(delay)
 
 
 def clone_repo(
@@ -332,11 +295,13 @@ def clone_repo(
     pat_token: str | None = None,
     auth_mode: AuthMode = "system_keys",
     oauth_token: str | None = None,
-) -> pygit2.Repository:
+) -> None:
     """Clone a repository into the given path.
 
     Sets up the clone with the specified branch and adds a .gitignore
-    for common OS artifacts.
+    for common OS artifacts. The pygit2 Repository is freed before returning
+    to release libgit2 file handles (required on Windows to allow subsequent
+    rename/move of the clone directory).
     """
     callbacks = make_credentials(pat_token, auth_mode, oauth_token=oauth_token)
 
@@ -347,9 +312,12 @@ def clone_repo(
         callbacks=callbacks,
     )
 
-    _ensure_gitignore(repo, clone_path, pat_token, auth_mode, oauth_token=oauth_token)
-
-    return repo
+    try:
+        _ensure_gitignore(
+            repo, clone_path, pat_token, auth_mode, oauth_token=oauth_token
+        )
+    finally:
+        repo.free()
 
 
 def _ensure_gitignore(
@@ -417,8 +385,12 @@ def test_write_access(
 ) -> tuple[bool, str]:
     """Test write access by pushing an empty commit.
 
+    The pygit2 Repository is freed before returning to release libgit2
+    file handles (required on Windows).
+
     Returns (success, message).
     """
+    repo: pygit2.Repository | None = None
     try:
         repo = pygit2.Repository(str(clone_path))
         sig = pygit2.Signature(get_committer_name(), get_committer_email())
@@ -456,6 +428,9 @@ def test_write_access(
         return False, f"Write access check failed: {e}"
     except Exception as e:
         return False, f"Write access check failed: {e}"
+    finally:
+        if repo is not None:
+            repo.free()
 
 
 def scan_for_projects(clone_path: Path) -> list[dict[str, str]]:

--- a/app/desktop/git_sync/clone.py
+++ b/app/desktop/git_sync/clone.py
@@ -3,7 +3,9 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +35,9 @@ ehthumbs.db
 """
 
 DEFAULT_REMOTE_NAME = "origin"
+
+_WINDOWS_RENAME_MAX_ATTEMPTS = 5
+_WINDOWS_RENAME_RETRY_DELAY = 2.0
 
 
 def make_push_callbacks(
@@ -275,6 +280,10 @@ def rename_clone_to_final_path(
     The caller is responsible for computing final_path (via compute_clone_path)
     and validating it before calling this function.
 
+    On Windows, retries on PermissionError up to 5 times with a 2-second delay
+    between attempts to handle transient file locks from antivirus or indexing
+    services.
+
     Returns the final path.
 
     Raises ValueError if current_path does not exist.
@@ -283,8 +292,25 @@ def rename_clone_to_final_path(
         raise ValueError(f"Clone path does not exist: {current_path}")
 
     final_path.parent.mkdir(parents=True, exist_ok=True)
-    os.rename(current_path, final_path)
 
+    if sys.platform == "win32":
+        for attempt in range(1, _WINDOWS_RENAME_MAX_ATTEMPTS + 1):
+            try:
+                os.rename(current_path, final_path)
+                return final_path
+            except PermissionError:
+                if attempt == _WINDOWS_RENAME_MAX_ATTEMPTS:
+                    raise
+                logger.warning(
+                    "Rename attempt %d/%d failed with PermissionError, "
+                    "retrying in %.1fs",
+                    attempt,
+                    _WINDOWS_RENAME_MAX_ATTEMPTS,
+                    _WINDOWS_RENAME_RETRY_DELAY,
+                )
+                time.sleep(_WINDOWS_RENAME_RETRY_DELAY)
+
+    os.rename(current_path, final_path)
     return final_path
 
 

--- a/app/desktop/git_sync/test_clone.py
+++ b/app/desktop/git_sync/test_clone.py
@@ -1,11 +1,14 @@
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pygit2
 import pytest
 
 from app.desktop.git_sync.clone import (
+    _WINDOWS_RENAME_BASE_DELAY,
+    _WINDOWS_RENAME_MAX_RETRIES,
+    _rename_with_retry,
     compute_clone_path,
     compute_temp_clone_path,
     list_remote_branches,
@@ -304,3 +307,132 @@ class TestListRemoteBranches:
             mock.return_value = refs
             branches, _ = list_remote_branches("https://github.com/org/repo.git")
             assert branches == ["main"]
+
+
+class TestRenameWithRetry:
+    def test_succeeds_on_first_attempt(self, tmp_path: Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+
+        with patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep:
+            _rename_with_retry(src, dst)
+
+        assert dst.exists()
+        assert not src.exists()
+        mock_sleep.assert_not_called()
+
+    def test_succeeds_after_transient_permission_errors(self, tmp_path: Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+
+        import os as real_os
+
+        real_rename = real_os.rename
+        call_count = 0
+
+        def flaky_rename(s, d):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise PermissionError("[WinError 5] Access is denied")
+            real_rename(s, d)
+
+        with (
+            patch("app.desktop.git_sync.clone.os.rename", side_effect=flaky_rename),
+            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
+        ):
+            _rename_with_retry(src, dst)
+
+        assert call_count == 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_has_calls(
+            [
+                call(_WINDOWS_RENAME_BASE_DELAY),
+                call(_WINDOWS_RENAME_BASE_DELAY * 2),
+            ]
+        )
+
+    def test_raises_after_all_retries_exhausted(self, tmp_path: Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+
+        with (
+            patch(
+                "app.desktop.git_sync.clone.os.rename",
+                side_effect=PermissionError("[WinError 5] Access is denied"),
+            ),
+            patch("app.desktop.git_sync.clone.time.sleep"),
+            pytest.raises(PermissionError, match="Access is denied"),
+        ):
+            _rename_with_retry(src, dst)
+
+    def test_non_permission_errors_propagate_immediately(self, tmp_path: Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+
+        with (
+            patch(
+                "app.desktop.git_sync.clone.os.rename",
+                side_effect=OSError("disk full"),
+            ),
+            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
+            pytest.raises(OSError, match="disk full"),
+        ):
+            _rename_with_retry(src, dst)
+
+        mock_sleep.assert_not_called()
+
+    def test_exponential_backoff_delays(self, tmp_path: Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+
+        with (
+            patch(
+                "app.desktop.git_sync.clone.os.rename",
+                side_effect=PermissionError("[WinError 5] Access is denied"),
+            ),
+            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
+            pytest.raises(PermissionError),
+        ):
+            _rename_with_retry(src, dst)
+
+        expected_delays = [
+            _WINDOWS_RENAME_BASE_DELAY * (2**i)
+            for i in range(_WINDOWS_RENAME_MAX_RETRIES - 1)
+        ]
+        mock_sleep.assert_has_calls([call(d) for d in expected_delays])
+
+
+class TestRenameCloneToFinalPathWindows:
+    def test_uses_retry_on_windows(self, tmp_path: Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+
+        with (
+            patch("app.desktop.git_sync.clone.sys.platform", "win32"),
+            patch("app.desktop.git_sync.clone._rename_with_retry") as mock_retry,
+        ):
+            rename_clone_to_final_path(src, dst)
+
+        mock_retry.assert_called_once_with(src, dst)
+
+    def test_skips_retry_on_non_windows(self, tmp_path: Path):
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+
+        with (
+            patch("app.desktop.git_sync.clone.sys.platform", "linux"),
+            patch("app.desktop.git_sync.clone.os.rename") as mock_rename,
+            patch("app.desktop.git_sync.clone._rename_with_retry") as mock_retry,
+        ):
+            rename_clone_to_final_path(src, dst)
+
+        mock_retry.assert_not_called()
+        mock_rename.assert_called_once_with(src, dst)

--- a/app/desktop/git_sync/test_clone.py
+++ b/app/desktop/git_sync/test_clone.py
@@ -1,14 +1,12 @@
 import json
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, patch
 
 import pygit2
 import pytest
 
 from app.desktop.git_sync.clone import (
-    _WINDOWS_RENAME_BASE_DELAY,
-    _WINDOWS_RENAME_MAX_RETRIES,
-    _rename_with_retry,
+    clone_repo,
     compute_clone_path,
     compute_temp_clone_path,
     list_remote_branches,
@@ -16,6 +14,7 @@ from app.desktop.git_sync.clone import (
     scan_for_projects,
 )
 from app.desktop.git_sync.clone import test_remote_access as check_remote_access
+from app.desktop.git_sync.clone import test_write_access as check_write_access
 
 
 class TestComputeClonePath:
@@ -309,130 +308,100 @@ class TestListRemoteBranches:
             assert branches == ["main"]
 
 
-class TestRenameWithRetry:
-    def test_succeeds_on_first_attempt(self, tmp_path: Path):
-        src = tmp_path / "src"
-        src.mkdir()
-        dst = tmp_path / "dst"
-
-        with patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep:
-            _rename_with_retry(src, dst)
-
-        assert dst.exists()
-        assert not src.exists()
-        mock_sleep.assert_not_called()
-
-    def test_succeeds_after_transient_permission_errors(self, tmp_path: Path):
-        src = tmp_path / "src"
-        src.mkdir()
-        dst = tmp_path / "dst"
-
-        import os as real_os
-
-        real_rename = real_os.rename
-        call_count = 0
-
-        def flaky_rename(s, d):
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 2:
-                raise PermissionError("[WinError 5] Access is denied")
-            real_rename(s, d)
-
+class TestCloneRepoFreesRepository:
+    def test_frees_repo_on_success(self):
+        mock_repo = MagicMock()
         with (
-            patch("app.desktop.git_sync.clone.os.rename", side_effect=flaky_rename),
-            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
+            patch("app.desktop.git_sync.clone.make_credentials"),
+            patch(
+                "app.desktop.git_sync.clone.pygit2.clone_repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone._ensure_gitignore"),
         ):
-            _rename_with_retry(src, dst)
+            clone_repo(
+                "https://github.com/org/repo.git",
+                Path("/tmp/clone"),
+                "main",
+            )
 
-        assert call_count == 3
-        assert mock_sleep.call_count == 2
-        mock_sleep.assert_has_calls(
-            [
-                call(_WINDOWS_RENAME_BASE_DELAY),
-                call(_WINDOWS_RENAME_BASE_DELAY * 2),
-            ]
-        )
+        mock_repo.free.assert_called_once()
 
-    def test_raises_after_all_retries_exhausted(self, tmp_path: Path):
-        src = tmp_path / "src"
-        src.mkdir()
-        dst = tmp_path / "dst"
+    def test_frees_repo_when_ensure_gitignore_raises(self):
+        mock_repo = MagicMock()
+        with (
+            patch("app.desktop.git_sync.clone.make_credentials"),
+            patch(
+                "app.desktop.git_sync.clone.pygit2.clone_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "app.desktop.git_sync.clone._ensure_gitignore",
+                side_effect=RuntimeError("push failed"),
+            ),
+            pytest.raises(RuntimeError, match="push failed"),
+        ):
+            clone_repo(
+                "https://github.com/org/repo.git",
+                Path("/tmp/clone"),
+                "main",
+            )
 
+        mock_repo.free.assert_called_once()
+
+
+class TestTestWriteAccessFreesRepository:
+    def _make_mock_repo(self) -> MagicMock:
+        mock_repo = MagicMock()
+        mock_repo.head.target = "abc123"
+        mock_repo.head.name = "refs/heads/main"
+        mock_repo.head.shorthand = "main"
+        mock_repo.index.write_tree.return_value = "tree_oid"
+        mock_repo.create_commit.return_value = "commit_oid"
+        return mock_repo
+
+    def test_frees_repo_on_success(self):
+        mock_repo = self._make_mock_repo()
         with (
             patch(
-                "app.desktop.git_sync.clone.os.rename",
-                side_effect=PermissionError("[WinError 5] Access is denied"),
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
             ),
-            patch("app.desktop.git_sync.clone.time.sleep"),
-            pytest.raises(PermissionError, match="Access is denied"),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+            patch("app.desktop.git_sync.clone.make_credentials"),
+            patch("app.desktop.git_sync.clone.make_push_callbacks"),
         ):
-            _rename_with_retry(src, dst)
+            success, msg = check_write_access(Path("/tmp/clone"))
 
-    def test_non_permission_errors_propagate_immediately(self, tmp_path: Path):
-        src = tmp_path / "src"
-        src.mkdir()
-        dst = tmp_path / "dst"
+        assert success is True
+        mock_repo.free.assert_called_once()
 
+    def test_frees_repo_on_git_error(self):
+        mock_repo = self._make_mock_repo()
+        mock_repo.index.write_tree.side_effect = pygit2.GitError("401 unauthorized")
         with (
             patch(
-                "app.desktop.git_sync.clone.os.rename",
-                side_effect=OSError("disk full"),
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
             ),
-            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
-            pytest.raises(OSError, match="disk full"),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
         ):
-            _rename_with_retry(src, dst)
+            success, msg = check_write_access(Path("/tmp/clone"))
 
-        mock_sleep.assert_not_called()
+        assert success is False
+        mock_repo.free.assert_called_once()
 
-    def test_exponential_backoff_delays(self, tmp_path: Path):
-        src = tmp_path / "src"
-        src.mkdir()
-        dst = tmp_path / "dst"
-
+    def test_frees_repo_on_unexpected_error(self):
+        mock_repo = self._make_mock_repo()
+        mock_repo.index.write_tree.side_effect = RuntimeError("unexpected")
         with (
             patch(
-                "app.desktop.git_sync.clone.os.rename",
-                side_effect=PermissionError("[WinError 5] Access is denied"),
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
             ),
-            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
-            pytest.raises(PermissionError),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
         ):
-            _rename_with_retry(src, dst)
+            success, msg = check_write_access(Path("/tmp/clone"))
 
-        expected_delays = [
-            _WINDOWS_RENAME_BASE_DELAY * (2**i)
-            for i in range(_WINDOWS_RENAME_MAX_RETRIES - 1)
-        ]
-        mock_sleep.assert_has_calls([call(d) for d in expected_delays])
-
-
-class TestRenameCloneToFinalPathWindows:
-    def test_uses_retry_on_windows(self, tmp_path: Path):
-        src = tmp_path / "src"
-        src.mkdir()
-        dst = tmp_path / "dst"
-
-        with (
-            patch("app.desktop.git_sync.clone.sys.platform", "win32"),
-            patch("app.desktop.git_sync.clone._rename_with_retry") as mock_retry,
-        ):
-            rename_clone_to_final_path(src, dst)
-
-        mock_retry.assert_called_once_with(src, dst)
-
-    def test_skips_retry_on_non_windows(self, tmp_path: Path):
-        src = tmp_path / "src"
-        src.mkdir()
-        dst = tmp_path / "dst"
-
-        with (
-            patch("app.desktop.git_sync.clone.sys.platform", "linux"),
-            patch("app.desktop.git_sync.clone.os.rename") as mock_rename,
-            patch("app.desktop.git_sync.clone._rename_with_retry") as mock_retry,
-        ):
-            rename_clone_to_final_path(src, dst)
-
-        mock_retry.assert_not_called()
-        mock_rename.assert_called_once_with(src, dst)
+        assert success is False
+        mock_repo.free.assert_called_once()

--- a/app/desktop/git_sync/test_clone.py
+++ b/app/desktop/git_sync/test_clone.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -6,6 +7,8 @@ import pygit2
 import pytest
 
 from app.desktop.git_sync.clone import (
+    _WINDOWS_RENAME_MAX_ATTEMPTS,
+    _WINDOWS_RENAME_RETRY_DELAY,
     clone_repo,
     compute_clone_path,
     compute_temp_clone_path,
@@ -117,6 +120,115 @@ class TestRenameCloneToFinalPath:
         final_path = compute_clone_path(tmp_path, "Test", "id1")
         result = rename_clone_to_final_path(temp_dir, final_path)
         assert result.name == "id1 - Test2"
+
+
+class TestRenameCloneRetryWindows:
+    def test_rename_succeeds_on_first_attempt(self, tmp_path: Path):
+        src = tmp_path / "source"
+        src.mkdir()
+        (src / "marker.txt").write_text("ok")
+        dest = tmp_path / "dest"
+
+        with (
+            patch("app.desktop.git_sync.clone.sys") as mock_sys,
+            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
+        ):
+            mock_sys.platform = "win32"
+            result = rename_clone_to_final_path(src, dest)
+
+        assert result == dest
+        assert (dest / "marker.txt").read_text() == "ok"
+        assert not src.exists()
+        mock_sleep.assert_not_called()
+
+    def test_rename_succeeds_after_transient_permission_errors(self, tmp_path: Path):
+        src = tmp_path / "source"
+        src.mkdir()
+        dest = tmp_path / "dest"
+
+        call_count = 0
+        original_rename = os.rename
+
+        def flaky_rename(s, d):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise PermissionError("Access is denied")
+            original_rename(s, d)
+
+        with (
+            patch("app.desktop.git_sync.clone.sys") as mock_sys,
+            patch("app.desktop.git_sync.clone.os.rename", side_effect=flaky_rename),
+            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
+        ):
+            mock_sys.platform = "win32"
+            result = rename_clone_to_final_path(src, dest)
+
+        assert result == dest
+        assert call_count == 3
+        assert mock_sleep.call_count == 2
+        for call in mock_sleep.call_args_list:
+            assert call[0][0] == _WINDOWS_RENAME_RETRY_DELAY
+
+    def test_rename_raises_after_all_retries_exhausted(self, tmp_path: Path):
+        src = tmp_path / "source"
+        src.mkdir()
+        dest = tmp_path / "dest"
+
+        with (
+            patch("app.desktop.git_sync.clone.sys") as mock_sys,
+            patch(
+                "app.desktop.git_sync.clone.os.rename",
+                side_effect=PermissionError("Access is denied"),
+            ) as mock_rename,
+            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
+            pytest.raises(PermissionError, match="Access is denied"),
+        ):
+            mock_sys.platform = "win32"
+            rename_clone_to_final_path(src, dest)
+
+        assert mock_rename.call_count == _WINDOWS_RENAME_MAX_ATTEMPTS
+        assert mock_sleep.call_count == _WINDOWS_RENAME_MAX_ATTEMPTS - 1
+
+    def test_non_permission_errors_propagate_immediately(self, tmp_path: Path):
+        src = tmp_path / "source"
+        src.mkdir()
+        dest = tmp_path / "dest"
+
+        with (
+            patch("app.desktop.git_sync.clone.sys") as mock_sys,
+            patch(
+                "app.desktop.git_sync.clone.os.rename",
+                side_effect=FileNotFoundError("No such file"),
+            ) as mock_rename,
+            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
+            pytest.raises(FileNotFoundError, match="No such file"),
+        ):
+            mock_sys.platform = "win32"
+            rename_clone_to_final_path(src, dest)
+
+        mock_rename.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    def test_non_windows_does_not_retry(self, tmp_path: Path):
+        src = tmp_path / "source"
+        src.mkdir()
+        dest = tmp_path / "dest"
+
+        with (
+            patch("app.desktop.git_sync.clone.sys") as mock_sys,
+            patch(
+                "app.desktop.git_sync.clone.os.rename",
+                side_effect=PermissionError("Access is denied"),
+            ) as mock_rename,
+            patch("app.desktop.git_sync.clone.time.sleep") as mock_sleep,
+            pytest.raises(PermissionError, match="Access is denied"),
+        ):
+            mock_sys.platform = "darwin"
+            rename_clone_to_final_path(src, dest)
+
+        mock_rename.assert_called_once()
+        mock_sleep.assert_not_called()
 
 
 class TestScanForProjects:


### PR DESCRIPTION
 lingering libgit2 file handles briefly lock files under the temp clone path, blocking copy from working. Now explicitly free it before copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure Git repository resources are always released after clone and write-access checks, and avoid returning internal repository handles to callers.
  * On Windows, add retry logic for transient file-permission rename failures to reduce intermittent clone errors.

* **Tests**
  * Added tests covering rename-retry behavior on Windows and verifying repository cleanup on success and on various error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->