### PR TITLE
Fix deep link in Chat

### DIFF
--- a/app/web_ui/src/lib/stores.ts
+++ b/app/web_ui/src/lib/stores.ts
@@ -60,7 +60,6 @@ export const ui_state = localStorageStore("ui_state", default_ui_state)
 export const projects = writable<AllProjects | null>(null)
 export const current_project = writable<Project | null>(null)
 export const current_task = writable<Task | null>(null)
-export const current_task_prompts = writable<PromptResponse | null>(null)
 
 // UI Stores we want persisted across page loads
 export const fine_tune_target_model: Writable<string | null> =
@@ -68,10 +67,6 @@ export const fine_tune_target_model: Writable<string | null> =
 
 export const chat_cost_disclaimer_acknowledged: Writable<boolean> =
   localStorageStore("kiln_chat_cost_disclaimer_v1_ack", false)
-
-// Rating options for the current task
-export const current_task_rating_options =
-  writable<RatingOptionResponse | null>(null)
 
 let previous_ui_state: UIState = default_ui_state
 
@@ -81,10 +76,8 @@ ui_state.subscribe((state) => {
     current_project.set(get_current_project())
   }
   if (state.current_task_id != previous_ui_state.current_task_id) {
-    // invalidate task caches. Rating options will load on demand.
+    // invalidate task cache. Rating options will load on demand.
     current_task.set(null)
-    current_task_rating_options.set(null)
-    current_task_prompts.set(null)
     load_current_task(get(current_project)?.id)
   }
   previous_ui_state = { ...state }
@@ -169,11 +162,6 @@ export async function load_current_task(project_id: string | null | undefined) {
       return
     }
     task = await load_task(project_id, task_id)
-
-    // Load the current task's prompts after 50ms, as it's not the most critical data
-    setTimeout(() => {
-      load_available_prompts()
-    }, 50)
   } catch (error: unknown) {
     // Can't load this task, likely deleted. Clear the ID, which will force the user to select a new task
     if (dev) {
@@ -598,10 +586,8 @@ export function prompt_name_from_id(
   prompt_id: string,
   prompt_response: PromptResponse | null,
 ): string {
-  // Dispatch a request to load the prompts if we don't have them yet
-  if (!prompt_response) {
-    load_available_prompts()
-  }
+  // Callers are responsible for loading prompts (typically via load_task_prompts
+  // in a reactive block). If they haven't, we just fall through to the raw ID.
   // Attempt to lookup a nice name for the prompt. First from named prompts, then from generators
   // Special case for fine-tuned prompts
   let prompt_name: string | undefined = undefined
@@ -624,95 +610,14 @@ export function prompt_name_from_id(
   return prompt_name
 }
 
-// Available prompts for the current task. Lock to avoid parallel requests.
-let is_loading_prompts = false
-export async function load_available_prompts(force: boolean = false) {
-  const project = get(current_project)
-  const task = get(current_task)
-  if (!project || !task || !project.id || !task.id) {
-    current_task_prompts.set(null)
-    return
-  }
-  if (!force && get(current_task_prompts)) {
-    return
-  }
-
-  try {
-    // Return early if already loading
-    if (is_loading_prompts) {
-      return
-    }
-    is_loading_prompts = true
-    const { data, error } = await client.GET(
-      "/api/projects/{project_id}/tasks/{task_id}/prompts",
-      {
-        params: {
-          path: {
-            project_id: project.id,
-            task_id: task.id,
-          },
-        },
-      },
-    )
-    if (error) {
-      throw error
-    }
-    current_task_prompts.set(data)
-  } catch (error: unknown) {
-    console.error(createKilnError(error).getMessage())
-    current_task_prompts.set(null)
-  } finally {
-    is_loading_prompts = false
-  }
-}
-
-// Lock to avoid parallel requests for rating options
-let is_loading_rating_options = false
-
-export async function load_rating_options() {
-  const project = get(current_project)
-  const task = get(current_task)
-  if (!project || !task || !project.id || !task.id) {
-    current_task_rating_options.set(null)
-    return
-  }
-
-  try {
-    // Return early if already loading
-    if (is_loading_rating_options) {
-      return
-    }
-    is_loading_rating_options = true
-    const { data, error } = await client.GET(
-      "/api/projects/{project_id}/tasks/{task_id}/rating_options",
-      {
-        params: {
-          path: {
-            project_id: project.id,
-            task_id: task.id,
-          },
-        },
-      },
-    )
-    if (error) {
-      throw error
-    }
-    current_task_rating_options.set(data)
-  } catch (error: unknown) {
-    console.error(createKilnError(error).getMessage())
-    current_task_rating_options.set(null)
-  } finally {
-    is_loading_rating_options = false
-  }
-}
-
 export function rating_options_for_sample(
   rating_options: RatingOptionResponse | null,
   tags: string[],
 ): TaskRequirement[] {
-  // Dispatch a request to load the rating options if we don't have them yet
+  // Callers are responsible for triggering load_rating_options(project_id, task_id)
+  // before reading; if not loaded yet, return an empty list and let the next
+  // reactive run produce the real one.
   if (!rating_options) {
-    load_rating_options()
     return []
   }
 

--- a/app/web_ui/src/lib/stores/prompts_store.ts
+++ b/app/web_ui/src/lib/stores/prompts_store.ts
@@ -1,11 +1,7 @@
 import { writable } from "svelte/store"
 import { client } from "$lib/api_client"
 import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
-import {
-  get_task_composite_id,
-  load_available_prompts,
-  type TaskCompositeId,
-} from "$lib/stores"
+import { get_task_composite_id, type TaskCompositeId } from "$lib/stores"
 import type { PromptResponse } from "$lib/types"
 
 export const prompts_by_task_composite_id = writable<
@@ -28,8 +24,6 @@ export async function load_task_prompts(
   task_id: string,
   force_refresh: boolean = false,
 ): Promise<void> {
-  await load_available_prompts(force_refresh) // For the case task_id = current task id and other clients use load_available_prompts still
-
   const composite_key = get_task_composite_id(project_id, task_id)
 
   if (composite_key in loading_task_prompts) {

--- a/app/web_ui/src/lib/stores/rating_options_store.ts
+++ b/app/web_ui/src/lib/stores/rating_options_store.ts
@@ -1,0 +1,103 @@
+import { writable } from "svelte/store"
+import { client } from "$lib/api_client"
+import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
+import { get_task_composite_id, type TaskCompositeId } from "$lib/stores"
+import type { RatingOptionResponse } from "$lib/types"
+
+export const rating_options_by_task_composite_id = writable<
+  Record<TaskCompositeId, RatingOptionResponse>
+>({})
+
+export const rating_options_errors_by_task_composite_id = writable<
+  Record<TaskCompositeId, KilnError>
+>({})
+
+export const rating_options_loading_by_task_composite_id = writable<
+  Record<TaskCompositeId, boolean>
+>({})
+
+// Promise map to dedup parallel requests for the same task
+const loading_rating_options: Record<TaskCompositeId, Promise<void>> = {}
+
+export async function load_rating_options(
+  project_id: string,
+  task_id: string,
+  force_refresh: boolean = false,
+): Promise<void> {
+  const composite_key = get_task_composite_id(project_id, task_id)
+
+  if (composite_key in loading_rating_options) {
+    if (force_refresh) {
+      try {
+        await loading_rating_options[composite_key]
+      } catch (error) {
+        console.warn(
+          "Previous rating options load failed; retrying due to force refresh: ",
+          error,
+        )
+      }
+    } else {
+      return loading_rating_options[composite_key]
+    }
+  }
+
+  const promise = (async () => {
+    rating_options_loading_by_task_composite_id.update((loading) => ({
+      ...loading,
+      [composite_key]: true,
+    }))
+
+    try {
+      const { data, error } = await client.GET(
+        "/api/projects/{project_id}/tasks/{task_id}/rating_options",
+        {
+          params: {
+            path: {
+              project_id,
+              task_id,
+            },
+          },
+        },
+      )
+      if (error) {
+        throw error
+      }
+
+      rating_options_by_task_composite_id.update((options) => ({
+        ...options,
+        [composite_key]: data,
+      }))
+
+      rating_options_errors_by_task_composite_id.update((errors) => {
+        const next = { ...errors }
+        delete next[composite_key]
+        return next
+      })
+    } catch (error) {
+      console.error("Failed to load rating options: ", error)
+
+      rating_options_errors_by_task_composite_id.update((errors) => ({
+        ...errors,
+        [composite_key]: createKilnError(error),
+      }))
+
+      rating_options_by_task_composite_id.update((options) => {
+        const next = { ...options }
+        delete next[composite_key]
+        return next
+      })
+
+      throw error
+    } finally {
+      rating_options_loading_by_task_composite_id.update((loading) => ({
+        ...loading,
+        [composite_key]: false,
+      }))
+
+      delete loading_rating_options[composite_key]
+    }
+  })()
+
+  loading_rating_options[composite_key] = promise
+  return promise
+}

--- a/app/web_ui/src/lib/ui/run_config_component/prompt_type_selector.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/prompt_type_selector.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import FormElement from "$lib/utils/form_element.svelte"
-  import { current_task_prompts } from "$lib/stores"
+  import { get_task_composite_id } from "$lib/stores"
+  import {
+    prompts_by_task_composite_id,
+    load_task_prompts,
+  } from "$lib/stores/prompts_store"
   import type { PromptResponse } from "$lib/types"
   import Warning from "$lib/ui/warning.svelte"
   import type { OptionGroup, Option } from "$lib/ui/fancy_select_types"
@@ -61,6 +65,19 @@
     return null
   }
 
+  // Drive the prompt list off the URL-scoped task params instead of the
+  // ui_state-scoped current_task_prompts, so a deep link to a task that
+  // doesn't match the sidebar still shows the right prompts.
+  $: task_prompts =
+    project_id && task_id
+      ? $prompts_by_task_composite_id[
+          get_task_composite_id(project_id, task_id)
+        ] ?? null
+      : null
+  $: if (project_id && task_id) {
+    load_task_prompts(project_id, task_id)
+  }
+
   // Re-fetch rated/repair data whenever project_id or task_id changes so the
   // generator disabled states stay in sync if the parent swaps tasks.
   let requirements_loaded_key: string | null = null
@@ -115,7 +132,7 @@
   }
 
   $: options = build_prompt_options(
-    $current_task_prompts,
+    task_prompts,
     exclude_cot,
     custom_prompt_name,
     fine_tune_prompt_id,
@@ -127,7 +144,7 @@
   )
 
   function build_prompt_options(
-    current_task_prompts: PromptResponse | null,
+    task_prompts: PromptResponse | null,
     exclude_cot: boolean,
     custom_prompt_name: string | undefined,
     fine_tune_prompt_id: string | undefined,
@@ -140,14 +157,14 @@
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _has_repair: boolean,
   ): OptionGroup[] {
-    if (!current_task_prompts) {
+    if (!task_prompts) {
       return []
     }
 
     const grouped_options: OptionGroup[] = []
 
     const generators: Option[] = []
-    for (const generator of current_task_prompts.generators) {
+    for (const generator of task_prompts.generators) {
       if (generator.chain_of_thought && exclude_cot) {
         continue
       }
@@ -189,7 +206,7 @@
     }
 
     const static_prompts: Option[] = []
-    for (const prompt of current_task_prompts.prompts) {
+    for (const prompt of task_prompts.prompts) {
       if (!prompt.id) {
         continue
       }
@@ -260,7 +277,7 @@
     }
     // This shouldn't be needed, but it is. Svelte doesn't re-evaluate the options when the fine-tune prompt id changes.
     options = build_prompt_options(
-      $current_task_prompts,
+      task_prompts,
       exclude_cot,
       custom_prompt_name,
       fine_tune_prompt_id,

--- a/app/web_ui/src/lib/ui/run_config_component/prompt_type_selector.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/prompt_type_selector.svelte
@@ -3,6 +3,7 @@
   import { get_task_composite_id } from "$lib/stores"
   import {
     prompts_by_task_composite_id,
+    prompts_errors_by_task_composite_id,
     load_task_prompts,
   } from "$lib/stores/prompts_store"
   import type { PromptResponse } from "$lib/types"
@@ -74,6 +75,13 @@
           get_task_composite_id(project_id, task_id)
         ] ?? null
       : null
+  $: prompt_load_error = !!(
+    project_id &&
+    task_id &&
+    $prompts_errors_by_task_composite_id[
+      get_task_composite_id(project_id, task_id)
+    ]
+  )
   $: if (project_id && task_id) {
     load_task_prompts(project_id, task_id)
   }
@@ -293,8 +301,10 @@
 <FormElement
   label="Prompt Method"
   inputType="fancy_select"
-  empty_state_message="Loading prompts..."
-  empty_state_subtitle="Please wait."
+  empty_state_message={prompt_load_error
+    ? "Failed to load prompts"
+    : "Loading prompts..."}
+  empty_state_subtitle={prompt_load_error ? null : "Please wait."}
   {description}
   {info_description}
   bind:value={prompt_method}

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
@@ -77,6 +77,12 @@
   ]
 
   $: if (project_id && task_id) {
+    runs = null
+    filtered_runs = null
+    error = null
+    select_mode = false
+    selected_runs = new Set()
+    last_selected_id = null
     get_runs(project_id, task_id)
   }
 

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
@@ -4,7 +4,6 @@
   import { client } from "$lib/api_client"
   import type { RunSummary } from "$lib/types"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
-  import { onMount } from "svelte"
   import { model_info, load_model_info, model_name } from "$lib/stores"
   import { goto } from "$app/navigation"
   import { page } from "$app/stores"
@@ -77,34 +76,33 @@
     { key: "tags", label: "Tags" },
   ]
 
-  onMount(async () => {
-    get_runs()
-  })
+  $: if (project_id && task_id) {
+    get_runs(project_id, task_id)
+  }
 
-  async function get_runs() {
+  async function get_runs(req_project_id: string, req_task_id: string) {
     try {
       load_model_info()
       loading = true
-      if (!project_id || !task_id) {
-        throw new Error("Project or task ID not set.")
-      }
       const { data: runs_response, error: get_error } = await client.GET(
         "/api/projects/{project_id}/tasks/{task_id}/runs_summaries",
         {
           params: {
             path: {
-              project_id,
-              task_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
             },
           },
         },
       )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (get_error) {
         throw get_error
       }
       runs = runs_response
       sortRuns()
     } catch (e) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (e instanceof Error && e.message.includes("Load failed")) {
         error = new KilnError(
           "Could not load dataset. It may belong to a project you don't have access to.",
@@ -114,7 +112,9 @@
         error = createKilnError(e)
       }
     } finally {
-      loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        loading = false
+      }
     }
   }
 
@@ -425,7 +425,7 @@
       // Reload UI, even on failure, as partial delete is possible
       selected_runs = new Set()
       select_mode = false
-      await get_runs()
+      await get_runs(project_id, task_id)
     }
   }
 
@@ -502,7 +502,7 @@
       selected_runs = new Set()
       add_tags = []
       select_mode = false
-      await get_runs()
+      await get_runs(project_id, task_id)
     }
   }
 </script>

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
@@ -4,22 +4,26 @@
   import Run from "../../../../../run/run.svelte"
   import Output from "$lib/ui/output.svelte"
   import {
-    current_task,
+    get_task_composite_id,
+    load_task,
     model_name,
     model_info,
     load_model_info,
     prompt_name_from_id,
-    current_task_prompts,
     provider_name_from_id,
     load_available_models,
     load_available_tools,
     available_tools,
   } from "$lib/stores"
+  import {
+    prompts_by_task_composite_id,
+    load_task_prompts,
+  } from "$lib/stores/prompts_store"
   import { page } from "$app/stores"
-  import { onMount, getContext } from "svelte"
+  import { getContext } from "svelte"
   import { client } from "$lib/api_client"
   import { createKilnError, KilnError } from "$lib/utils/error_handlers"
-  import type { TaskRun, StructuredOutputMode } from "$lib/types"
+  import type { Task, TaskRun, StructuredOutputMode } from "$lib/types"
   import { isMcpRunConfig } from "$lib/types"
   import {
     formatDate,
@@ -52,7 +56,7 @@
   // @ts-expect-error list_page is not a property of PageState
   $: list_page = ($page.state.list_page || []) as string[]
 
-  // We should remove task_id from the URL, or load it by ID. $current_task is a lie
+  let task: Task | null = null
   let run: TaskRun | null = null
   let loading = true
   let load_error: KilnError | null = null
@@ -338,40 +342,70 @@
     void tools_property_value
     void skills_property_value
     properties_for_list = [
-      ...get_properties(run, $current_task_prompts, $model_info),
+      ...get_properties(
+        run,
+        $prompts_by_task_composite_id[
+          get_task_composite_id(project_id, task_id)
+        ] ?? null,
+        $model_info,
+      ),
       ...(see_all_properties ? get_advanced_properties(run) : []),
     ]
   }
 
-  onMount(async () => {
-    await Promise.all([
-      load_run(),
-      load_model_info(),
-      load_available_models(),
-      load_available_tools(project_id),
-    ])
-  })
+  $: if (project_id && task_id && run_id) {
+    load_run(project_id, task_id, run_id)
+    load_task_for_page(project_id, task_id)
+    load_task_prompts(project_id, task_id)
+    load_available_tools(project_id)
+    load_model_info()
+    load_available_models()
+  }
 
-  async function load_run() {
-    // Snapshot run_id so we can detect if it changes during the await
-    // (e.g. user hits arrow again) and discard this stale response.
-    const requested_run_id = run_id
+  async function load_task_for_page(
+    req_project_id: string,
+    req_task_id: string,
+  ) {
+    const loaded = await load_task(req_project_id, req_task_id)
+    if (req_project_id !== project_id || req_task_id !== task_id) return
+    task = loaded
+  }
+
+  async function load_run(
+    req_project_id: string,
+    req_task_id: string,
+    req_run_id: string,
+  ) {
     try {
       const { data, error } = await client.GET(
         "/api/projects/{project_id}/tasks/{task_id}/runs/{run_id}",
         {
           params: {
-            path: { project_id, task_id, run_id: requested_run_id },
+            path: {
+              project_id: req_project_id,
+              task_id: req_task_id,
+              run_id: req_run_id,
+            },
           },
         },
       )
-      if (requested_run_id !== run_id) return
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_run_id !== run_id
+      )
+        return
       if (error) {
         throw error
       }
       run = data
     } catch (error) {
-      if (requested_run_id !== run_id) return
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_run_id !== run_id
+      )
+        return
       if (error instanceof Error && error.message.includes("Load failed")) {
         load_error = new KilnError(
           "Could not load run. It may belong to a project you don't have access to.",
@@ -381,7 +415,11 @@
         load_error = createKilnError(error)
       }
     } finally {
-      if (requested_run_id === run_id) {
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_run_id === run_id
+      ) {
         loading = false
       }
     }
@@ -412,13 +450,11 @@
 
   function load_run_by_id(new_run_id: string) {
     load_error = null
-    run_id = new_run_id
     run = null
     loading = true
-    goto(`/dataset/${project_id}/${task_id}/${run_id}/run`, {
+    goto(`/dataset/${project_id}/${task_id}/${new_run_id}/run`, {
       state: { list_page: list_page },
     })
-    load_run()
   }
 
   let buttons: ActionButton[] = []
@@ -496,7 +532,7 @@
       <div class="badge badge-error badge-lg p-4">Run Deleted</div>
     {:else if load_error}
       <div class="text-error">{load_error.getMessage()}</div>
-    {:else if run && $current_task}
+    {:else if run && task}
       <div class="flex flex-col xl:flex-row gap-8 xl:gap-16 mb-8">
         <div class="grow">
           <div class="text-xl font-bold mb-4">Input</div>
@@ -512,7 +548,7 @@
           </button>
         </div>
       </div>
-      <Run initial_run={run} task={$current_task} {project_id} />
+      <Run initial_run={run} {task} {project_id} />
     {:else}
       <div class="text-gray-500 text-lg">Run not found</div>
     {/if}

--- a/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/[extractor_id]/extractor/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/[extractor_id]/extractor/+page.svelte
@@ -6,7 +6,6 @@
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
   import AppPage from "../../../../../app_page.svelte"
   import PropertyList from "$lib/ui/property_list.svelte"
-  import { onMount } from "svelte"
   import { extractor_output_format, formatDate } from "$lib/utils/formatters"
   import Output from "$lib/ui/output.svelte"
   import Warning from "$lib/ui/warning.svelte"
@@ -25,24 +24,31 @@
   let archive_error: KilnError | null = null
   let extractor_config: ExtractorConfig | null = null
 
-  onMount(async () => {
-    await get_extractor_config()
-  })
+  $: if (project_id && extractor_id) {
+    get_extractor_config(project_id, extractor_id)
+  }
 
-  async function get_extractor_config() {
+  async function get_extractor_config(
+    req_project_id: string,
+    req_extractor_id: string,
+  ) {
     try {
       loading = true
+      error = null
       const { error: get_extractor_error, data } = await client.GET(
         "/api/projects/{project_id}/extractor_configs/{extractor_config_id}",
         {
           params: {
             path: {
-              project_id,
-              extractor_config_id: extractor_id,
+              project_id: req_project_id,
+              extractor_config_id: req_extractor_id,
             },
           },
         },
       )
+
+      if (req_project_id !== project_id || req_extractor_id !== extractor_id)
+        return
 
       if (get_extractor_error) {
         error = createKilnError(get_extractor_error)
@@ -51,7 +57,9 @@
 
       extractor_config = data
     } finally {
-      loading = false
+      if (req_project_id === project_id && req_extractor_id === extractor_id) {
+        loading = false
+      }
     }
   }
 
@@ -78,7 +86,7 @@
         throw archive_extractor_error
       }
 
-      await get_extractor_config()
+      await get_extractor_config(project_id, extractor_id)
     } catch (e) {
       archive_error = createKilnError(e)
     } finally {

--- a/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/[extractor_id]/extractor/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/extractors/[project_id]/[extractor_id]/extractor/+page.svelte
@@ -25,6 +25,9 @@
   let extractor_config: ExtractorConfig | null = null
 
   $: if (project_id && extractor_id) {
+    extractor_config = null
+    archive_error = null
+    error = null
     get_extractor_config(project_id, extractor_id)
   }
 

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
@@ -3,7 +3,6 @@
   import { client } from "$lib/api_client"
   import type { KilnDocument } from "$lib/types"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
-  import { onMount } from "svelte"
   import { load_model_info, ui_state } from "$lib/stores"
   import { page } from "$app/stores"
   import { goto, replaceState } from "$app/navigation"
@@ -77,33 +76,32 @@
     { key: "created_at", label: "Created At" },
   ]
 
-  onMount(async () => {
-    get_documents()
-  })
+  $: if (project_id) {
+    get_documents(project_id)
+  }
 
-  async function get_documents() {
+  async function get_documents(req_project_id: string) {
     try {
       load_model_info()
       loading = true
-      if (!project_id) {
-        throw new Error("Project ID not set.")
-      }
       const { data: documents_response, error: get_error } = await client.GET(
         "/api/projects/{project_id}/documents",
         {
           params: {
             path: {
-              project_id,
+              project_id: req_project_id,
             },
           },
         },
       )
+      if (req_project_id !== project_id) return
       if (get_error) {
         throw get_error
       }
       documents = documents_response
       sortDocuments()
     } catch (e) {
+      if (req_project_id !== project_id) return
       if (e instanceof Error && e.message.includes("Load failed")) {
         error = new KilnError(
           "Could not load dataset. It may belong to a project you don't have access to.",
@@ -113,7 +111,9 @@
         error = createKilnError(e)
       }
     } finally {
-      loading = false
+      if (req_project_id === project_id) {
+        loading = false
+      }
     }
   }
 
@@ -392,7 +392,7 @@
       // Reload UI, even on failure, as partial delete is possible
       selected_documents = new Set()
       select_mode = false
-      await get_documents()
+      await get_documents(project_id)
     }
   }
 
@@ -474,7 +474,7 @@
       selected_documents = new Set()
       add_tags = []
       select_mode = false
-      await get_documents()
+      await get_documents(project_id)
     }
   }
 </script>
@@ -802,6 +802,6 @@
 <UploadFileDialog
   bind:this={upload_file_dialog}
   onUploadCompleted={() => {
-    get_documents()
+    get_documents(project_id)
   }}
 />

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/+page.svelte
@@ -77,6 +77,8 @@
   ]
 
   $: if (project_id) {
+    error = null
+    documents = null
     get_documents(project_id)
   }
 

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
@@ -25,7 +25,10 @@
   let updated_document: KilnDocument | null = null
   $: document = updated_document || initial_document
   let error: KilnError | null = null
-  let loading = true
+  let document_loading = true
+  let extractions_loading = true
+  let folder_loading = false
+  $: loading = document_loading || extractions_loading || folder_loading
   let results: ExtractionSummary[] | null = null
 
   $: project_id = $page.params.project_id!
@@ -54,7 +57,7 @@
 
   async function get_document(req_project_id: string, req_document_id: string) {
     try {
-      loading = true
+      document_loading = true
       const { data: document_response, error: get_error } = await client.GET(
         "/api/projects/{project_id}/documents/{document_id}",
         {
@@ -85,7 +88,7 @@
       }
     } finally {
       if (req_project_id === project_id && req_document_id === document_id) {
-        loading = false
+        document_loading = false
       }
     }
   }
@@ -95,7 +98,7 @@
     req_document_id: string,
   ) {
     try {
-      loading = true
+      extractions_loading = true
       const { data: extractions_response, error: get_error } = await client.GET(
         "/api/projects/{project_id}/documents/{document_id}/extractions",
         {
@@ -115,14 +118,14 @@
       results = extractions_response
     } finally {
       if (req_project_id === project_id && req_document_id === document_id) {
-        loading = false
+        extractions_loading = false
       }
     }
   }
 
   async function open_enclosing_folder() {
     try {
-      loading = true
+      folder_loading = true
       const { error: open_error } = await client.POST(
         "/api/projects/{project_id}/documents/{document_id}/open_enclosing_folder",
         {
@@ -138,7 +141,7 @@
         throw createKilnError(open_error)
       }
     } finally {
-      loading = false
+      folder_loading = false
     }
   }
 

--- a/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/library/[project_id]/[document_id]/+page.svelte
@@ -3,7 +3,6 @@
   import { base_url, client } from "$lib/api_client"
   import type { ExtractionSummary, KilnDocument } from "$lib/types"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
-  import { onMount } from "svelte"
   import { page } from "$app/stores"
   import { formatDate, formatSize } from "$lib/utils/formatters"
   import Dialog from "$lib/ui/dialog.svelte"
@@ -44,33 +43,38 @@
 
   $: download_document_url = `${base_url}/api/projects/${project_id}/documents/${document_id}/download`
 
-  onMount(async () => {
-    get_document()
-    get_extractions()
-  })
+  $: if (project_id && document_id) {
+    initial_document = null
+    updated_document = null
+    results = null
+    error = null
+    get_document(project_id, document_id)
+    get_extractions(project_id, document_id)
+  }
 
-  async function get_document() {
+  async function get_document(req_project_id: string, req_document_id: string) {
     try {
       loading = true
-      if (!project_id) {
-        throw new Error("Project ID not set.")
-      }
       const { data: document_response, error: get_error } = await client.GET(
         "/api/projects/{project_id}/documents/{document_id}",
         {
           params: {
             path: {
-              project_id,
-              document_id,
+              project_id: req_project_id,
+              document_id: req_document_id,
             },
           },
         },
       )
+      if (req_project_id !== project_id || req_document_id !== document_id)
+        return
       if (get_error) {
         throw get_error
       }
       updated_document = document_response
     } catch (e) {
+      if (req_project_id !== project_id || req_document_id !== document_id)
+        return
       if (e instanceof Error && e.message.includes("Load failed")) {
         error = new KilnError(
           "Could not load dataset. It may belong to a project you don't have access to.",
@@ -80,11 +84,16 @@
         error = createKilnError(e)
       }
     } finally {
-      loading = false
+      if (req_project_id === project_id && req_document_id === document_id) {
+        loading = false
+      }
     }
   }
 
-  async function get_extractions() {
+  async function get_extractions(
+    req_project_id: string,
+    req_document_id: string,
+  ) {
     try {
       loading = true
       const { data: extractions_response, error: get_error } = await client.GET(
@@ -92,18 +101,22 @@
         {
           params: {
             path: {
-              project_id,
-              document_id,
+              project_id: req_project_id,
+              document_id: req_document_id,
             },
           },
         },
       )
+      if (req_project_id !== project_id || req_document_id !== document_id)
+        return
       if (get_error) {
         throw get_error
       }
       results = extractions_response
     } finally {
-      loading = false
+      if (req_project_id === project_id && req_document_id === document_id) {
+        loading = false
+      }
     }
   }
 
@@ -142,7 +155,7 @@
   let delete_extraction_dialog: DeleteDialog | null = null
   $: delete_extraction_url = `/api/projects/${project_id}/documents/${document_id}/extractions/${delete_extraction_id}`
   async function after_delete_extraction() {
-    get_extractions()
+    get_extractions(project_id, document_id)
   }
 
   let tags_error: KilnError | null = null
@@ -472,8 +485,8 @@
 <EditDialog
   bind:this={edit_dialog}
   after_save={() => {
-    get_document()
-    get_extractions()
+    get_document(project_id, document_id)
+    get_extractions(project_id, document_id)
   }}
   name="Document"
   patch_url={`/api/projects/${project_id}/documents/${document_id}`}

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
@@ -6,7 +6,6 @@
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
   import AppPage from "../../../../../app_page.svelte"
   import PropertyList from "$lib/ui/property_list.svelte"
-  import { onMount } from "svelte"
   import { extractor_output_format, formatDate } from "$lib/utils/formatters"
   import {
     embedding_model_name,
@@ -64,16 +63,17 @@
     similarity: number | null
   }> = []
 
-  onMount(async () => {
-    await Promise.all([
-      load_available_models(),
-      load_available_embedding_models(),
-      load_available_reranker_models(),
-      get_rag_config(),
-    ])
-  })
+  $: if (project_id && rag_config_id) {
+    load_available_models()
+    load_available_embedding_models()
+    load_available_reranker_models()
+    get_rag_config(project_id, rag_config_id)
+  }
 
-  async function get_rag_config() {
+  async function get_rag_config(
+    req_project_id: string,
+    req_rag_config_id: string,
+  ) {
     try {
       loading = true
       const { error: get_rag_config_error, data: rag_config_data } =
@@ -82,12 +82,15 @@
           {
             params: {
               path: {
-                project_id,
-                rag_config_id,
+                project_id: req_project_id,
+                rag_config_id: req_rag_config_id,
               },
             },
           },
         )
+
+      if (req_project_id !== project_id || req_rag_config_id !== rag_config_id)
+        return
 
       if (get_rag_config_error) {
         error = createKilnError(get_rag_config_error)
@@ -96,7 +99,12 @@
 
       rag_config = rag_config_data
     } finally {
-      loading = false
+      if (
+        req_project_id === project_id &&
+        req_rag_config_id === rag_config_id
+      ) {
+        loading = false
+      }
     }
   }
 
@@ -128,7 +136,7 @@
         is_archived,
       )
 
-      await get_rag_config()
+      await get_rag_config(project_id, rag_config_id)
     } catch (e) {
       update_error = createKilnError(e)
     } finally {

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/+page.svelte
@@ -64,6 +64,12 @@
   }> = []
 
   $: if (project_id && rag_config_id) {
+    error = null
+    rag_config = null
+    searchQuery = ""
+    searchError = null
+    lastSearchQuery = null
+    searchResults = []
     load_available_models()
     load_available_embedding_models()
     load_available_reranker_models()

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/clone/+page.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/[rag_config_id]/rag_config/clone/+page.svelte
@@ -6,7 +6,6 @@
   import { client } from "$lib/api_client"
   import { createKilnError, KilnError } from "$lib/utils/error_handlers"
   import type { RagConfigWithSubConfigs } from "$lib/types"
-  import { onMount } from "svelte"
   import EditRagConfigForm from "../../../create_rag_config/edit_rag_config_form.svelte"
 
   import { agentInfo } from "$lib/agent"
@@ -21,11 +20,14 @@
   let error: KilnError | null = null
   let rag_config: RagConfigWithSubConfigs | null = null
 
-  onMount(async () => {
-    await get_rag_config()
-  })
+  $: if (project_id && rag_config_id) {
+    get_rag_config(project_id, rag_config_id)
+  }
 
-  async function get_rag_config() {
+  async function get_rag_config(
+    req_project_id: string,
+    req_rag_config_id: string,
+  ) {
     try {
       loading = true
       const { data: rag_config_data, error: get_rag_config_error } =
@@ -34,12 +36,15 @@
           {
             params: {
               path: {
-                project_id,
-                rag_config_id,
+                project_id: req_project_id,
+                rag_config_id: req_rag_config_id,
               },
             },
           },
         )
+
+      if (req_project_id !== project_id || req_rag_config_id !== rag_config_id)
+        return
 
       if (get_rag_config_error) {
         throw get_rag_config_error
@@ -47,9 +52,16 @@
 
       rag_config = rag_config_data
     } catch (e) {
+      if (req_project_id !== project_id || req_rag_config_id !== rag_config_id)
+        return
       error = createKilnError(e)
     } finally {
-      loading = false
+      if (
+        req_project_id === project_id &&
+        req_rag_config_id === rag_config_id
+      ) {
+        loading = false
+      }
     }
   }
 </script>

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/+page.svelte
@@ -4,7 +4,6 @@
   import { client } from "$lib/api_client"
   import type { Finetune } from "$lib/types"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
-  import { onMount } from "svelte"
   import { goto } from "$app/navigation"
   import { page } from "$app/stores"
   import { formatDate } from "$lib/utils/formatters"
@@ -24,24 +23,21 @@
   let finetunes_error: KilnError | null = null
   let finetunes_loading = true
 
-  onMount(async () => {
-    await load_available_models()
-    get_finetunes()
-  })
+  $: if (project_id && task_id) {
+    load_available_models()
+    get_finetunes(project_id, task_id)
+  }
 
-  async function get_finetunes() {
+  async function get_finetunes(req_project_id: string, req_task_id: string) {
     try {
       finetunes_loading = true
-      if (!project_id || !task_id) {
-        throw new Error("Project or task ID not set.")
-      }
       const { data: finetunes_response, error: get_error } = await client.GET(
         "/api/projects/{project_id}/tasks/{task_id}/finetunes",
         {
           params: {
             path: {
-              project_id,
-              task_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
             },
             query: {
               update_status: true,
@@ -49,6 +45,7 @@
           },
         },
       )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (get_error) {
         throw get_error
       }
@@ -60,6 +57,7 @@
       })
       finetunes = sorted_finetunes
     } catch (e) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (e instanceof Error && e.message.includes("Load failed")) {
         finetunes_error = new KilnError(
           "Could not load finetunes. This task may belong to a project you don't have access to.",
@@ -69,7 +67,9 @@
         finetunes_error = createKilnError(e)
       }
     } finally {
-      finetunes_loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        finetunes_loading = false
+      }
     }
   }
 

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/+page.svelte
@@ -24,6 +24,8 @@
   let finetunes_loading = true
 
   $: if (project_id && task_id) {
+    finetunes_error = null
+    finetunes = null
     load_available_models()
     get_finetunes(project_id, task_id)
   }

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/fine_tune/[finetune_id]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import AppPage from "../../../../../app_page.svelte"
   import { page } from "$app/stores"
-  import { onMount } from "svelte"
   import { client } from "$lib/api_client"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
   import type { FinetuneWithStatus } from "$lib/types"
@@ -25,16 +24,20 @@
     finetune?.status.status === "pending" ||
     finetune?.status.status === "running"
 
-  onMount(async () => {
-    await load_available_models()
-    get_fine_tune()
-  })
+  $: if (project_id && task_id && finetune_id) {
+    load_available_models()
+    get_fine_tune(project_id, task_id, finetune_id)
+  }
 
   let finetune: FinetuneWithStatus | null = null
   let finetune_error: KilnError | null = null
   let finetune_loading = true
 
-  const get_fine_tune = async () => {
+  const get_fine_tune = async (
+    req_project_id: string,
+    req_task_id: string,
+    req_finetune_id: string,
+  ) => {
     try {
       finetune_loading = true
       finetune_error = null
@@ -44,22 +47,40 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              finetune_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              finetune_id: req_finetune_id,
             },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_finetune_id !== finetune_id
+      )
+        return
       if (get_error) {
         throw get_error
       }
       finetune = finetune_response
       build_properties()
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_finetune_id !== finetune_id
+      )
+        return
       finetune_error = createKilnError(error)
     } finally {
-      finetune_loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_finetune_id === finetune_id
+      ) {
+        finetune_loading = false
+      }
     }
   }
 
@@ -289,7 +310,10 @@
               {/if}
               {finetune.status.status.charAt(0).toUpperCase() +
                 finetune.status.status.slice(1)}
-              <button class="link ml-2 font-medium" on:click={get_fine_tune}>
+              <button
+                class="link ml-2 font-medium"
+                on:click={() => get_fine_tune(project_id, task_id, finetune_id)}
+              >
                 Reload Status
               </button>
             </div>

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import AppPage from "../../../app_page.svelte"
-  import { onMount } from "svelte"
   import { page } from "$app/stores"
   import { goto } from "$app/navigation"
   import DataGenIntro from "./data_gen_intro.svelte"
@@ -36,11 +35,17 @@
     gen_type: null,
   })
 
-  onMount(async () => {
-    await handle_routing()
-  })
+  let last_handled_key: string | null = null
 
-  async function handle_routing() {
+  $: if (project_id && task_id) {
+    const key = `${project_id}/${task_id}`
+    if (last_handled_key !== key) {
+      last_handled_key = key
+      handle_routing(project_id, task_id)
+    }
+  }
+
+  async function handle_routing(req_project_id: string, req_task_id: string) {
     loading = true
     const reason_param = $page.url.searchParams.get(
       "reason",
@@ -51,12 +56,14 @@
     if (reason_param === "eval" || reason_param === "fine_tune") {
       const params = $page.url.searchParams
       await goto(
-        `/generate/${project_id}/${task_id}/synth?${params.toString()}`,
+        `/generate/${req_project_id}/${req_task_id}/synth?${params.toString()}`,
       )
       return
     } else if (reason_param === "qna") {
       const params = $page.url.searchParams
-      await goto(`/generate/${project_id}/${task_id}/qna?${params.toString()}`)
+      await goto(
+        `/generate/${req_project_id}/${req_task_id}/qna?${params.toString()}`,
+      )
       return
     } else if (reason_param) {
       //typecheck will flag this if we add a new case that we don't handle
@@ -67,16 +74,20 @@
     // user lands on this page without any specific state in the URL, we want to redirect
     // them to wherever they last were (i.e. synth page) if they have any ongoing session
     try {
-      const currentSessionGenType = await getCurrentSessionGenType()
+      const currentSessionGenType = await getCurrentSessionGenType(
+        req_project_id,
+        req_task_id,
+      )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       switch (currentSessionGenType) {
         case "training":
-          await goto(`/generate/${project_id}/${task_id}/synth`)
+          await goto(`/generate/${req_project_id}/${req_task_id}/synth`)
           return
         case "eval":
-          await goto(`/generate/${project_id}/${task_id}/synth`)
+          await goto(`/generate/${req_project_id}/${req_task_id}/synth`)
           return
         case "qna":
-          await goto(`/generate/${project_id}/${task_id}/qna`)
+          await goto(`/generate/${req_project_id}/${req_task_id}/qna`)
           return
         case null:
           // no ongoing session, stay on this page and show intro
@@ -92,21 +103,24 @@
       console.error("Error checking for ongoing session:", error)
     }
 
-    loading = false
+    if (req_project_id === project_id && req_task_id === task_id) {
+      loading = false
+    }
   }
 
-  async function getCurrentSessionGenType(): Promise<
-    "training" | "eval" | "qna" | null
-  > {
+  async function getCurrentSessionGenType(
+    req_project_id: string,
+    req_task_id: string,
+  ): Promise<"training" | "eval" | "qna" | null> {
     // Check for saved Q&A session first
     if (
       !cachedQnaStore ||
-      cachedQnaProjectId !== project_id ||
-      cachedQnaTaskId !== task_id
+      cachedQnaProjectId !== req_project_id ||
+      cachedQnaTaskId !== req_task_id
     ) {
-      cachedQnaStore = createQnaStore(project_id, task_id)
-      cachedQnaProjectId = project_id
-      cachedQnaTaskId = task_id
+      cachedQnaStore = createQnaStore(req_project_id, req_task_id)
+      cachedQnaProjectId = req_project_id
+      cachedQnaTaskId = req_task_id
       cachedQnaInitialized = false
     }
     if (!cachedQnaInitialized) {
@@ -118,7 +132,7 @@
       return "qna"
     }
     // Check for saved synthetic data session
-    const synth_data_key = `synth_data_${project_id}_${task_id}_v2`
+    const synth_data_key = `synth_data_${req_project_id}_${req_task_id}_v2`
     const { store, initialized } = indexedDBStore(synth_data_key, {
       gen_type: null,
       template_id: null,

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
@@ -38,7 +38,7 @@
   let last_handled_key: string | null = null
 
   $: if (project_id && task_id) {
-    const key = `${project_id}/${task_id}`
+    const key = `${project_id}/${task_id}?${$page.url.searchParams.toString()}`
     if (last_handled_key !== key) {
       last_handled_key = key
       handle_routing(project_id, task_id)

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/+page.svelte
@@ -99,7 +99,7 @@
   let last_initialized_key: string | null = null
 
   $: if (project_id && task_id) {
-    const key = `${project_id}/${task_id}`
+    const key = `${project_id}/${task_id}?${$page.url.searchParams.toString()}`
     if (last_initialized_key !== key) {
       last_initialized_key = key
       init_qna(project_id, task_id)

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/qna/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import AppPage from "../../../../app_page.svelte"
-  import { onMount } from "svelte"
   import { page } from "$app/stores"
   import { get } from "svelte/store"
   import Dialog from "$lib/ui/dialog.svelte"
@@ -97,9 +96,21 @@
 
   let pendingUrlSplits: Record<string, number> = {}
 
-  onMount(async () => {
-    qna = createQnaStore(project_id, task_id)
-    await qna.init(DEFAULT_QNA_GUIDANCE)
+  let last_initialized_key: string | null = null
+
+  $: if (project_id && task_id) {
+    const key = `${project_id}/${task_id}`
+    if (last_initialized_key !== key) {
+      last_initialized_key = key
+      init_qna(project_id, task_id)
+    }
+  }
+
+  async function init_qna(req_project_id: string, req_task_id: string) {
+    const new_qna = createQnaStore(req_project_id, req_task_id)
+    await new_qna.init(DEFAULT_QNA_GUIDANCE)
+    if (req_project_id !== project_id || req_task_id !== task_id) return
+    qna = new_qna
 
     // Check for splits in URL parameters (for non-reference answer evals)
     const splitsParam = $page.url.searchParams.get("splits")
@@ -114,7 +125,7 @@
     } else if (!hasDocuments && Object.keys(urlSplits).length > 0) {
       qna.setSplits(urlSplits)
     }
-  })
+  }
 
   // Dialogs
   let clear_existing_state_dialog: Dialog | null = null

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import AppPage from "../../../../app_page.svelte"
   import { client } from "$lib/api_client"
-  import { current_task } from "$lib/stores"
   import type { RunConfigProperties, Task } from "$lib/types"
   import { isKilnAgentRunConfig } from "$lib/types"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
@@ -392,10 +391,6 @@
       task_loading = true
       if (!project_id || !task_id) {
         throw new Error("Project or task ID not set.")
-      }
-      if ($current_task?.id === task_id) {
-        task = $current_task
-        return
       }
       const { data: task_response, error: get_error } = await client.GET(
         "/api/projects/{project_id}/tasks/{task_id}",

--- a/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/+page.svelte
@@ -3,7 +3,6 @@
   import FeatureCarousel from "$lib/ui/feature_carousel.svelte"
   import { get_optimizers, type Optimizer } from "./optimizers"
   import { page } from "$app/stores"
-  import { onMount } from "svelte"
   import {
     available_tools,
     get_task_composite_id,
@@ -96,28 +95,36 @@
     await load_task_run_configs(project_id, task_id, true)
   }
 
-  onMount(async () => {
+  $: if (project_id && task_id) {
+    load_task_data(project_id, task_id)
+  }
+
+  async function load_task_data(req_project_id: string, req_task_id: string) {
     loading = true
-    load_available_tools(project_id)
+    load_available_tools(req_project_id)
     try {
       await Promise.all([
         load_model_info(),
-        load_task_prompts(project_id, task_id),
-
+        load_task_prompts(req_project_id, req_task_id),
         // some run configs are created server-side as a result of async jobs
         // frontend does not know about them until the store is refreshed
-        load_task_run_configs(project_id, task_id, true),
+        load_task_run_configs(req_project_id, req_task_id, true),
       ])
-      task = await load_task(project_id, task_id)
-      if (!task) {
+      const loaded_task = await load_task(req_project_id, req_task_id)
+      if (req_project_id !== project_id || req_task_id !== task_id) return
+      if (!loaded_task) {
         throw new Error("Task not found")
       }
+      task = loaded_task
     } catch (e) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       error = createKilnError(e)
     } finally {
-      loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        loading = false
+      }
     }
-  })
+  }
 
   $: task_prompts =
     $prompts_by_task_composite_id[get_task_composite_id(project_id, task_id)] ||

--- a/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/+page.svelte
@@ -96,11 +96,13 @@
   }
 
   $: if (project_id && task_id) {
+    cancelSelection()
     load_task_data(project_id, task_id)
   }
 
   async function load_task_data(req_project_id: string, req_task_id: string) {
     loading = true
+    error = null
     load_available_tools(req_project_id)
     try {
       await Promise.all([

--- a/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/run_config/[run_config_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/run_config/[run_config_id]/+page.svelte
@@ -21,7 +21,6 @@
   import type { Task, TaskRunConfig } from "$lib/types"
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
   import { getRunConfigUiProperties } from "$lib/utils/run_config_formatters"
-  import { onMount } from "svelte"
   import AppPage from "../../../../../app_page.svelte"
   import EditDialog from "$lib/ui/edit_dialog.svelte"
   import PropertyList from "$lib/ui/property_list.svelte"
@@ -44,20 +43,29 @@
   let edit_dialog: EditDialog | null = null
   let create_run_config_dialog: CreateNewRunConfigDialog | null = null
 
-  onMount(async () => {
+  $: if (project_id && task_id) {
+    load_task_data(project_id, task_id)
+  }
+
+  async function load_task_data(req_project_id: string, req_task_id: string) {
     try {
-      load_available_tools(project_id)
-      await Promise.all([load_model_info(), load_available_models()])
-      await Promise.all([
-        load_task_prompts(project_id, task_id),
-        load_task_run_configs(project_id, task_id),
-      ])
-      task = await load_task(project_id, task_id)
+      load_available_tools(req_project_id)
+      load_model_info()
+      load_available_models()
+      load_task_prompts(req_project_id, req_task_id)
+      load_task_run_configs(req_project_id, req_task_id)
+      const loaded_task = await load_task(req_project_id, req_task_id)
+      if (req_project_id !== project_id || req_task_id !== task_id) return
+      task = loaded_task
     } catch (e) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       error = createKilnError(e)
+    } finally {
+      if (req_project_id === project_id && req_task_id === task_id) {
+        loading = false
+      }
     }
-    loading = false
-  })
+  }
 
   $: run_config =
     $run_configs_by_task_composite_id[

--- a/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/run_config/[run_config_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/run_config/[run_config_id]/+page.svelte
@@ -48,13 +48,17 @@
   }
 
   async function load_task_data(req_project_id: string, req_task_id: string) {
+    loading = true
+    error = null
     try {
-      load_available_tools(req_project_id)
-      load_model_info()
-      load_available_models()
-      load_task_prompts(req_project_id, req_task_id)
-      load_task_run_configs(req_project_id, req_task_id)
-      const loaded_task = await load_task(req_project_id, req_task_id)
+      const [, , , , , loaded_task] = await Promise.all([
+        load_available_tools(req_project_id),
+        load_model_info(),
+        load_available_models(),
+        load_task_prompts(req_project_id, req_task_id),
+        load_task_run_configs(req_project_id, req_task_id),
+        load_task(req_project_id, req_task_id),
+      ])
       if (req_project_id !== project_id || req_task_id !== task_id) return
       task = loaded_task
     } catch (e) {

--- a/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/+page.svelte
@@ -43,6 +43,7 @@
     req_task_id: string,
   ) {
     loading = true
+    copilot_check_error = null
     await get_prompt_optimization_jobs(req_project_id, req_task_id)
 
     if (req_project_id !== project_id || req_task_id !== task_id) return

--- a/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/+page.svelte
@@ -3,7 +3,6 @@
   import { client } from "$lib/api_client"
   import type { PromptOptimizationJob } from "$lib/types"
   import { createKilnError, KilnError } from "$lib/utils/error_handlers"
-  import { onMount } from "svelte"
   import { goto } from "$app/navigation"
   import { page } from "$app/stores"
   import { formatDate } from "$lib/utils/formatters"
@@ -35,20 +34,34 @@
   $: is_empty =
     !prompt_optimization_jobs || prompt_optimization_jobs.length === 0
 
-  onMount(async () => {
-    await get_prompt_optimization_jobs()
+  $: if (project_id && task_id) {
+    load_jobs_and_copilot_status(project_id, task_id)
+  }
+
+  async function load_jobs_and_copilot_status(
+    req_project_id: string,
+    req_task_id: string,
+  ) {
+    loading = true
+    await get_prompt_optimization_jobs(req_project_id, req_task_id)
+
+    if (req_project_id !== project_id || req_task_id !== task_id) return
 
     if (!prompt_optimization_jobs || prompt_optimization_jobs.length === 0) {
       try {
         kiln_copilot_connected = await checkKilnCopilotAvailable()
       } catch (e) {
+        if (req_project_id !== project_id || req_task_id !== task_id) return
         copilot_check_error = createKilnError(e)
         kiln_copilot_connected = false
       }
 
+      if (req_project_id !== project_id || req_task_id !== task_id) return
+
       if (kiln_copilot_connected) {
         const { has_access, error: entitlement_error } =
           await checkPromptOptimizationAccess()
+        if (req_project_id !== project_id || req_task_id !== task_id) return
         has_prompt_optimization_entitlement = has_access
         if (entitlement_error) {
           copilot_check_error = entitlement_error
@@ -56,23 +69,25 @@
       }
     }
 
-    loading = false
-  })
+    if (req_project_id === project_id && req_task_id === task_id) {
+      loading = false
+    }
+  }
 
-  async function get_prompt_optimization_jobs() {
+  async function get_prompt_optimization_jobs(
+    req_project_id: string,
+    req_task_id: string,
+  ) {
     try {
       prompt_optimization_jobs_error = null
-      if (!project_id || !task_id) {
-        throw new Error("Project or task ID not set.")
-      }
       const { data: prompt_optimization_jobs_response, error: get_error } =
         await client.GET(
           "/api/projects/{project_id}/tasks/{task_id}/prompt_optimization_jobs",
           {
             params: {
               path: {
-                project_id,
-                task_id,
+                project_id: req_project_id,
+                task_id: req_task_id,
               },
               query: {
                 update_status: true,
@@ -80,6 +95,7 @@
             },
           },
         )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (get_error) {
         throw get_error
       }
@@ -92,6 +108,7 @@
         })
       prompt_optimization_jobs = sorted_prompt_optimization_jobs
     } catch (e) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (e instanceof Error && e.message.includes("Load failed")) {
         prompt_optimization_jobs_error = new KilnError(
           "Could not load Prompt Optimization jobs. This task may belong to a project you don't have access to.",

--- a/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/prompt_optimization_job/[job_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/prompt_optimization_job/[job_id]/+page.svelte
@@ -115,7 +115,6 @@
         throw get_error
       }
       prompt_optimization_job = prompt_optimization_job_response
-      build_properties()
     } catch (error) {
       if (
         req_project_id !== project_id ||
@@ -199,10 +198,20 @@
     return s.charAt(0).toUpperCase() + s.slice(1)
   }
 
-  function build_properties() {
+  // Re-derive whenever the job, run configs, evals, or model info store change —
+  // any of them feeding the property list mid-render would otherwise show stale
+  // names ("Unknown", raw IDs) until the next refresh.
+  $: {
+    void prompt_optimization_job
+    void run_configs
+    void evals
+    void $model_info
+    properties = build_properties()
+  }
+
+  function build_properties(): UiProperty[] {
     if (!prompt_optimization_job) {
-      properties = []
-      return
+      return []
     }
 
     const target_run_config_page_link = `/optimize/${project_id}/${task_id}/run_config/${prompt_optimization_job.target_run_config_id}`
@@ -280,7 +289,7 @@
       ].filter((p) => !!p.value),
     )
 
-    properties = base
+    return base
   }
 
   function no_optimized_prompt_status_message(status: string): string {

--- a/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/prompt_optimization_job/[job_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/prompt_optimization_job/[job_id]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import AppPage from "../../../../../app_page.svelte"
   import { page } from "$app/stores"
-  import { onMount, onDestroy } from "svelte"
+  import { onDestroy } from "svelte"
   import { client } from "$lib/api_client"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
   import type { PromptOptimizationJob, Eval, TaskRunConfig } from "$lib/types"
@@ -9,7 +9,11 @@
   import Output from "$lib/ui/output.svelte"
   import PropertyList from "$lib/ui/property_list.svelte"
   import type { UiProperty } from "$lib/ui/property_list"
-  import { get_task_composite_id, model_info } from "$lib/stores"
+  import {
+    get_task_composite_id,
+    load_model_info,
+    model_info,
+  } from "$lib/stores"
   import {
     load_task_run_configs,
     run_configs_by_task_composite_id,
@@ -47,7 +51,12 @@
   function start_polling() {
     stop_polling()
     polling_timer = setInterval(() => {
-      get_prompt_optimization_job(false)
+      get_prompt_optimization_job(
+        project_id,
+        task_id,
+        prompt_optimization_job_id,
+        false,
+      )
     }, 60000)
   }
 
@@ -58,19 +67,23 @@
     }
   }
 
-  onMount(async () => {
-    await Promise.all([
-      load_task_run_configs(project_id, task_id),
-      load_evals(),
-    ])
-    await get_prompt_optimization_job()
-  })
+  $: if (project_id && task_id && prompt_optimization_job_id) {
+    load_evals(project_id, task_id)
+    load_task_run_configs(project_id, task_id)
+    load_model_info()
+    get_prompt_optimization_job(project_id, task_id, prompt_optimization_job_id)
+  }
 
   onDestroy(() => {
     stop_polling()
   })
 
-  const get_prompt_optimization_job = async (show_loading = true) => {
+  const get_prompt_optimization_job = async (
+    req_project_id: string,
+    req_task_id: string,
+    req_job_id: string,
+    show_loading = true,
+  ) => {
     try {
       if (show_loading) {
         prompt_optimization_job_loading = true
@@ -84,25 +97,42 @@
           {
             params: {
               path: {
-                project_id,
-                task_id,
-                prompt_optimization_job_id,
+                project_id: req_project_id,
+                task_id: req_task_id,
+                prompt_optimization_job_id: req_job_id,
               },
             },
           },
         )
 
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_job_id !== prompt_optimization_job_id
+      )
+        return
       if (get_error) {
         throw get_error
       }
       prompt_optimization_job = prompt_optimization_job_response
       build_properties()
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_job_id !== prompt_optimization_job_id
+      )
+        return
       if (show_loading) {
         prompt_optimization_job_error = createKilnError(error)
       }
     } finally {
-      if (show_loading) {
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_job_id === prompt_optimization_job_id &&
+        show_loading
+      ) {
         prompt_optimization_job_loading = false
       }
     }
@@ -121,21 +151,23 @@
     prompt_optimization_job?.latest_status === "failed" ||
     prompt_optimization_job?.latest_status === "cancelled"
 
-  async function load_evals() {
+  async function load_evals(req_project_id: string, req_task_id: string) {
     try {
       const { data, error } = await client.GET(
         "/api/projects/{project_id}/tasks/{task_id}/evals",
         {
           params: {
-            path: { project_id, task_id },
+            path: { project_id: req_project_id, task_id: req_task_id },
           },
         },
       )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (error) {
         throw error
       }
       evals = data || []
     } catch {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       evals = []
     }
   }
@@ -324,7 +356,13 @@
               {#if !is_terminal}
                 <button
                   class="btn btn-sm btn-outline btn-primary w-fit"
-                  on:click={() => get_prompt_optimization_job(false)}
+                  on:click={() =>
+                    get_prompt_optimization_job(
+                      project_id,
+                      task_id,
+                      prompt_optimization_job_id,
+                      false,
+                    )}
                 >
                   ↻ Refresh Status
                 </button>

--- a/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import AppPage from "../../../app_page.svelte"
-  import { current_task, get_task_composite_id, load_task } from "$lib/stores"
+  import { get_task_composite_id, load_task } from "$lib/stores"
   import { page } from "$app/stores"
   import { goto } from "$app/navigation"
   import { formatDate } from "$lib/utils/formatters"
@@ -10,7 +10,6 @@
     load_task_prompts,
     prompts_by_task_composite_id,
   } from "$lib/stores/prompts_store"
-  import { onMount } from "svelte"
   import type { Task, ApiPrompt } from "$lib/types"
   import { createKilnError, KilnError } from "$lib/utils/error_handlers"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
@@ -28,16 +27,31 @@
   let error: KilnError | null = null
   let task: Task | null = null
 
-  onMount(async () => {
+  $: if (project_id && task_id) {
+    load_prompts_and_task(project_id, task_id)
+  }
+
+  async function load_prompts_and_task(
+    req_project_id: string,
+    req_task_id: string,
+  ) {
     try {
-      await load_task_prompts(project_id, task_id, true)
-      task = await load_task(project_id, task_id)
+      loading = true
+      error = null
+      task = null
+      await load_task_prompts(req_project_id, req_task_id, true)
+      const loaded_task = await load_task(req_project_id, req_task_id)
+      if (req_project_id !== project_id || req_task_id !== task_id) return
+      task = loaded_task
     } catch (e) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       error = createKilnError(e)
     } finally {
-      loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        loading = false
+      }
     }
-  })
+  }
 
   $: task_prompts =
     $prompts_by_task_composite_id[get_task_composite_id(project_id, task_id)] ||
@@ -156,12 +170,6 @@
     {:else if error}
       <div class="text-error text-sm">
         {error?.getMessage() || "An unknown error occurred"}
-      </div>
-    {:else if $current_task?.id != task_id}
-      <div class="flex flex-col gap-4 text-error">
-        This link is to another task's prompts. Either select that task in the
-        sidebar, or click prompts in the sidebar to load the current task's
-        prompts.
       </div>
     {:else}
       <div class="flex flex-col gap-6">

--- a/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/clone/[prompt_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/clone/[prompt_id]/+page.svelte
@@ -7,7 +7,6 @@
     prompts_by_task_composite_id,
   } from "$lib/stores/prompts_store"
   import { get_task_composite_id } from "$lib/stores"
-  import { onMount } from "svelte"
   import PromptForm from "../../prompt_form.svelte"
 
   import { agentInfo } from "$lib/agent"
@@ -25,15 +24,31 @@
   let loading = true
   let loading_error: KilnError | null = null
 
-  onMount(async () => {
+  $: if (project_id && task_id && prompt_id) {
+    load_source_prompt(project_id, task_id, prompt_id)
+  }
+
+  async function load_source_prompt(
+    req_project_id: string,
+    req_task_id: string,
+    req_prompt_id: string,
+  ) {
     try {
-      await load_task_prompts(project_id, task_id)
+      loading = true
+      loading_error = null
+      await load_task_prompts(req_project_id, req_task_id)
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_prompt_id !== prompt_id
+      )
+        return
       const task_prompts =
         $prompts_by_task_composite_id[
-          get_task_composite_id(project_id, task_id)
+          get_task_composite_id(req_project_id, req_task_id)
         ]
       const source_prompt = task_prompts?.prompts.find(
-        (p) => p.id === prompt_id,
+        (p) => p.id === req_prompt_id,
       )
 
       if (!source_prompt) {
@@ -45,11 +60,23 @@
       initial_chain_of_thought_instructions =
         source_prompt.chain_of_thought_instructions || null
     } catch (e) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_prompt_id !== prompt_id
+      )
+        return
       loading_error = createKilnError(e)
     } finally {
-      loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_prompt_id === prompt_id
+      ) {
+        loading = false
+      }
     }
-  })
+  }
 </script>
 
 <div class="max-w-[1400px]">

--- a/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/create/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/create/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import AppPage from "../../../../app_page.svelte"
-  import { current_task } from "$lib/stores"
+  import { load_task } from "$lib/stores"
   import { page } from "$app/stores"
   import { client } from "$lib/api_client"
   import { createKilnError, KilnError } from "$lib/utils/error_handlers"
@@ -63,8 +63,13 @@
     } else {
       generator_name = "Custom"
 
-      if ($current_task?.instruction) {
-        initial_prompt = $current_task.instruction
+      try {
+        const task = await load_task(project_id, task_id)
+        if (task?.instruction) {
+          initial_prompt = task.instruction
+        }
+      } catch (e) {
+        loading_error = createKilnError(e)
       }
     }
 

--- a/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/create/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/create/+page.svelte
@@ -4,7 +4,6 @@
   import { page } from "$app/stores"
   import { client } from "$lib/api_client"
   import { createKilnError, KilnError } from "$lib/utils/error_handlers"
-  import { onMount } from "svelte"
   import { prompt_generator_categories } from "$lib/prompt_generators"
   import { generate_memorable_name } from "$lib/utils/name_generator"
   import PromptForm from "../prompt_form.svelte"
@@ -23,28 +22,59 @@
   let initial_chain_of_thought_instructions: string | null = null
   let loading_error: KilnError | null = null
 
-  let generator_id: string | null = null
+  $: generator_id = $page.url.searchParams.get("generator_id") || null
   let loading = true
-  let is_custom = true
+  $: is_custom = !generator_id
 
-  onMount(async () => {
-    generator_id = $page.url.searchParams.get("generator_id") || null
-    is_custom = !generator_id
+  // Re-load when route params or generator search param changes
+  let last_loaded_key: string | null = null
+  $: if (project_id && task_id) {
+    const key = `${project_id}/${task_id}/${generator_id ?? ""}`
+    if (last_loaded_key !== key) {
+      last_loaded_key = key
+      loading_error = null
+      initial_prompt = ""
+      initial_chain_of_thought_instructions = null
+      generator_name = ""
+      initial_prompt_name = generate_memorable_name()
+      load_create_prompt_data(project_id, task_id, generator_id)
+    }
+  }
 
-    if (generator_id) {
-      try {
+  function is_stale(
+    req_project_id: string,
+    req_task_id: string,
+    req_generator_id: string | null,
+  ): boolean {
+    return (
+      req_project_id !== project_id ||
+      req_task_id !== task_id ||
+      req_generator_id !== generator_id
+    )
+  }
+
+  async function load_create_prompt_data(
+    req_project_id: string,
+    req_task_id: string,
+    req_generator_id: string | null,
+  ) {
+    try {
+      loading = true
+
+      if (req_generator_id) {
         const { data: prompt_response, error: get_error } = await client.GET(
           "/api/projects/{project_id}/tasks/{task_id}/gen_prompt/{prompt_id}",
           {
             params: {
               path: {
-                project_id,
-                task_id,
-                prompt_id: generator_id,
+                project_id: req_project_id,
+                task_id: req_task_id,
+                prompt_id: req_generator_id,
               },
             },
           },
         )
+        if (is_stale(req_project_id, req_task_id, req_generator_id)) return
         if (get_error) {
           throw get_error
         }
@@ -54,27 +84,27 @@
 
         const template = prompt_generator_categories
           .flatMap((c) => c.templates)
-          .find((t) => t.generator_id === generator_id)
-        generator_name = template?.name || generator_id
+          .find((t) => t.generator_id === req_generator_id)
+        generator_name = template?.name || req_generator_id
         initial_prompt_name = `${generate_memorable_name()} - ${generator_name}`
-      } catch (e) {
-        loading_error = createKilnError(e)
-      }
-    } else {
-      generator_name = "Custom"
+      } else {
+        generator_name = "Custom"
 
-      try {
-        const task = await load_task(project_id, task_id)
+        const task = await load_task(req_project_id, req_task_id)
+        if (is_stale(req_project_id, req_task_id, req_generator_id)) return
         if (task?.instruction) {
           initial_prompt = task.instruction
         }
-      } catch (e) {
-        loading_error = createKilnError(e)
+      }
+    } catch (e) {
+      if (is_stale(req_project_id, req_task_id, req_generator_id)) return
+      loading_error = createKilnError(e)
+    } finally {
+      if (!is_stale(req_project_id, req_task_id, req_generator_id)) {
+        loading = false
       }
     }
-
-    loading = false
-  })
+  }
 </script>
 
 <div class="max-w-[1400px]">

--- a/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/prompt_form.svelte
+++ b/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/prompt_form.svelte
@@ -7,7 +7,7 @@
     filename_string_validator_default,
     normalize_filename_string,
   } from "$lib/utils/input_validators"
-  import { load_available_prompts } from "$lib/stores"
+  import { load_task_prompts } from "$lib/stores/prompts_store"
   import { goto } from "$app/navigation"
   import posthog from "posthog-js"
 
@@ -76,7 +76,7 @@
         is_clone: clone_mode,
       })
 
-      await load_available_prompts(true)
+      await load_task_prompts(project_id, task_id, true)
 
       complete = true
       if (redirect_from === "optimize") {

--- a/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/prompt_form.svelte
+++ b/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/prompt_form.svelte
@@ -76,7 +76,14 @@
         is_clone: clone_mode,
       })
 
-      await load_task_prompts(project_id, task_id, true)
+      try {
+        await load_task_prompts(project_id, task_id, true)
+      } catch (refreshError) {
+        console.warn(
+          "Prompt was created, but refreshing the task prompt cache failed",
+          refreshError,
+        )
+      }
 
       complete = true
       if (redirect_from === "optimize") {

--- a/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/saved/[prompt_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompts/[project_id]/[task_id]/saved/[prompt_id]/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { page } from "$app/stores"
-  import { current_task, current_task_prompts } from "$lib/stores"
+  import { get_task_composite_id } from "$lib/stores"
+  import {
+    prompts_by_task_composite_id,
+    load_task_prompts,
+  } from "$lib/stores/prompts_store"
   import AppPage from "../../../../../app_page.svelte"
   import Output from "$lib/ui/output.svelte"
   import { formatDate } from "$lib/utils/formatters"
@@ -15,7 +19,14 @@
     description: `Saved prompt detail for prompt ID ${prompt_id} in project ID ${project_id}, task ID ${task_id}. Prompt name: ${prompt_model?.name ?? "[loading]"}. Shows prompt content, version history, and options to clone or edit.`,
   })
 
-  $: prompt_model = $current_task_prompts?.prompts.find(
+  $: if (project_id && task_id) {
+    load_task_prompts(project_id, task_id)
+  }
+
+  $: task_prompts =
+    $prompts_by_task_composite_id[get_task_composite_id(project_id, task_id)] ??
+    null
+  $: prompt_model = task_prompts?.prompts.find(
     (prompt) => prompt.id === prompt_id,
   )
 
@@ -72,15 +83,9 @@
         : []),
     ]}
   >
-    {#if !$current_task_prompts}
+    {#if !task_prompts}
       <div class="w-full min-h-[50vh] flex justify-center items-center">
         <div class="loading loading-spinner loading-lg"></div>
-      </div>
-    {:else if $current_task?.id != task_id}
-      <div class="text-error">
-        This link is to another task's prompt. Either select that task in the
-        sidebar, or click 'Prompts' in the sidebar to load the current task's
-        prompts.
       </div>
     {:else if prompt_model}
       <div class="flex flex-col xl:flex-row gap-8 xl:gap-16 mb-8">

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -22,10 +22,14 @@
   import FormElement from "$lib/utils/form_element.svelte"
   import {
     rating_options_for_sample,
-    current_task_rating_options,
+    get_task_composite_id,
     model_info,
     model_name as model_name_from_id,
   } from "$lib/stores"
+  import {
+    rating_options_by_task_composite_id,
+    load_rating_options,
+  } from "$lib/stores/rating_options_store"
   import posthog from "posthog-js"
   import TraceComponent from "$lib/ui/trace/trace.svelte"
   import PropertyList from "$lib/ui/property_list.svelte"
@@ -178,9 +182,20 @@
   export let run_complete: boolean = false
   export let focus_repair_on_appear: boolean = false
 
+  // URL-scoped rating options keyed by project/task composite id.
+  $: task_rating_options =
+    project_id && task.id
+      ? $rating_options_by_task_composite_id[
+          get_task_composite_id(project_id, task.id)
+        ] ?? null
+      : null
+  $: if (project_id && task.id) {
+    load_rating_options(project_id, task.id)
+  }
+
   // Dynamic rating requirements based on tags
   $: rating_requirements = rating_options_for_sample(
-    $current_task_rating_options,
+    task_rating_options,
     run?.tags || [],
   )
 
@@ -272,7 +287,7 @@
   let seeded_ratings_for_run_id: string | null = null
   let seeded_ratings_with_options = false
   $: {
-    const options_loaded = !!$current_task_rating_options
+    const options_loaded = !!task_rating_options
     const on_new_run = !!run?.id && run.id !== seeded_ratings_for_run_id
     const options_just_loaded = options_loaded && !seeded_ratings_with_options
     if (run?.id && (on_new_run || options_just_loaded)) {

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -190,7 +190,9 @@
         ] ?? null
       : null
   $: if (project_id && task.id) {
-    load_rating_options(project_id, task.id)
+    load_rating_options(project_id, task.id).catch((e: unknown) => {
+      console.warn("Failed to load rating options", e)
+    })
   }
 
   // Dynamic rating requirements based on tags

--- a/app/web_ui/src/routes/(app)/select_tasks_menu.svelte
+++ b/app/web_ui/src/routes/(app)/select_tasks_menu.svelte
@@ -104,7 +104,7 @@
       }
     })
 
-    goto(`/`, { replaceState: true })
+    goto(`/`)
     dispatch("dismiss")
   }
 </script>

--- a/app/web_ui/src/routes/(app)/skills/[project_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/skills/[project_id]/+page.svelte
@@ -4,7 +4,6 @@
   import Warning from "$lib/ui/warning.svelte"
   import { client } from "$lib/api_client"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
-  import { onMount } from "svelte"
   import { page } from "$app/stores"
   import { goto } from "$app/navigation"
   import { formatDate } from "$lib/utils/formatters"
@@ -24,27 +23,32 @@
   let loading = true
   let error: KilnError | null = null
 
-  onMount(async () => {
-    await fetch_skills()
-  })
+  $: if (project_id) {
+    fetch_skills(project_id)
+  }
 
-  async function fetch_skills() {
+  async function fetch_skills(req_project_id: string) {
     try {
+      loading = true
       error = null
       const { data, error: fetch_error } = await client.GET(
         "/api/projects/{project_id}/skills",
         {
-          params: { path: { project_id } },
+          params: { path: { project_id: req_project_id } },
         },
       )
+      if (req_project_id !== project_id) return
       if (fetch_error) {
         throw fetch_error
       }
       skills = data
     } catch (err) {
+      if (req_project_id !== project_id) return
       error = createKilnError(err)
     } finally {
-      loading = false
+      if (req_project_id === project_id) {
+        loading = false
+      }
     }
   }
 

--- a/app/web_ui/src/routes/(app)/skills/[project_id]/[skill_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/skills/[project_id]/[skill_id]/+page.svelte
@@ -4,7 +4,6 @@
   import Warning from "$lib/ui/warning.svelte"
   import { client } from "$lib/api_client"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
-  import { onMount } from "svelte"
   import { page } from "$app/stores"
   import { goto } from "$app/navigation"
   import { uncache_available_tools, ui_state } from "$lib/stores"
@@ -30,21 +29,24 @@
   let archive_loading = false
   let open_folder_error: KilnError | null = null
 
-  onMount(async () => {
-    await fetch_skill()
-  })
+  $: if (project_id && skill_id) {
+    fetch_skill(project_id, skill_id)
+  }
 
-  async function fetch_skill() {
+  async function fetch_skill(req_project_id: string, req_skill_id: string) {
     try {
       loading = true
       loading_error = null
-      const params = { path: { project_id, skill_id } }
+      const params = {
+        path: { project_id: req_project_id, skill_id: req_skill_id },
+      }
       const [skill_res, content_res] = await Promise.all([
         client.GET("/api/projects/{project_id}/skills/{skill_id}", { params }),
         client.GET("/api/projects/{project_id}/skills/{skill_id}/content", {
           params,
         }),
       ])
+      if (req_project_id !== project_id || req_skill_id !== skill_id) return
       if (skill_res.error || content_res.error) {
         throw skill_res.error ?? content_res.error
       }
@@ -52,9 +54,12 @@
       skill_description = skill_res.data?.description ?? null
       skill_body = content_res.data?.body ?? null
     } catch (err) {
+      if (req_project_id !== project_id || req_skill_id !== skill_id) return
       loading_error = createKilnError(err)
     } finally {
-      loading = false
+      if (req_project_id === project_id && req_skill_id === skill_id) {
+        loading = false
+      }
     }
   }
 
@@ -112,7 +117,7 @@
     } catch (e) {
       archive_error = createKilnError(e)
     } finally {
-      await fetch_skill()
+      await fetch_skill(project_id, skill_id)
       archive_loading = false
     }
   }

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/+page.svelte
@@ -139,8 +139,13 @@
     ? specs.some((spec) => spec.status === "archived")
     : false
 
+  $: if (project_id && task_id) {
+    load_specs(project_id, task_id)
+    load_evals(project_id, task_id)
+  }
+
   onMount(async () => {
-    await Promise.all([load_specs(), load_evals(), load_has_kiln_copilot()])
+    await load_has_kiln_copilot()
   })
 
   async function load_has_kiln_copilot() {
@@ -155,7 +160,7 @@
     }
   }
 
-  async function load_specs() {
+  async function load_specs(req_project_id: string, req_task_id: string) {
     try {
       specs_loading = true
       specs_error = null
@@ -163,10 +168,11 @@
         "/api/projects/{project_id}/tasks/{task_id}/specs",
         {
           params: {
-            path: { project_id, task_id },
+            path: { project_id: req_project_id, task_id: req_task_id },
           },
         },
       )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (error) {
         throw error
       }
@@ -179,13 +185,16 @@
       }
       filterAndSortSpecs()
     } catch (error) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       specs_error = createKilnError(error)
     } finally {
-      specs_loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        specs_loading = false
+      }
     }
   }
 
-  async function load_evals() {
+  async function load_evals(req_project_id: string, req_task_id: string) {
     try {
       evals_loading = true
       evals_error = null
@@ -193,19 +202,23 @@
         "/api/projects/{project_id}/tasks/{task_id}/evals",
         {
           params: {
-            path: { project_id, task_id },
+            path: { project_id: req_project_id, task_id: req_task_id },
           },
         },
       )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (error) {
         throw error
       }
       evals = data
       filterAndSortSpecs()
     } catch (error) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       evals_error = createKilnError(error)
     } finally {
-      evals_loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        evals_loading = false
+      }
     }
   }
 
@@ -546,7 +559,7 @@
         selected_specs = new Set()
         add_tags = []
         select_mode = false
-        await load_specs()
+        await load_specs(project_id, task_id)
       }
     }
   }
@@ -601,7 +614,7 @@
       if (success) {
         selected_specs = new Set()
         select_mode = false
-        await load_specs()
+        await load_specs(project_id, task_id)
       }
     }
   }

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
@@ -2,7 +2,7 @@
   import PropertyList from "$lib/ui/property_list.svelte"
   import AppPage from "../../../../app_page.svelte"
   import { page } from "$app/stores"
-  import { onMount, tick } from "svelte"
+  import { tick } from "svelte"
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
   import EditablePriorityField from "../editable_priority_field.svelte"
   import EditableStatusField from "../editable_status_field.svelte"
@@ -197,24 +197,54 @@
   $: has_default_eval_config = evaluator && evaluator.current_config_id
   $: should_show_compare_table = has_eval && has_default_eval_config
 
-  onMount(async () => {
+  $: if (project_id && task_id && spec_id) {
+    load_all(project_id, task_id, spec_id)
+  }
+
+  async function load_all(
+    req_project_id: string,
+    req_task_id: string,
+    req_spec_id: string,
+  ) {
     await tick()
     load_model_info()
-    await load_spec()
+    await load_spec(req_project_id, req_task_id, req_spec_id)
+    if (
+      req_project_id !== project_id ||
+      req_task_id !== task_id ||
+      req_spec_id !== spec_id
+    )
+      return
     if (spec?.eval_id) {
+      const eval_id = spec.eval_id
       await Promise.all([
-        load_eval_data(),
-        load_task_data(),
-        load_run_configs_data(),
-        get_eval_progress(),
+        load_eval_data(req_project_id, req_task_id, eval_id),
+        load_task_data(req_project_id, req_task_id),
+        load_run_configs_data(req_project_id, req_task_id),
+        get_eval_progress(req_project_id, req_task_id, eval_id),
       ])
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_spec_id !== spec_id
+      )
+        return
       if (evaluator?.current_config_id) {
-        await load_score_summary()
+        await load_score_summary(
+          req_project_id,
+          req_task_id,
+          eval_id,
+          evaluator.current_config_id,
+        )
       }
     }
-  })
+  }
 
-  async function load_spec() {
+  async function load_spec(
+    req_project_id: string,
+    req_task_id: string,
+    req_spec_id: string,
+  ) {
     try {
       spec_loading = true
       spec_error = null
@@ -222,24 +252,49 @@
         "/api/projects/{project_id}/tasks/{task_id}/specs/{spec_id}",
         {
           params: {
-            path: { project_id, task_id, spec_id },
+            path: {
+              project_id: req_project_id,
+              task_id: req_task_id,
+              spec_id: req_spec_id,
+            },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_spec_id !== spec_id
+      )
+        return
       if (error) {
         throw error
       }
       spec = data
       current_tags = spec.tags || []
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_spec_id !== spec_id
+      )
+        return
       spec_error = createKilnError(error)
     } finally {
-      spec_loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_spec_id === spec_id
+      ) {
+        spec_loading = false
+      }
     }
   }
 
-  async function load_eval_data() {
-    if (!spec?.eval_id) return
+  async function load_eval_data(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+  ) {
     try {
       eval_loading = true
       eval_error = null
@@ -248,50 +303,69 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              eval_id: spec.eval_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              eval_id: req_eval_id,
             },
           },
         },
       )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (error) {
         throw error
       }
       evaluator = data
     } catch (error) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       eval_error = createKilnError(error)
     } finally {
-      eval_loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        eval_loading = false
+      }
     }
   }
 
