### PR TITLE
agent policy: allow sub-agent (Kiln Task as Tool) creation with approval

### DIFF
--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -32,7 +32,11 @@ from kiln_ai.utils.config import Config
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 from kiln_server.project_api import project_from_id
 from kiln_server.task_api import task_from_id
-from kiln_server.utils.agent_checks.policy import ALLOW_AGENT, DENY_AGENT
+from kiln_server.utils.agent_checks.policy import (
+    ALLOW_AGENT,
+    DENY_AGENT,
+    agent_policy_require_approval,
+)
 from mcp.types import Tool as MCPTool
 from pydantic import BaseModel, Field
 
@@ -818,7 +822,9 @@ def connect_tool_servers_api(app: FastAPI):
     @app.post(
         "/api/projects/{project_id}/kiln_task_tool",
         tags=["Tools & MCP"],
-        openapi_extra=DENY_AGENT,
+        openapi_extra=agent_policy_require_approval(
+            "Register a Kiln task as a tool (also called a sub-agent), making it callable by other agents and run configs."
+        ),
     )
     async def add_kiln_task_tool(
         project_id: Annotated[
@@ -852,7 +858,9 @@ def connect_tool_servers_api(app: FastAPI):
     @app.patch(
         "/api/projects/{project_id}/edit_kiln_task_tool/{tool_server_id}",
         tags=["Tools & MCP"],
-        openapi_extra=DENY_AGENT,
+        openapi_extra=agent_policy_require_approval(
+            "Edit a Kiln task tool (also called a sub-agent), including its name, description, underlying task, or run config."
+        ),
     )
     async def edit_kiln_task_tool(
         project_id: Annotated[

--- a/libs/server/kiln_server/utils/agent_checks/annotations/patch_api_projects_project_id_edit_kiln_task_tool_tool_server_id.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/patch_api_projects_project_id_edit_kiln_task_tool_tool_server_id.json
@@ -2,7 +2,8 @@
   "method": "patch",
   "path": "/api/projects/{project_id}/edit_kiln_task_tool/{tool_server_id}",
   "agent_policy": {
-    "permission": "deny",
-    "requires_approval": false
+    "permission": "allow",
+    "requires_approval": true,
+    "approval_description": "Edit a Kiln task tool (also called a sub-agent), including its name, description, underlying task, or run config."
   }
 }

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_kiln_task_tool.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_kiln_task_tool.json
@@ -2,7 +2,8 @@
   "method": "post",
   "path": "/api/projects/{project_id}/kiln_task_tool",
   "agent_policy": {
-    "permission": "deny",
-    "requires_approval": false
+    "permission": "allow",
+    "requires_approval": true,
+    "approval_description": "Register a Kiln task as a tool (also called a sub-agent), making it callable by other agents and run configs."
   }
 }


### PR DESCRIPTION
## What does this PR do?

Flip the agent policy on the two Kiln-task-as-tool mutation endpoints from `DENY_AGENT` to `agent_policy_require_approval(...)`, so the chat agent can register / edit sub-agents on the user's behalf instead of falling back to a UI deep-link workaround.
- `POST /api/projects/{project_id}/kiln_task_tool` (`add_kiln_task_tool`)
- `PATCH /api/projects/{project_id}/edit_kiln_task_tool/{tool_server_id}` (`edit_kiln_task_tool`)
Both routes are now `permission: allow` + `requires_approval: true`. The user sees a description of the action and explicitly accepts before the agent's `call_kiln_api` invocation runs. This matches the pattern already used by the fine-tune POST/PATCH and other state-changing endpoints. Approval descriptions name the feature as both "Kiln task tool" and "sub-agent" so the chat surface vocabulary matches what users actually say.
Annotation JSONs under `libs/server/kiln_server/utils/agent_checks/annotations/` regenerated via `dump_annotations` against the live OpenAPI spec.



## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib
