### PR TITLE
chore: downgrade starlette to 0.41.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
 
 [tool.uv]
 override-dependencies = [
-  "starlette>=0.49.1",   # forces a safe minimum for the transitive dep
+  "starlette==0.41.3",   # pin to last release before #2732 broke SSE disconnect cancellation
 ]
 
 [tool.uv.workspace]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -17,7 +17,7 @@ members = [
     "kiln-server",
     "kiln-studio-desktop",
 ]
-overrides = [{ name = "starlette", specifier = ">=0.49.1" }]
+overrides = [{ name = "starlette", specifier = "==0.41.3" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1825,7 +1825,7 @@ dev = [
 
 [[package]]
 name = "kiln-studio-desktop"
-version = "0.27.3"
+version = "0.28.0"
 source = { editable = "app/desktop" }
 dependencies = [
     { name = "kiln-server" },
@@ -3764,15 +3764,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "0.41.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/4c/9b5764bd22eec91c4039ef4c55334e9187085da2d8a2df7bd570869aae18/starlette-0.41.3.tar.gz", hash = "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835", size = 2574159, upload-time = "2024-11-18T19:45:04.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/96/00/2b325970b3060c7cecebab6d295afe763365822b1306a12eeab198f74323/starlette-0.41.3-py3-none-any.whl", hash = "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7", size = 73225, upload-time = "2024-11-18T19:45:02.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

`starlette` dependency broke handling of disconnects that we rely on for SSE - to terminate the handler execution when the client disconnects. This is problematic for endpoints like eval running, RAG running, etc. where client disconnecting is also supposed to terminate an expensive batch job.

To avoid a complex large risk fix (https://github.com/Kiln-AI/Kiln/pull/1322), we can downgrade `starlette` back to `0.41.3`, before the breaking change.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Starlette dependency version constraint for consistent resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->