### PR TITLE
chore: add analytics to chat

### DIFF
--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -135,7 +135,7 @@ export function createChatSessionStore(
     }))
   }
 
-  function beginStreaming(text: string) {
+  function beginStreaming(text: string, isRetry = false) {
     removeErrors()
     const currentMessages = get(persisted).messages
     const traceId =
@@ -167,12 +167,12 @@ export function createChatSessionStore(
     }))
 
     posthog.capture("chat_message_sent", {
-      is_new_conversation: !traceId,
+      is_new_conversation: !traceId && !isRetry,
       message_length: text.length,
       has_app_context_header: !!header,
       message_count: currentMessages.length,
     })
-    if (!traceId) {
+    if (!traceId && !isRetry) {
       posthog.capture("chat_conversation_started")
     }
 
@@ -317,7 +317,7 @@ export function createChatSessionStore(
       ...p,
       messages: p.messages.slice(0, lastUserIdx),
     }))
-    beginStreaming(userText)
+    beginStreaming(userText, true)
   }
 
   function reset(): void {

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -1,4 +1,5 @@
 import { writable, get, type Readable } from "svelte/store"
+import posthog from "posthog-js"
 import {
   streamChat,
   chatGenerateId,
@@ -165,6 +166,16 @@ export function createChatSessionStore(
       lastSentAppState: currentAppState,
     }))
 
