### PR TITLE
fix: repair for run with custom provider

### DIFF
--- a/app/desktop/studio_server/test_repair_api.py
+++ b/app/desktop/studio_server/test_repair_api.py
@@ -5,6 +5,12 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from kiln_server.custom_errors import connect_custom_errors
+from litellm.types.utils import ModelResponse
+from litellm.types.utils import Usage as LiteLlmUsage
+
+from kiln_ai.adapters.adapter_registry import adapter_for_task
+from kiln_ai.adapters.ml_model_list import ModelProviderName
+from kiln_ai.adapters.model_adapters.litellm_adapter import LiteLlmAdapter
 from kiln_ai.datamodel import (
     DataSource,
     DataSourceType,
@@ -13,6 +19,8 @@ from kiln_ai.datamodel import (
     TaskOutput,
     TaskRun,
 )
+from kiln_ai.datamodel.datamodel_enums import StructuredOutputMode
+from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.utils.config import Config
 
 from app.desktop.studio_server.repair_api import (
@@ -236,3 +244,93 @@ def test_repair_run_human_source(
     assert (
         repaired_output["source"]["properties"]["created_by"] == Config.shared().user_id
     )
+
+
+async def test_run_then_repair_legacy_openai_compatible_e2e(client, tmp_path):
+    """Integration: a Run on a custom OpenAI-compatible provider followed by a Repair.
+
+    Regression test for the bug where legacy "{provider}::{model_id}" slugs were
+    stripped in flight, persisted to disk without their prefix, then crashed Repair
+    when adapter_for_task tried to split the (now bare) name. We mock only the
+    litellm completion call; everything else (adapter wiring, persistence, repair
+    endpoint) runs for real.
+    """
+    project_path = tmp_path / "e2e_project" / "project.kiln"
+    project_path.parent.mkdir()
+    project = Project(name="E2E", path=str(project_path))
+    project.save_to_file()
+
+    task = Task(name="t", instruction="be brief", parent=project)
+    task.save_to_file()
+
+    canned_initial_output = "initial reply"
+    canned_repair_output = "repaired reply"
+    queued_outputs = [canned_initial_output, canned_repair_output]
+
+    async def mock_acompletion_checking_response(self, **kwargs):
+        content = queued_outputs.pop(0)
+        response = ModelResponse(
+            model="openai/openai/gpt-oss-safeguard-20b",
+            choices=[{"message": {"content": content, "tool_calls": None}}],
+            usage=LiteLlmUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+        return response, response.choices[0]
+
+    with (
+        patch("kiln_ai.utils.config.Config.shared") as cfg_shared,
+        patch.object(
+            LiteLlmAdapter,
+            "acompletion_checking_response",
+            new=mock_acompletion_checking_response,
+        ),
+    ):
+        cfg_shared.return_value.openai_compatible_providers = [
+            {
+                "name": "vllm local",
+                "base_url": "http://localhost:8000/v1",
+                "api_key": "",
+            }
+        ]
+        cfg_shared.return_value.user_id = "test_user"
+        cfg_shared.return_value.autosave_runs = True
+
+        run_config = KilnAgentRunConfigProperties(
+            model_name="vllm local::openai/gpt-oss-safeguard-20b",
+            model_provider_name=ModelProviderName.openai_compatible,
+            prompt_id="simple_prompt_builder",
+            structured_output_mode=StructuredOutputMode.default,
+        )
+
+        # Step 1: original Run.
+        adapter = adapter_for_task(task, run_config)
+        run = await adapter.invoke("hello")
+        if run.path is None:
+            run.save_to_file()
+
+        # The full slug must round-trip into the persisted properties.
+        # Pre-fix this would have been the bare "openai/gpt-oss-safeguard-20b".
+        assert (
+            run.output.source.properties["model_name"]
+            == "vllm local::openai/gpt-oss-safeguard-20b"
+        )
+        assert run.output.source.properties["model_provider"] == "openai_compatible"
+        assert run.output.output == canned_initial_output
+
+        # Step 2: Repair, hitting the real endpoint with the persisted run.
+        with patch(
+            "app.desktop.studio_server.repair_api.task_and_run_from_id"
+        ) as mock_lookup:
+            mock_lookup.return_value = (task, run)
+            response = client.post(
+                f"/api/projects/{project.id}/tasks/{task.id}/runs/{run.id}/generate_repair",
+                json={"evaluator_feedback": "be more concise"},
+            )
+
+        assert response.status_code == 200, response.text
+        repaired = response.json()
+        assert repaired["output"]["output"] == canned_repair_output
+        # Repair preserves the slug too.
+        assert (
+            repaired["output"]["source"]["properties"]["model_name"]
+            == "vllm local::openai/gpt-oss-safeguard-20b"
+        )

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -90,16 +90,13 @@ def litellm_core_provider_config(
         run_config_properties.model_provider_name == ModelProviderName.openai_compatible
         and not run_config_properties.model_name.startswith("user_model::")
     ):
+        # Legacy openai_compatible model ids are "provider_name::model_id". We pull the
+        # provider name out for base_url lookup, but keep the full slug on the run config
+        # so it is faithfully persisted to disk and can be rehydrated later (e.g. on repair).
         model_id = run_config_properties.model_name
-        try:
-            openai_compatible_provider_name, model_id = model_id.split("::")
-        except Exception:
+        if "::" not in model_id:
             raise ValueError(f"Invalid openai compatible model ID: {model_id}")
-
-        # Update a copy of the run config properties to use the openai compatible provider
-        updated_run_config_properties = run_config_properties.model_copy(deep=True)
-        updated_run_config_properties.model_name = model_id
-        run_config_properties = updated_run_config_properties
+        openai_compatible_provider_name = model_id.split("::", 1)[0]
 
     config = lite_llm_core_config_for_provider(
         core_provider_name, openai_compatible_provider_name

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -96,7 +96,10 @@ def litellm_core_provider_config(
         model_id = run_config_properties.model_name
         if "::" not in model_id:
             raise ValueError(f"Invalid openai compatible model ID: {model_id}")
-        openai_compatible_provider_name = model_id.split("::", 1)[0]
+        provider_part, model_part = model_id.split("::", 1)
+        if not provider_part or not model_part:
+            raise ValueError(f"Invalid openai compatible model ID: {model_id}")
+        openai_compatible_provider_name = provider_part
 
     config = lite_llm_core_config_for_provider(
         core_provider_name, openai_compatible_provider_name

--- a/libs/core/kiln_ai/adapters/provider_tools.py
+++ b/libs/core/kiln_ai/adapters/provider_tools.py
@@ -245,6 +245,11 @@ def kiln_model_provider_from(
 def lite_llm_provider_model(
     model_id: str,
 ) -> KilnModelProvider:
+    # Legacy openai_compatible model ids are "{provider_name}::{model_id}".
+    # litellm only needs the bare model id (it builds "openai/<model_id>"),
+    # so strip the provider prefix here. The full slug stays on run_config.model_name.
+    if "::" in model_id:
+        model_id = model_id.split("::", 1)[1]
     return KilnModelProvider(
         name=ModelProviderName.openai_compatible,
         model_id=model_id,

--- a/libs/core/kiln_ai/adapters/test_adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/test_adapter_registry.py
@@ -289,15 +289,70 @@ def test_openai_compatible_adapter(basic_task):
         assert isinstance(adapter, LiteLlmAdapter)
         assert adapter.config.additional_body_options == {"api_key": "test-key"}
         assert adapter.config.base_url == "https://test.com/v1"
-        assert adapter.config.run_config_properties.model_name == "test-model"
+        # The full slug is preserved on the run config so it can be persisted and rehydrated.
+        # The bare model id is only stripped at the litellm boundary (see lite_llm_provider_model).
+        assert (
+            adapter.config.run_config_properties.model_name
+            == "some-provider::test-model"
+        )
         assert (
             adapter.config.run_config_properties.model_provider_name
             == "openai_compatible"
         )
+        assert adapter.model_provider().model_id == "test-model"
         assert adapter.config.run_config_properties.prompt_id == "simple_prompt_builder"
         assert (
             adapter.config.run_config_properties.structured_output_mode == "json_schema"
         )
+
+
+def test_openai_compatible_adapter_preserves_model_name_for_rehydration(basic_task):
+    """Regression: building an adapter must not strip the legacy "{provider}::{model_id}"
+    prefix off run_config.model_name. _properties_for_task_output writes that name to
+    disk; if it's stripped, repair (and any other rehydration path) re-reads a name
+    without "::" and crashes splitting it again. See: openai/gpt-oss-safeguard-20b repair bug.
+    """
+    with patch("kiln_ai.adapters.provider_tools.Config.shared") as mock_config_shared:
+        mock_config_shared.return_value.openai_compatible_providers = [
+            {
+                "name": "vllm local",
+                "base_url": "http://localhost:8000/v1",
+                "api_key": "",
+            }
+        ]
+
+        original_run_config = KilnAgentRunConfigProperties(
+            model_name="vllm local::openai/gpt-oss-safeguard-20b",
+            model_provider_name=ModelProviderName.openai_compatible,
+            prompt_id="simple_prompt_builder",
+            structured_output_mode="json_schema",
+        )
+
+        adapter = adapter_for_task(
+            kiln_task=basic_task,
+            run_config_properties=original_run_config,
+        )
+
+        assert isinstance(adapter, LiteLlmAdapter)
+        # The slug round-trips intact on the run config that gets persisted.
+        assert (
+            adapter.config.run_config_properties.model_name
+            == "vllm local::openai/gpt-oss-safeguard-20b"
+        )
+        # Litellm sees the bare model id (no "::").
+        assert adapter.model_provider().model_id == "openai/gpt-oss-safeguard-20b"
+
+        # Simulate the repair flow: rebuild the adapter from the (now-correctly persisted)
+        # run config. This used to raise "Invalid openai compatible model ID: ..." because
+        # the first call had stripped the prefix.
+        rehydrated = adapter_for_task(
+            kiln_task=basic_task,
+            run_config_properties=adapter.config.run_config_properties.model_copy(
+                deep=True
+            ),
+        )
+        assert isinstance(rehydrated, LiteLlmAdapter)
+        assert rehydrated.config.base_url == "http://localhost:8000/v1"
 
 
 def test_custom_openai_compatible_provider(mock_config, basic_task):

--- a/libs/core/kiln_ai/adapters/test_provider_tools.py
+++ b/libs/core/kiln_ai/adapters/test_provider_tools.py
@@ -662,19 +662,24 @@ def test_openai_compatible_provider_config(mock_shared_config):
         config.run_config_properties.model_provider_name
         == ModelProviderName.openai_compatible
     )
-    assert config.run_config_properties.model_name == "gpt-4"
+    # Full slug is preserved on the run config; the bare model id is only used at the litellm boundary.
+    assert config.run_config_properties.model_name == "test_provider::gpt-4"
     assert config.additional_body_options == {"api_key": "test-key"}
     assert config.base_url == "https://api.test.com"
 
 
 def test_litellm_provider_model_success(mock_shared_config):
-    """Test successful creation of an OpenAI compatible provider"""
+    """Test successful creation of an OpenAI compatible provider.
+
+    The provider's model_id is the bare model id (without the legacy "provider::" prefix),
+    since that's what litellm needs to call the upstream API.
+    """
     model_id = "test_provider::gpt-4"
 
     provider = lite_llm_provider_model(model_id)
 
     assert provider.name == ModelProviderName.openai_compatible
-    assert provider.model_id == model_id
+    assert provider.model_id == "gpt-4"
     assert provider.supports_structured_output is False
     assert provider.supports_data_gen is False
     assert provider.untested_model is True
@@ -697,7 +702,7 @@ def test_lite_llm_config_no_api_key(mock_shared_config):
         config.run_config_properties.model_provider_name
         == ModelProviderName.openai_compatible
     )
-    assert config.run_config_properties.model_name == "gpt-4"
+    assert config.run_config_properties.model_name == "no_key_provider::gpt-4"
     assert config.additional_body_options == {"api_key": "NA"}
     assert config.base_url == "https://api.nokey.com"
 


### PR DESCRIPTION
## What does this PR do?

Bug where a run generated using a custom model provider cannot be repaired - we split the slug before persisting and on the repair run later we don't have the provider info anymore.

The fix does not fix the already-persisted runs (that already have no provider).

## Related Issues

Fixes: https://github.com/Kiln-AI/Kiln/issues/1330

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
