### PR TITLE
Skill: Add fine-tune deprecation check skill

### DIFF
--- a/.agents/scripts/provider_utils.py
+++ b/.agents/scripts/provider_utils.py
@@ -246,7 +246,10 @@ def fetch_fireworks_individual(api_key: str, model_ids: list[str]) -> set[str]:
 
 
 def fetch_fireworks_tunable(api_key: str) -> list[dict]:
-    """Fetch all models marked tunable from Fireworks API.
+    """Fetch all models that support supervised fine-tuning from Fireworks API.
+
+    Uses the supervisedLoraTunable and supervisedFullParameterTunable fields,
+    which are accurate. The older tunable field is stale and unreliable.
 
     Returns list of dicts with keys: id, display_name, supports_tools.
     """
@@ -269,7 +272,10 @@ def fetch_fireworks_tunable(api_key: str) -> list[dict]:
 
     tunable = []
     for m in models:
-        if m.get("tunable", False):
+        is_supervised_tunable = m.get("supervisedLoraTunable", False) or m.get(
+            "supervisedFullParameterTunable", False
+        )
+        if is_supervised_tunable:
             tunable.append(
                 {
                     "id": m.get("name", ""),

--- a/.agents/scripts/provider_utils.py
+++ b/.agents/scripts/provider_utils.py
@@ -187,25 +187,40 @@ def fetch_vertex(project_id: str) -> set[str]:
     Kiln Vertex entries may use a 'meta/' prefix for LiteLLM routing — callers should
     strip this before comparing.
     """
-    token = subprocess.check_output(
-        ["gcloud", "auth", "print-access-token"], text=True
-    ).strip()
+    try:
+        token = subprocess.check_output(
+            ["gcloud", "auth", "print-access-token"], text=True
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise RuntimeError(f"gcloud auth failed: {e}") from e
 
     ids: set[str] = set()
     errors: list[str] = []
     for publisher in ("google", "anthropic", "meta"):
-        url = f"https://us-central1-aiplatform.googleapis.com/v1beta1/publishers/{publisher}/models"
-        req = Request(url)
-        req.add_header("Authorization", f"Bearer {token}")
-        req.add_header("x-goog-user-project", project_id)
-        req.add_header("User-Agent", "kiln-model-check/1.0")
-        try:
-            with urlopen(req, timeout=15) as resp:
-                data = json.loads(resp.read())
-                for m in data.get("publisherModels", []):
-                    ids.add(m["name"].split("/")[-1])
-        except (HTTPError, URLError, OSError, KeyError, ValueError) as e:
-            errors.append(f"{publisher}: {e}")
+        next_page_token: str | None = None
+        while True:
+            url = (
+                "https://us-central1-aiplatform.googleapis.com/"
+                f"v1beta1/publishers/{publisher}/models?listAllVersions=true"
+            )
+            if next_page_token:
+                url += f"&pageToken={next_page_token}"
+
+            req = Request(url)
+            req.add_header("Authorization", f"Bearer {token}")
+            req.add_header("x-goog-user-project", project_id)
+            req.add_header("User-Agent", "kiln-model-check/1.0")
+            try:
+                with urlopen(req, timeout=15) as resp:
+                    data = json.loads(resp.read())
+                    for m in data.get("publisherModels", []):
+                        ids.add(m["name"].split("/")[-1])
+                    next_page_token = data.get("nextPageToken")
+                    if not next_page_token:
+                        break
+            except (HTTPError, URLError, OSError, KeyError, ValueError) as e:
+                errors.append(f"{publisher}: {e}")
+                break
     if not ids and errors:
         raise RuntimeError(f"All Vertex publishers failed: {'; '.join(errors)}")
     return ids

--- a/.agents/scripts/provider_utils.py
+++ b/.agents/scripts/provider_utils.py
@@ -1,0 +1,281 @@
+"""Shared provider API utilities for Kiln model-checking skills.
+
+Provides functions to fetch model listings from each provider's API,
+plus common helpers. Used by both the deprecation check and
+fine-tune deprecation check skills.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def find_repo_root() -> Path:
+    """Walk up from this file to find the repo root (directory containing .agents/)."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / ".agents").is_dir() and (current / "libs").is_dir():
+            return current
+        current = current.parent
+    raise RuntimeError("Could not find repo root")
+
+
+# ---------------------------------------------------------------------------
+# Provider configuration
+# ---------------------------------------------------------------------------
+
+PROVIDER_CONFIG = {
+    "openrouter": {
+        "type": "openrouter",
+        "url": "https://openrouter.ai/api/v1/models",
+    },
+    "openai": {
+        "type": "openai_compat",
+        "url": "https://api.openai.com/v1/models",
+        "env": "OPENAI_API_KEY",
+    },
+    "anthropic": {
+        "type": "anthropic",
+        "url": "https://api.anthropic.com/v1/models",
+        "env": "ANTHROPIC_API_KEY",
+    },
+    "gemini_api": {
+        "type": "gemini",
+        "env": "GEMINI_API_KEY",
+    },
+    "fireworks_ai": {
+        "type": "fireworks",
+        "env": "FIREWORKS_API_KEY",
+    },
+    "together_ai": {
+        "type": "openai_compat",
+        "url": "https://api.together.xyz/v1/models",
+        "env": "TOGETHER_API_KEY",
+    },
+    "siliconflow_cn": {
+        "type": "openai_compat",
+        "url": "https://api.siliconflow.cn/v1/models",
+        "env": "SILICONFLOW_CN_API_KEY",
+    },
+    "cerebras": {
+        "type": "openai_compat",
+        "url": "https://api.cerebras.ai/v1/models",
+        "env": "CEREBRAS_API_KEY",
+    },
+    "groq": {
+        "type": "openai_compat",
+        "url": "https://api.groq.com/openai/v1/models",
+        "env": "GROQ_API_KEY",
+    },
+    "vertex": {
+        "type": "vertex",
+        "env": "VERTEX_PROJECT_ID",
+    },
+}
+
+SKIP_PROVIDERS = {
+    "amazon_bedrock",
+    "ollama",
+    "docker_model_runner",
+    "kiln_fine_tune",
+    "kiln_custom_registry",
+    "openai_compatible",
+    "azure_openai",
+    "huggingface",
+}
+
+CASE_INSENSITIVE_PROVIDERS = {"siliconflow_cn"}
+
+# OpenRouter virtual suffixes that are never listed in the API.
+OPENROUTER_VIRTUAL_SUFFIXES = (":exacto",)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def log(msg: str = "") -> None:
+    sys.stderr.write(msg + "\n")
+
+
+def fetch_json(url: str, headers: dict | None = None, timeout: int = 30) -> Any:
+    req = Request(url)
+    req.add_header("User-Agent", "kiln-model-check/1.0")
+    if headers:
+        for k, v in headers.items():
+            req.add_header(k, v)
+    with urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def get_api_key(env_var: str) -> str | None:
+    """Return the API key from environment, or None if not set."""
+    val = os.environ.get(env_var, "")
+    return val if val else None
+
+
+# ---------------------------------------------------------------------------
+# Provider model-listing functions
+#
+# Each returns a set of model IDs available on the provider.
+# ---------------------------------------------------------------------------
+
+
+def fetch_openrouter() -> tuple[set[str], dict[str, str]]:
+    """Returns (model_ids, expiring_dict) from OpenRouter. No auth required."""
+    data = fetch_json("https://openrouter.ai/api/v1/models")
+    ids: set[str] = set()
+    expiring: dict[str, str] = {}
+    for m in data["data"]:
+        ids.add(m["id"])
+        if m.get("expiration_date"):
+            expiring[m["id"]] = m["expiration_date"]
+    return ids, expiring
+
+
+def fetch_openai_compat(url: str, api_key: str) -> set[str]:
+    """Fetch model IDs from an OpenAI-compatible /v1/models endpoint.
+
+    Handles both {data:[...]} (most providers) and flat [...] (Together AI).
+    """
+    headers = {"Authorization": f"Bearer {api_key}"}
+    data = fetch_json(url, headers)
+    if isinstance(data, list):
+        return {m["id"] for m in data}
+    return {m["id"] for m in data["data"]}
+
+
+def fetch_anthropic(api_key: str) -> set[str]:
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+    data = fetch_json("https://api.anthropic.com/v1/models", headers)
+    return {m["id"] for m in data["data"]}
+
+
+def fetch_gemini(api_key: str) -> set[str]:
+    """Fetches from both v1 and v1beta — preview/Gemma models only appear on v1beta."""
+    ids: set[str] = set()
+    errors: list[str] = []
+    for version in ("v1", "v1beta"):
+        url = f"https://generativelanguage.googleapis.com/{version}/models?pageSize=100"
+        try:
+            data = fetch_json(url, {"x-goog-api-key": api_key})
+            for m in data.get("models", []):
+                ids.add(m["name"].removeprefix("models/"))
+        except (HTTPError, URLError, OSError, KeyError, ValueError) as e:
+            errors.append(f"{version}: {e}")
+    if not ids and errors:
+        raise RuntimeError(f"All Gemini endpoints failed: {'; '.join(errors)}")
+    return ids
+
+
+def fetch_vertex(project_id: str) -> set[str]:
+    """Fetch models from Vertex AI publisher listing across google/anthropic/meta.
+
+    Requires gcloud CLI auth. Uses v1beta1 endpoint with x-goog-user-project header.
+    Model names come as 'publishers/{pub}/models/{name}' — we extract just {name}.
+    Kiln Vertex entries may use a 'meta/' prefix for LiteLLM routing — callers should
+    strip this before comparing.
+    """
+    token = subprocess.check_output(
+        ["gcloud", "auth", "print-access-token"], text=True
+    ).strip()
+
+    ids: set[str] = set()
+    errors: list[str] = []
+    for publisher in ("google", "anthropic", "meta"):
+        url = f"https://us-central1-aiplatform.googleapis.com/v1beta1/publishers/{publisher}/models"
+        req = Request(url)
+        req.add_header("Authorization", f"Bearer {token}")
+        req.add_header("x-goog-user-project", project_id)
+        req.add_header("User-Agent", "kiln-model-check/1.0")
+        try:
+            with urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read())
+                for m in data.get("publisherModels", []):
+                    ids.add(m["name"].split("/")[-1])
+        except (HTTPError, URLError, OSError, KeyError, ValueError) as e:
+            errors.append(f"{publisher}: {e}")
+    if not ids and errors:
+        raise RuntimeError(f"All Vertex publishers failed: {'; '.join(errors)}")
+    return ids
+
+
+def fetch_vertex_with_aliases(project_id: str) -> set[str]:
+    """Like fetch_vertex but also adds unversioned aliases (e.g. gemini-2.0-flash-001 -> gemini-2.0-flash)."""
+    ids = fetch_vertex(project_id)
+    with_aliases = set(ids)
+    for model_id in ids:
+        if re.match(r".*-\d{3}$", model_id):
+            with_aliases.add(re.sub(r"-\d{3}$", "", model_id))
+    return with_aliases
+
+
+def fetch_fireworks_individual(api_key: str, model_ids: list[str]) -> set[str]:
+    """Check each model via Fireworks model detail API.
+
+    The /v1/models listing only returns serverless models, but models may still
+    be available via on-demand deployments. The detail API at
+    GET https://api.fireworks.ai/v1/{model_id} returns info for ALL models
+    regardless of deployment tier. Returns 404 only for truly removed models.
+    """
+    available: set[str] = set()
+    for model_id in model_ids:
+        url = f"https://api.fireworks.ai/v1/{model_id}"
+        req = Request(url)
+        req.add_header("Authorization", f"Bearer {api_key}")
+        req.add_header("User-Agent", "kiln-model-check/1.0")
+        try:
+            with urlopen(req, timeout=10) as _:
+                available.add(model_id)
+        except HTTPError as e:
+            if e.code == 404:
+                continue
+            raise
+    return available
+
+
+def fetch_fireworks_tunable(api_key: str) -> list[dict]:
+    """Fetch all models marked tunable from Fireworks API.
+
+    Returns list of dicts with keys: id, display_name, supports_tools.
+    """
+    url = "https://api.fireworks.ai/v1/accounts/fireworks/models"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    models: list[dict] = []
+    page_url = f"{url}?pageSize=200"
+
+    while True:
+        data = fetch_json(page_url, headers)
+        if "models" not in data or not isinstance(data["models"], list):
+            raise ValueError("Invalid Fireworks response: expected 'models' key")
+        models.extend(data["models"])
+        next_token = data.get("nextPageToken")
+        if next_token and isinstance(next_token, str) and len(next_token) > 0:
+            page_url = f"{url}?pageSize=200&pageToken={next_token}"
+        else:
+            break
+
+    tunable = []
+    for m in models:
+        if m.get("tunable", False):
+            tunable.append(
+                {
+                    "id": m.get("name", ""),
+                    "display_name": m.get("displayName", ""),
+                    "supports_tools": m.get("supportsTools", False),
+                }
+            )
+
+    return tunable

