### PR TITLE
Fine-tune Prompt Method not loading 

### DIFF
--- a/app/web_ui/src/lib/ui/run_config_component/prompt_type_selector.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/prompt_type_selector.svelte
@@ -22,8 +22,8 @@
   export let fine_tune_prompt_id: string | undefined = undefined
   export let description: string | undefined = undefined
   export let info_description: string | undefined = undefined
-  export let project_id: string | null = null
-  export let task_id: string | null = null
+  export let project_id: string | null
+  export let task_id: string | null
 
   let has_rated_data = false
   let has_repair_data = false

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
@@ -779,6 +779,8 @@
             info_description="There are tradeoffs to consider when choosing a system prompt for fine-tuning. Read more: [OpenAI Docs](https://platform.openai.com/docs/guides/fine-tuning/#crafting-prompts)."
             exclude_cot={true}
             custom_prompt_name="Custom Fine Tuning Prompt"
+            project_id={$page.params.project_id}
+            task_id={$page.params.task_id}
           />
           {#if system_prompt_method === "custom"}
             <div class="p-4 border-l-4 border-gray-300">

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
@@ -779,8 +779,8 @@
             info_description="There are tradeoffs to consider when choosing a system prompt for fine-tuning. Read more: [OpenAI Docs](https://platform.openai.com/docs/guides/fine-tuning/#crafting-prompts)."
             exclude_cot={true}
             custom_prompt_name="Custom Fine Tuning Prompt"
-            project_id={$page.params.project_id}
-            task_id={$page.params.task_id}
+            {project_id}
+            {task_id}
           />
           {#if system_prompt_method === "custom"}
             <div class="p-4 border-l-4 border-gray-300">


### PR DESCRIPTION
## What does this PR do?

The PromptTypeSelector in the fine-tune create page was missing `project_id` and `task_id` so it never fetched prompts. This was introduced when we migrated from global stores to task-scoped stores in fca43577b and the fine-tune page was missed during that migration.

Now it loads:
<img width="985" height="980" alt="image" src="https://github.com/user-attachments/assets/f4997977-1bc4-441d-972d-2cc27904b6f7" />

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
