### PR TITLE
KIL-612 Update out of date model strings

### DIFF
--- a/app/web_ui/src/lib/ui/run_config_component/available_models_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/available_models_dropdown.svelte
@@ -403,7 +403,7 @@
         : selected_model_suggested_data_gen
           ? "success"
           : "warning"}
-      warning_message="For data gen we suggest using a high quality model such as GPT 4.1, Sonnet, Gemini Pro or R1."
+      warning_message={`For data gen we suggest using one of the models marked "Recommended" in the dropdown.`}
     />
   {:else if settings.suggested_mode === "uncensored_data_gen"}
     <Warning
@@ -417,7 +417,7 @@
         : selected_model_suggested_uncensored_data_gen
           ? "success"
           : "warning"}
-      warning_message="For this data gen template we suggest a large uncensored model like Grok 4."
+      warning_message={`For this data gen template we suggest using one of the models marked "Recommended" in the dropdown.`}
     />
   {:else if settings.suggested_mode === "evals"}
     <Warning
@@ -431,7 +431,7 @@
         : selected_model_suggested_evals
           ? "success"
           : "warning"}
-      warning_message="For evals we suggest using a high quality model such as GPT 4.1, Sonnet, Gemini Pro or R1."
+      warning_message={`For evals we suggest using one of the models marked "Recommended" in the dropdown.`}
     />
   {:else if settings.suggested_mode === "doc_extraction"}
     <Warning
@@ -445,7 +445,7 @@
         : selected_model_suggested_doc_extraction
           ? "success"
           : "warning"}
-      warning_message="For doc extraction, we recommend using a high quality multimodal model like Gemini Pro."
+      warning_message={`For doc extraction we suggest using one of the models marked "Recommended" in the dropdown.`}
     />
   {/if}
 </div>


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-612/update-out-of-date-model-strings

## Description

> For example: "For data gen we suggest using a high quality model such as GPT 4.1, Sonnet, Gemini Pro or R1." should just be "For data generation we suggest using one of our models recommended in the dropdown."
>
> Audit if there's anywhere else in the code we display something like that.

## Summary

- Replace the hard-coded model lists (GPT 4.1, Sonnet, Gemini Pro, R1, Grok 4, Gemini Pro multimodal) in the four `suggested_mode` warning messages in `available_models_dropdown.svelte` with a generic pointer to models marked "Recommended" in the dropdown. The dropdown already tags suggested models with a **Recommended** badge per-mode, so the warning can defer to that instead of listing names that go stale.
- Affected modes: `data_gen`, `uncensored_data_gen`, `evals`, `doc_extraction`.

## Audit notes (out of scope)

- The hard-requirement warning on line 379 (`requires_uncensored_data_gen` mismatch) still mentions "Grok" — this is a hard mismatch, different context, leaving as-is.
- `rag_config_templates.ts` references specific models, but those are describing the actual configuration each template uses — load-bearing, not genericize.
- `dataset_formatter.py` "(R1, QwQ, etc)" is an illustrative list, not exhaustive.
- `connect_providers.svelte` mentions stable family names (Sonnet/Haiku/Opus, GPT-4o) as provider examples.
- Comment-only references (`formatters.ts`, adapter implementation comments) aren't user-facing.

## Test plan

- [x] `uv run ./checks.sh --agent-mode` (all pass)
- [ ] Visual spot-check: open a task that shows each warning variant and confirm the new copy reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)