### PR TITLE
fix: test breaking caused by race in non-idempotent create folder op

### DIFF
--- a/libs/core/kiln_ai/utils/config.py
+++ b/libs/core/kiln_ai/utils/config.py
@@ -282,8 +282,8 @@ class Config:
     @classmethod
     def settings_dir(cls, create=True) -> str:
         settings_dir = os.path.join(Path.home(), ".kiln_ai")
-        if create and not os.path.exists(settings_dir):
-            os.makedirs(settings_dir)
+        if create:
+            os.makedirs(settings_dir, exist_ok=True)
         return settings_dir
 
     @classmethod


### PR DESCRIPTION
## What does this PR do?

Non-idempotent folder creation op seems to break tests on `main` due to a race.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
