### PR TITLE
Fix DeepSeek V4 thinking level control on OpenRouter

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -4540,6 +4540,7 @@ built_in_models: List[KilnModel] = [
                 supports_data_gen=True,
                 available_thinking_levels=DEEPSEEK_V4_OPENROUTER_THINKING_LEVELS,
                 default_thinking_level="high",
+                openrouter_reasoning_object=True,
             ),
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
@@ -4570,6 +4571,7 @@ built_in_models: List[KilnModel] = [
                 supports_data_gen=True,
                 available_thinking_levels=DEEPSEEK_V4_OPENROUTER_THINKING_LEVELS,
                 default_thinking_level="high",
+                openrouter_reasoning_object=True,
             ),
         ],
     ),


### PR DESCRIPTION
Added missing `openrouter_reasoning_object=True` to DeepSeek V4 Pro and V4 Flash for OpenRouter. This is required per their guideline. 

Previously when this field was missing, the adapter sends reasoning_effort as a top-level param, which litellm silently drops for DeepSeek models (not GPT). This meant thinking level settings like "none" were ignored and the model always produced reasoning content. With the flag, we send OpenRouter's unified reasoning object format instead.