### PR TITLE
Fix race condition causing 2 attempts to restart SDG 

### DIFF
--- a/app/web_ui/src/lib/stores/index_db_store.test.ts
+++ b/app/web_ui/src/lib/stores/index_db_store.test.ts
@@ -329,6 +329,72 @@ describe("indexedDBStore", () => {
     })
   })
 
+  describe("persist", () => {
+    it("should write current store value to IndexedDB and resolve when complete", async () => {
+      // Setup: simulate successful DB open so setValue can work
+      mockObjectStore.get.mockImplementation(() => {
+        const request: MockIDBRequest = {
+          result: null,
+          error: null,
+          onsuccess: null,
+          onerror: null,
+        }
+        process.nextTick(() => {
+          if (request.onsuccess) request.onsuccess()
+        })
+        return request
+      })
+
+      const {
+        store: storeInstance,
+        initialized,
+        persist,
+      } = indexedDBStore("test-key", "initial-value")
+
+      // Trigger DB init success
+      process.nextTick(() => {
+        if (mockRequest.onsuccess) mockRequest.onsuccess()
+      })
+      await initialized
+
+      // Update store value (this triggers an async write via subscriber)
+      storeInstance.set("updated-value")
+
+      // Mock the transaction for the persist call to complete
+      mockDatabase.transaction.mockImplementation(() => {
+        const tx: MockIDBTransaction = {
+          objectStore: vi.fn<[string], MockIDBObjectStore>(
+            () => mockObjectStore,
+          ),
+          oncomplete: null,
+          onerror: null,
+          error: null,
+        }
+        // Simulate transaction completing asynchronously
+        process.nextTick(() => {
+          if (tx.oncomplete) tx.oncomplete()
+        })
+        return tx
+      })
+
+      // persist() should resolve after IndexedDB write completes
+      await persist()
+
+      // Verify put was called with the updated value
+      expect(mockObjectStore.put).toHaveBeenCalledWith({
+        key: "test-key",
+        value: "updated-value",
+      })
+    })
+
+    it("should resolve immediately in non-browser environment", async () => {
+      vi.unstubAllGlobals()
+      const { persist } = indexedDBStore("test-key", "initial-value")
+      // Should not throw or hang
+      await persist()
+    })
+  })
+
   describe("edge cases", () => {
     it("should handle IndexedDB not being available", () => {
       // Mock browser environment without IndexedDB

--- a/app/web_ui/src/lib/stores/index_db_store.ts
+++ b/app/web_ui/src/lib/stores/index_db_store.ts
@@ -121,13 +121,27 @@ export function indexedDBStore<T>(key: string, initialValue: T) {
         })
       }
     })
+    // Flush the current store value to IndexedDB, resolving when the write completes
+    const persist = (): Promise<void> => {
+      let currentValue: T | undefined
+      const unsub = store.subscribe((v) => (currentValue = v))
+      unsub()
+      return setValue(currentValue as T)
+    }
+
+    return {
+      store,
+      initialized: initPromise,
+      persist,
+    }
   } else {
     // If not in browser, resolve immediately
     initPromise = Promise.resolve()
-  }
 
-  return {
-    store,
-    initialized: initPromise,
+    return {
+      store,
+      initialized: initPromise,
+      persist: () => Promise.resolve(),
+    }
   }
 }

--- a/app/web_ui/src/lib/stores/index_db_store.ts
+++ b/app/web_ui/src/lib/stores/index_db_store.ts
@@ -122,7 +122,8 @@ export function indexedDBStore<T>(key: string, initialValue: T) {
       }
     })
     // Flush the current store value to IndexedDB, resolving when the write completes
-    const persist = (): Promise<void> => {
+    const persist = async (): Promise<void> => {
+      await initPromise
       let currentValue: T | undefined
       const unsub = store.subscribe((v) => (currentValue = v))
       unsub()

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
@@ -118,6 +118,7 @@
   }
   // Empty to start but will be populated from IndexedDB after task is loaded
   // Note: load the state vars into the guidance_data model and use that, this is just for the initial load/persistence
+  let persist_state: () => Promise<void> = () => Promise.resolve()
   let saved_state: Writable<SavedDataGenState> = writable({
     gen_type: null,
     template_id: null,
@@ -146,13 +147,19 @@
     guidance_data.splits.set($saved_state.splits)
   }
 
-  function clear_all_with_confirm() {
+  async function clear_all_with_confirm() {
     let msg =
       "Are you sure you want to clear all synthetic data gen state? This cannot be undone."
 
     if (confirm(msg)) {
       clear_all_state()
-      // Load the page again with clear URL params to get fresh state
+      // Flush to IndexedDB before navigating. The store subscriber writes async,
+      // so without this the page reloads with stale state and re-shows the dialog.
+      try {
+        await persist_state()
+      } catch (e) {
+        console.error("Failed to persist cleared state:", e)
+      }
       window.location.href = `/generate/${project_id}/${task_id}/synth`
     }
   }
@@ -175,16 +182,24 @@
     }))
   }
 
