### PR TITLE
SDG-intro: branch CI hygiene (svelte cleanup + agent annotations)

### DIFF
--- a/app/web_ui/src/lib/utils/task_sample_selector.svelte
+++ b/app/web_ui/src/lib/utils/task_sample_selector.svelte
@@ -10,7 +10,6 @@
   import FormElement from "$lib/utils/form_element.svelte"
   import Output from "$lib/ui/output.svelte"
   import Collapse from "$lib/ui/collapse.svelte"
-  import Dialog from "$lib/ui/dialog.svelte"
   import TaskRunPicker from "$lib/utils/task_run_picker.svelte"
 
   export let project_id: string
@@ -32,25 +31,6 @@
   let is_changing_selection: boolean = false
   let user_verification_desired: boolean = false // tracks if user should verify the selection before continuing (open collapse for them)
 
-  // Pagination
-  const PAGE_SIZE = 5
-  let current_page = 0
-  $: total_pages = Math.ceil(available_runs.length / PAGE_SIZE)
-  $: page_start = current_page * PAGE_SIZE
-  $: page_end = Math.min(page_start + PAGE_SIZE, available_runs.length)
-  $: paged_runs = available_runs.slice(page_start, page_end)
-
-  // Preview dialog
-  let preview_dialog: Dialog
-  let previewing_run: TaskRun | null = null
-
-  function show_preview(run: TaskRun, event: MouseEvent) {
-    // Don't show preview if clicking on a button
-    if ((event.target as HTMLElement).closest("button")) return
-    previewing_run = run
-    preview_dialog?.show()
-  }
-
   // Handle run selection
   function select_run(run: TaskRun) {
     selected_example = task_run_to_example(run)
@@ -63,7 +43,6 @@
   function start_changing_selection() {
     is_changing_selection = true
     show_manual_entry = false
-    current_page = 0
   }
 
   // Start manual entry from the selected example view
@@ -283,18 +262,3 @@
     {/if}
   </div>
 </Collapse>
-
-<Dialog bind:this={preview_dialog} title="Example" width="wide">
-  {#if previewing_run}
-    <div class="flex flex-col gap-4">
-      <div>
-        <div class="text-sm font-medium text-left mb-1">Input</div>
-        <Output raw_output={previewing_run.input} />
-      </div>
-      <div>
-        <div class="text-sm font-medium text-left mb-1">Output</div>
-        <Output raw_output={previewing_run.output?.output || ""} />
-      </div>
-    </div>
-  {/if}
-</Dialog>

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/data_guide_setup/guide_refine_view.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/data_guide_setup/guide_refine_view.svelte
@@ -161,18 +161,6 @@
     dispatch("save", { guide: editing_guide })
   }
 
-  function handle_save_without_verifying_main() {
-    page_error = null
-    if (!guide.trim()) {
-      page_error = new KilnError(
-        "Data guide cannot be empty. Add some content first.",
-        null,
-      )
-      return
-    }
-    dispatch("save", { guide })
-  }
-
   $: data_guide_properties = build_data_guide_properties(data_guide)
 
   function build_data_guide_properties(g: DataGuide | null): UiProperty[] {

--- a/libs/server/kiln_server/utils/agent_checks/annotations/delete_api_projects_project_id_tasks_task_id_data_gen_guide.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/delete_api_projects_project_id_tasks_task_id_data_gen_guide.json
@@ -1,0 +1,8 @@
+{
+  "method": "delete",
+  "path": "/api/projects/{project_id}/tasks/{task_id}/data_gen_guide",
+  "agent_policy": {
+    "permission": "allow",
+    "requires_approval": false
+  }
+}

--- a/libs/server/kiln_server/utils/agent_checks/annotations/get_api_projects_project_id_tasks_task_id_data_gen_guide.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/get_api_projects_project_id_tasks_task_id_data_gen_guide.json
@@ -1,0 +1,8 @@
+{
+  "method": "get",
+  "path": "/api/projects/{project_id}/tasks/{task_id}/data_gen_guide",
+  "agent_policy": {
+    "permission": "allow",
+    "requires_approval": false
+  }
+}

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_data_gen_guide_preview.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_data_gen_guide_preview.json
@@ -1,0 +1,9 @@
+{
+  "method": "post",
+  "path": "/api/projects/{project_id}/tasks/{task_id}/data_gen_guide_preview",
+  "agent_policy": {
+    "permission": "allow",
+    "requires_approval": true,
+    "approval_description": "Generate preview samples using LLM?"
+  }
+}

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_data_gen_guide_refine.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_data_gen_guide_refine.json
@@ -1,0 +1,9 @@
+{
+  "method": "post",
+  "path": "/api/projects/{project_id}/tasks/{task_id}/data_gen_guide_refine",
+  "agent_policy": {
+    "permission": "allow",
+    "requires_approval": true,
+    "approval_description": "Refine guidance using LLM?"
+  }
+}

--- a/libs/server/kiln_server/utils/agent_checks/annotations/put_api_projects_project_id_tasks_task_id_data_gen_guide.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/put_api_projects_project_id_tasks_task_id_data_gen_guide.json
@@ -1,0 +1,8 @@
+{
+  "method": "put",
+  "path": "/api/projects/{project_id}/tasks/{task_id}/data_gen_guide",
+  "agent_policy": {
+    "permission": "allow",
+    "requires_approval": false
+  }
+}


### PR DESCRIPTION
**TL;DR**: Two unrelated CI-unblockers found while working on follow-up changes. Pre-existing failures on the `KIL-485/SDG-intro` branch tip. Pure additive / pure deletion. No behavior change.

| Commit | What | Why |
|---|---|---|
| chore: svelte cleanup | Remove orphaned pagination block + unused handler in `task_sample_selector.svelte` and `guide_refine_view.svelte` | Pre-existing eslint errors (orphaned vars from earlier refactors) |
| chore: agent annotations | Add 5 missing annotation JSON files for the `data_gen_guide` endpoints | Pre-existing `Check API Schema Bindings` CI failure — endpoints existed without their annotations |

Both surfaced as soon as anything else touched the branch — splitting them out keeps the parallel data-guide PRs focused.

## Test plan
- [x] `npm run lint` clean
- [x] `Check API Schema Bindings` green (this is what the second commit fixes)
- [x] All targeted Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)