### PR TITLE
chore: regen uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -1825,7 +1825,7 @@ dev = [
 
 [[package]]
 name = "kiln-studio-desktop"
-version = "0.27.3"
+version = "0.28.0"
 source = { editable = "app/desktop" }
 dependencies = [
     { name = "kiln-server" },


### PR DESCRIPTION
## What does this PR do?

Running `uv sync` on the latest version updates the version, which looks like it was out of sync with the latest release. Regened the `uv.lock` by running `uv sync` again.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
