### PR TITLE
Add GPT-5.5 to model list (openai)

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -567,6 +567,10 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
                 default_thinking_level="none",
+                # OpenAI rejects reasoning_effort + tools on /v1/chat/completions
+                # for gpt-5.4 direct. Disable function calling until Kiln routes
+                # these models to /v1/responses. The OpenRouter route is unaffected.
+                supports_function_calling=False,
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
                 supports_doc_extraction=True,

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -551,6 +551,27 @@ built_in_models: List[KilnModel] = [
                     KilnMimeType.PNG,
                 ],
             ),
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="openai/gpt-5.5",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
+                default_thinking_level="none",
+                suggested_for_evals=True,
+                suggested_for_data_gen=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
         ],
     ),
     # GPT 5.4

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -532,6 +532,10 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
                 default_thinking_level="none",
+                # OpenAI rejects reasoning_effort + tools on /v1/chat/completions
+                # for gpt-5.4+. Disable function calling until Kiln routes these
+                # models to /v1/responses.
+                supports_function_calling=False,
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
                 supports_doc_extraction=True,

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -64,6 +64,7 @@ class ModelName(str, Enum):
     llama_3_3_70b = "llama_3_3_70b"
     llama_4_maverick = "llama_4_maverick"
     llama_4_scout = "llama_4_scout"
+    gpt_5_5 = "gpt_5_5"
     gpt_5_4 = "gpt_5_4"
     gpt_5_4_pro = "gpt_5_4_pro"
     gpt_5_4_mini = "gpt_5_4_mini"