--- a/.agents/scripts/provider_utils.py
+++ b/.agents/scripts/provider_utils.py
@@ -335,3 +335,26 @@ def fetch_fireworks_docs_models() -> set[str]:
         raise RuntimeError("Parsed zero models from Fireworks docs table")
 
     return model_ids
+
+
+def fetch_together_docs_models() -> set[str]:
+    """Scrape Together AI docs page to get the list of supported fine-tune models.
+
+    Parses the fine-tuning models page for model IDs in org/model format
+    (e.g. "meta-llama/Meta-Llama-3.1-8B-Instruct-Reference").
+
+    Raises RuntimeError if the page can't be fetched or no models are found.
+    """
+    url = "https://docs.together.ai/docs/fine-tuning-models"
+    req = Request(url)
+    req.add_header("User-Agent", "kiln-model-check/1.0")
+    with urlopen(req, timeout=15) as resp:
+        html = resp.read().decode("utf-8")
+
+    # Model IDs appear as >org/model-name< in table cells
+    model_ids = set(re.findall(r">([A-Za-z][\w\-]+/[\w\.\-]+)<", html))
+
+    if not model_ids:
+        raise RuntimeError("Parsed zero models from Together docs page")
+
+    return model_ids

--- a/.agents/scripts/provider_utils.py
+++ b/.agents/scripts/provider_utils.py
@@ -300,3 +300,38 @@ def fetch_fireworks_tunable(api_key: str) -> list[dict]:
             )
 
     return tunable
+
+
+def fetch_fireworks_docs_models() -> set[str]:
+    """Scrape Fireworks docs page to get the list of officially supported fine-tune models.
+
+    Parses the "Supported base models" table from the managed fine-tuning docs.
+    Returns bare tail IDs (e.g. "qwen3-8b") matching the format used in
+    FIREWORKS_SUPPORTED_FINETUNE_MODELS.
+
+    Raises RuntimeError if the page can't be fetched or the table can't be parsed.
+    """
+    url = "https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro"
+    req = Request(url)
+    req.add_header("User-Agent", "kiln-model-check/1.0")
+    with urlopen(req, timeout=15) as resp:
+        html = resp.read().decode("utf-8")
+
+    # Find the supported base models table by locating a known model ID
+    # then walking back to the table start
+    marker = html.find("<td><code>")
+    if marker < 0:
+        raise RuntimeError("Could not find model table in Fireworks docs page")
+
+    table_start = html.rfind("<table", 0, marker)
+    table_end = html.find("</table>", marker)
+    if table_start < 0 or table_end < 0:
+        raise RuntimeError("Could not find table boundaries in Fireworks docs page")
+
+    table_html = html[table_start:table_end]
+    model_ids = set(re.findall(r"<td><code>([^<]+)</code></td>", table_html))
+
+    if not model_ids:
+        raise RuntimeError("Parsed zero models from Fireworks docs table")
+
+    return model_ids

--- a/.agents/skills/kiln-check-deprecation/scripts/check_provider.py
+++ b/.agents/skills/kiln-check-deprecation/scripts/check_provider.py
@@ -20,7 +20,7 @@ Requires:
     - API keys set as environment variables (source .env first)
     - required_permissions: ["all"] when run via Cursor Shell (network access needed)
 
-API format quirks handled by this script:
+API format quirks handled by the shared provider_api module:
     - Together AI returns a flat JSON array, not {data: [...]}
     - Gemini API needs both v1 and v1beta endpoints (preview models only on v1beta)
     - Gemini model names are prefixed with "models/" — stripped automatically
@@ -39,191 +39,30 @@ API format quirks handled by this script:
 import argparse
 import json
 import os
-import re
-import subprocess
 import sys
-from typing import Any
+from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
-PROVIDER_CONFIG = {
-    "openrouter": {
-        "type": "openrouter",
-        "url": "https://openrouter.ai/api/v1/models",
-    },
-    "openai": {
-        "type": "openai_compat",
-        "url": "https://api.openai.com/v1/models",
-        "env": "OPENAI_API_KEY",
-    },
-    "anthropic": {
-        "type": "anthropic",
-        "url": "https://api.anthropic.com/v1/models",
-        "env": "ANTHROPIC_API_KEY",
-    },
-    "gemini_api": {
-        "type": "gemini",
-        "env": "GEMINI_API_KEY",
-    },
-    "fireworks_ai": {
-        "type": "fireworks",
-        "env": "FIREWORKS_API_KEY",
-    },
-    "together_ai": {
-        "type": "openai_compat",
-        "url": "https://api.together.xyz/v1/models",
-        "env": "TOGETHER_API_KEY",
-    },
-    "siliconflow_cn": {
-        "type": "openai_compat",
-        "url": "https://api.siliconflow.cn/v1/models",
-        "env": "SILICONFLOW_CN_API_KEY",
-    },
-    "cerebras": {
-        "type": "openai_compat",
-        "url": "https://api.cerebras.ai/v1/models",
-        "env": "CEREBRAS_API_KEY",
-    },
-    "groq": {
-        "type": "openai_compat",
-        "url": "https://api.groq.com/openai/v1/models",
-        "env": "GROQ_API_KEY",
-    },
-    "vertex": {
-        "type": "vertex",
-        "env": "VERTEX_PROJECT_ID",
-    },
-}
+# Add shared scripts directory to path
+# Script is at .agents/skills/<skill>/scripts/<file>.py
+# parent chain: scripts -> <skill> -> skills -> .agents
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent.parent.parent / "scripts")
+)
 
-SKIP_PROVIDERS = {
-    "amazon_bedrock",
-    "ollama",
-    "docker_model_runner",
-    "kiln_fine_tune",
-    "kiln_custom_registry",
-    "openai_compatible",
-    "azure_openai",
-    "huggingface",
-}
-
-CASE_INSENSITIVE_PROVIDERS = {"siliconflow_cn"}
-
-
-def fetch_json(url: str, headers: dict | None = None, timeout: int = 30) -> Any:
-    req = Request(url)
-    req.add_header("User-Agent", "kiln-deprecation-check/1.0")
-    if headers:
-        for k, v in headers.items():
-            req.add_header(k, v)
-    with urlopen(req, timeout=timeout) as resp:
-        return json.loads(resp.read())
-
-
-# OpenRouter virtual suffixes that are never listed in the API.
-# If a Kiln model_id has one of these, strip it and check the base model instead.
-OPENROUTER_VIRTUAL_SUFFIXES = (":exacto",)
-
-
-def fetch_openrouter() -> tuple[set[str], dict[str, str]]:
-    data = fetch_json("https://openrouter.ai/api/v1/models")
-    ids: set[str] = set()
-    expiring: dict[str, str] = {}
-    for m in data["data"]:
-        ids.add(m["id"])
-        if m.get("expiration_date"):
-            expiring[m["id"]] = m["expiration_date"]
-    return ids, expiring
-
-
-def fetch_openai_compat(url: str, api_key: str) -> set[str]:
-    """Handles both {data:[...]} (most providers) and flat [...] (Together AI)."""
-    headers = {"Authorization": f"Bearer {api_key}"}
-    data = fetch_json(url, headers)
-    if isinstance(data, list):
-        return {m["id"] for m in data}
-    return {m["id"] for m in data["data"]}
-
-
-def fetch_anthropic(api_key: str) -> set[str]:
-    headers = {
-        "x-api-key": api_key,
-        "anthropic-version": "2023-06-01",
-    }
-    data = fetch_json("https://api.anthropic.com/v1/models", headers)
-    return {m["id"] for m in data["data"]}
-
-
-def fetch_gemini(api_key: str) -> set[str]:
-    """Fetches from both v1 and v1beta — preview/Gemma models only appear on v1beta."""
-    ids: set[str] = set()
-    errors: list[str] = []
-    for version in ("v1", "v1beta"):
-        url = f"https://generativelanguage.googleapis.com/{version}/models?key={api_key}&pageSize=100"
-        try:
-            data = fetch_json(url)
-            for m in data.get("models", []):
-                ids.add(m["name"].removeprefix("models/"))
-        except (HTTPError, URLError, OSError, KeyError, ValueError) as e:
-            errors.append(f"{version}: {e}")
-    if not ids and errors:
-        raise RuntimeError(f"All Gemini endpoints failed: {'; '.join(errors)}")
-    return ids
-
-
-def fetch_vertex(project_id: str) -> set[str]:
-    """Fetch models from Vertex AI publisher listing across google/anthropic/meta.
-
-    Requires gcloud CLI auth. Uses v1beta1 endpoint with x-goog-user-project header.
-    Model names come as 'publishers/{pub}/models/{name}' — we extract just {name}.
-    Kiln Vertex entries may use a 'meta/' prefix for LiteLLM routing — callers should
-    strip this before comparing.
-    """
-    token = subprocess.check_output(
-        ["gcloud", "auth", "print-access-token"], text=True
-    ).strip()
-
-    ids: set[str] = set()
-    errors: list[str] = []
-    for publisher in ("google", "anthropic", "meta"):
-        url = f"https://us-central1-aiplatform.googleapis.com/v1beta1/publishers/{publisher}/models"
-        req = Request(url)
-        req.add_header("Authorization", f"Bearer {token}")
-        req.add_header("x-goog-user-project", project_id)
-        req.add_header("User-Agent", "kiln-deprecation-check/1.0")
-        try:
-            with urlopen(req, timeout=15) as resp:
-                data = json.loads(resp.read())
-                for m in data.get("publisherModels", []):
-                    ids.add(m["name"].split("/")[-1])
-        except (HTTPError, URLError, OSError, KeyError, ValueError) as e:
-            errors.append(f"{publisher}: {e}")
-    if not ids and errors:
-        raise RuntimeError(f"All Vertex publishers failed: {'; '.join(errors)}")
-    return ids
-
-
-def fetch_fireworks_individual(api_key: str, model_ids: list[str]) -> set[str]:
-    """Check each model via Fireworks model detail API.
-
-    The /v1/models listing only returns serverless models, but models may still
-    be available via on-demand deployments. The detail API at
-    GET https://api.fireworks.ai/v1/{model_id} returns info for ALL models
-    regardless of deployment tier. Returns 404 only for truly removed models.
-    """
-    available: set[str] = set()
-    for model_id in model_ids:
-        url = f"https://api.fireworks.ai/v1/{model_id}"
-        req = Request(url)
-        req.add_header("Authorization", f"Bearer {api_key}")
-        req.add_header("User-Agent", "kiln-deprecation-check/1.0")
-        try:
-            with urlopen(req, timeout=10) as _:
-                available.add(model_id)
-        except HTTPError as e:
-            if e.code == 404:
-                continue
-            raise
-    return available
+from provider_utils import (  # type: ignore[import-not-found]
+    CASE_INSENSITIVE_PROVIDERS,
+    OPENROUTER_VIRTUAL_SUFFIXES,
+    PROVIDER_CONFIG,
+    SKIP_PROVIDERS,
+    fetch_anthropic,
+    fetch_fireworks_individual,
+    fetch_gemini,
+    fetch_openai_compat,
+    fetch_openrouter,
+    fetch_vertex_with_aliases,
+    log,
+)
 
 
 def check_provider(provider_name: str, extracted: dict) -> dict:
@@ -258,7 +97,7 @@ def check_provider(provider_name: str, extracted: dict) -> dict:
     elif ptype == "fireworks":
         available = fetch_fireworks_individual(api_key, kiln_models)
     elif ptype == "vertex":
-        available = fetch_vertex(api_key)
+        available = fetch_vertex_with_aliases(api_key)
     elif ptype == "openai_compat":
         available = fetch_openai_compat(config["url"], api_key)
     else:
@@ -279,13 +118,6 @@ def check_provider(provider_name: str, extracted: dict) -> dict:
         if case_insensitive:
             mid = mid.lower()
         return mid
-
-    if provider_name == "vertex":
-        available_with_aliases = set(available)
-        for a in available:
-            if re.match(r".*-\d{3}$", a):
-                available_with_aliases.add(re.sub(r"-\d{3}$", "", a))
-        available = available_with_aliases
 
     missing = sorted(m for m in kiln_models if _effective_id(m) not in available)
     expiring_entries = sorted(
@@ -314,10 +146,6 @@ def check_provider(provider_name: str, extracted: dict) -> dict:
     }
 
 
