### PR TITLE
fix: broken coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,10 +34,11 @@ jobs:
 
       - name: Run coverage
         run: |
-          uv run coverage run -m pytest
-          uv run coverage report
-          uv run coverage html
-          uv run coverage xml
+          # Use pytest-cov so coverage data is collected from pytest-xdist
+          # worker subprocesses (plain `coverage run` only traces the main
+          # process, which silently dropped most of our coverage when -n auto
+          # was enabled in pyproject.toml).
+          uv run pytest --cov --cov-report=xml --cov-report=html --cov-report=term
 
       - name: Upload coverage HTML report as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What does this PR do?

Fixes the coverage workflow, which has been under-reporting since the `.coveragerc` / `pytest.ini` consolidation in [31121ece5](https://github.com/Kiln-AI/Kiln/commit/31121ece539c978c17509e78713a94f0e9d9553b). On recent PRs, overall coverage shows ~45% and diff coverage is lower than it should be (e.g. PR #1361 reported 33% on a fully-tested file).

### The bug

The consolidation commit moved `addopts = -n auto` from a commented-out line in `pytest.ini` to an active line in `[tool.pytest.ini_options]`. The commit reasoned that CI was unaffected because `checks.sh` already passed `-n auto` explicitly — but that overlooked the coverage workflow, which runs `coverage run -m pytest` directly.

`coverage run` only traces the main process. With `-n auto` now active, pytest-xdist spawns worker subprocesses where the actual tests execute, and those subprocesses are not traced. Result: only import-time code (module bodies, class/function definitions) registered as covered; everything inside test-exercised functions showed up as missing.

### The fix

Switch the workflow to invoke `pytest --cov` instead of `coverage run -m pytest`. `pytest-cov` (already a dependency of `kiln-ai`) handles xdist workers transparently — each worker writes its own data file and pytest-cov combines them at the end. The downstream `coverage.xml`, `htmlcov/`, and `coverage report` consumers in the workflow are unaffected.

## How to verify locally

You can run `pytest --cov --cov-report=term libs/core/kiln_ai/utils/test_open_ai_types.py` against the file from #1361 — `open_ai_types.py` now reports **100%** (was 33% on the PR comment).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
