### PR TITLE
refactor: add no_write_lock on chat sse endpoints

### DIFF
--- a/app/desktop/studio_server/chat/routes.py
+++ b/app/desktop/studio_server/chat/routes.py
@@ -27,6 +27,7 @@ from app.desktop.studio_server.chat.stream_session import (
 from app.desktop.studio_server.utils.copilot_utils import get_copilot_api_key
 from fastapi import FastAPI, HTTPException, Path, Query
 from fastapi.responses import StreamingResponse
+from kiln_server.git_sync_decorators import no_write_lock
 from kiln_server.utils.agent_checks.policy import DENY_AGENT
 from pydantic import BaseModel, ConfigDict
 
@@ -123,6 +124,7 @@ def connect_chat_api(app: FastAPI) -> None:
         tags=["Copilot"],
         openapi_extra=DENY_AGENT,
     )
+    @no_write_lock
     async def post_execute_tools(body: ExecuteToolsRequest) -> StreamingResponse:
         """
         Tool calls that require user approval are streamed to the client for approval, along with the
@@ -248,6 +250,7 @@ def connect_chat_api(app: FastAPI) -> None:
         tags=["Copilot"],
         openapi_extra=DENY_AGENT,
     )
+    @no_write_lock
     async def chat(body: ChatRequest) -> StreamingResponse:
         """Forward chat to Kiln Copilot and stream AI SDK events as Server-Sent Events."""
         api_key = get_copilot_api_key()

--- a/app/desktop/studio_server/chat/test_routes.py
+++ b/app/desktop/studio_server/chat/test_routes.py
@@ -1029,3 +1029,21 @@ class TestMockedFlows:
         assert len(tool_outputs) == 1
         assert tool_outputs[0]["toolCallId"] == "tc_shape"
         assert tool_outputs[0]["output"] == "15"
+
+
+def _find_endpoint_by_path(app, path: str):
+    """Locate the endpoint function for a route with exact path match."""
+    for route in app.routes:
+        if getattr(route, "path", None) == path:
+            return route.endpoint  # type: ignore[attr-defined]
+    raise AssertionError(f"Route with path {path} not found")
+
+
+def test_chat_stream_has_no_write_lock(app):
+    endpoint = _find_endpoint_by_path(app, "/api/chat")
+    assert getattr(endpoint, "_git_sync_no_write_lock", False) is True
+
+
+def test_execute_tools_has_no_write_lock(app):
+    endpoint = _find_endpoint_by_path(app, "/api/chat/execute-tools")
+    assert getattr(endpoint, "_git_sync_no_write_lock", False) is True


### PR DESCRIPTION
## What does this PR do?

Add `@no_write_lock` decorator on SSE chat endpoints - should not be needed as they do not match the prefix pattern (`/api/projects/xxx`) the middleware targets, but might in the future so costs nothing to add now.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved concurrency control mechanisms on chat endpoints to ensure reliable operation when handling simultaneous requests.
  * Added validation tests for endpoint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->