### PR TITLE
refactor: preserve kiln fields in multiturn trace

### DIFF
--- a/libs/core/kiln_ai/adapters/chat/chat_formatter.py
+++ b/libs/core/kiln_ai/adapters/chat/chat_formatter.py
@@ -44,6 +44,9 @@ class ToolResponseMessage:
     role: Literal["tool"]
     content: str
     tool_call_id: str
+    is_error: Optional[bool] = None
+    error_message: Optional[str] = None
+    kiln_task_tool_data: Optional[str] = None
 
 
 ChatMessage = Union[
@@ -51,6 +54,24 @@ ChatMessage = Union[
     ToolCallMessage,
     ToolResponseMessage,
 ]
+
+
+def chat_message_to_dict(message: ChatMessage) -> dict:
+    """Convert a ChatMessage dataclass to an OpenAI-shaped message dict, including
+    Kiln-specific fields (``is_error``, ``error_message``, ``kiln_task_tool_data``)
+    when present on tool responses."""
+    msg_dict: dict = {"role": message.role, "content": message.content}
+    if isinstance(message, ToolCallMessage):
+        msg_dict["tool_calls"] = message.tool_calls
+    elif isinstance(message, ToolResponseMessage):
+        msg_dict["tool_call_id"] = message.tool_call_id
+        if message.is_error is not None:
+            msg_dict["is_error"] = message.is_error
+        if message.error_message is not None:
+            msg_dict["error_message"] = message.error_message
+        if message.kiln_task_tool_data is not None:
+            msg_dict["kiln_task_tool_data"] = message.kiln_task_tool_data
+    return msg_dict
 
 
 @dataclass
@@ -303,6 +324,9 @@ class MultiturnFormatter(ChatFormatter):
                         role="tool",
                         content=str(item.get("content", "")),
                         tool_call_id=item["tool_call_id"],
+                        is_error=item.get("is_error"),
+                        error_message=item.get("error_message"),
+                        kiln_task_tool_data=item.get("kiln_task_tool_data"),
                     )
                     for item in raw_items
                 ]

--- a/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
@@ -7,14 +7,10 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
-from litellm.types.utils import (
-    ChatCompletionMessageToolCall,
-    Choices,
-    ModelResponse,
-)
+from litellm.types.utils import ChatCompletionMessageToolCall, Choices, ModelResponse
 
 from kiln_ai.adapters.chat import ChatCompletionMessageIncludingLiteLLM
