### PR TITLE
fix: CI broken for remote config deploy (requires openai api key now)

### DIFF
--- a/libs/core/kiln_ai/adapters/test_remote_config.py
+++ b/libs/core/kiln_ai/adapters/test_remote_config.py
@@ -1472,9 +1472,18 @@ except Exception as e:
         script_path = tmp_path / "test_v0_19.py"
         script_path.write_text(test_script)
 
+        # v0.19 constructs openai.AsyncOpenAI(api_key=Config.shared().open_ai_api_key or "")
+        # at import time (kiln_ai/adapters/fine_tune/openai_finetune.py), and newer openai
+        # SDKs reject an empty api_key with a "Missing credentials" error. Provide a dummy
+        # key so the import succeeds in environments without OPENAI_API_KEY (e.g. CI).
+        subprocess_env = {**os.environ, "OPENAI_API_KEY": "dummy-for-import"}
+
         # Run the script using uv
         result = subprocess.run(
-            ["uv", "run", str(script_path)], capture_output=True, text=True
+            ["uv", "run", str(script_path)],
+            capture_output=True,
+            text=True,
+            env=subprocess_env,
         )
 
         # Check if the test passed


### PR DESCRIPTION
## What does this PR do?

CI broken for remote config deploy: https://github.com/Kiln-AI/Kiln/actions/runs/25686044830/job/75410565430

Issue: remote config CI is broken because the backward compatibility test requires an OpenAI API key - some mock must have gotten removed upstream or some import must have caused this to be required by side effect.

Error message seems to be coming out of here: https://github.com/openai/openai-python/blob/38d75d74a5626472cd7d1be9705ea8aba29a6b22/src/openai/_client.py#L195

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