+    posthog.capture("chat_message_sent", {
+      is_new_conversation: !traceId,
+      message_length: text.length,
+      has_app_context_header: !!header,
+      message_count: currentMessages.length,
+    })
+    if (!traceId) {
+      posthog.capture("chat_conversation_started")
+    }
+
     combined.update((s) => ({
       ...s,
       toolExecuting: false,
@@ -284,6 +295,7 @@ export function createChatSessionStore(
 
   function stop(): void {
     if (abortController) {
+      posthog.capture("chat_stopped")
       abortController.abort()
     }
   }
@@ -299,6 +311,7 @@ export function createChatSessionStore(
       }
     }
     if (lastUserIdx === -1) return
+    posthog.capture("chat_retry")
     const userText = msgs[lastUserIdx].content ?? ""
     persisted.update((p) => ({
       ...p,
@@ -390,8 +403,17 @@ export function createChatSessionStore(
     resolver(decisions)
   }
 
+  function toolNameForCallId(toolCallId: string): string | undefined {
+    return get(combined).toolApprovalWaiter?.payload.items.find(
+      (i) => i.toolCallId === toolCallId,
+    )?.toolName
+  }
+
   function applyToolApprovalRun(toolCallId: string): void {
     if (!get(combined).toolApprovalWaiter) return
+    posthog.capture("chat_tool_approval_run", {
+      tool_name: toolNameForCallId(toolCallId),
+    })
     combined.update((s) => ({
       ...s,
       toolApprovalPicks: { ...s.toolApprovalPicks, [toolCallId]: true },
@@ -401,6 +423,9 @@ export function createChatSessionStore(
 
   function applyToolApprovalSkip(toolCallId: string): void {
     if (!get(combined).toolApprovalWaiter) return
+    posthog.capture("chat_tool_approval_skip", {
+      tool_name: toolNameForCallId(toolCallId),
+    })
     combined.update((s) => ({
       ...s,
       toolApprovalPicks: { ...s.toolApprovalPicks, [toolCallId]: false },

--- a/app/web_ui/src/routes/(app)/chat/chat.svelte
+++ b/app/web_ui/src/routes/(app)/chat/chat.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from "svelte"
+  import { get } from "svelte/store"
   import { fly } from "svelte/transition"
+  import posthog from "posthog-js"
   import ChatCostDisclaimer from "./chat_cost_disclaimer.svelte"
   import type { ChatMessage, ChatMessagePart } from "$lib/chat/streaming_chat"
   import { CHAT_CLIENT_VERSION_TOO_OLD } from "$lib/error_codes"
@@ -430,6 +432,9 @@
   }
 
   export function newChat() {
+    posthog.capture("chat_new_chat_clicked", {
+      had_messages: get(store).messages.length > 0,
+    })
     store.reset()
   }
 

--- a/app/web_ui/src/routes/(app)/chat/chat_cost_disclaimer.svelte
+++ b/app/web_ui/src/routes/(app)/chat/chat_cost_disclaimer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import posthog from "posthog-js"
   import { chat_cost_disclaimer_acknowledged } from "$lib/stores"
   import Dialog from "$lib/ui/dialog.svelte"
 
@@ -9,6 +10,7 @@
 
   export function prompt(): Promise<boolean> {
     if (pendingPromise) return pendingPromise
+    posthog.capture("chat_cost_disclaimer_shown")
     pendingPromise = new Promise<boolean>((resolve) => {
       pendingResolve = resolve
       dialog.show()
@@ -17,6 +19,7 @@
   }
 
   function approve(): boolean {
+    posthog.capture("chat_cost_disclaimer_accepted")
     chat_cost_disclaimer_acknowledged.set(true)
     const resolve = pendingResolve
     pendingResolve = null
@@ -26,6 +29,8 @@
   }
 
   function dismiss() {
+    if (pendingResolve === null) return
+    posthog.capture("chat_cost_disclaimer_declined")
     const resolve = pendingResolve
     pendingResolve = null
     pendingPromise = null

--- a/app/web_ui/src/routes/(app)/chat/chat_history.svelte
+++ b/app/web_ui/src/routes/(app)/chat/chat_history.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte"
+  import posthog from "posthog-js"
   import { client } from "$lib/api_client"
   import { hydrateSessionFromSnapshot } from "$lib/chat/session_messages"
   import type { LoadedChatSessionDetail } from "$lib/chat/chat_history_apply"
@@ -48,6 +49,7 @@
   }
 
   export function open() {
+    posthog.capture("chat_history_opened")
     historyDialog?.show()
     void loadSessionList()
   }
@@ -77,6 +79,9 @@
       const { messages, continuationTraceId } =
         hydrateSessionFromSnapshot(snapshot)
       dispatch("apply", { messages, continuationTraceId })
+      posthog.capture("chat_history_session_loaded", {
+        message_count: messages.length,
+      })
       close()
     } catch (e) {
       sessionsError = createKilnError(e)
@@ -97,6 +102,7 @@
         return
       }
       sessionRows = sessionRows.filter((r) => r.id !== sessionId)
+      posthog.capture("chat_history_session_deleted")
     } catch (e) {
       sessionsError = createKilnError(e)
     } finally {

--- a/app/web_ui/src/routes/(app)/chat/chat_history.svelte
+++ b/app/web_ui/src/routes/(app)/chat/chat_history.svelte
@@ -49,8 +49,9 @@
   }
 
   export function open() {
+    if (!historyDialog) return
+    historyDialog.show()
     posthog.capture("chat_history_opened")
-    historyDialog?.show()
     void loadSessionList()
   }
 


### PR DESCRIPTION
## What does this PR do?

Add analytics events to chat.

New events:

| Event | Fields |
| --- | --- |
| `chat_message_sent` | `is_new_conversation` (boolean), `message_length` (number), `has_app_context_header` (boolean), `message_count` (number) |
| `chat_conversation_started` | — |
| `chat_stopped` | — |
| `chat_retry` | — |
| `chat_tool_approval_run` | `tool_name` (string \| undefined) |
| `chat_tool_approval_skip` | `tool_name` (string \| undefined) |
| `chat_new_chat_clicked` | `had_messages` (boolean) |
| `chat_cost_disclaimer_shown` | — |
| `chat_cost_disclaimer_accepted` | — |
| `chat_cost_disclaimer_declined` | — |
| `chat_history_opened` | — |
| `chat_history_session_loaded` | `message_count` (number) |
| `chat_history_session_deleted` | — |

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added analytics event tracking across chat flows: message submissions, conversation start/stop/retry, tool approval run/skip, new-chat clicks (with had_messages), cost-disclaimer shown/accepted/declined, and chat-history opened/session loaded/deleted to improve product insights.
* **Bug Fixes**
  * Prevented duplicate dismissal of the cost-disclaimer dialog by adding an early return when no pending resolver exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->