-  function clear_state_and_reload() {
+  async function clear_state_and_reload() {
     clear_all_state()
-    // reload the window keeping the same URL
+    try {
+      await persist_state()
+    } catch (e) {
+      console.error("Failed to persist cleared state:", e)
+    }
     window.location.reload()
     return true
   }
 
-  function clear_state_and_go_to_intro() {
+  async function clear_state_and_go_to_intro() {
     clear_all_state()
-    // Redirect back to intro to choose mode
+    try {
+      await persist_state()
+    } catch (e) {
+      console.error("Failed to persist cleared state:", e)
+    }
     window.location.href = `/generate/${project_id}/${task_id}`
     return true
   }
@@ -212,7 +227,7 @@
     if (project_id && task_id) {
       // Setup the root node store
       const synth_data_key = `synth_data_${project_id}_${task_id}_v2`
-      const { store, initialized } = indexedDBStore(synth_data_key, {
+      const { store, initialized, persist } = indexedDBStore(synth_data_key, {
         gen_type: null,
         template_id: null,
         eval_id: null,
@@ -225,6 +240,7 @@
       // Wait for the store to be initialized, then set the state
       await initialized
       saved_state = store
+      persist_state = persist
 
       // Special case: if we have some state (goal) but no root_node data, we should reset the state
       // Cleaner to give the user a fresh UI since there's very little data saved, and the clean UI is about picking goal.
@@ -1483,7 +1499,7 @@
     {
       label: "New Session (Clear Existing)",
       isWarning: true,
-      action: clear_state_and_reload,
+      asyncAction: clear_state_and_reload,
     },
   ]}
 >
@@ -1506,7 +1522,7 @@
   action_buttons={[
     {
       label: "New Session",
-      action: clear_state_and_go_to_intro,
+      asyncAction: clear_state_and_go_to_intro,
     },
     {
       label: "Continue Session",

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
@@ -152,14 +152,7 @@
       "Are you sure you want to clear all synthetic data gen state? This cannot be undone."
 
     if (confirm(msg)) {
-      clear_all_state()
-      // Flush to IndexedDB before navigating. The store subscriber writes async,
-      // so without this the page reloads with stale state and re-shows the dialog.
-      try {
-        await persist_state()
-      } catch (e) {
-        console.error("Failed to persist cleared state:", e)
-      }
+      await clear_and_persist()
       window.location.href = `/generate/${project_id}/${task_id}/synth`
     }
   }
@@ -182,24 +175,26 @@
     }))
   }
 
-  async function clear_state_and_reload() {
+  // Clears state and flushes to IndexedDB before navigating. The store
+  // subscriber writes async, so without this the page reloads with stale
+  // state and re-shows the dialog.
+  async function clear_and_persist() {
     clear_all_state()
     try {
       await persist_state()
     } catch (e) {
       console.error("Failed to persist cleared state:", e)
     }
+  }
+
+  async function clear_state_and_reload() {
+    await clear_and_persist()
     window.location.reload()
     return true
   }
 
   async function clear_state_and_go_to_intro() {
-    clear_all_state()
-    try {
-      await persist_state()
-    } catch (e) {
-      console.error("Failed to persist cleared state:", e)
-    }
+    await clear_and_persist()
     window.location.href = `/generate/${project_id}/${task_id}`
     return true
   }


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the "Clear Existing Session?" dialog requires two clicks to actually clear when starting a new SDG session. 

Root cause: clear_state_and_reload() calls window.location.reload() before the async IndexedDB write completes, so the page reloads with stale session state

  - Added persist() method to indexedDBStore that flushes the current value and returns a promise when the write is done
  - All three clear-then-navigate paths now await the persist before reloading/navigating
  - Added tests for the new persist() method

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
