### PR TITLE
Fix progress widget overlap with main app content on 14' MBP

### DIFF
--- a/app/web_ui/src/lib/ui/progress_widget.svelte
+++ b/app/web_ui/src/lib/ui/progress_widget.svelte
@@ -34,8 +34,7 @@
 
 {#if $state}
   <button
-    class="bg-white border border-primary rounded-lg p-3 flex flex-col gap-1 items-start relative text-left text-xs 2xl:text-sm"
-    style="max-width: 100%;"
+    class="bg-white border border-primary rounded-lg p-3 flex flex-col gap-1 items-start relative text-left text-xs 2xl:text-sm max-w-full"
     on:click={openLink}
   >
     <button

--- a/app/web_ui/src/lib/ui/progress_widget.svelte
+++ b/app/web_ui/src/lib/ui/progress_widget.svelte
@@ -35,6 +35,7 @@
 {#if $state}
   <button
     class="bg-white border border-primary rounded-lg p-3 flex flex-col gap-1 items-start relative text-left text-xs 2xl:text-sm"
+    style="max-width: 100%;"
     on:click={openLink}
   >
     <button
@@ -56,7 +57,7 @@
         max="100"
       ></progress>
     {:else if $state?.step_count !== null && $state?.current_step !== null}
-      <div class="h-4 overflow-hidden w-48 mt-1 ml-[-8px]">
+      <div class="h-4 overflow-hidden w-40 mt-1 ml-[-8px]">
         <div class="scale-[0.35] origin-top-left w-[160]">
           <ul class="steps pl-0 ml-0">
             {#each Array($state.step_count) as _, index}

--- a/app/web_ui/src/lib/ui/progress_widget.svelte
+++ b/app/web_ui/src/lib/ui/progress_widget.svelte
@@ -57,7 +57,7 @@
       ></progress>
     {:else if $state?.step_count !== null && $state?.current_step !== null}
       <div class="h-4 overflow-hidden w-40 mt-1 ml-[-8px]">
-        <div class="scale-[0.35] origin-top-left w-[160]">
+        <div class="scale-[0.35] origin-top-left w-[160px]">
           <ul class="steps pl-0 ml-0">
             {#each Array($state.step_count) as _, index}
               <li

--- a/app/web_ui/src/routes/(app)/+layout.svelte
+++ b/app/web_ui/src/routes/(app)/+layout.svelte
@@ -120,7 +120,10 @@
   })
 </script>
 
-<div class="drawer lg:drawer-open">
+<div
+  class="drawer lg:drawer-open"
+  style="grid-auto-columns: max-content minmax(0, 1fr);"
+>
   <input id="main-drawer" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content flex flex-col lg:mr-4 min-h-screen">
     <div class="flex-none h-12 lg:h-6">

--- a/app/web_ui/src/routes/(app)/+layout.svelte
+++ b/app/web_ui/src/routes/(app)/+layout.svelte
@@ -120,10 +120,7 @@
   })
 </script>
 
-<div
-  class="drawer lg:drawer-open"
-  style="grid-auto-columns: max-content minmax(0, 1fr);"
->
+<div class="drawer lg:drawer-open auto-cols-[max-content_minmax(0,1fr)]">
   <input id="main-drawer" type="checkbox" class="drawer-toggle" />
   <div class="drawer-content flex flex-col lg:mr-4 min-h-screen">
     <div class="flex-none h-12 lg:h-6">


### PR DESCRIPTION
## What does this PR do?

Fix app content overlapping sidebar on small screen (14" MBP).

Two issues fixed:
- ProgressWidget button in sidebar overflowed its parent because <button> elements don't respect flex stretch. Added max-width: 100% and reduced step indicator from w-48 to w-40 to fit the 160px content area.
- Main content card could expand into sidebar grid column due to DaisyUI's default `grid-auto-columns: max-content auto`. Overrode with `max-content minmax(0, 1fr)` to strictly constrain the content column.

<img width="1512" height="746" alt="image" src="https://github.com/user-attachments/assets/e9c9ba1d-a57a-4c43-9485-c07d5739d37f" />

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