-  async function load_task_data() {
+  async function load_task_data(req_project_id: string, req_task_id: string) {
     try {
       task_loading = true
       task_error = null
-      task = await load_task(project_id, task_id)
+      const loaded_task = await load_task(req_project_id, req_task_id)
+      if (req_project_id !== project_id || req_task_id !== task_id) return
+      task = loaded_task
     } catch (error) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       task_error = createKilnError(error)
     } finally {
-      task_loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        task_loading = false
+      }
     }
   }
 
-  async function load_run_configs_data() {
+  async function load_run_configs_data(
+    req_project_id: string,
+    req_task_id: string,
+  ) {
     try {
       run_configs_loading = true
       run_configs_error = null
-      await load_task_run_configs(project_id, task_id)
+      await load_task_run_configs(req_project_id, req_task_id)
     } catch (error) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       run_configs_error = createKilnError(error)
     } finally {
-      run_configs_loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        run_configs_loading = false
+      }
     }
   }
 
-  async function load_score_summary() {
-    if (!spec?.eval_id || !evaluator?.current_config_id) return
+  async function load_score_summary(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+    req_eval_config_id: string,
+  ) {
     try {
       score_summary_error = null
       const { data, error } = await client.GET(
@@ -299,19 +373,21 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              eval_id: spec.eval_id,
-              eval_config_id: evaluator.current_config_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              eval_id: req_eval_id,
+              eval_config_id: req_eval_config_id,
             },
           },
         },
       )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (error) {
         throw error
       }
       score_summary = data
     } catch (error) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       score_summary_error = createKilnError(error)
     }
   }