@@ -517,6 +518,37 @@ CLAUDE_OPUS_4_7_ANTHROPIC_THINKING_LEVELS = {
 
 
 built_in_models: List[KilnModel] = [
+    # GPT 5.5
+    KilnModel(
+        family=ModelFamily.gpt,
+        name=ModelName.gpt_5_5,
+        friendly_name="GPT-5.5",
+        featured_rank=1,
+        editorial_notes="OpenAI's most capable GPT model. Powerful reasoning and multimodal.",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openai,
+                model_id="gpt-5.5",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
+                default_thinking_level="none",
+                suggested_for_evals=True,
+                suggested_for_data_gen=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
     # GPT 5.4
     KilnModel(
         family=ModelFamily.gpt,

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -557,6 +557,10 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
                 default_thinking_level="none",
+                # Use OpenRouter's reasoning object so reasoning is preserved
+                # when tools are sent (the bare reasoning_effort param is
+                # silently dropped on tool calls for openai/gpt-5.5).
+                openrouter_reasoning_object=True,
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
                 supports_doc_extraction=True,


### PR DESCRIPTION
## What does this PR do?

Adds GPT-5.5 (released 2026-04-23) to the built-in model list. Configuration mirrors the GPT-5.4 predecessor: `json_schema` structured output, `GPT_5_4_OPENAI_THINKING_LEVELS` (none/low/medium/high/xhigh, default `none`), `featured_rank=1`, suggested for evals and data gen, vision + PDF/MD/TXT extraction. Both **OpenAI direct** and **OpenRouter** providers are wired up — OpenRouter listed `openai/gpt-5.5` shortly after the initial push so it was added in a follow-up commit.

Also disables function calling on **gpt-5.5 / gpt-5.4 OpenAI-direct** providers because OpenAI's `/v1/chat/completions` rejects `reasoning_effort` + tools with a 400 on these two models. Even with `default_thinking_level="none"`, Kiln currently sends `reasoning_effort: "none"` which trips the same check, so any tool call fails at runtime. Disabling `supports_function_calling` matches what actually works today; once Kiln routes these models to `/v1/responses` (or strips `reasoning_effort` when tools are present) the flag can be flipped back. **The OpenRouter route is unaffected** — function calling works there — and so are `gpt-5.4-pro/mini/nano` and earlier GPT-5.x models.

## Test Results

The full thinking-level matrix passed end-to-end (none/low/medium/high/xhigh) on the OpenAI-direct provider, confirming the predecessor's `GPT_5_4_OPENAI_THINKING_LEVELS` constant carries over. Extraction works for PDF, JPG, and PNG. After applying `supports_function_calling=False` on the OpenAI provider, `test_tools_all_built_in_models[gpt_5_5-openai]` and `test_tools_all_built_in_models[gpt_5_4-openai]` both skip cleanly. The OpenRouter route ran the full suite with no failures, including the tools test.

To pin down the scope of the OpenAI policy change, I re-ran the tools test across the existing GPT-5.x family while preparing this PR: `gpt-5` ✅, `gpt-5.1` ✅, `gpt-5.2` ✅, `gpt-5.4` ❌ (now disabled on direct), `gpt-5.4-pro` ✅, `gpt-5.4-mini` (openai entry has no thinking levels, openrouter ✅), `gpt-5.4-nano` (same), `gpt-5.5` ❌ (now disabled on direct), `gpt-5.5-openrouter` ✅. The breakage is limited to the `gpt-5.4` and `gpt-5.5` OpenAI-direct entries.

GPT-5.5 (openai):
- 21 passed, 11 skipped, 0 failed (after `supports_function_calling=False`)

GPT-5.5 (openrouter):
- 17 passed, 9 skipped, 0 failed

---
GPT-5.5 (openai):
✅ test_data_gen_all_models_providers[gpt_5_5-openai]
✅ test_data_gen_sample_all_models_providers[gpt_5_5-openai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[gpt_5_5-openai]
✅ test_all_built_in_models_llm_as_judge[gpt_5_5-openai]
✅ test_all_built_in_models_structured_output[gpt_5_5-openai]
✅ test_all_built_in_models_structured_input[gpt_5_5-openai]
✅ test_structured_output_cot_prompt_builder[gpt_5_5-openai]
✅ test_structured_input_cot_prompt_builder[gpt_5_5-openai]
✅ test_all_models_providers_plaintext[gpt_5_5-openai]
✅ test_cot_prompt_builder[gpt_5_5-openai]
✅ test_thinking_level_reasoning_content[ModelProviderName.openai/gpt_5_5/none]
✅ test_thinking_level_reasoning_content[ModelProviderName.openai/gpt_5_5/low]
✅ test_thinking_level_reasoning_content[ModelProviderName.openai/gpt_5_5/medium]
✅ test_thinking_level_reasoning_content[ModelProviderName.openai/gpt_5_5/high]
✅ test_thinking_level_reasoning_content[ModelProviderName.openai/gpt_5_5/xhigh]
✅ test_supports_vision_is_coherent[gpt_5_5-openai]
✅ test_provider_bad_request[gpt_5_5-openai]
✅ test_extract_document_success[application/pdf-text_probe0-gpt_5_5-openai]
✅ test_extract_document_success[image/png-text_probe5-gpt_5_5-openai]
✅ test_extract_document_success[image/jpeg-text_probe6-gpt_5_5-openai]
✅ test_extract_document_success[image/jpeg-text_probe7-gpt_5_5-openai]
⏭ test_tools_all_built_in_models[gpt_5_5-openai] — skipped via `supports_function_calling=False`

GPT-5.5 (openrouter):
✅ test_data_gen_all_models_providers[gpt_5_5-openrouter]
✅ test_data_gen_sample_all_models_providers[gpt_5_5-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[gpt_5_5-openrouter]
✅ test_all_built_in_models_llm_as_judge[gpt_5_5-openrouter]
✅ test_all_built_in_models_structured_output[gpt_5_5-openrouter]
✅ test_all_built_in_models_structured_input[gpt_5_5-openrouter]
✅ test_structured_output_cot_prompt_builder[gpt_5_5-openrouter]
✅ test_structured_input_cot_prompt_builder[gpt_5_5-openrouter]
✅ test_all_models_providers_plaintext[gpt_5_5-openrouter]
✅ test_cot_prompt_builder[gpt_5_5-openrouter]
✅ test_tools_all_built_in_models[gpt_5_5-openrouter]
✅ test_supports_vision_is_coherent[gpt_5_5-openrouter]
✅ test_provider_bad_request[gpt_5_5-openrouter]
✅ test_extract_document_success[application/pdf-text_probe0-gpt_5_5-openrouter]
✅ test_extract_document_success[image/png-text_probe5-gpt_5_5-openrouter]
✅ test_extract_document_success[image/jpeg-text_probe6-gpt_5_5-openrouter]
✅ test_extract_document_success[image/jpeg-text_probe7-gpt_5_5-openrouter]

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib
