### PR TITLE
chore: run remote-config CI also before merge

### DIFF
--- a/.github/workflows/publish_remote_config.yml
+++ b/.github/workflows/publish_remote_config.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - remote_config
+  pull_request:
+    branches:
+      - remote_config
 
 permissions:
   contents: read
@@ -33,10 +36,12 @@ jobs:
           KILN_TEST_COMPATIBILITY=1 uv run python3 -m pytest libs/core/kiln_ai/adapters/test_remote_config.py::test_backwards_compatibility_with_v0_19 -s -v
 
       - name: Generate Config
+        if: github.event_name == 'push'
         run: |
           uv run python -m kiln_ai.adapters.remote_config static/kiln_config_v2.json
 
       - name: Publish to Cloudflare Pages
+        if: github.event_name == 'push'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_REMOTE_CONFIG_API_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Remote config CI is only working on push to `remote_config`, not PRs going into it - so we do not know before merging if CI / deploy is going to pass.

Changes:
- run on PRs targeting `remote_config` branch so we can test CI without merging

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