-from kiln_ai.adapters.chat.chat_formatter import ChatFormatter, ToolResponseMessage
+from kiln_ai.adapters.chat.chat_formatter import ChatFormatter, chat_message_to_dict
 from kiln_ai.adapters.litellm_utils.litellm_streaming import StreamingCompletion
 from kiln_ai.adapters.ml_model_list import KilnModelProvider
 from kiln_ai.adapters.model_adapters.stream_events import (
@@ -103,10 +99,7 @@ class AdapterStream:
             for message in turn.messages:
                 if message.content is None:
                     raise ValueError("Empty message content isn't allowed")
-                msg_dict: dict = {"role": message.role, "content": message.content}
-                if isinstance(message, ToolResponseMessage):
-                    msg_dict["tool_call_id"] = message.tool_call_id
-                self._messages.append(msg_dict)  # type: ignore[arg-type]
+                self._messages.append(chat_message_to_dict(message))  # type: ignore[arg-type]
 
             skip_response_format = not turn.final_call
             turn_top_logprobs = self._top_logprobs if turn.final_call else None

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -21,7 +21,7 @@ from openai.types.chat.chat_completion_message_tool_call_param import (
 
 import kiln_ai.datamodel as datamodel
 from kiln_ai.adapters.chat import ChatCompletionMessageIncludingLiteLLM
-from kiln_ai.adapters.chat.chat_formatter import ToolResponseMessage
+from kiln_ai.adapters.chat.chat_formatter import chat_message_to_dict
 from kiln_ai.adapters.ml_model_list import (
     KilnModelProvider,
     ModelProviderName,
@@ -56,6 +56,7 @@ from kiln_ai.utils.open_ai_types import (
     ChatCompletionAssistantMessageParamWrapper,
     ChatCompletionMessageParam,
     ChatCompletionToolMessageParamWrapper,
+    sanitize_messages_for_provider,
 )
 
 MAX_CALLS_PER_TURN = 10
@@ -274,11 +275,7 @@ class LiteLlmAdapter(BaseAdapter):
             for message in turn.messages:
                 if message.content is None:
                     raise ValueError("Empty message content isn't allowed")
-                # pyright incorrectly warns about this, but it's valid so we can ignore. It can't handle the multi-value role.
-                msg_dict: dict = {"role": message.role, "content": message.content}
-                if isinstance(message, ToolResponseMessage):
-                    msg_dict["tool_call_id"] = message.tool_call_id
-                messages.append(msg_dict)  # type: ignore
+                messages.append(chat_message_to_dict(message))  # type: ignore
 
             skip_response_format = not turn.final_call
             turn_result = await self._run_model_turn(
@@ -719,6 +716,8 @@ class LiteLlmAdapter(BaseAdapter):
         )
         if len(allowed_openai_params) > 0:
             completion_kwargs["allowed_openai_params"] = allowed_openai_params
+
+        completion_kwargs["messages"] = sanitize_messages_for_provider(messages)
 
         return completion_kwargs
 

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -784,6 +785,45 @@ async def test_build_completion_kwargs(
     # Verify extra body is included
     for key, value in extra_body.items():
         assert kwargs[key] == value
+
+
+@pytest.mark.asyncio
+async def test_build_completion_kwargs_strips_kiln_only_fields(config, mock_task):
+    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    mock_provider = Mock()
+    mock_provider.temp_top_p_exclusive = False
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "hello",
+            "latency_ms": 123,
+        },
+        {
+            "role": "tool",
+            "content": "{}",
+            "tool_call_id": "c1",
+            "is_error": True,
+            "error_message": "boom",
+            "kiln_task_tool_data": "p:::t:::ta:::r",
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    with (
+        patch.object(adapter, "model_provider", return_value=mock_provider),
+        patch.object(adapter, "litellm_model_id", return_value="openai/test-model"),
+        patch.object(adapter, "build_extra_body", return_value={}),
+        patch.object(adapter, "response_format_options", return_value={}),
+    ):
+        kwargs = await adapter.build_completion_kwargs(mock_provider, messages, None)
+
+    assert kwargs["messages"] == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "tool", "content": "{}", "tool_call_id": "c1"},
+    ]
+    assert messages == original
 
 
 @pytest.mark.parametrize(
@@ -2429,6 +2469,198 @@ async def test_process_tool_calls_propagates_error_fields(config, mock_task):
     assert success_msg["content"] == "all good"
     assert success_msg.get("is_error") is None
     assert success_msg.get("error_message") is None
+
+
+@pytest.fixture
+def unstructured_task(tmp_path):
+    project_path = tmp_path / "test_project_multiturn" / "project.kiln"
+    project_path.parent.mkdir()
+    project = Project(name="Multiturn Test Project", path=str(project_path))
+    project.save_to_file()
+
+    task = Task(
+        name="Multiturn Task",
+        instruction="Plain conversational assistant.",
+        parent=project,
+    )
+    task.save_to_file()
+    return task
+
+
+@pytest.mark.asyncio
+async def test_invoke_multiturn_preserves_kiln_fields_on_prior_trace(
+    config, unstructured_task
+):
+    adapter = LiteLlmAdapter(config=config, kiln_task=unstructured_task)
+
+    prior_trace = [
+        {"role": "user", "content": "what is 2+2"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "add", "arguments": '{"a": 2, "b": 2}'},
+                }
+            ],
+            "latency_ms": 321,
+        },
+        {
+            "role": "tool",
+            "content": "boom",
+            "tool_call_id": "call_1",
+            "is_error": True,
+            "error_message": "boom",
+            "kiln_task_tool_data": "p:::t:::ta:::r",
+        },
+        {
+            "role": "assistant",
+            "content": "Sorry, the tool failed. Try again.",
+            "latency_ms": 654,
+        },
+    ]
+
+    final_response = ModelResponse(
+        model="test-model",
+        choices=[
+            {"message": {"content": "ok, here is the answer", "tool_calls": None}}
+        ],
+    )
+
+    captured_kwargs: dict = {}
+
+    async def mock_acompletion(self, **kwargs):
+        captured_kwargs.update(kwargs)
+        return final_response, final_response.choices[0]
+
+    mock_provider = Mock()
+    mock_provider.temp_top_p_exclusive = False
+    mock_provider.reasoning_capable = False
+    mock_provider.parser = None
+    mock_provider.formatter = None
+
+    with (
+        patch.object(adapter, "model_provider", return_value=mock_provider),
+        patch.object(adapter, "litellm_model_id", return_value="openai/test-model"),
+        patch.object(adapter, "build_extra_body", return_value={}),
+        patch.object(adapter, "response_format_options", return_value={}),
+        patch.object(adapter, "available_tools", return_value=[]),
+        patch.object(
+            LiteLlmAdapter,
+            "acompletion_checking_response",
+            new=mock_acompletion,
+        ),
+    ):
+        task_run = await adapter.invoke("try again please", prior_trace=prior_trace)
+
+    sent_messages = captured_kwargs["messages"]
+    for m in sent_messages:
+        if isinstance(m, dict):
+            assert "is_error" not in m
+            assert "error_message" not in m
+            assert "kiln_task_tool_data" not in m
+            assert "latency_ms" not in m
+
+    trace = task_run.trace
+    assert trace is not None
+    prior_assistant = trace[1]
+    prior_tool = trace[2]
+    prior_assistant_2 = trace[3]
+    assert prior_assistant.get("latency_ms") == 321
+    assert prior_tool.get("is_error") is True
+    assert prior_tool.get("error_message") == "boom"
+    assert prior_tool.get("kiln_task_tool_data") == "p:::t:::ta:::r"
+    assert prior_assistant_2.get("latency_ms") == 654
+
+    new_assistant = trace[-1]
+    assert new_assistant["role"] == "assistant"
+    assert new_assistant.get("content") == "ok, here is the answer"
+    assert "latency_ms" in new_assistant
+
+
+@pytest.mark.asyncio
+async def test_invoke_multiturn_resume_preserves_kiln_fields_on_tool_results(
+    config, unstructured_task
+):
+    adapter = LiteLlmAdapter(config=config, kiln_task=unstructured_task)
+
+    prior_trace = [
+        {"role": "user", "content": "what is 2+2"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "add", "arguments": '{"a": 2, "b": 2}'},
+                }
+            ],
+            "latency_ms": 111,
+        },
+    ]
+
+    tool_results = [
+        {
+            "tool_call_id": "call_1",
+            "content": "boom",
+            "is_error": True,
+            "error_message": "boom",
+            "kiln_task_tool_data": "p:::t:::ta:::r",
+        }
+    ]
+
+    final_response = ModelResponse(
+        model="test-model",
+        choices=[{"message": {"content": "Got it.", "tool_calls": None}}],
+    )
+
+    captured_kwargs: dict = {}
+
+    async def mock_acompletion(self, **kwargs):
+        captured_kwargs.update(kwargs)
+        return final_response, final_response.choices[0]
+
+    mock_provider = Mock()
+    mock_provider.temp_top_p_exclusive = False
+    mock_provider.reasoning_capable = False
+    mock_provider.parser = None
+    mock_provider.formatter = None
+
+    with (
+        patch.object(adapter, "model_provider", return_value=mock_provider),
+        patch.object(adapter, "litellm_model_id", return_value="openai/test-model"),
+        patch.object(adapter, "build_extra_body", return_value={}),
+        patch.object(adapter, "response_format_options", return_value={}),
+        patch.object(adapter, "available_tools", return_value=[]),
+        patch.object(
+            LiteLlmAdapter,
+            "acompletion_checking_response",
+            new=mock_acompletion,
+        ),
+    ):
+        task_run = await adapter.invoke(tool_results, prior_trace=prior_trace)
+
+    sent_messages = captured_kwargs["messages"]
+    for m in sent_messages:
+        if isinstance(m, dict):
+            assert "is_error" not in m
+            assert "error_message" not in m
+            assert "kiln_task_tool_data" not in m
+            assert "latency_ms" not in m
+
+    trace = task_run.trace
+    assert trace is not None
+    new_tool_msg = next(
+        m
+        for m in trace
+        if m.get("role") == "tool" and m.get("tool_call_id") == "call_1"
+    )
+    assert new_tool_msg.get("is_error") is True
+    assert new_tool_msg.get("error_message") == "boom"
+    assert new_tool_msg.get("kiln_task_tool_data") == "p:::t:::ta:::r"
 
 
 class TestLatencyTracking:

--- a/libs/core/kiln_ai/utils/open_ai_types.py
+++ b/libs/core/kiln_ai/utils/open_ai_types.py
@@ -140,6 +140,9 @@ def sanitize_messages_for_provider(messages: Iterable[Any]) -> list[Any]:
     pass through unchanged. The input list and its dicts are not mutated."""
     sanitized: list[Any] = []
     for message in messages:
+        # Traces mix TypedDict messages (which may carry kiln-only fields) with
+        # LiteLLM Message pydantic objects returned from prior calls (which never
+        # do). Only dicts need stripping; pass other types through untouched.
         if isinstance(message, dict):
             sanitized.append(
                 {k: v for k, v in message.items() if k not in KILN_ONLY_MESSAGE_FIELDS}

--- a/libs/core/kiln_ai/utils/open_ai_types.py
+++ b/libs/core/kiln_ai/utils/open_ai_types.py
@@ -8,6 +8,7 @@ Otherwise we are using OpenAI SDK types directly.
 """
 
 from typing import (
+    Any,
     Iterable,
     List,
     Literal,
@@ -118,6 +119,34 @@ ChatCompletionMessageParam: TypeAlias = Union[
     ChatCompletionToolMessageParamWrapper,
     ChatCompletionFunctionMessageParam,
 ]
+
+
+KILN_ONLY_MESSAGE_FIELDS: frozenset[str] = frozenset(
+    {
+        "latency_ms",
+        "is_error",
+        "error_message",
+        "kiln_task_tool_data",
+    }
+)
+"""Per-message fields kept on traces for UI/diagnostics. Providers reject unknown
+keys, so these are stripped before sending to LiteLLM. Add new Kiln-only message
+fields here when extending the wrappers above."""
+
+
+def sanitize_messages_for_provider(messages: Iterable[Any]) -> list[Any]:
+    """Return a copy of ``messages`` with ``KILN_ONLY_MESSAGE_FIELDS`` removed
+    from any dict entries. Non-dict entries (e.g. LiteLLM ``Message`` objects)
+    pass through unchanged. The input list and its dicts are not mutated."""
+    sanitized: list[Any] = []
+    for message in messages:
+        if isinstance(message, dict):
+            sanitized.append(
+                {k: v for k, v in message.items() if k not in KILN_ONLY_MESSAGE_FIELDS}
+            )
+        else:
+            sanitized.append(message)
+    return sanitized
 
 
 def trace_has_pending_client_tool_calls(

--- a/libs/core/kiln_ai/utils/test_open_ai_types.py
+++ b/libs/core/kiln_ai/utils/test_open_ai_types.py
@@ -13,8 +13,10 @@ from openai.types.chat import (
 )
 
 from kiln_ai.utils.open_ai_types import (
+    KILN_ONLY_MESSAGE_FIELDS,
     ChatCompletionAssistantMessageParamWrapper,
     ChatCompletionToolMessageParamWrapper,
+    sanitize_messages_for_provider,
     trace_has_pending_client_tool_calls,
 )
 from kiln_ai.utils.open_ai_types import (
@@ -209,6 +211,95 @@ def test_tool_message_wrapper_can_be_instantiated():
     }
 
     assert sample_with_none_kiln_data.get("kiln_task_tool_data") is None
+
+
+def test_kiln_only_message_fields_set():
+    assert KILN_ONLY_MESSAGE_FIELDS == frozenset(
+        {"latency_ms", "is_error", "error_message", "kiln_task_tool_data"}
+    )
+
+
+def test_sanitize_messages_strips_kiln_only_fields():
+    messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "hello",
+            "latency_ms": 200,
+        },
+        {
+            "role": "tool",
+            "content": "{}",
+            "tool_call_id": "c1",
+            "is_error": True,
+            "error_message": "boom",
+            "kiln_task_tool_data": "p:::t:::ta:::r",
+        },
+    ]
+
+    sanitized = sanitize_messages_for_provider(messages)
+
+    assert sanitized == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "tool", "content": "{}", "tool_call_id": "c1"},
+    ]
+
+
+def test_sanitize_messages_does_not_mutate_input():
+    original = [
+        {
+            "role": "tool",
+            "content": "{}",
+            "tool_call_id": "c1",
+            "is_error": True,
+            "error_message": "boom",
+        }
+    ]
+    snapshot = [dict(m) for m in original]
+
+    sanitize_messages_for_provider(original)
+
+    assert original == snapshot
+
+
+def test_sanitize_messages_passes_non_dicts_through_unchanged():
+    class Sentinel:
+        pass
+
+    sentinel = Sentinel()
+    messages = [
+        sentinel,
+        {"role": "user", "content": "hi", "latency_ms": 5},
+    ]
+
+    sanitized = sanitize_messages_for_provider(messages)
+
+    assert sanitized[0] is sentinel
+    assert sanitized[1] == {"role": "user", "content": "hi"}
+
+
+def test_sanitize_messages_preserves_other_extension_fields():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "hi",
+            "reasoning_content": "thinking...",
+            "latency_ms": 50,
+        }
+    ]
+
+    sanitized = sanitize_messages_for_provider(messages)
+
+    assert sanitized == [
+        {
+            "role": "assistant",
+            "content": "hi",
+            "reasoning_content": "thinking...",
+        }
+    ]
 
 
 def test_trace_has_pending_client_tool_calls_empty_trace():


### PR DESCRIPTION
## What does this PR do?

Currently if a toolcall is marked with `is_error` and `error_message` in the `prior_trace`, we lose the fields on the next turn. We should preserve past `is_error` and `error_message` in the trace.

Changes:
- refactor: ensure the special fields are preserved in prior trace when running a multiturn turn

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