-def _log(msg: str = "") -> None:
-    sys.stderr.write(msg + "\n")
-
-
 def main():
     parser = argparse.ArgumentParser(
         description="Check provider model availability against Kiln model list"
@@ -343,38 +171,38 @@ def main():
 
     results = {}
     for provider in providers:
-        _log(f"Checking {provider}...")
+        log(f"Checking {provider}...")
         try:
             result = check_provider(provider, extracted)
             results[provider] = result
 
             if result.get("skipped"):
-                _log(f"  ⏭️  Skipped: {result['reason']}")
+                log(f"  ⏭️  Skipped: {result['reason']}")
             elif result.get("error"):
-                _log(f"  ❗ Error: {result['error']}")
+                log(f"  ❗ Error: {result['error']}")
             elif result["missing_count"] > 0:
-                _log(
+                log(
                     f"  ❌ {result['missing_count']}/{result['kiln_count']} missing "
                     f"(provider has {result['available_count']} models total)"
                 )
                 for m in result["missing"]:
-                    _log(f"     - {m}")
+                    log(f"     - {m}")
                 if result.get("expiring"):
                     for e in result["expiring"]:
-                        _log(f"  ⚠️  Expiring: {e['model_id']} ({e['expiration_date']})")
+                        log(f"  ⚠️  Expiring: {e['model_id']} ({e['expiration_date']})")
             else:
                 msg = f"  ✅ {result['kiln_count']}/{result['kiln_count']} found"
                 if result.get("expiring"):
                     msg += f" ({len(result['expiring'])} expiring soon)"
-                _log(msg)
+                log(msg)
                 for e in result.get("expiring", []):
-                    _log(f"  ⚠️  Expiring: {e['model_id']} ({e['expiration_date']})")
+                    log(f"  ⚠️  Expiring: {e['model_id']} ({e['expiration_date']})")
         except (HTTPError, URLError, OSError) as e:
             results[provider] = {"provider": provider, "error": str(e)}
-            _log(f"  ❗ Network error: {e}")
+            log(f"  ❗ Network error: {e}")
         except Exception as e:
             results[provider] = {"provider": provider, "error": str(e)}
-            _log(f"  ❗ Error: {e}")
+            log(f"  ❗ Error: {e}")
 
     json.dump(results, sys.stdout, indent=2)
     sys.stdout.write("\n")

--- a/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
+++ b/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: kiln-check-finetune-deprecation
+description: Check Kiln's fine-tunable model list for deprecated or unsupported base models. Use when the user wants to audit fine-tuning support, check if fine-tune base models are still valid, or mentions fine-tune model deprecation.
+---
+
+# Check Fine-Tune Model Deprecation in Kiln
+
+Audit the fine-tunable models listed in Kiln to find base models that are no longer supported for fine-tuning by their providers. This is separate from general model deprecation — a model can still be available for inference but no longer supported as a fine-tuning base.
+
+---
+
+## Global Rules
+
+- **Sandbox:** All `curl`, `uv run`, and `python3` commands that hit the network MUST use `required_permissions: ["all"]`. The sandbox blocks network access.
+- **Env vars:** Source `.env` before running check scripts: `export $(grep -v '^#' .env | xargs)`
+- **Vertex AI auth:** The Vertex check requires `gcloud` CLI authentication. Before running, ask the user to run `gcloud auth login` if they haven't recently. If `gcloud auth print-access-token` fails, prompt the user to authenticate.
+- **Non-destructive:** This skill only reports findings. It does not automatically remove or deprecate models.
+
+---
+
+## Supported Providers
+
+| Provider | Env Var | Auth |
+|----------|---------|------|
+| OpenAI | `OPENAI_API_KEY` | Bearer |
+| Together AI | `TOGETHER_API_KEY` | Bearer |
+| Vertex AI | `VERTEX_PROJECT_ID` + `gcloud` CLI auth | OAuth (gcloud) |
+| Fireworks AI | `FIREWORKS_API_KEY` | Bearer |
+
+---
+
+## Background
+
+Kiln has two types of fine-tunable model entries:
+
+1. **Static entries** — Models in `libs/core/kiln_ai/adapters/ml_model_list.py` with `provider_finetune_id` set. Currently used by OpenAI, Together AI, and Vertex AI.
+2. **Dynamic entries (Fireworks)** — Fetched at runtime from `api.fireworks.ai/v1/accounts/fireworks/models` filtering by `tunable=True`. This list is managed by Fireworks and may include stale/unsupported models.
+
+The API endpoint that serves the fine-tune dropdown is `GET /api/finetune_providers` in `app/desktop/studio_server/finetune_api.py`.
+
+---
+
+## Phase 1 – Check Static Fine-Tune IDs
+
+Run the check script from the repo root:
+
+```bash
+python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py static > /tmp/kiln_finetune_static.json
+```
+
+This extracts all `provider_finetune_id` entries from `ml_model_list.py` and checks each provider's API to see if the model is still available for fine-tuning:
+
+- **OpenAI:** Checks `GET https://api.openai.com/v1/models` — fine-tunable models are those with ID matching the `provider_finetune_id`. OpenAI date-stamps fine-tunable model IDs (e.g. `gpt-4o-2024-08-06`), so if the dated version is removed, it's no longer fine-tunable.
+- **Together AI:** Checks `GET https://api.together.xyz/v1/models` and filters for models with `"type": "chat"` that match the `provider_finetune_id`. Together uses full HuggingFace-style IDs (e.g. `meta-llama/Meta-Llama-3.1-8B-Instruct-Reference`).
+- **Vertex AI:** Checks the Vertex AI tuning documentation / API. Vertex fine-tuning uses specific versioned model IDs (e.g. `gemini-2.0-flash-001`).
+
+**Output:** JSON to stdout with per-provider results, human summary to stderr.
+
+---
+
+## Phase 2 – Check Fireworks Dynamic Models
+
+Fireworks fine-tunable models are fetched dynamically from their API, not stored in `ml_model_list.py`. The concern here is that the Fireworks API's `tunable=True` flag may be stale — listing models that Fireworks no longer actually supports for fine-tuning.
+
+```bash
+python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py fireworks > /tmp/kiln_finetune_fireworks.json
+```
+
+This script:
+1. Fetches all `tunable=True` models from `api.fireworks.ai/v1/accounts/fireworks/models`
+2. Cross-references against a hardcoded list of known-good models in `FIREWORKS_DOCUMENTED_MODELS` (sourced from https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro#supported-base-models)
+3. Reports models that appear in the API as tunable but are NOT in the known-good list
+
+The hardcoded list must be manually updated when Fireworks changes their supported base models. Check the docs URL above for the current list.
+
+**Output:** JSON to stdout, human summary to stderr.
+
+---
+
+## Phase 3 – Report Findings
+
+Read the JSON outputs and present findings in a clear table:
+
+```text
+Fine-Tune Deprecation Audit Results
+====================================
+
+STATIC PROVIDERS (provider_finetune_id in ml_model_list.py):
+
+  ✅ OpenAI: 5/5 found
+     gpt-4.1-2025-04-14, gpt-4.1-mini-2025-04-14, gpt-4.1-nano-2025-04-14,
+     gpt-4o-2024-08-06, gpt-4o-mini-2024-07-18
+
+  ✅ Vertex AI: 2/2 found
+     gemini-2.0-flash-001, gemini-2.0-flash-lite-001
+
+  ❌ Together AI: 2/4 missing
+     ✅ Qwen/Qwen2.5-72B-Instruct — found
+     ✅ Qwen/Qwen2.5-14B-Instruct — found
+     ❌ meta-llama/Meta-Llama-3.1-8B-Instruct-Reference — NOT FOUND
+     ❌ meta-llama/Meta-Llama-3.1-70B-Instruct-Reference — NOT FOUND
+
+  ⏭️ SKIPPED (no credentials):
+     - vertex (VERTEX_PROJECT_ID not set)
+
+DYNAMIC PROVIDER (Fireworks):
+
+  ⚠️ 167 models marked tunable in API
+  ⚠️ 15 models in known-good docs list
+  ✅ 11 models in both API and docs
+  ❌ 156 models in API but NOT in docs (likely stale)
+     - accounts/fireworks/models/qwen2-72b-instruct
+     - accounts/fireworks/models/code-llama-7b
+     - ...
+  ⚠️ 4 models in docs but NOT in API
+     - accounts/fireworks/models/gemma-2-9b-it
+     - ...
+```
+
+Note: The example above is illustrative. Actual model counts and entries will vary.
+
+---
+
+## Phase 4 – Remediation
+
+Based on findings, recommend specific actions:
+
+### For static entries (`provider_finetune_id`):
+- If a model's fine-tune ID is no longer valid, either:
+  - **Update** the `provider_finetune_id` to a newer version if one exists
+  - **Remove** the `provider_finetune_id` field to stop offering fine-tuning for that model on that provider
+  - **Set `deprecated=True`** on the provider entry if the model is fully gone
+
+### For Fireworks dynamic entries:
+- The stale models come from Fireworks' API, not our code. Options:
+  - **Filter in our code** — update `fetch_fireworks_finetune_models()` in `finetune_api.py` to filter against a known-good list
+  - **Report to Fireworks** — flag the stale models to Fireworks support
+  - **Both** — filter now, report later
+
+**Always ask the user to confirm** before making any code changes.
+
+---
+
+## Phase 5 – Verify
+
+After any changes, run the relevant tests:
+
+```bash
+uv run python3 -m pytest app/desktop/studio_server/test_finetune_api.py -q
+```
+
+---
+
+## Checklist
+
+- [ ] Env vars sourced from `.env`
+- [ ] Vertex auth confirmed (`gcloud auth print-access-token` works, or skip Vertex)
+- [ ] Static fine-tune IDs checked against provider APIs (OpenAI, Together, Vertex)
+- [ ] Fireworks dynamic models cross-referenced against known-good list
+- [ ] Findings reported to user with clear table
+- [ ] User confirmed remediation approach
+- [ ] Code changes made (if any)
+- [ ] Tests pass after changes
+- [ ] FIREWORKS_DOCUMENTED_MODELS updated if docs have changed

--- a/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
+++ b/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
@@ -75,6 +75,8 @@ This script:
 
 The canonical allowlist lives in `fireworks_finetune.py` and is shared between the runtime dropdown filter and this audit skill. There is a single place to update when Fireworks changes their supported models.
 
+**Interpreting results:** The supervised API fields return ~43 models, but our allowlist intentionally filters to ~20 that match Fireworks' documented supported models. Seeing ~23 "models in API but NOT in allowlist" is normal — these are models Fireworks marks as technically tunable but doesn't officially document or support. Only flag these if a model appears in the Fireworks docs but is missing from our allowlist. The important direction is **stale allowlist entries** — models we ship that the API no longer marks as supervised-tunable.
+
 **Output:** JSON to stdout, human summary to stderr.
 
 ---

--- a/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
+++ b/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
@@ -68,10 +68,10 @@ python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
 
 This script:
 1. Fetches all `tunable=True` models from `api.fireworks.ai/v1/accounts/fireworks/models`
-2. Cross-references against a hardcoded list of known-good models in `FIREWORKS_DOCUMENTED_MODELS` (sourced from https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro#supported-base-models)
-3. Reports models that appear in the API as tunable but are NOT in the known-good list
+2. Cross-references against `FIREWORKS_SUPPORTED_FINETUNE_MODELS` from `app/desktop/studio_server/finetune_api.py` — the same allowlist that filters the runtime fine-tune dropdown
+3. Reports models that appear in the API as tunable but are NOT in the allowlist
 
-The hardcoded list must be manually updated when Fireworks changes their supported base models. Check the docs URL above for the current list.
+The canonical allowlist lives in `finetune_api.py` and is shared between the runtime dropdown filter and this audit skill. There is a single place to update when Fireworks changes their supported models.
 
 **Output:** JSON to stdout, human summary to stderr.
 
@@ -161,4 +161,4 @@ uv run python3 -m pytest app/desktop/studio_server/test_finetune_api.py -q
 - [ ] User confirmed remediation approach
 - [ ] Code changes made (if any)
 - [ ] Tests pass after changes
-- [ ] FIREWORKS_DOCUMENTED_MODELS updated if docs have changed
+- [ ] FIREWORKS_SUPPORTED_FINETUNE_MODELS in finetune_api.py updated if docs have changed

--- a/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
+++ b/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
@@ -45,7 +45,7 @@ The API endpoint that serves the fine-tune dropdown is `GET /api/finetune_provid
 Run the check script from the repo root:
 
 ```bash
-python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py static > /tmp/kiln_finetune_static.json
+uv run python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py static > /tmp/kiln_finetune_static.json
 ```
 
 This extracts all `provider_finetune_id` entries from `ml_model_list.py` and checks each provider's API to see if the model is still available for fine-tuning:
@@ -63,7 +63,7 @@ This extracts all `provider_finetune_id` entries from `ml_model_list.py` and che
 Fireworks fine-tunable models are fetched dynamically from their API, not stored in `ml_model_list.py`. The script checks the API's `supervisedLoraTunable` and `supervisedFullParameterTunable` fields (not the old `tunable` field, which is stale) and cross-references against our allowlist.
 
 ```bash
-python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py fireworks > /tmp/kiln_finetune_fireworks.json
+uv run python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py fireworks > /tmp/kiln_finetune_fireworks.json
 ```
 
 This script:

--- a/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
+++ b/.agents/skills/kiln-check-finetune-deprecation/SKILL.md
@@ -60,18 +60,20 @@ This extracts all `provider_finetune_id` entries from `ml_model_list.py` and che
 
 ## Phase 2 – Check Fireworks Dynamic Models
 
-Fireworks fine-tunable models are fetched dynamically from their API, not stored in `ml_model_list.py`. The concern here is that the Fireworks API's `tunable=True` flag may be stale — listing models that Fireworks no longer actually supports for fine-tuning.
+Fireworks fine-tunable models are fetched dynamically from their API, not stored in `ml_model_list.py`. The script checks the API's `supervisedLoraTunable` and `supervisedFullParameterTunable` fields (not the old `tunable` field, which is stale) and cross-references against our allowlist.
 
 ```bash
 python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py fireworks > /tmp/kiln_finetune_fireworks.json
 ```
 
 This script:
-1. Fetches all `tunable=True` models from `api.fireworks.ai/v1/accounts/fireworks/models`
-2. Cross-references against `FIREWORKS_SUPPORTED_FINETUNE_MODELS` from `app/desktop/studio_server/finetune_api.py` — the same allowlist that filters the runtime fine-tune dropdown
-3. Reports models that appear in the API as tunable but are NOT in the allowlist
+1. Fetches all models with `supervisedLoraTunable=True` or `supervisedFullParameterTunable=True` from `api.fireworks.ai/v1/accounts/fireworks/models`
+2. Cross-references against `FIREWORKS_SUPPORTED_FINETUNE_MODELS` from `libs/core/kiln_ai/adapters/fine_tune/fireworks_finetune.py` — the same allowlist that filters the runtime fine-tune dropdown
+3. Checks both directions:
+   - **Stale allowlist entries**: models in our allowlist that the API no longer marks as supervised-tunable — these may need to be removed
+   - **Missing from allowlist**: models the API marks as supervised-tunable but aren't in our allowlist — these are candidates to add
 
-The canonical allowlist lives in `finetune_api.py` and is shared between the runtime dropdown filter and this audit skill. There is a single place to update when Fireworks changes their supported models.
+The canonical allowlist lives in `fireworks_finetune.py` and is shared between the runtime dropdown filter and this audit skill. There is a single place to update when Fireworks changes their supported models.
 
 **Output:** JSON to stdout, human summary to stderr.
 
@@ -161,4 +163,4 @@ uv run python3 -m pytest app/desktop/studio_server/test_finetune_api.py -q
 - [ ] User confirmed remediation approach
 - [ ] Code changes made (if any)
 - [ ] Tests pass after changes
-- [ ] FIREWORKS_SUPPORTED_FINETUNE_MODELS in finetune_api.py updated if docs have changed
+- [ ] FIREWORKS_SUPPORTED_FINETUNE_MODELS in fireworks_finetune.py updated if docs have changed

--- a/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
+++ b/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
@@ -23,7 +23,7 @@ import sys
 from pathlib import Path
 
 # Add shared scripts directory and repo root to path so we can import from
-# provider_utils.py and app.desktop.studio_server.finetune_api
+# provider_utils.py and kiln_ai.adapters.fine_tune.fireworks_finetune
 # Script is at .agents/skills/<skill>/scripts/<file>.py
 # parent chain: scripts -> <skill> -> skills -> .agents
 sys.path.insert(
@@ -40,9 +40,9 @@ from provider_utils import (  # type: ignore[import-not-found]
 )
 
 REPO_ROOT = find_repo_root()
-sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "libs" / "core"))
 
-from app.desktop.studio_server.finetune_api import (  # noqa: E402  # type: ignore[import-not-found]
+from kiln_ai.adapters.fine_tune.fireworks_finetune import (  # noqa: E402  # type: ignore[import-not-found]
     FIREWORKS_SUPPORTED_FINETUNE_MODELS,
 )
 
@@ -200,7 +200,7 @@ def check_static() -> dict:
 
 
 def _fireworks_supported_full_paths() -> set[str]:
-    """Build full Fireworks model paths from the canonical allowlist in finetune_api.py.
+    """Build full Fireworks model paths from the canonical allowlist in fireworks_finetune.py.
 
     The allowlist uses bare tail IDs (e.g. "qwen3-8b") but the Fireworks API
     returns full paths (e.g. "accounts/fireworks/models/qwen3-8b"). This function
@@ -226,7 +226,7 @@ def check_fireworks() -> dict:
     except Exception as e:
         return {"type": "fireworks", "skipped": True, "reason": str(e)}
 
-    log(f"  Fireworks API reports {len(tunable)} tunable models")
+    log(f"  Fireworks API reports {len(tunable)} supervised-tunable models")
 
     supported = _fireworks_supported_full_paths()
     tunable_ids = {m["id"] for m in tunable}
@@ -238,12 +238,14 @@ def check_fireworks() -> dict:
     log(f"  ✅ {len(in_both)} models in both API and allowlist")
     if in_api_only:
         log(
-            f"  ⚠️  {len(in_api_only)} models in API but NOT in allowlist (possibly stale):"
+            f"  ⚠️  {len(in_api_only)} models in API but NOT in allowlist (candidates to add):"
         )
         for m in in_api_only:
             log(f"     - {m}")
     if in_supported_only:
-        log(f"  ⚠️  {len(in_supported_only)} models in allowlist but NOT in API:")
+        log(
+            f"  ❌ {len(in_supported_only)} models in allowlist but NOT in API (possibly stale):"
+        )
         for m in in_supported_only:
             log(f"     - {m}")
 

--- a/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
+++ b/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
@@ -18,7 +18,6 @@ Requires:
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 
@@ -45,60 +44,35 @@ sys.path.insert(0, str(REPO_ROOT / "libs" / "core"))
 from kiln_ai.adapters.fine_tune.fireworks_finetune import (  # noqa: E402  # type: ignore[import-not-found]
     FIREWORKS_SUPPORTED_FINETUNE_MODELS,
 )
-
-MODEL_LIST_PATH = (
-    REPO_ROOT / "libs" / "core" / "kiln_ai" / "adapters" / "ml_model_list.py"
+from kiln_ai.adapters.ml_model_list import (  # noqa: E402  # type: ignore[import-not-found]
+    built_in_models,
 )
 
 FIREWORKS_MODEL_PREFIX = "accounts/fireworks/models/"
 
 
 # ---------------------------------------------------------------------------
-# Extract static provider_finetune_id entries from ml_model_list.py
+# Extract static provider_finetune_id entries from the model list
 # ---------------------------------------------------------------------------
 
 
 def extract_static_finetune_ids() -> list[dict]:
-    """Parse ml_model_list.py to find all provider_finetune_id entries.
+    """Extract all provider_finetune_id entries from built_in_models.
 
     Returns list of {model_name, provider, finetune_id} dicts.
     """
-    source = MODEL_LIST_PATH.read_text()
     entries: list[dict] = []
 
-    model_pattern = re.compile(
-        r"KilnModel\s*\((.*?)\n    \)",
-        re.DOTALL,
-    )
-    name_pattern = re.compile(r'friendly_name\s*=\s*"([^"]+)"')
-    provider_block_pattern = re.compile(
-        r"KilnModelProvider\s*\((.*?)\)",
-        re.DOTALL,
-    )
-    provider_name_pattern = re.compile(r"name\s*=\s*ModelProviderName\.(\w+)")
-    finetune_id_pattern = re.compile(r'provider_finetune_id\s*=\s*"([^"]+)"')
-
-    for model_match in model_pattern.finditer(source):
-        model_block = model_match.group(1)
-        name_match = name_pattern.search(model_block)
-        model_name = name_match.group(1) if name_match else "Unknown"
-
-        for provider_match in provider_block_pattern.finditer(model_block):
-            provider_block = provider_match.group(1)
-            finetune_match = finetune_id_pattern.search(provider_block)
-            if not finetune_match:
-                continue
-
-            pname_match = provider_name_pattern.search(provider_block)
-            provider = pname_match.group(1) if pname_match else "unknown"
-
-            entries.append(
-                {
-                    "model_name": model_name,
-                    "provider": provider,
-                    "finetune_id": finetune_match.group(1),
-                }
-            )
+    for model in built_in_models:
+        for provider in model.providers:
+            if provider.provider_finetune_id:
+                entries.append(
+                    {
+                        "model_name": model.friendly_name,
+                        "provider": provider.name.value,
+                        "finetune_id": provider.provider_finetune_id,
+                    }
+                )
 
     return entries
 
@@ -137,8 +111,8 @@ def check_vertex_finetune(finetune_ids: list[str]) -> dict:
 
     try:
         available = fetch_vertex_with_aliases(project_id)
-    except (RuntimeError, FileNotFoundError, Exception) as e:
-        return {"skipped": True, "reason": f"Vertex API error: {e}"}
+    except (RuntimeError, FileNotFoundError) as e:
+        return {"skipped": True, "reason": f"Vertex API error: {type(e).__name__}"}
 
     found = [fid for fid in finetune_ids if fid in available]
     missing = [fid for fid in finetune_ids if fid not in available]
@@ -178,15 +152,19 @@ def check_static() -> dict:
             log(f"    ⏭️  No checker for {provider}")
             continue
 
-        result = checker(finetune_ids)
+        try:
+            result = checker(finetune_ids)
+        except Exception as e:
+            result = {"skipped": True, "reason": f"{type(e).__name__}"}
         result["entries"] = entry_map[provider]
         results[provider] = result
 
         if result.get("skipped"):
             log(f"    ⏭️  Skipped: {result['reason']}")
         elif result.get("missing"):
-            log(f"    ❌ {len(result['missing'])}/{len(finetune_ids)} missing")
-            for m in result["missing"]:
+            missing = result["missing"]
+            log(f"    ❌ {len(missing)}/{len(finetune_ids)} missing")  # type: ignore[arg-type]
+            for m in missing:  # type: ignore[union-attr]
                 log(f"       - {m}")
         else:
             log(f"    ✅ {len(finetune_ids)}/{len(finetune_ids)} found")
@@ -223,8 +201,8 @@ def check_fireworks() -> dict:
 
     try:
         tunable = fetch_fireworks_tunable(api_key)
-    except Exception as e:
-        return {"type": "fireworks", "skipped": True, "reason": str(e)}
+    except (RuntimeError, ValueError, OSError) as e:
+        return {"type": "fireworks", "skipped": True, "reason": type(e).__name__}
 
     log(f"  Fireworks API reports {len(tunable)} supervised-tunable models")
 

--- a/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
+++ b/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
@@ -33,6 +33,7 @@ from provider_utils import (  # type: ignore[import-not-found]
     fetch_fireworks_docs_models,
     fetch_fireworks_tunable,
     fetch_openai_compat,
+    fetch_together_docs_models,
     fetch_vertex_with_aliases,
     find_repo_root,
     get_api_key,
@@ -95,14 +96,22 @@ def check_openai_finetune(finetune_ids: list[str]) -> dict:
 
 
 def check_together_finetune(finetune_ids: list[str]) -> dict:
-    api_key = get_api_key("TOGETHER_API_KEY")
-    if not api_key:
-        return {"skipped": True, "reason": "TOGETHER_API_KEY not set"}
+    """Check Together fine-tune IDs against the Together docs page.
 
-    available = fetch_openai_compat("https://api.together.xyz/v1/models", api_key)
-    found = [fid for fid in finetune_ids if fid in available]
-    missing = [fid for fid in finetune_ids if fid not in available]
-    return {"found": found, "missing": missing, "available_count": len(available)}
+    The /v1/models API only lists inference models, not fine-tuning Reference
+    models. The docs page is the source of truth for fine-tuning support.
+    """
+    try:
+        docs_models = fetch_together_docs_models()
+    except (RuntimeError, OSError) as e:
+        return {
+            "skipped": True,
+            "reason": f"Could not scrape Together docs: {type(e).__name__}",
+        }
+
+    found = [fid for fid in finetune_ids if fid in docs_models]
+    missing = [fid for fid in finetune_ids if fid not in docs_models]
+    return {"found": found, "missing": missing, "available_count": len(docs_models)}
 
 
 def check_vertex_finetune(finetune_ids: list[str]) -> dict:

--- a/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
+++ b/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
@@ -30,6 +30,7 @@ sys.path.insert(
 )
 
 from provider_utils import (  # type: ignore[import-not-found]
+    fetch_fireworks_docs_models,
     fetch_fireworks_tunable,
     fetch_openai_compat,
     fetch_vertex_with_aliases,
@@ -206,6 +207,41 @@ def check_fireworks() -> dict:
 
     log(f"  Fireworks API reports {len(tunable)} supervised-tunable models")
 
+    # Scrape the Fireworks docs page for the ground-truth supported models
+    docs_models: set[str] | None = None
+    try:
+        docs_models = fetch_fireworks_docs_models()
+        log(f"  Fireworks docs list {len(docs_models)} supported models")
+    except (RuntimeError, OSError) as e:
+        log(f"  ⚠️  Could not scrape Fireworks docs: {type(e).__name__}")
+        log("     Falling back to allowlist-only comparison")
+
+    allowlist = FIREWORKS_SUPPORTED_FINETUNE_MODELS
+
+    # If docs scraping succeeded, check for allowlist drift against docs
+    if docs_models is not None:
+        in_docs_not_allowlist = sorted(docs_models - allowlist)
+        in_allowlist_not_docs = sorted(allowlist - docs_models)
+
+        if in_docs_not_allowlist:
+            log(
+                f"  ❌ {len(in_docs_not_allowlist)} models in docs but NOT in our allowlist (need to add):"
+            )
+            for m in in_docs_not_allowlist:
+                log(f"     - {m}")
+        if in_allowlist_not_docs:
+            log(
+                f"  ❌ {len(in_allowlist_not_docs)} models in our allowlist but NOT in docs (need to remove):"
+            )
+            for m in in_allowlist_not_docs:
+                log(f"     - {m}")
+        if not in_docs_not_allowlist and not in_allowlist_not_docs:
+            log(f"  ✅ Allowlist matches docs exactly ({len(allowlist)} models)")
+    else:
+        in_docs_not_allowlist = []
+        in_allowlist_not_docs = []
+
+    # Also compare allowlist against API (secondary signal)
     supported = _fireworks_supported_full_paths()
     tunable_ids = {m["id"] for m in tunable}
 
@@ -213,29 +249,28 @@ def check_fireworks() -> dict:
     in_api_only = sorted(tunable_ids - supported)
     in_supported_only = sorted(supported - tunable_ids)
 
-    log(f"  ✅ {len(in_both)} models in both API and allowlist")
-    if in_api_only:
-        log(
-            f"  ⚠️  {len(in_api_only)} models in API but NOT in allowlist (candidates to add):"
-        )
-        for m in in_api_only:
-            log(f"     - {m}")
+    log(f"  ✅ {len(in_both)} allowlist models found in API")
     if in_supported_only:
         log(
-            f"  ❌ {len(in_supported_only)} models in allowlist but NOT in API (possibly stale):"
+            f"  ❌ {len(in_supported_only)} allowlist models NOT in API (possibly stale):"
         )
         for m in in_supported_only:
             log(f"     - {m}")
 
-    api_only_details = [m for m in tunable if m["id"] in set(in_api_only)]
-
     return {
         "type": "fireworks",
         "total_tunable": len(tunable),
-        "supported_count": len(supported),
-        "in_both": in_both,
-        "in_api_only": api_only_details,
-        "in_supported_only": in_supported_only,
+        "allowlist_count": len(allowlist),
+        "docs_count": len(docs_models) if docs_models else None,
+        "docs_vs_allowlist": {
+            "in_docs_not_allowlist": in_docs_not_allowlist,
+            "in_allowlist_not_docs": in_allowlist_not_docs,
+        },
+        "api_vs_allowlist": {
+            "in_both": in_both,
+            "in_api_only_count": len(in_api_only),
+            "in_allowlist_not_api": in_supported_only,
+        },
     }
 
 

--- a/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
+++ b/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
@@ -189,6 +189,11 @@ def check_static() -> dict:
 # ---------------------------------------------------------------------------
 
 # Known supported base models from Fireworks docs.
+# Hardcoded because Fireworks' API `tunable` flag is unreliable — it marks ~167
+# models as tunable when only ~15 are actually supported for fine-tuning. The docs
+# page is the real source of truth, but it's HTML (not a structured API), so we
+# maintain this list manually. Update it when Fireworks changes their supported models.
+#
 # Last updated: 2026-05-13
 # Source: https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro#supported-base-models
 FIREWORKS_DOCUMENTED_MODELS = {

--- a/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
+++ b/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Check fine-tunable model availability across providers.
+
+Two modes:
+  - "static"    — checks provider_finetune_id entries in ml_model_list.py
+  - "fireworks" — cross-references Fireworks API tunable models against their docs
+  - "all"       — runs both checks
+
+Usage:
+    python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py static
+    python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py fireworks
+    python3 .agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py all
+
+Requires:
+    - API keys set as environment variables (source .env first)
+    - required_permissions: ["all"] when run via sandbox (network access needed)
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Add shared scripts directory to path
+# Script is at .agents/skills/<skill>/scripts/<file>.py
+# parent chain: scripts -> <skill> -> skills -> .agents
+sys.path.insert(
+    0, str(Path(__file__).resolve().parent.parent.parent.parent / "scripts")
+)
+
+from provider_utils import (  # type: ignore[import-not-found]
+    fetch_fireworks_tunable,
+    fetch_openai_compat,
+    fetch_vertex_with_aliases,
+    find_repo_root,
+    get_api_key,
+    log,
+)
+
+MODEL_LIST_PATH = (
+    find_repo_root() / "libs" / "core" / "kiln_ai" / "adapters" / "ml_model_list.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# Extract static provider_finetune_id entries from ml_model_list.py
+# ---------------------------------------------------------------------------
+
+
+def extract_static_finetune_ids() -> list[dict]:
+    """Parse ml_model_list.py to find all provider_finetune_id entries.
+
+    Returns list of {model_name, provider, finetune_id} dicts.
+    """
+    source = MODEL_LIST_PATH.read_text()
+    entries: list[dict] = []
+
+    model_pattern = re.compile(
+        r"KilnModel\s*\((.*?)\n    \)",
+        re.DOTALL,
+    )
+    name_pattern = re.compile(r'friendly_name\s*=\s*"([^"]+)"')
+    provider_block_pattern = re.compile(
+        r"KilnModelProvider\s*\((.*?)\)",
+        re.DOTALL,
+    )
+    provider_name_pattern = re.compile(r"name\s*=\s*ModelProviderName\.(\w+)")
+    finetune_id_pattern = re.compile(r'provider_finetune_id\s*=\s*"([^"]+)"')
+
+    for model_match in model_pattern.finditer(source):
+        model_block = model_match.group(1)
+        name_match = name_pattern.search(model_block)
+        model_name = name_match.group(1) if name_match else "Unknown"
+
+        for provider_match in provider_block_pattern.finditer(model_block):
+            provider_block = provider_match.group(1)
+            finetune_match = finetune_id_pattern.search(provider_block)
+            if not finetune_match:
+                continue
+
+            pname_match = provider_name_pattern.search(provider_block)
+            provider = pname_match.group(1) if pname_match else "unknown"
+
+            entries.append(
+                {
+                    "model_name": model_name,
+                    "provider": provider,
+                    "finetune_id": finetune_match.group(1),
+                }
+            )
+
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Check static providers
+# ---------------------------------------------------------------------------
+
+
+def check_openai_finetune(finetune_ids: list[str]) -> dict:
+    api_key = get_api_key("OPENAI_API_KEY")
+    if not api_key:
+        return {"skipped": True, "reason": "OPENAI_API_KEY not set"}
+
+    available = fetch_openai_compat("https://api.openai.com/v1/models", api_key)
+    found = [fid for fid in finetune_ids if fid in available]
+    missing = [fid for fid in finetune_ids if fid not in available]
+    return {"found": found, "missing": missing, "available_count": len(available)}
+
+
+def check_together_finetune(finetune_ids: list[str]) -> dict:
+    api_key = get_api_key("TOGETHER_API_KEY")
+    if not api_key:
+        return {"skipped": True, "reason": "TOGETHER_API_KEY not set"}
+
+    available = fetch_openai_compat("https://api.together.xyz/v1/models", api_key)
+    found = [fid for fid in finetune_ids if fid in available]
+    missing = [fid for fid in finetune_ids if fid not in available]
+    return {"found": found, "missing": missing, "available_count": len(available)}
+
+
+def check_vertex_finetune(finetune_ids: list[str]) -> dict:
+    project_id = get_api_key("VERTEX_PROJECT_ID")
+    if not project_id:
+        return {"skipped": True, "reason": "VERTEX_PROJECT_ID not set"}
+
+    try:
+        available = fetch_vertex_with_aliases(project_id)
+    except (RuntimeError, FileNotFoundError, Exception) as e:
+        return {"skipped": True, "reason": f"Vertex API error: {e}"}
+
+    found = [fid for fid in finetune_ids if fid in available]
+    missing = [fid for fid in finetune_ids if fid not in available]
+    return {"found": found, "missing": missing, "available_count": len(available)}
+
+
+def check_static() -> dict:
+    entries = extract_static_finetune_ids()
+    log(f"Found {len(entries)} static provider_finetune_id entries")
+
+    by_provider: dict[str, list[str]] = {}
+    entry_map: dict[str, list[dict]] = {}
+    for e in entries:
+        provider = e["provider"]
+        if provider not in by_provider:
+            by_provider[provider] = []
+            entry_map[provider] = []
+        by_provider[provider].append(e["finetune_id"])
+        entry_map[provider].append(e)
+
+    results: dict[str, dict] = {}
+    checkers = {
+        "openai": check_openai_finetune,
+        "together_ai": check_together_finetune,
+        "vertex": check_vertex_finetune,
+    }
+
+    for provider, finetune_ids in by_provider.items():
+        log(f"  Checking {provider} ({len(finetune_ids)} models)...")
+        checker = checkers.get(provider)
+        if not checker:
+            results[provider] = {
+                "skipped": True,
+                "reason": f"No checker implemented for {provider}",
+                "finetune_ids": finetune_ids,
+            }
+            log(f"    ⏭️  No checker for {provider}")
+            continue
+
+        result = checker(finetune_ids)
+        result["entries"] = entry_map[provider]
+        results[provider] = result
+
+        if result.get("skipped"):
+            log(f"    ⏭️  Skipped: {result['reason']}")
+        elif result.get("missing"):
+            log(f"    ❌ {len(result['missing'])}/{len(finetune_ids)} missing")
+            for m in result["missing"]:
+                log(f"       - {m}")
+        else:
+            log(f"    ✅ {len(finetune_ids)}/{len(finetune_ids)} found")
+
+    return {"type": "static", "results": results}
+
+
+# ---------------------------------------------------------------------------
+# Fireworks dynamic model check
+# ---------------------------------------------------------------------------
+
+# Known supported base models from Fireworks docs.
+# Last updated: 2026-05-13
+# Source: https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro#supported-base-models
+FIREWORKS_DOCUMENTED_MODELS = {
+    "accounts/fireworks/models/llama-v3p1-8b-instruct",
+    "accounts/fireworks/models/llama-v3p1-70b-instruct",
+    "accounts/fireworks/models/llama-v3p1-405b-instruct",
+    "accounts/fireworks/models/llama-v3p2-1b-instruct",
+    "accounts/fireworks/models/llama-v3p2-3b-instruct",
+    "accounts/fireworks/models/llama-v3p3-70b-instruct",
+    "accounts/fireworks/models/llama4-scout-instruct-basic",
+    "accounts/fireworks/models/llama4-maverick-instruct-basic",
+    "accounts/fireworks/models/qwen2p5-72b-instruct",
+    "accounts/fireworks/models/qwen2p5-coder-32b-instruct",
+    "accounts/fireworks/models/qwen3-8b",
+    "accounts/fireworks/models/qwen3-32b",
+    "accounts/fireworks/models/deepseek-v3-0324",
+    "accounts/fireworks/models/gemma-2-9b-it",
+    "accounts/fireworks/models/phi-3-vision-128k-instruct",
+}
+
+
+def check_fireworks() -> dict:
+    api_key = get_api_key("FIREWORKS_API_KEY")
+    if not api_key:
+        return {
+            "type": "fireworks",
+            "skipped": True,
+            "reason": "FIREWORKS_API_KEY not set",
+        }
+
+    try:
+        tunable = fetch_fireworks_tunable(api_key)
+    except Exception as e:
+        return {"type": "fireworks", "skipped": True, "reason": str(e)}
+
+    log(f"  Fireworks API reports {len(tunable)} tunable models")
+
+    tunable_ids = {m["id"] for m in tunable}
+
+    in_docs = sorted(tunable_ids & FIREWORKS_DOCUMENTED_MODELS)
+    in_api_only = sorted(tunable_ids - FIREWORKS_DOCUMENTED_MODELS)
+    in_docs_only = sorted(FIREWORKS_DOCUMENTED_MODELS - tunable_ids)
+
+    log(f"  ✅ {len(in_docs)} models in both API and docs")
+    if in_api_only:
+        log(f"  ⚠️  {len(in_api_only)} models in API but NOT in docs (possibly stale):")
+        for m in in_api_only:
+            log(f"     - {m}")
+    if in_docs_only:
+        log(f"  ⚠️  {len(in_docs_only)} models in docs but NOT in API:")
+        for m in in_docs_only:
+            log(f"     - {m}")
+
+    api_only_details = [m for m in tunable if m["id"] in set(in_api_only)]
+
+    return {
+        "type": "fireworks",
+        "total_tunable": len(tunable),
+        "documented_count": len(FIREWORKS_DOCUMENTED_MODELS),
+        "in_both": in_docs,
+        "in_api_only": api_only_details,
+        "in_docs_only": in_docs_only,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check fine-tunable model availability"
+    )
+    parser.add_argument(
+        "mode",
+        choices=["static", "fireworks", "all"],
+        help="Which check to run",
+    )
+    args = parser.parse_args()
+
+    results = {}
+
+    if args.mode in ("static", "all"):
+        log("Checking static provider_finetune_id entries...")
+        results["static"] = check_static()
+        log()
+
+    if args.mode in ("fireworks", "all"):
+        log("Checking Fireworks dynamic tunable models...")
+        results["fireworks"] = check_fireworks()
+        log()
+
+    json.dump(results, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
+++ b/.agents/skills/kiln-check-finetune-deprecation/scripts/check_finetune.py
@@ -22,7 +22,8 @@ import re
 import sys
 from pathlib import Path
 
-# Add shared scripts directory to path
+# Add shared scripts directory and repo root to path so we can import from
+# provider_utils.py and app.desktop.studio_server.finetune_api
 # Script is at .agents/skills/<skill>/scripts/<file>.py
 # parent chain: scripts -> <skill> -> skills -> .agents
 sys.path.insert(
@@ -38,9 +39,18 @@ from provider_utils import (  # type: ignore[import-not-found]
     log,
 )
 
-MODEL_LIST_PATH = (
-    find_repo_root() / "libs" / "core" / "kiln_ai" / "adapters" / "ml_model_list.py"
+REPO_ROOT = find_repo_root()
+sys.path.insert(0, str(REPO_ROOT))
+
+from app.desktop.studio_server.finetune_api import (  # noqa: E402  # type: ignore[import-not-found]
+    FIREWORKS_SUPPORTED_FINETUNE_MODELS,
 )
+
+MODEL_LIST_PATH = (
+    REPO_ROOT / "libs" / "core" / "kiln_ai" / "adapters" / "ml_model_list.py"
+)
+
+FIREWORKS_MODEL_PREFIX = "accounts/fireworks/models/"
 
 
 # ---------------------------------------------------------------------------
@@ -188,31 +198,18 @@ def check_static() -> dict:
 # Fireworks dynamic model check
 # ---------------------------------------------------------------------------
 
-# Known supported base models from Fireworks docs.
-# Hardcoded because Fireworks' API `tunable` flag is unreliable — it marks ~167
-# models as tunable when only ~15 are actually supported for fine-tuning. The docs
-# page is the real source of truth, but it's HTML (not a structured API), so we
-# maintain this list manually. Update it when Fireworks changes their supported models.
-#
-# Last updated: 2026-05-13
-# Source: https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro#supported-base-models
-FIREWORKS_DOCUMENTED_MODELS = {
-    "accounts/fireworks/models/llama-v3p1-8b-instruct",
-    "accounts/fireworks/models/llama-v3p1-70b-instruct",
-    "accounts/fireworks/models/llama-v3p1-405b-instruct",
-    "accounts/fireworks/models/llama-v3p2-1b-instruct",
-    "accounts/fireworks/models/llama-v3p2-3b-instruct",
-    "accounts/fireworks/models/llama-v3p3-70b-instruct",
-    "accounts/fireworks/models/llama4-scout-instruct-basic",
-    "accounts/fireworks/models/llama4-maverick-instruct-basic",
-    "accounts/fireworks/models/qwen2p5-72b-instruct",
-    "accounts/fireworks/models/qwen2p5-coder-32b-instruct",
-    "accounts/fireworks/models/qwen3-8b",
-    "accounts/fireworks/models/qwen3-32b",
-    "accounts/fireworks/models/deepseek-v3-0324",
-    "accounts/fireworks/models/gemma-2-9b-it",
-    "accounts/fireworks/models/phi-3-vision-128k-instruct",
-}
+
+def _fireworks_supported_full_paths() -> set[str]:
+    """Build full Fireworks model paths from the canonical allowlist in finetune_api.py.
+
+    The allowlist uses bare tail IDs (e.g. "qwen3-8b") but the Fireworks API
+    returns full paths (e.g. "accounts/fireworks/models/qwen3-8b"). This function
+    prepends the prefix so we can cross-reference.
+    """
+    return {
+        f"{FIREWORKS_MODEL_PREFIX}{tail}"
+        for tail in FIREWORKS_SUPPORTED_FINETUNE_MODELS
+    }
 
 
 def check_fireworks() -> dict:
@@ -231,20 +228,23 @@ def check_fireworks() -> dict:
 
     log(f"  Fireworks API reports {len(tunable)} tunable models")
 
+    supported = _fireworks_supported_full_paths()
     tunable_ids = {m["id"] for m in tunable}
 
-    in_docs = sorted(tunable_ids & FIREWORKS_DOCUMENTED_MODELS)
-    in_api_only = sorted(tunable_ids - FIREWORKS_DOCUMENTED_MODELS)
-    in_docs_only = sorted(FIREWORKS_DOCUMENTED_MODELS - tunable_ids)
+    in_both = sorted(tunable_ids & supported)
+    in_api_only = sorted(tunable_ids - supported)
+    in_supported_only = sorted(supported - tunable_ids)
 
-    log(f"  ✅ {len(in_docs)} models in both API and docs")
+    log(f"  ✅ {len(in_both)} models in both API and allowlist")
     if in_api_only:
-        log(f"  ⚠️  {len(in_api_only)} models in API but NOT in docs (possibly stale):")
+        log(
+            f"  ⚠️  {len(in_api_only)} models in API but NOT in allowlist (possibly stale):"
+        )
         for m in in_api_only:
             log(f"     - {m}")
-    if in_docs_only:
-        log(f"  ⚠️  {len(in_docs_only)} models in docs but NOT in API:")
-        for m in in_docs_only:
+    if in_supported_only:
+        log(f"  ⚠️  {len(in_supported_only)} models in allowlist but NOT in API:")
+        for m in in_supported_only:
             log(f"     - {m}")
 
     api_only_details = [m for m in tunable if m["id"] in set(in_api_only)]
@@ -252,10 +252,10 @@ def check_fireworks() -> dict:
     return {
         "type": "fireworks",
         "total_tunable": len(tunable),
-        "documented_count": len(FIREWORKS_DOCUMENTED_MODELS),
-        "in_both": in_docs,
+        "supported_count": len(supported),
+        "in_both": in_both,
         "in_api_only": api_only_details,
-        "in_docs_only": in_docs_only,
+        "in_supported_only": in_supported_only,
     }
 
 

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -3221,6 +3221,7 @@ built_in_models: List[KilnModel] = [
                 model_id="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
                 supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
+                provider_finetune_id="meta-llama/Meta-Llama-3.1-8B-Instruct-Reference",
                 # Constrained decode? They make function calling work when no one else does!
             ),
             KilnModelProvider(
@@ -3278,6 +3279,7 @@ built_in_models: List[KilnModel] = [
                 model_id="meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
                 supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
+                provider_finetune_id="meta-llama/Meta-Llama-3.1-70B-Instruct-Reference",
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -3221,7 +3221,6 @@ built_in_models: List[KilnModel] = [
                 model_id="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
                 supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
-                provider_finetune_id="meta-llama/Meta-Llama-3.1-8B-Instruct-Reference",
                 # Constrained decode? They make function calling work when no one else does!
             ),
             KilnModelProvider(
@@ -3279,7 +3278,6 @@ built_in_models: List[KilnModel] = [
                 model_id="meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
                 supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
-                provider_finetune_id="meta-llama/Meta-Llama-3.1-70B-Instruct-Reference",
             ),
         ],
     ),


### PR DESCRIPTION
## What does this PR do?

Add bew skill to check if our fine-tunable models are still actually supported by providers.

- Extracted shared provider API utils from Mike's `check_provider.py` into `provider_utils.py` so both skills reuse the same code
- New `kiln-check-finetune-deprecation` skill checks static provider_finetune_id entries (OpenAI, Together,
  Vertex) and cross-refs Fireworks tunable models against their docs
- Fixed Gemini API key leak, was in URL query param, now uses header
- Audit results: Together has 2 dead Llama 3.1 fine-tune IDs, Fireworks API reports 167 tunable models but only 11 are in their docs. OpenAI and Vertex are clean.
- Removed 2 dead models for Together for finetune. Will do fireworks in a separate PR. 

## Related Issues

<!--- Link to related issues. For example: "Fixes: https://github.com/Kiln-AI/Kiln/issues/12345" -->

## Contributor License Agreement

I, @<your-github-username>, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
