### PR TITLE
feat: let users pick a repair model

### DIFF
--- a/app/desktop/studio_server/repair_api.py
+++ b/app/desktop/studio_server/repair_api.py
@@ -25,6 +25,14 @@ class RepairTaskApiInput(BaseModel):
     evaluator_feedback: str = Field(
         description="Feedback from an evaluator on how to repair the task run."
     )
+    model_name: str | None = Field(
+        default=None,
+        description="Optional override for the model used to generate the repair. When omitted, the model from the original run's source properties is used.",
+    )
+    provider: str | None = Field(
+        default=None,
+        description="Optional override for the model provider used to generate the repair. Must be set together with model_name.",
+    )
 
     # Allows use of the model_name field (usually pydantic will reserve model_*)
     model_config = ConfigDict(protected_namespaces=())
@@ -66,36 +74,55 @@ def connect_repair_api(app: FastAPI):
             evaluator_feedback=input.evaluator_feedback,
         )
 
-        # Build the same run config properties as the original run. The persisted data has changed over time, so lots of error checks.
+        # Build run config properties for the repair. Caller can override the model
+        # via the request body; otherwise we read the original run's persisted source
+        # properties. The persisted data has changed over time, so lots of error checks.
         source_properties = (
             run.output.source.properties
             if run.output.source and run.output.source.properties
             else {}
         )
+        override_model_name = input.model_name
+        override_provider = input.provider
+        if (override_model_name is None) != (override_provider is None):
+            raise HTTPException(
+                status_code=422,
+                detail="model_name and provider must be set together.",
+            )
         try:
-            model_name = source_properties.get("model_name", None)
-            provider = source_properties.get("model_provider", None)
-            if (
-                not model_name
-                or not provider
-                or not isinstance(model_name, str)
-                or not isinstance(provider, str)
-            ):
-                raise HTTPException(
-                    status_code=422,
-                    detail="Model name and provider must be specified.",
-                )
-            model_name = str(model_name)
-            provider = model_provider_from_string(provider)
-
-            sdm = source_properties.get("structured_output_mode", None)
-            if sdm is None or not isinstance(sdm, str):
+            if override_model_name and override_provider:
+                model_name = override_model_name
+                provider = model_provider_from_string(override_provider)
+                # Don't reuse the original run's structured_output_mode: it may not be
+                # supported on the chosen model. Re-derive from the model's defaults.
                 sdm = default_structured_output_mode_for_model_provider(
                     model_name,
                     provider,
                 )
             else:
-                sdm = StructuredOutputMode(sdm)
+                model_name = source_properties.get("model_name", None)
+                provider = source_properties.get("model_provider", None)
+                if (
+                    not model_name
+                    or not provider
+                    or not isinstance(model_name, str)
+                    or not isinstance(provider, str)
+                ):
+                    raise HTTPException(
+                        status_code=422,
+                        detail="Model name and provider must be specified.",
+                    )
+                model_name = str(model_name)
+                provider = model_provider_from_string(provider)
+
+                sdm = source_properties.get("structured_output_mode", None)
+                if sdm is None or not isinstance(sdm, str):
+                    sdm = default_structured_output_mode_for_model_provider(
+                        model_name,
+                        provider,
+                    )
+                else:
+                    sdm = StructuredOutputMode(sdm)
 
             run_config_properties = KilnAgentRunConfigProperties(
                 model_name=model_name,
@@ -104,6 +131,8 @@ def connect_repair_api(app: FastAPI):
                 structured_output_mode=sdm,
             )
 
+            # Temperature/top_p from the original run still apply; the user is only
+            # overriding the model, not the sampling knobs.
             temperature = source_properties.get("temperature", None)
             if temperature is not None and isinstance(temperature, float):
                 run_config_properties.temperature = temperature

--- a/app/desktop/studio_server/test_repair_api.py
+++ b/app/desktop/studio_server/test_repair_api.py
@@ -9,7 +9,6 @@ from litellm.types.utils import ModelResponse
 from litellm.types.utils import Usage as LiteLlmUsage
 
 from kiln_ai.adapters.adapter_registry import adapter_for_task
-from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.model_adapters.litellm_adapter import LiteLlmAdapter
 from kiln_ai.datamodel import (
     DataSource,
@@ -19,7 +18,7 @@ from kiln_ai.datamodel import (
     TaskOutput,
     TaskRun,
 )
-from kiln_ai.datamodel.datamodel_enums import StructuredOutputMode
+from kiln_ai.datamodel.datamodel_enums import ModelProviderName, StructuredOutputMode
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.utils.config import Config
 
@@ -392,7 +391,14 @@ def test_repair_run_override_rederives_structured_output_mode(
         "structured_output_mode"
     ] = "json_schema"
 
-    with patch("app.desktop.studio_server.repair_api.adapter_for_task") as mock:
+    sentinel_mode = StructuredOutputMode.function_calling
+    with (
+        patch("app.desktop.studio_server.repair_api.adapter_for_task") as mock,
+        patch(
+            "app.desktop.studio_server.repair_api.default_structured_output_mode_for_model_provider",
+            return_value=sentinel_mode,
+        ) as mock_default_sdm,
+    ):
         mock_adapter = AsyncMock()
         mock_adapter.invoke = AsyncMock(return_value=mock_repair_task_run)
         mock.return_value = mock_adapter
@@ -406,8 +412,9 @@ def test_repair_run_override_rederives_structured_output_mode(
             },
         )
         assert response.status_code == 200
+        # The lookup must be called with the override model/provider (not the
+        # original run's gpt_4o/openai), and its result must be the mode used —
+        # proving we didn't blindly forward the original "json_schema".
+        mock_default_sdm.assert_called_once_with("llama_3_1_8b", ModelProviderName.groq)
         run_config = mock.call_args.kwargs["run_config_properties"]
-        # We don't assert a specific mode (it's whatever the model's default is),
-        # only that we did NOT just blindly forward the original "json_schema".
-        # Any value is fine as long as it came from the lookup, not the source props.
-        assert run_config.structured_output_mode is not None
+        assert run_config.structured_output_mode == sentinel_mode

--- a/app/desktop/studio_server/test_repair_api.py
+++ b/app/desktop/studio_server/test_repair_api.py
@@ -13,6 +13,7 @@ from kiln_ai.datamodel import (
     TaskOutput,
     TaskRun,
 )
+from kiln_ai.datamodel.datamodel_enums import ModelProviderName, StructuredOutputMode
 from kiln_ai.utils.config import Config
 
 from app.desktop.studio_server.repair_api import (
@@ -294,7 +295,14 @@ def test_repair_run_override_rederives_structured_output_mode(
         "structured_output_mode"
     ] = "json_schema"
 
-    with patch("app.desktop.studio_server.repair_api.adapter_for_task") as mock:
+    sentinel_mode = StructuredOutputMode.function_calling
+    with (
+        patch("app.desktop.studio_server.repair_api.adapter_for_task") as mock,
+        patch(
+            "app.desktop.studio_server.repair_api.default_structured_output_mode_for_model_provider",
+            return_value=sentinel_mode,
+        ) as mock_default_sdm,
+    ):
         mock_adapter = AsyncMock()
         mock_adapter.invoke = AsyncMock(return_value=mock_repair_task_run)
         mock.return_value = mock_adapter
@@ -308,8 +316,9 @@ def test_repair_run_override_rederives_structured_output_mode(
             },
         )
         assert response.status_code == 200
+        # The lookup must be called with the override model/provider (not the
+        # original run's gpt_4o/openai), and its result must be the mode used —
+        # proving we didn't blindly forward the original "json_schema".
+        mock_default_sdm.assert_called_once_with("llama_3_1_8b", ModelProviderName.groq)
         run_config = mock.call_args.kwargs["run_config_properties"]
-        # We don't assert a specific mode (it's whatever the model's default is),
-        # only that we did NOT just blindly forward the original "json_schema".
-        # Any value is fine as long as it came from the lookup, not the source props.
-        assert run_config.structured_output_mode is not None
+        assert run_config.structured_output_mode == sentinel_mode

--- a/app/desktop/studio_server/test_repair_api.py
+++ b/app/desktop/studio_server/test_repair_api.py
@@ -236,3 +236,80 @@ def test_repair_run_human_source(
     assert (
         repaired_output["source"]["properties"]["created_by"] == Config.shared().user_id
     )
+
+
+def test_repair_run_with_model_override(
+    mock_run_and_task,
+    client,
+    improvement_task,
+    mock_repair_task_run,
+):
+    """The caller can override which model generates the repair by sending model_name/provider."""
+    with patch("app.desktop.studio_server.repair_api.adapter_for_task") as mock:
+        mock_adapter = AsyncMock()
+        mock_adapter.invoke = AsyncMock(return_value=mock_repair_task_run)
+        mock.return_value = mock_adapter
+
+        response = client.post(
+            "/api/projects/proj-ID/tasks/task-ID/runs/run-ID/generate_repair",
+            json={
+                "evaluator_feedback": "Fix this issue",
+                "model_name": "llama_3_1_8b",
+                "provider": "groq",
+            },
+        )
+
+        assert response.status_code == 200
+        # The run config that built the adapter must reflect the override, not the
+        # (mock) original run's "gpt_4o" / "openai".
+        run_config = mock.call_args.kwargs["run_config_properties"]
+        assert run_config.model_name == "llama_3_1_8b"
+        assert run_config.model_provider_name == "groq"
+
+
+def test_repair_run_override_requires_both_fields(
+    mock_run_and_task,
+    mock_langchain_adapter,
+    client,
+):
+    """Sending only one of model_name/provider is rejected."""
+    response = client.post(
+        "/api/projects/proj-ID/tasks/task-ID/runs/run-ID/generate_repair",
+        json={"evaluator_feedback": "Fix this issue", "model_name": "llama_3_1_8b"},
+    )
+    assert response.status_code == 422
+    assert "must be set together" in response.json()["message"]
+
+
+def test_repair_run_override_rederives_structured_output_mode(
+    mock_run_and_task,
+    client,
+    mock_repair_task_run,
+):
+    """When a different model is chosen, structured_output_mode should be derived
+    from the new model's defaults, not the original run's mode (which may be
+    incompatible with the new model)."""
+    # Original run was saved with json_schema mode.
+    mock_run_and_task.return_value[1].output.source.properties[
+        "structured_output_mode"
+    ] = "json_schema"
+
+    with patch("app.desktop.studio_server.repair_api.adapter_for_task") as mock:
+        mock_adapter = AsyncMock()
+        mock_adapter.invoke = AsyncMock(return_value=mock_repair_task_run)
+        mock.return_value = mock_adapter
+
+        response = client.post(
+            "/api/projects/proj-ID/tasks/task-ID/runs/run-ID/generate_repair",
+            json={
+                "evaluator_feedback": "Fix",
+                "model_name": "llama_3_1_8b",
+                "provider": "groq",
+            },
+        )
+        assert response.status_code == 200
+        run_config = mock.call_args.kwargs["run_config_properties"]
+        # We don't assert a specific mode (it's whatever the model's default is),
+        # only that we did NOT just blindly forward the original "json_schema".
+        # Any value is fine as long as it came from the lookup, not the source props.
+        assert run_config.structured_output_mode is not None

--- a/app/desktop/studio_server/test_repair_api.py
+++ b/app/desktop/studio_server/test_repair_api.py
@@ -334,3 +334,80 @@ async def test_run_then_repair_legacy_openai_compatible_e2e(client, tmp_path):
             repaired["output"]["source"]["properties"]["model_name"]
             == "vllm local::openai/gpt-oss-safeguard-20b"
         )
+
+
+def test_repair_run_with_model_override(
+    mock_run_and_task,
+    client,
+    improvement_task,
+    mock_repair_task_run,
+):
+    """The caller can override which model generates the repair by sending model_name/provider."""
+    with patch("app.desktop.studio_server.repair_api.adapter_for_task") as mock:
+        mock_adapter = AsyncMock()
+        mock_adapter.invoke = AsyncMock(return_value=mock_repair_task_run)
+        mock.return_value = mock_adapter
+
+        response = client.post(
+            "/api/projects/proj-ID/tasks/task-ID/runs/run-ID/generate_repair",
+            json={
+                "evaluator_feedback": "Fix this issue",
+                "model_name": "llama_3_1_8b",
+                "provider": "groq",
+            },
+        )
+
+        assert response.status_code == 200
+        # The run config that built the adapter must reflect the override, not the
+        # (mock) original run's "gpt_4o" / "openai".
+        run_config = mock.call_args.kwargs["run_config_properties"]
+        assert run_config.model_name == "llama_3_1_8b"
+        assert run_config.model_provider_name == "groq"
+
+
+def test_repair_run_override_requires_both_fields(
+    mock_run_and_task,
+    mock_langchain_adapter,
+    client,
+):
+    """Sending only one of model_name/provider is rejected."""
+    response = client.post(
+        "/api/projects/proj-ID/tasks/task-ID/runs/run-ID/generate_repair",
+        json={"evaluator_feedback": "Fix this issue", "model_name": "llama_3_1_8b"},
+    )
+    assert response.status_code == 422
+    assert "must be set together" in response.json()["message"]
+
+
+def test_repair_run_override_rederives_structured_output_mode(
+    mock_run_and_task,
+    client,
+    mock_repair_task_run,
+):
+    """When a different model is chosen, structured_output_mode should be derived
+    from the new model's defaults, not the original run's mode (which may be
+    incompatible with the new model)."""
+    # Original run was saved with json_schema mode.
+    mock_run_and_task.return_value[1].output.source.properties[
+        "structured_output_mode"
+    ] = "json_schema"
+
+    with patch("app.desktop.studio_server.repair_api.adapter_for_task") as mock:
+        mock_adapter = AsyncMock()
+        mock_adapter.invoke = AsyncMock(return_value=mock_repair_task_run)
+        mock.return_value = mock_adapter
+
+        response = client.post(
+            "/api/projects/proj-ID/tasks/task-ID/runs/run-ID/generate_repair",
+            json={
+                "evaluator_feedback": "Fix",
+                "model_name": "llama_3_1_8b",
+                "provider": "groq",
+            },
+        )
+        assert response.status_code == 200
+        run_config = mock.call_args.kwargs["run_config_properties"]
+        # We don't assert a specific mode (it's whatever the model's default is),
+        # only that we did NOT just blindly forward the original "json_schema".
+        # Any value is fine as long as it came from the lookup, not the source props.
+        assert run_config.structured_output_mode is not None

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -8093,6 +8093,16 @@ export interface components {
              * @description Feedback from an evaluator on how to repair the task run.
              */
             evaluator_feedback: string;
+            /**
+             * Model Name
+             * @description Optional override for the model used to generate the repair. When omitted, the model from the original run's source properties is used.
+             */
+            model_name?: string | null;
+            /**
+             * Provider
+             * @description Optional override for the model provider used to generate the repair. Must be set together with model_name.
+             */
+            provider?: string | null;
         };
         /**
          * RequirementRating

--- a/app/web_ui/src/lib/ui/run_config_component/available_models_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/available_models_dropdown.svelte
@@ -37,7 +37,7 @@
   export let inline_action: InlineAction | null = null
   export let optional: boolean = false
   export let hide_optional_badge: boolean = false
-  export let empty_label: string = "Select an option"
+  export let empty_label: string = "Select a model"
 
   let default_model_dropdown_settings: ModelDropdownSettings = {
     filter_models_predicate: (_) => true,
@@ -372,7 +372,6 @@
     on_select={confirm_model_select}
     bind:error_message
     fancy_select_options={model_options}
-    placeholder="Select a model"
   />
 
   {#if selected_model_untested}

--- a/app/web_ui/src/lib/ui/run_config_component/available_models_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/available_models_dropdown.svelte
@@ -16,7 +16,9 @@
   } from "$lib/stores/recent_model_store"
   import type { AvailableModels, ProviderModels } from "$lib/types"
   import { onMount } from "svelte"
-  import FormElement from "$lib/utils/form_element.svelte"
+  import FormElement, {
+    type InlineAction,
+  } from "$lib/utils/form_element.svelte"
   import Warning from "$lib/ui/warning.svelte"
   import type { OptionGroup, Option } from "$lib/ui/fancy_select_types"
   import { mime_type_to_string } from "$lib/utils/formatters"
@@ -32,6 +34,10 @@
   export let info_description: string | undefined = undefined
   export let settings: Partial<ModelDropdownSettings> = {}
   export let error_message: string | null = null
+  export let inline_action: InlineAction | null = null
+  export let optional: boolean = false
+  export let hide_optional_badge: boolean = false
+  export let empty_label: string = "Select an option"
 
   let default_model_dropdown_settings: ModelDropdownSettings = {
     filter_models_predicate: (_) => true,
@@ -356,6 +362,10 @@
     {label}
     {description}
     {info_description}
+    {inline_action}
+    {optional}
+    {hide_optional_badge}
+    {empty_label}
     bind:value={model}
     id="model"
     inputType="fancy_select"

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -360,6 +360,8 @@
     : null
   $: if (repair_model_storage_key) {
     repair_model_override = load_repair_model_override(repair_model_storage_key)
+  } else {
+    repair_model_override = null
   }
 
   function load_repair_model_override(key: string): RepairModelOverride | null {

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -23,6 +23,8 @@
   import {
     rating_options_for_sample,
     current_task_rating_options,
+    model_info,
+    model_name as model_name_from_id,
   } from "$lib/stores"
   import posthog from "posthog-js"
   import TraceComponent from "$lib/ui/trace/trace.svelte"
@@ -30,6 +32,7 @@
   import TableActionMenu from "$lib/ui/table_action_menu.svelte"
   import Warning from "$lib/ui/warning.svelte"
   import OutputRepairEditForm from "./output_repair_edit_form.svelte"
+  import AvailableModelsDropdown from "$lib/ui/run_config_component/available_models_dropdown.svelte"
   import type { components } from "$lib/api_schema"
 
   type SubtaskReference = {
@@ -343,6 +346,62 @@
     }
   }
 
+  // Optional per-task override for which model generates the repair. Persisted in
+  // localStorage so the choice survives reloads. Useful when the original run's
+  // model can't be rehydrated (e.g. pre-fix legacy openai_compatible runs whose
+  // persisted model_name lost its "{provider}::" prefix on disk).
+  type RepairModelOverride = {
+    model_name: string
+    provider: string
+  }
+  let repair_model_override: RepairModelOverride | null = null
+  $: repair_model_storage_key = task?.id
+    ? `kiln_repair_model_override:${project_id}:${task.id}`
+    : null
+  $: if (repair_model_storage_key) {
+    repair_model_override = load_repair_model_override(repair_model_storage_key)
+  }
+
+  function load_repair_model_override(key: string): RepairModelOverride | null {
+    try {
+      const raw = localStorage.getItem(key)
+      if (!raw) return null
+      const parsed = JSON.parse(raw)
+      if (
+        parsed &&
+        typeof parsed.model_name === "string" &&
+        typeof parsed.provider === "string"
+      ) {
+        return { model_name: parsed.model_name, provider: parsed.provider }
+      }
+    } catch {
+      // ignore corrupted entries
+    }
+    return null
+  }
+
+  // The original run's model (what produced the saved output). Treated as the
+  // canonical "default" for repair: the dialog preselects it and the Reset
+  // button snaps the selection back to it.
+  $: original_run_model_name =
+    typeof run?.output?.source?.properties?.model_name === "string"
+      ? (run.output.source.properties.model_name as string)
+      : null
+  $: original_run_provider =
+    typeof run?.output?.source?.properties?.model_provider === "string"
+      ? (run.output.source.properties.model_provider as string)
+      : null
+
+  // The model that will actually be used to generate the repair: override
+  // wins, otherwise we fall back to the original run's model.
+  $: effective_repair_model_name =
+    repair_model_override?.model_name ?? original_run_model_name
+  $: effective_repair_provider =
+    repair_model_override?.provider ?? original_run_provider
+  $: effective_repair_model_display = effective_repair_model_name
+    ? model_name_from_id(effective_repair_model_name, $model_info)
+    : null
+
   let repair_submitting = false
   let repair_error: KilnError | null = null
   async function attempt_repair() {
@@ -358,6 +417,8 @@
           null,
         )
       }
+      // Only send the override on the wire — when no override is set, the
+      // server reads the original run's persisted model from source_properties.
       const {
         data: repair_data, // only present if 2XX response
         error: fetch_error, // only present if 4XX or 5XX response
@@ -371,16 +432,15 @@
               run_id: run?.id,
             },
           },
-          body:
-            model_name && provider
-              ? {
-                  evaluator_feedback: trimmed_instructions,
-                  model_name: model_name,
-                  provider: provider,
-                }
-              : {
-                  evaluator_feedback: trimmed_instructions,
-                },
+          body: repair_model_override
+            ? {
+                evaluator_feedback: trimmed_instructions,
+                model_name: repair_model_override.model_name,
+                provider: repair_model_override.provider,
+              }
+            : {
+                evaluator_feedback: trimmed_instructions,
+              },
         },
       )
       if (fetch_error) {
@@ -476,6 +536,61 @@
   function retry_repair() {
     repair_run = null
     accept_repair_error = null
+  }
+
+  // Repair-model override dialog state
+  let repair_model_dialog: Dialog | null = null
+  let dialog_combined_model: string | null = null
+  let dialog_model_name: string | null = null
+  let dialog_provider_name: string | null = null
+
+  function open_repair_model_dialog() {
+    // Preselect the currently effective repair model (override > original run's model).
+    dialog_combined_model =
+      effective_repair_model_name && effective_repair_provider
+        ? `${effective_repair_provider}/${effective_repair_model_name}`
+        : null
+    repair_model_dialog?.show()
+  }
+
+  function reset_repair_model_dialog() {
+    // Reset = no override. Each run will fall back to whichever model originally
+    // produced it (which can vary across runs in the same task). Clear the dropdown
+    // visually; the actual override is cleared on Save (or stays as-is on Cancel).
+    dialog_combined_model = null
+  }
+
+  function save_repair_model_override(): boolean {
+    // Persist whatever is currently selected at the time Save is clicked.
+    // Empty selection = clear the override; per-run defaults take over.
+    if (!dialog_model_name || !dialog_provider_name) {
+      clear_repair_model_override()
+      return true
+    }
+    const next: RepairModelOverride = {
+      model_name: dialog_model_name,
+      provider: dialog_provider_name,
+    }
+    repair_model_override = next
+    if (repair_model_storage_key) {
+      try {
+        localStorage.setItem(repair_model_storage_key, JSON.stringify(next))
+      } catch {
+        // ignore quota/availability errors; in-memory state still applies
+      }
+    }
+    return true
+  }
+
+  function clear_repair_model_override() {
+    repair_model_override = null
+    if (repair_model_storage_key) {
+      try {
+        localStorage.removeItem(repair_model_storage_key)
+      } catch {
+        // ignore
+      }
+    }
   }
 
   let repair_edit_mode = false
@@ -797,7 +912,25 @@
 
       {#if repair_enabled_for_source && (should_offer_repair || repair_review_available || repair_complete)}
         <div class="grow mt-10">
-          <div class="text-xl font-bold mb-2">Repair Output</div>
+          <div class="flex items-baseline justify-between gap-4 flex-wrap mb-2">
+            <div class="text-xl font-bold">Repair Output</div>
+            {#if should_offer_repair}
+              <div class="text-xs text-gray-500">
+                {#if effective_repair_model_display}
+                  Repairing with <span class="font-medium text-gray-700"
+                    >{effective_repair_model_display}</span
+                  >
+                  ·
+                {/if}
+                <button
+                  type="button"
+                  class="link"
+                  on:click={open_repair_model_dialog}
+                  >Select different model</button
+                >
+              </div>
+            {/if}
+          </div>
           {#if should_offer_repair}
             <p class="text-sm text-gray-500 mb-4">
               Since the output isn't 5-star, provide instructions for the model
@@ -1089,6 +1222,38 @@
       />
     </FormContainer>
   {/if}
+</Dialog>
+
+<Dialog
+  bind:this={repair_model_dialog}
+  title="Repair Model"
+  sub_subtitle="Override the model used to generate repairs for this task. Reset to use each run's original model."
+  action_buttons={[
+    {
+      label: "Reset",
+      action: () => {
+        reset_repair_model_dialog()
+        return false // keep dialog open so Save still applies the cleared selection
+      },
+      hide: !dialog_combined_model,
+    },
+    { label: "Cancel", isCancel: true },
+    {
+      label: "Save",
+      isPrimary: true,
+      action: save_repair_model_override,
+    },
+  ]}
+>
+  <div class="pt-2">
+    <AvailableModelsDropdown
+      label="Repair Model"
+      description="Leave empty to use each run's original model. Pick a specific model to override."
+      bind:model={dialog_combined_model}
+      bind:model_name={dialog_model_name}
+      bind:provider_name={dialog_provider_name}
+    />
+  </div>
 </Dialog>
 
 <Dialog bind:this={view_feedback_dialog} title="All Feedback" width="wide">

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -1231,14 +1231,6 @@
   title="Repair Model"
   sub_subtitle="Override the model used to generate repairs for this task. Reset to use each run's original model."
   action_buttons={[
-    {
-      label: "Reset",
-      action: () => {
-        reset_repair_model_dialog()
-        return false // keep dialog open so Save still applies the cleared selection
-      },
-      hide: !dialog_combined_model,
-    },
     { label: "Cancel", isCancel: true },
     {
       label: "Save",
@@ -1254,6 +1246,15 @@
       bind:model={dialog_combined_model}
       bind:model_name={dialog_model_name}
       bind:provider_name={dialog_provider_name}
+      optional
+      hide_optional_badge
+      empty_label="Use the same model as the original run"
+      inline_action={dialog_combined_model
+        ? {
+            handler: reset_repair_model_dialog,
+            label: "Reset",
+          }
+        : null}
     />
   </div>
 </Dialog>


### PR DESCRIPTION
## What does this PR do?

Add a UI to let the user override the repair model when repairing a `TaskRun`; multiple reasons for this:
1. Broken custom provider repair (https://github.com/Kiln-AI/Kiln/issues/1330); issue is fixed in https://github.com/Kiln-AI/Kiln/pull/1355 but it does not retroactively fixes the issue for existing task runs that have dropped the custom provider info.
2. Users may use a worse model for dataset generation and a better model for targeted complex repairs.
3. Users may use a slow model for dataset generation and then want to use a much faster one for repair.

We persist the choice for the current Task. We provide a way for users to `Reset`, which will just switch back to the original model (same as TaskRun).

<img width="762" height="324" alt="image" src="https://github.com/user-attachments/assets/9b5ffaee-649e-4a06-85b7-7122f0a4b861" />

<img width="724" height="589" alt="image" src="https://github.com/user-attachments/assets/ed67eada-cf3e-4a4f-8b48-09df3cb2a431" />

<img width="599" height="517" alt="image" src="https://github.com/user-attachments/assets/79ba7577-7e91-42a7-8307-b064b84339e9" />


## Related Issues

Related to issue: https://github.com/Kiln-AI/Kiln/issues/1330 - this PR now provides a workaround for existing task runs with the problem

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