@@ -386,8 +462,11 @@
     }
   }
 
-  async function get_eval_progress() {
-    if (!spec?.eval_id) return
+  async function get_eval_progress(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+  ) {
     try {
       eval_progress_loading = true
       eval_progress = null
@@ -396,21 +475,25 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              eval_id: spec.eval_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              eval_id: req_eval_id,
             },
           },
         },
       )
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       if (error) {
         throw error
       }
       eval_progress = data
     } catch (error) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
       eval_progress_error = createKilnError(error)
     } finally {
-      eval_progress_loading = false
+      if (req_project_id === project_id && req_task_id === task_id) {
+        eval_progress_loading = false
+      }
     }
   }
 </script>
@@ -622,7 +705,14 @@
               create_new_run_config_dialog?.show()
             }}
             on_eval_complete={async () => {
-              await load_score_summary()
+              if (spec?.eval_id && evaluator?.current_config_id) {
+                await load_score_summary(
+                  project_id,
+                  task_id,
+                  spec.eval_id,
+                  evaluator.current_config_id,
+                )
+              }
             }}
           />
         </div>

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
@@ -237,6 +237,20 @@
           evaluator.current_config_id,
         )
       }
+    } else if (
+      req_project_id === project_id &&
+      req_task_id === task_id &&
+      req_spec_id === spec_id
+    ) {
+      // Spec exists but has no eval_id yet — clear eval-scoped loading flags
+      // so the page doesn't sit on the global spinner forever.
+      eval_progress_loading = false
+      eval_loading = false
+      task_loading = false
+      run_configs_loading = false
+      eval_progress = null
+      evaluator = null
+      score_summary = null
     }
   }
 

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
@@ -75,7 +75,11 @@
     req_spec_id: string,
   ) {
     if (req_spec_id === "legacy") {
-      if (req_project_id === project_id && req_task_id === task_id) {
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_spec_id === spec_id
+      ) {
         spec_loading = false
       }
       return

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
@@ -3,7 +3,7 @@
   import type { Eval, Spec } from "$lib/types"
   import { client } from "$lib/api_client"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
-  import { onMount, tick } from "svelte"
+  import { tick } from "svelte"
   import { page } from "$app/stores"
   import type { EvalProgress } from "$lib/types"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
@@ -49,19 +49,35 @@
   $: loading = spec_loading || eval_loading || eval_progress_loading
   $: error = spec_error || eval_error || eval_progress_error
 
-  onMount(async () => {
-    // Wait for page params to load
+  $: if (project_id && task_id && spec_id && eval_id) {
+    load_all(project_id, task_id, spec_id, eval_id)
+  }
+
+  async function load_all(
+    req_project_id: string,
+    req_task_id: string,
+    req_spec_id: string,
+    req_eval_id: string,
+  ) {
     await tick()
-    // can be async
     load_model_info()
     load_available_models()
-    // Load spec and eval data in parallel
-    await Promise.all([get_spec(), get_eval(), get_eval_progress()])
-  })
+    await Promise.all([
+      get_spec(req_project_id, req_task_id, req_spec_id),
+      get_eval(req_project_id, req_task_id, req_eval_id),
+      get_eval_progress(req_project_id, req_task_id, req_eval_id),
+    ])
+  }
 
-  async function get_spec() {
-    if (spec_id === "legacy") {
-      spec_loading = false
+  async function get_spec(
+    req_project_id: string,
+    req_task_id: string,
+    req_spec_id: string,
+  ) {
+    if (req_spec_id === "legacy") {
+      if (req_project_id === project_id && req_task_id === task_id) {
+        spec_loading = false
+      }
       return
     }
     try {
@@ -70,22 +86,48 @@
         "/api/projects/{project_id}/tasks/{task_id}/specs/{spec_id}",
         {
           params: {
-            path: { project_id, task_id, spec_id },
+            path: {
+              project_id: req_project_id,
+              task_id: req_task_id,
+              spec_id: req_spec_id,
+            },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_spec_id !== spec_id
+      )
+        return
       if (error) {
         throw error
       }
       spec = data
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_spec_id !== spec_id
+      )
+        return
       spec_error = createKilnError(error)
     } finally {
-      spec_loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_spec_id === spec_id
+      ) {
+        spec_loading = false
+      }
     }
   }
 
-  async function get_eval() {
+  async function get_eval(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+  ) {
     try {
       eval_loading = true
       const { data, error } = await client.GET(
@@ -93,25 +135,47 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              eval_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              eval_id: req_eval_id,
             },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       if (error) {
         throw error
       }
       evaluator = data
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       eval_error = createKilnError(error)
     } finally {
-      eval_loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_eval_id === eval_id
+      ) {
+        eval_loading = false
+      }
     }
   }
 
-  async function get_eval_progress() {
+  async function get_eval_progress(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+  ) {
     try {
       eval_progress_loading = true
       eval_progress = null
@@ -120,21 +184,39 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              eval_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              eval_id: req_eval_id,
             },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       if (error) {
         throw error
       }
       eval_progress = data
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       eval_progress_error = createKilnError(error)
     } finally {
-      eval_progress_loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_eval_id === eval_id
+      ) {
+        eval_progress_loading = false
+      }
     }
   }
 

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/[eval_config_id]/[run_config_id]/run_result/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/[eval_config_id]/[run_config_id]/run_result/+page.svelte
@@ -17,15 +17,18 @@
   import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
   import { eval_config_to_ui_name } from "$lib/utils/formatters"
   import {
+    get_task_composite_id,
     model_info,
     load_model_info,
     model_name,
     provider_name_from_id,
     prompt_name_from_id,
-    current_task_prompts,
-    load_available_prompts,
     load_available_models,
   } from "$lib/stores"
+  import {
+    prompts_by_task_composite_id,
+    load_task_prompts,
+  } from "$lib/stores/prompts_store"
   import OutputTypeTablePreview from "$lib/components/output_type_table_preview.svelte"
 
   import { agentInfo } from "$lib/agent"
@@ -46,20 +49,41 @@
   let thinking_dialog: Dialog | null = null
   let displayed_result: EvalRun | null = null
 
-  onMount(async () => {
+  onMount(() => {
     peek_dialog?.show()
-    // Wait for params to load
-    await tick()
-    // Wait for these 3 to load, as they are needed for better labels. Usually already cached and instant.
-    await Promise.all([
-      load_model_info(),
-      load_available_prompts(),
-      load_available_models(),
-    ])
-    get_evals()
   })
 
-  async function get_evals() {
+  $: if (project_id && task_id && eval_id && eval_config_id && run_config_id) {
+    load_all(project_id, task_id, eval_id, eval_config_id, run_config_id)
+  }
+
+  async function load_all(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+    req_eval_config_id: string,
+    req_run_config_id: string,
+  ) {
+    await tick()
+    load_model_info()
+    load_task_prompts(req_project_id, req_task_id)
+    load_available_models()
+    get_evals(
+      req_project_id,
+      req_task_id,
+      req_eval_id,
+      req_eval_config_id,
+      req_run_config_id,
+    )
+  }
+
+  async function get_evals(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+    req_eval_config_id: string,
+    req_run_config_id: string,
+  ) {
     try {
       results_loading = true
       const { data, error } = await client.GET(
@@ -67,23 +91,47 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              eval_id,
-              eval_config_id,
-              run_config_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              eval_id: req_eval_id,
+              eval_config_id: req_eval_config_id,
+              run_config_id: req_run_config_id,
             },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id ||
+        req_eval_config_id !== eval_config_id ||
+        req_run_config_id !== run_config_id
+      )
+        return
       if (error) {
         throw error
       }
       results = data
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id ||
+        req_eval_config_id !== eval_config_id ||
+        req_run_config_id !== run_config_id
+      )
+        return
       results_error = createKilnError(error)
     } finally {
-      results_loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_eval_id === eval_id &&
+        req_eval_config_id === eval_config_id &&
+        req_run_config_id === run_config_id
+      ) {
+        results_loading = false
+      }
     }
   }
 
@@ -116,7 +164,9 @@
       ),
       Prompt: prompt_name_from_id(
         run_config.run_config_properties.prompt_id,
-        $current_task_prompts,
+        $prompts_by_task_composite_id[
+          get_task_composite_id(project_id, task_id)
+        ] ?? null,
       ),
     }
   }

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/[eval_config_id]/[run_config_id]/run_result/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/[eval_config_id]/[run_config_id]/run_result/+page.svelte
@@ -85,6 +85,8 @@
     req_run_config_id: string,
   ) {
     try {
+      results = null
+      results_error = null
       results_loading = true
       const { data, error } = await client.GET(
         "/api/projects/{project_id}/tasks/{task_id}/evals/{eval_id}/eval_config/{eval_config_id}/run_config/{run_config_id}/results",

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/compare_run_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/compare_run_configs/+page.svelte
@@ -13,7 +13,6 @@
   import {
     model_info,
     load_model_info,
-    load_available_prompts,
     load_available_models,
     load_task,
     get_task_composite_id,
@@ -93,7 +92,7 @@
     // Wait for these to load, as they are needed for better labels. Usually already cached and instant.
     await Promise.all([
       load_model_info(),
-      load_available_prompts(),
+      load_task_prompts(project_id, task_id),
       load_available_models(),
       get_task(),
       get_spec(),

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_configs/+page.svelte
@@ -13,9 +13,9 @@
     load_model_info,
     model_name,
     provider_name_from_id,
-    load_available_prompts,
     load_available_models,
   } from "$lib/stores"
+  import { load_task_prompts } from "$lib/stores/prompts_store"
   import { set_current_eval_config } from "$lib/stores/evals_store"
   import Warning from "$lib/ui/warning.svelte"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
@@ -202,7 +202,7 @@
     await tick()
     await Promise.all([
       load_model_info(),
-      load_available_prompts(),
+      load_task_prompts(req_project_id, req_task_id),
       load_available_models(),
       get_spec(req_project_id, req_task_id, req_spec_id),
       get_eval(req_project_id, req_task_id, req_eval_id),

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_configs/+page.svelte
@@ -3,7 +3,7 @@
   import type { Eval, Spec } from "$lib/types"
   import { client } from "$lib/api_client"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
-  import { onMount, tick } from "svelte"
+  import { tick } from "svelte"
   import { page } from "$app/stores"
   import RunEval from "$lib/components/run_eval.svelte"
   import type { EvalConfig, EvalConfigCompareSummary } from "$lib/types"
@@ -189,26 +189,43 @@
     }
   }
 
-  onMount(async () => {
-    // Wait for page params to load
+  $: if (project_id && task_id && spec_id && eval_id) {
+    load_all(project_id, task_id, spec_id, eval_id)
+  }
+
+  async function load_all(
+    req_project_id: string,
+    req_task_id: string,
+    req_spec_id: string,
+    req_eval_id: string,
+  ) {
     await tick()
-    // Wait for these 3 to load, as they are needed for better labels. Usually already cached and instant.
     await Promise.all([
       load_model_info(),
       load_available_prompts(),
       load_available_models(),
-      get_spec(),
-      // Get this first, as we want to know "current" for sorting
-      get_eval(),
+      get_spec(req_project_id, req_task_id, req_spec_id),
+      get_eval(req_project_id, req_task_id, req_eval_id),
     ])
-    // These can be parallel
-    get_eval_config()
-    get_score_summary()
-  })
+    if (
+      req_project_id !== project_id ||
+      req_task_id !== task_id ||
+      req_eval_id !== eval_id
+    )
+      return
+    get_eval_config(req_project_id, req_task_id, req_eval_id)
+    get_score_summary(req_project_id, req_task_id, req_eval_id)
+  }
 
-  async function get_spec() {
-    if (spec_id === "legacy") {
-      spec_loading = false
+  async function get_spec(
+    req_project_id: string,
+    req_task_id: string,
+    req_spec_id: string,
+  ) {
+    if (req_spec_id === "legacy") {
+      if (req_project_id === project_id && req_task_id === task_id) {
+        spec_loading = false
+      }
       return
     }
     try {
@@ -218,25 +235,47 @@
         {
           params: {
             path: {
-              project_id: project_id,
-              task_id: task_id,
-              spec_id: spec_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              spec_id: req_spec_id,
             },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_spec_id !== spec_id
+      )
+        return
       if (error) {
         throw error
       }
       spec = data
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_spec_id !== spec_id
+      )
+        return
       spec_error = createKilnError(error)
     } finally {
-      spec_loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_spec_id === spec_id
+      ) {
+        spec_loading = false
+      }
     }
   }
 
-  async function get_eval() {
+  async function get_eval(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+  ) {
     try {
       eval_loading = true
       const { data, error } = await client.GET(
@@ -244,13 +283,19 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              eval_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              eval_id: req_eval_id,
             },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       if (error) {
         throw error
       }
@@ -265,13 +310,29 @@
         score_type = "mse"
       }
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       eval_error = createKilnError(error)
     } finally {
-      eval_loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_eval_id === eval_id
+      ) {
+        eval_loading = false
+      }
     }
   }
 
-  async function get_eval_config() {
+  async function get_eval_config(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+  ) {
     try {
       eval_configs_loading = true
       const { data, error } = await client.GET(
@@ -279,13 +340,19 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              eval_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              eval_id: req_eval_id,
             },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       if (error) {
         throw error
       }
@@ -293,13 +360,29 @@
       eval_configs = data
       // Initial sort will be handled by the reactive statement
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       eval_configs_error = createKilnError(error)
     } finally {
-      eval_configs_loading = false
+      if (
+        req_project_id === project_id &&
+        req_task_id === task_id &&
+        req_eval_id === eval_id
+      ) {
+        eval_configs_loading = false
+      }
     }
   }
 
-  async function get_score_summary() {
+  async function get_score_summary(
+    req_project_id: string,
+    req_task_id: string,
+    req_eval_id: string,
+  ) {
     try {
       score_summary = null
       score_summary_error = null
@@ -308,18 +391,30 @@
         {
           params: {
             path: {
-              project_id,
-              task_id,
-              eval_id,
+              project_id: req_project_id,
+              task_id: req_task_id,
+              eval_id: req_eval_id,
             },
           },
         },
       )
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       if (error) {
         throw error
       }
       score_summary = data
     } catch (error) {
+      if (
+        req_project_id !== project_id ||
+        req_task_id !== task_id ||
+        req_eval_id !== eval_id
+      )
+        return
       score_summary_error = createKilnError(error)
     }
   }
@@ -569,7 +664,7 @@
                 btn_primary={!focus_select_eval_config}
                 eval_type="eval_config"
                 on_run_complete={() => {
-                  get_score_summary()
+                  get_score_summary(project_id, task_id, eval_id)
                 }}
               />
             </div>

--- a/app/web_ui/src/routes/(app)/tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/tools/[project_id]/tool_servers/[tool_server_id]/+page.svelte
@@ -3,7 +3,6 @@
   import PropertyList from "$lib/ui/property_list.svelte"
   import { client } from "$lib/api_client"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
-  import { onMount } from "svelte"
   import { page } from "$app/stores"
   import { goto } from "$app/navigation"
   import {
@@ -38,12 +37,15 @@
   let unarchive_error: KilnError | null = null
   let archive_loading = false
 
-  onMount(async () => {
-    await fetch_tool_server()
-  })
+  $: if (project_id && tool_server_id) {
+    fetch_tool_server(project_id, tool_server_id)
+  }
 
-  async function fetch_tool_server_config(): Promise<ExternalToolServerApiDescription | null> {
-    if (!project_id || !tool_server_id) {
+  async function fetch_tool_server_config(
+    req_project_id: string,
+    req_tool_server_id: string,
+  ): Promise<ExternalToolServerApiDescription | null> {
+    if (!req_project_id || !req_tool_server_id) {
       return null
     }
 
@@ -52,8 +54,8 @@
       {
         params: {
           path: {
-            project_id,
-            tool_server_id,
+            project_id: req_project_id,
+            tool_server_id: req_tool_server_id,
           },
         },
       },
@@ -66,16 +68,19 @@
     return data as ExternalToolServerApiDescription
   }
 
-  async function fetch_tool_server() {
+  async function fetch_tool_server(
+    req_project_id: string,
+    req_tool_server_id: string,
+  ) {
     try {
       loading = true
       loading_error = null
 
-      if (!project_id) {
+      if (!req_project_id) {
         throw new Error("No project ID provided")
       }
 
-      if (!tool_server_id) {
+      if (!req_tool_server_id) {
         throw new Error("No tool ID provided")
       }
 
@@ -85,12 +90,18 @@
         {
           params: {
             path: {
-              project_id,
-              tool_server_id,
+              project_id: req_project_id,
+              tool_server_id: req_tool_server_id,
             },
           },
         },
       )
+
+      if (
+        req_project_id !== project_id ||
+        req_tool_server_id !== tool_server_id
+      )
+        return
 
       if (fetch_error) {
         throw fetch_error
@@ -98,16 +109,38 @@
 
       tool_server = data as ExternalToolServerApiDescription
     } catch (err) {
+      if (
+        req_project_id !== project_id ||
+        req_tool_server_id !== tool_server_id
+      )
+        return
       loading_error = createKilnError(err)
-      // If the full tool-server fetch fails, fall back to persisted config
-      // so archive/unarchive still works.
       try {
-        tool_server = await fetch_tool_server_config()
+        const fallback = await fetch_tool_server_config(
+          req_project_id,
+          req_tool_server_id,
+        )
+        if (
+          req_project_id !== project_id ||
+          req_tool_server_id !== tool_server_id
+        )
+          return
+        tool_server = fallback
       } catch {
+        if (
+          req_project_id !== project_id ||
+          req_tool_server_id !== tool_server_id
+        )
+          return
         tool_server = null
       }
     } finally {
-      loading = false
+      if (
+        req_project_id === project_id &&
+        req_tool_server_id === tool_server_id
+      ) {
+        loading = false
+      }
     }
   }
 
@@ -350,7 +383,8 @@
       unarchive_error = null
 
       const current_tool_server =
-        tool_server ?? (await fetch_tool_server_config())
+        tool_server ??
+        (await fetch_tool_server_config(project_id, tool_server_id))
       if (!current_tool_server) {
         return
       }
@@ -404,7 +438,7 @@
     } finally {
       try {
         await Promise.all([
-          fetch_tool_server(),
+          fetch_tool_server(project_id, tool_server_id),
           project_id
             ? load_available_tools(project_id, true)
             : Promise.resolve(),

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -197,7 +197,14 @@
       // e.g. the rating options
       await load_current_task(get(current_project)?.id)
       if (target_project_id && data.id) {
-        await load_rating_options(target_project_id, data.id, true)
+        try {
+          await load_rating_options(target_project_id, data.id, true)
+        } catch (refreshError) {
+          console.warn(
+            "Task was saved, but refreshing rating options failed",
+            refreshError,
+          )
+        }
       }
 
       // Wait for the saved change to propagate to the warn_before_unload

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/edit_task.svelte
@@ -9,11 +9,8 @@
     normalize_filename_string,
   } from "$lib/utils/input_validators"
   import SchemaSection from "./schema_section.svelte"
-  import {
-    current_project,
-    load_current_task,
-    load_rating_options,
-  } from "$lib/stores"
+  import { current_project, load_current_task } from "$lib/stores"
+  import { load_rating_options } from "$lib/stores/rating_options_store"
   import { goto } from "$app/navigation"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
   import { ui_state, projects } from "$lib/stores"
@@ -199,7 +196,9 @@
       // reload the current task to make sure changes propagate throughout the UI
       // e.g. the rating options
       await load_current_task(get(current_project)?.id)
-      await load_rating_options()
+      if (target_project_id && data.id) {
+        await load_rating_options(target_project_id, data.id, true)
+      }
 
       // Wait for the saved change to propagate to the warn_before_unload
       await tick()


### PR DESCRIPTION
When navigating between projects/tasks via deep links without a full page reload, pages would show the previous task's data. This is due to `onMount` only fires once per component mount so the data never refetches when route params change.

Fixed by converting ~30 pages from onMount to reactive $: blocks keyed on route params. Each async loader captures request-scoped IDs and discards stale responses if the user navigated away before the request completed.

- State (loading flags, errors, data) is reset on param change so previous data doesn't leak
- Extracted `current_task_prompts` and `current_task_rating_options` into dedicated task-scoped stores keyed by project/task composite ID