### PR TITLE
refactor: no_write_lock on run endpoint to avoid long lock

### DIFF
--- a/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
@@ -66,6 +66,7 @@ from kiln_ai.tools.skill_tool import SkillTool
 from kiln_ai.tools.tool_registry import tool_from_id
 from kiln_ai.utils.config import Config
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
+from kiln_ai.utils.git_sync_protocols import SaveContext, default_save_context
 from kiln_ai.utils.open_ai_types import ChatCompletionMessageParam
 
 if TYPE_CHECKING:
@@ -204,9 +205,10 @@ class BaseAdapter(metaclass=ABCMeta):
         input_source: DataSource | None = None,
         prior_trace: list[ChatCompletionMessageParam] | None = None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> TaskRun:
         task_run, _ = await self.invoke_returning_run_output(
-            input, input_source, prior_trace, parent_task_run
+            input, input_source, prior_trace, parent_task_run, save_context=save_context
         )
         return task_run
 
@@ -216,6 +218,7 @@ class BaseAdapter(metaclass=ABCMeta):
         input_source: DataSource | None = None,
         prior_trace: list[ChatCompletionMessageParam] | None = None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> Tuple[TaskRun, RunOutput]:
         prior_trace = self._normalize_prior_trace(prior_trace)
         self._reject_multiturn_with_structured_input(prior_trace)
@@ -300,7 +303,8 @@ class BaseAdapter(metaclass=ABCMeta):
             and Config.shared().autosave_runs
             and self.task.path is not None
         ):
-            run.save_to_file()
+            async with (save_context or default_save_context)():
+                run.save_to_file()
         else:
             # Clear the ID to indicate it's not persisted
             run.id = None
@@ -313,6 +317,7 @@ class BaseAdapter(metaclass=ABCMeta):
         input_source: DataSource | None = None,
         prior_trace: list[ChatCompletionMessageParam] | None = None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> Tuple[TaskRun, RunOutput]:
         # Determine if this is the root agent (no existing run context)
         is_root_agent = get_agent_run_id() is None
@@ -323,7 +328,11 @@ class BaseAdapter(metaclass=ABCMeta):
 
         try:
             return await self._run_returning_run_output(
-                input, input_source, prior_trace, parent_task_run
+                input,
+                input_source,
+                prior_trace,
+                parent_task_run,
+                save_context=save_context,
             )
         finally:
             if is_root_agent:
