### PR TITLE
fix: crank up timeout for git

### DIFF
--- a/app/desktop/git_sync/git_sync_manager.py
+++ b/app/desktop/git_sync/git_sync_manager.py
@@ -4,8 +4,6 @@ import subprocess
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-
-from app.desktop.git_sync.config import AuthMode
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Callable, TypeVar
@@ -14,6 +12,7 @@ import pygit2
 import pygit2.enums
 
 from app.desktop.git_sync.commit_message import generate_commit_message
+from app.desktop.git_sync.config import AuthMode
 from app.desktop.git_sync.errors import (
     CorruptRepoError,
     RemoteUnreachableError,
@@ -86,7 +85,7 @@ def reset_committer_cache() -> None:
 
 class GitSyncManager:
     _GIT_EXECUTOR_TIMEOUT = 30.0
-    _WRITE_LOCK_TIMEOUT = 600.0
+    _WRITE_LOCK_TIMEOUT = 90.0
 
     def __init__(
         self,

--- a/app/desktop/git_sync/git_sync_manager.py
+++ b/app/desktop/git_sync/git_sync_manager.py
@@ -86,7 +86,7 @@ def reset_committer_cache() -> None:
 
 class GitSyncManager:
     _GIT_EXECUTOR_TIMEOUT = 30.0
-    _WRITE_LOCK_TIMEOUT = 30.0
+    _WRITE_LOCK_TIMEOUT = 600.0
 
     def __init__(
         self,


### PR DESCRIPTION
## What does this PR do?

Running a RAG config on a git-sync-enabled project sometimes: every document errors with `Another save is in progress` during the extraction step.

`RagExtractorStepRunner` runs jobs at `concurrency=10`. Each worker enters its own `atomic_write` block, which:
1. Acquires the project-wide `threading.Lock` (`_WRITE_LOCK_TIMEOUT = 30s`)
2. Does a git commit + **network push**, serialized through a single-thread executor (to avoid partial or entangled commit problems and so on)

With 10 workers each holding the lock for one push (~few seconds over the network), the queue exceeds 30s by the ~10th worker. Subsequent workers time out and raise `WriteLockTimeoutError`. More docs → more cascading failures.

## When it triggers

Race between extraction time and commit+push time:

- **Fast extractor / slow network** → all 10 workers finish extracting at roughly the same time, pile up on the lock, queue exceeds 30s. **Bug fires.**
- **Slow extractor / fast network** → extractions space out; each worker pushes before the next one finishes. Queue never builds. **Bug doesn't fire.**

So it's the combinations that surface it: small docs (fast extraction), high concurrency, lots of docs, slow git remote (corp VPN, mobile tether), pushes to a busy remote. Local-only repos with no `origin` push effectively never hit it.

## Fix

Bumped `_WRITE_LOCK_TIMEOUT` to 600s. Enough headroom for ~200 serialized pushes; still short enough that a truly stuck push doesn't pin the process forever.

## Not the real fix

This is a stopgap. The actual problem is one network push per document. Real fixes (future work):

- Batch saves: one `atomic_write` per N jobs in `rag_runners.py` / `extractor_runner.py`.
- Or split the lock: fast in-memory lock for file writes, async background loop for commit+push.

Once either lands, drop `_WRITE_LOCK_TIMEOUT` back to 60–120s.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
