### PR TITLE
Add git sync to `import_project` analytics event

### DIFF
--- a/app/web_ui/src/lib/components/import/import_project.svelte
+++ b/app/web_ui/src/lib/components/import/import_project.svelte
@@ -13,6 +13,7 @@
   import { replaceState } from "$app/navigation"
   import { tick, onMount, onDestroy } from "svelte"
   import posthog from "posthog-js"
+  import { isGitHubUrl, isGitLabUrl } from "$lib/git_sync/api"
   import {
     sync_url_query_param,
     read_url_query_param,
@@ -211,7 +212,18 @@
     set_step("complete")
   }
 
+  function git_host_label(url: string): string {
+    if (isGitHubUrl(url)) return "github"
+    if (isGitLabUrl(url)) return "gitlab"
+    return "other"
+  }
+
   function on_wizard_complete(project_id: string) {
+    posthog.capture("import_project", {
+      method: "git_sync",
+      git_host: git_host_label(git_url ?? ""),
+      auth_mode: auth_mode,
+    })
     clear_wizard_store()
     on_complete(project_id)
   }
@@ -282,7 +294,7 @@
         throw post_error
       }
 
-      posthog.capture("import_project", {})
+      posthog.capture("import_project", { method: "local" })
 
       await load_projects()
       import_done = true
@@ -333,7 +345,10 @@
 
       <button
         class="w-full text-left p-5 border rounded-lg hover:border-primary hover:bg-base-200 transition-colors"
-        on:click={() => set_step("url")}
+        on:click={() => {
+          posthog.capture("git_sync_setup_start")
+          set_step("url")
+        }}
       >
         <div class="font-medium flex flex-row gap-2 items-center">
           <div class="flex-1">Git Auto Sync</div>

--- a/app/web_ui/src/lib/components/import/import_project.svelte
+++ b/app/web_ui/src/lib/components/import/import_project.svelte
@@ -13,7 +13,6 @@
   import { replaceState } from "$app/navigation"
   import { tick, onMount, onDestroy } from "svelte"
   import posthog from "posthog-js"
-  import { isGitHubUrl, isGitLabUrl } from "$lib/git_sync/api"
   import {
     sync_url_query_param,
     read_url_query_param,
@@ -212,18 +211,7 @@
     set_step("complete")
   }
 
-  function git_host_label(url: string): string {
-    if (isGitHubUrl(url)) return "github"
-    if (isGitLabUrl(url)) return "gitlab"
-    return "other"
-  }
-
   function on_wizard_complete(project_id: string) {
-    posthog.capture("import_project", {
-      method: "git_sync",
-      git_host: git_host_label(git_url ?? ""),
-      auth_mode: auth_mode,
-    })
     clear_wizard_store()
     on_complete(project_id)
   }

--- a/app/web_ui/src/lib/components/import/step_complete.svelte
+++ b/app/web_ui/src/lib/components/import/step_complete.svelte
@@ -5,8 +5,11 @@
     renameClone,
     saveConfig,
     is_stale_clone_error,
+    isGitHubUrl,
+    isGitLabUrl,
   } from "$lib/git_sync/api"
   import { clear_wizard_store } from "$lib/stores/git_import_wizard_store"
+  import posthog from "posthog-js"
   import { load_projects } from "$lib/stores"
   import { onMount } from "svelte"
 
@@ -31,6 +34,12 @@
   let saving = true
   let error: KilnError | null = null
   let done = false
+
+  function git_host_label(url: string): string {
+    if (isGitHubUrl(url)) return "github"
+    if (isGitLabUrl(url)) return "gitlab"
+    return "other"
+  }
 
   onMount(async () => {
     try {
@@ -60,6 +69,12 @@
         oauth_token: oauth_token,
         auth_mode: auth_mode,
         sync_mode: "auto",
+      })
+
+      posthog.capture("import_project", {
+        method: "git_sync",
+        git_host: git_host_label(git_url),
+        auth_mode: auth_mode,
       })
 
       clear_wizard_store()


### PR DESCRIPTION
## What does this PR do?

Add git sync to `import_project` analytics event which fires on any successful project import. We added git sync specific properties this time. 

Added 3 new props
* method
* git_host
* auth_mode

Sample:
```
  Local import:
  { "method": "local" }

  Git sync import:
  {
    "method": "git_sync",
    "git_host": "github", 
    "auth_mode": "github_oauth"
  }
```

Verified by adding temp console logs.

## Contributor License Agreement

I, @<your-github-username>, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics for project imports: import events now include explicit method (method: "local" or method: "git_sync") and include detected git host and selected auth mode.
* **New Features**
  * Captures a "git_sync_setup_start" analytics event when the Git Auto Sync entry is selected before opening the wizard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->