@@ -340,6 +349,7 @@ class BaseAdapter(metaclass=ABCMeta):
         input_source: DataSource | None = None,
         prior_trace: list[ChatCompletionMessageParam] | None = None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> OpenAIStreamResult:
         """Stream raw OpenAI-protocol chunks for the task execution.
 
@@ -352,7 +362,7 @@ class BaseAdapter(metaclass=ABCMeta):
         ``invoke_ai_sdk_stream`` if you need tool-call events.
         """
         return OpenAIStreamResult(
-            self, input, input_source, prior_trace, parent_task_run
+            self, input, input_source, prior_trace, parent_task_run, save_context
         )
 
     def invoke_ai_sdk_stream(
@@ -361,6 +371,7 @@ class BaseAdapter(metaclass=ABCMeta):
         input_source: DataSource | None = None,
         prior_trace: list[ChatCompletionMessageParam] | None = None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> AiSdkStreamResult:
         """Stream AI SDK protocol events for the task execution.
 
@@ -370,7 +381,7 @@ class BaseAdapter(metaclass=ABCMeta):
         ``TaskRun`` is available via the ``.task_run`` property.
         """
         return AiSdkStreamResult(
-            self, input, input_source, prior_trace, parent_task_run
+            self, input, input_source, prior_trace, parent_task_run, save_context
         )
 
     def _prepare_stream(
@@ -397,12 +408,13 @@ class BaseAdapter(metaclass=ABCMeta):
 
         return self._create_run_stream(formatted_input, prior_trace)
 
-    def _finalize_stream(
+    async def _finalize_stream(
         self,
         adapter_stream: AdapterStream,
         input: InputType,
         input_source: DataSource | None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> TaskRun:
         """Streaming invocations are only concerned with passing through events as they come in.
         At the end of the stream, we still need to validate the output, create a run and everything
@@ -467,7 +479,8 @@ class BaseAdapter(metaclass=ABCMeta):
             and Config.shared().autosave_runs
             and self.task.path is not None
         ):
-            run.save_to_file()
+            async with (save_context or default_save_context)():
+                run.save_to_file()
         else:
             run.id = None
 
@@ -778,12 +791,14 @@ class OpenAIStreamResult:
         input_source: DataSource | None,
         prior_trace: list[ChatCompletionMessageParam] | None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> None:
         self._adapter = adapter
         self._input = input
         self._input_source = input_source
         self._prior_trace = prior_trace
         self._parent_task_run = parent_task_run
+        self._save_context = save_context
         self._task_run: TaskRun | None = None
 
     @property
@@ -810,8 +825,12 @@ class OpenAIStreamResult:
                 if isinstance(event, ModelResponseStream):
                     yield event
 
-            self._task_run = self._adapter._finalize_stream(
-                adapter_stream, self._input, self._input_source, self._parent_task_run
+            self._task_run = await self._adapter._finalize_stream(
+                adapter_stream,
+                self._input,
+                self._input_source,
+                self._parent_task_run,
+                save_context=self._save_context,
             )
         finally:
             if is_root_agent:
@@ -841,12 +860,14 @@ class AiSdkStreamResult:
         input_source: DataSource | None,
         prior_trace: list[ChatCompletionMessageParam] | None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> None:
         self._adapter = adapter
         self._input = input
         self._input_source = input_source
         self._prior_trace = prior_trace
         self._parent_task_run = parent_task_run
+        self._save_context = save_context
         self._task_run: TaskRun | None = None
 
     @property
@@ -893,8 +914,12 @@ class AiSdkStreamResult:
 
             yield FinishStepEvent()
 
-            self._task_run = self._adapter._finalize_stream(
-                adapter_stream, self._input, self._input_source, self._parent_task_run
+            self._task_run = await self._adapter._finalize_stream(
+                adapter_stream,
+                self._input,
+                self._input_source,
+                self._parent_task_run,
+                save_context=self._save_context,
             )
 
             if self._task_run.is_toolcall_pending:

--- a/libs/core/kiln_ai/adapters/model_adapters/mcp_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/mcp_adapter.py
@@ -21,6 +21,7 @@ from kiln_ai.run_context import (
 from kiln_ai.tools.mcp_session_manager import MCPSessionManager
 from kiln_ai.tools.tool_registry import tool_from_id
 from kiln_ai.utils.config import Config
+from kiln_ai.utils.git_sync_protocols import SaveContext, default_save_context
 from kiln_ai.utils.open_ai_types import (
     ChatCompletionAssistantMessageParamWrapper,
     ChatCompletionMessageParam,
@@ -87,6 +88,7 @@ class MCPAdapter(BaseAdapter):
         input_source: DataSource | None = None,
         prior_trace: list[ChatCompletionMessageParam] | None = None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> TaskRun:
         if prior_trace or parent_task_run is not None:
             raise NotImplementedError(
@@ -95,7 +97,7 @@ class MCPAdapter(BaseAdapter):
             )
 
         run_output, _ = await self.invoke_returning_run_output(
-            input, input_source, prior_trace, parent_task_run
+            input, input_source, prior_trace, parent_task_run, save_context=save_context
         )
         return run_output
 
@@ -105,6 +107,7 @@ class MCPAdapter(BaseAdapter):
         input_source: DataSource | None = None,
         prior_trace: list[ChatCompletionMessageParam] | None = None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> Tuple[TaskRun, RunOutput]:
         """
         Runs the task and returns both the persisted TaskRun and raw RunOutput.
@@ -124,7 +127,7 @@ class MCPAdapter(BaseAdapter):
 
         try:
             return await self._run_and_validate_output(
-                input, input_source, parent_task_run
+                input, input_source, parent_task_run, save_context=save_context
             )
         finally:
             if is_root_agent:
@@ -140,6 +143,7 @@ class MCPAdapter(BaseAdapter):
         input: InputType,
         input_source: DataSource | None,
         parent_task_run: TaskRun | None = None,
+        save_context: SaveContext | None = None,
     ) -> Tuple[TaskRun, RunOutput]:
         """
         Run the MCP task and validate the output.
@@ -187,7 +191,8 @@ class MCPAdapter(BaseAdapter):
             and Config.shared().autosave_runs
             and self.task.path is not None
         ):
-            run.save_to_file()
+            async with (save_context or default_save_context)():
+                run.save_to_file()
         else:
             run.id = None
 

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -1395,7 +1395,7 @@ class TestStreamMethods:
                 "_prepare_stream",
                 return_value=FakeAdapterStream(),
             ),
-            patch.object(stream_adapter, "_finalize_stream"),
+            patch.object(stream_adapter, "_finalize_stream", new_callable=AsyncMock),
         ):
             events = []
             async for event in stream_adapter.invoke_ai_sdk_stream("test input"):
@@ -1437,7 +1437,12 @@ class TestStreamMethods:
                 "_prepare_stream",
                 return_value=FakeAdapterStream(),
             ),
-            patch.object(stream_adapter, "_finalize_stream", return_value=expected_run),
+            patch.object(
+                stream_adapter,
+                "_finalize_stream",
+                new_callable=AsyncMock,
+                return_value=expected_run,
+            ),
         ):
             stream = stream_adapter.invoke_openai_stream("test input")
 
@@ -1476,7 +1481,12 @@ class TestStreamMethods:
                 "_prepare_stream",
                 return_value=FakeAdapterStream(),
             ),
-            patch.object(stream_adapter, "_finalize_stream", return_value=expected_run),
+            patch.object(
+                stream_adapter,
+                "_finalize_stream",
+                new_callable=AsyncMock,
+                return_value=expected_run,
+            ),
         ):
             stream = stream_adapter.invoke_ai_sdk_stream("test input")
 
@@ -1518,14 +1528,16 @@ class TestFinalizeStream:
         )
         return stream
 
-    def test_finalize_stream_plain_text(self, finalize_adapter):
+    async def test_finalize_stream_plain_text(self, finalize_adapter):
         provider = MagicMock()
         provider.parser = None
         provider.reasoning_capable = False
         finalize_adapter.model_provider = MagicMock(return_value=provider)
 
         adapter_stream = self._make_adapter_stream("Hello world")
-        run = finalize_adapter._finalize_stream(adapter_stream, "test input", None)
+        run = await finalize_adapter._finalize_stream(
+            adapter_stream, "test input", None
+        )
 
         assert isinstance(run, TaskRun)
         assert run.output.output == "Hello world"
@@ -1544,7 +1556,7 @@ class TestFinalizeStream:
         )
         return adapter
 
-    def test_finalize_stream_structured_output(self, base_task):
+    async def test_finalize_stream_structured_output(self, base_task):
         schema = '{"type": "object", "properties": {"name": {"type": "string"}}, "required": ["name"]}'
         adapter = self._make_structured_adapter(base_task, schema)
 
@@ -1554,12 +1566,12 @@ class TestFinalizeStream:
         adapter.model_provider = MagicMock(return_value=provider)
 
         adapter_stream = self._make_adapter_stream({"name": "test"})
-        run = adapter._finalize_stream(adapter_stream, "test input", None)
+        run = await adapter._finalize_stream(adapter_stream, "test input", None)
 
         assert isinstance(run, TaskRun)
         assert '"name"' in run.output.output
 
-    def test_finalize_stream_structured_output_from_json_string(self, base_task):
+    async def test_finalize_stream_structured_output_from_json_string(self, base_task):
         schema = '{"type": "object", "properties": {"val": {"type": "integer"}}, "required": ["val"]}'
         adapter = self._make_structured_adapter(base_task, schema)
 
@@ -1569,10 +1581,10 @@ class TestFinalizeStream:
         adapter.model_provider = MagicMock(return_value=provider)
 
         adapter_stream = self._make_adapter_stream('{"val": 42}')
-        run = adapter._finalize_stream(adapter_stream, "test input", None)
+        run = await adapter._finalize_stream(adapter_stream, "test input", None)
         assert isinstance(run, TaskRun)
 
-    def test_finalize_stream_structured_output_not_dict_raises(self, base_task):
+    async def test_finalize_stream_structured_output_not_dict_raises(self, base_task):
         schema = '{"type": "object", "properties": {"x": {"type": "string"}}, "required": ["x"]}'
         adapter = self._make_structured_adapter(base_task, schema)
 
@@ -1583,9 +1595,11 @@ class TestFinalizeStream:
 
         adapter_stream = self._make_adapter_stream(42)
         with pytest.raises(RuntimeError, match="structured response is not a dict"):
-            adapter._finalize_stream(adapter_stream, "test input", None)
+            await adapter._finalize_stream(adapter_stream, "test input", None)
 
-    def test_finalize_stream_non_structured_non_string_raises(self, finalize_adapter):
+    async def test_finalize_stream_non_structured_non_string_raises(
+        self, finalize_adapter
+    ):
         provider = MagicMock()
         provider.parser = None
         provider.reasoning_capable = False
@@ -1593,9 +1607,11 @@ class TestFinalizeStream:
 
         adapter_stream = self._make_adapter_stream({"unexpected": "dict"})
         with pytest.raises(RuntimeError, match="not a string for non-structured"):
-            finalize_adapter._finalize_stream(adapter_stream, "test input", None)
+            await finalize_adapter._finalize_stream(adapter_stream, "test input", None)
 
-    def test_finalize_stream_reasoning_required_but_missing(self, finalize_adapter):
+    async def test_finalize_stream_reasoning_required_but_missing(
+        self, finalize_adapter
+    ):
         provider = MagicMock()
         provider.parser = None
         provider.reasoning_capable = True
@@ -1604,9 +1620,9 @@ class TestFinalizeStream:
 
         adapter_stream = self._make_adapter_stream("output")
         with pytest.raises(RuntimeError, match="Reasoning is required"):
-            finalize_adapter._finalize_stream(adapter_stream, "test input", None)
+            await finalize_adapter._finalize_stream(adapter_stream, "test input", None)
 
-    def test_finalize_stream_reasoning_not_required_with_tool_calls(
+    async def test_finalize_stream_reasoning_not_required_with_tool_calls(
         self, finalize_adapter
     ):
         provider = MagicMock()
@@ -1620,10 +1636,12 @@ class TestFinalizeStream:
             {"role": "tool", "content": "result", "tool_call_id": "call_1"},
         ]
         adapter_stream = self._make_adapter_stream("output", trace=trace)
-        run = finalize_adapter._finalize_stream(adapter_stream, "test input", None)
+        run = await finalize_adapter._finalize_stream(
+            adapter_stream, "test input", None
+        )
         assert isinstance(run, TaskRun)
 
-    def test_finalize_stream_saves_when_allowed(self, tmp_path):
+    async def test_finalize_stream_saves_when_allowed(self, tmp_path):
         project_path = tmp_path / "proj" / "project.kiln"
         project_path.parent.mkdir()
         project = Project(name="test", path=project_path)
@@ -1653,7 +1671,7 @@ class TestFinalizeStream:
         ) as mock_config:
             mock_config.shared.return_value.autosave_runs = True
             mock_config.shared.return_value.user_id = "test_user"
-            run = adapter._finalize_stream(adapter_stream, "test input", None)
+            run = await adapter._finalize_stream(adapter_stream, "test input", None)
         assert run.id is not None
 
 

--- a/libs/server/kiln_server/run_api.py
+++ b/libs/server/kiln_server/run_api.py
@@ -7,7 +7,7 @@ from asyncio import Lock
 from datetime import datetime
 from typing import Annotated, Any, Dict
 
-from fastapi import Body, FastAPI, File, Form, HTTPException, Path, UploadFile
+from fastapi import Body, FastAPI, File, Form, HTTPException, Path, Request, UploadFile
 from kiln_ai.adapters.adapter_registry import adapter_for_task, load_skills_for_task
 from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig
@@ -24,6 +24,7 @@ from kiln_ai.utils.dataset_import import (
 )
 from pydantic import BaseModel, ConfigDict, Field
 
+from kiln_server.git_sync_decorators import build_save_context, no_write_lock
 from kiln_server.task_api import task_from_id
 from kiln_server.utils.agent_checks.policy import (
     ALLOW_AGENT,
@@ -379,7 +380,9 @@ def connect_run_api(app: FastAPI):
         tags=["Runs"],
         openapi_extra=agent_policy_require_approval("Run task with LLM?"),
     )
+    @no_write_lock
     async def run_task(
+        http_request: Request,
         project_id: Annotated[
             str, Path(description="The unique identifier of the project.")
         ],
@@ -411,7 +414,9 @@ def connect_run_api(app: FastAPI):
                 detail="No input provided. Ensure your provided the proper format (plaintext or structured).",
             )
 
-        return await adapter.invoke(input)
+        return await adapter.invoke(
+            input, save_context=build_save_context(http_request)
+        )
 
     @app.patch(
         "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}",

--- a/libs/server/kiln_server/test_run_api.py
+++ b/libs/server/kiln_server/test_run_api.py
@@ -1854,3 +1854,51 @@ async def test_run_task_adapter_sanity_math_tools(
     assert response4.status_code == 200
     res4 = response4.json()
     _assert_math_tools_response(res4, "7")
+
+
+# --- /run endpoint self-manages the git-sync write lock ---
+
+
+def _find_endpoint_by_path(app, path_suffix: str):
+    """Locate the endpoint function for a route ending with path_suffix."""
+    for route in app.routes:
+        if getattr(route, "path", "").endswith(path_suffix):
+            return route.endpoint  # type: ignore[attr-defined]
+    raise AssertionError(f"Route ending in {path_suffix} not found")
+
+
+def test_run_task_has_no_write_lock(app):
+    endpoint = _find_endpoint_by_path(app, "/tasks/{task_id}/run")
+    assert getattr(endpoint, "_git_sync_no_write_lock", False) is True
+
+
+@pytest.mark.asyncio
+async def test_run_task_passes_save_context_to_adapter(client, task_run_setup):
+    """The endpoint must forward build_save_context(request) into adapter.invoke
+    so the write lock wraps only the fs write, not the whole LLM call."""
+    project = task_run_setup["project"]
+    task = task_run_setup["task"]
+    run_task_request = task_run_setup["run_task_request"]
+
+    sentinel_save_context = object()
+
+    with (
+        patch("kiln_server.run_api.task_from_id") as mock_task_from_id,
+        patch.object(LiteLlmAdapter, "invoke", new_callable=AsyncMock) as mock_invoke,
+        patch(
+            "kiln_server.run_api.build_save_context",
+            return_value=sentinel_save_context,
+        ) as mock_build_save_context,
+        patch("kiln_ai.utils.config.Config.shared") as MockConfig,
+    ):
+        mock_task_from_id.return_value = task
+        mock_invoke.return_value = task_run_setup["task_run"]
+        MockConfig.return_value.ollama_base_url = "http://localhost:11434/v1"
+
+        response = client.post(
+            f"/api/projects/{project.id}/tasks/{task.id}/run", json=run_task_request
+        )
+
+    assert response.status_code == 200
+    mock_build_save_context.assert_called_once()
+    assert mock_invoke.call_args.kwargs["save_context"] is sentinel_save_context


### PR DESCRIPTION
## What does this PR do?

Git sync requires locking. The `/run` page calls an endpoint entirely covered by the lock, but the task running itself may take a long time and may include toolcall looping and so on. We only need to locking to cover the TaskRun file write, not the whole waiting on the agent to complete execution.

Two ways we could implement that; the most obvious would have been to `allow_saving=false` on the `AdapterConfig`, and save the file in the API controller and cover it with the lock there. However, that does not work in the streaming case since that lifecycle forks off the controller - so we need to pass down the context to the adapter.

Changes:
- refactor: `@no_write_lock` on the run endpoint and pass `save_context` to the adapter to let it lock only around the write

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved streaming finalization to properly support async execution
  * Enhanced run persistence to better utilize request context information

* **Tests**
  * Updated streaming tests to verify async execution behavior
  * Added tests to validate request context propagation in run execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->