### PR TITLE
Add Hide/Show button for evals on the compare screen

### DIFF
--- a/app/web_ui/src/lib/ui/floating_menu.svelte
+++ b/app/web_ui/src/lib/ui/floating_menu.svelte
@@ -104,28 +104,34 @@
       <Float {placement} strategy="fixed">
         <ul class="menu bg-base-100 rounded-box p-2 shadow z-[1] {width}">
           {#each visibleItems as item}
-            <li>
-              {#if item.href}
-                <a
-                  href={item.href}
-                  target={item.target}
-                  rel={item.rel}
-                  on:click|stopPropagation={() => {
-                    item.onclick?.()
-                    close()
-                  }}
-                >
-                  {item.label}
-                </a>
-              {:else}
-                <button
-                  type="button"
-                  on:click={(e) => handleItemClick(e, item)}
-                >
-                  {item.label}
-                </button>
-              {/if}
-            </li>
+            {#if item.header}
+              <li class="menu-title">
+                <span>{item.label}</span>
+              </li>
+            {:else}
+              <li>
+                {#if item.href}
+                  <a
+                    href={item.href}
+                    target={item.target}
+                    rel={item.rel}
+                    on:click|stopPropagation={() => {
+                      item.onclick?.()
+                      close()
+                    }}
+                  >
+                    {item.label}
+                  </a>
+                {:else}
+                  <button
+                    type="button"
+                    on:click={(e) => handleItemClick(e, item)}
+                  >
+                    {item.label}
+                  </button>
+                {/if}
+              </li>
+            {/if}
           {/each}
         </ul>
       </Float>

--- a/app/web_ui/src/lib/ui/floating_menu_types.ts
+++ b/app/web_ui/src/lib/ui/floating_menu_types.ts
@@ -5,4 +5,5 @@ export type FloatingMenuItem = {
   rel?: string
   onclick?: () => void
   hidden?: boolean
+  header?: boolean
 }

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -98,13 +98,14 @@
     // Initialize selectedModels array with correct length
     selectedModels = new Array(columns).fill(null)
 
-    // Hidden evals can be restored before run configs are loaded - they are just IDs
+    // Hidden evals can be restored before run configs are loaded - they are just IDs.
+    // Defensive: drop the cost section ID in case a hand-edited URL sneaks it in.
     const urlHidden = urlParams.get("hidden_evals")
     if (urlHidden) {
       hiddenEvalIds = urlHidden
         .split(",")
         .map((id) => id.trim())
-        .filter((id) => id.length > 0)
+        .filter((id) => id.length > 0 && id !== "kiln_cost_section")
     }
   }
 
@@ -367,18 +368,15 @@
   )
 
   // Names of currently-hidden evals (used for the "show hidden" dropdown).
-  // Prefer chartComparisonFeatures so we still show names when no models are selected.
+  // chartComparisonFeatures is built from ALL run configs for the task and is a
+  // superset of comparisonFeatures (which only covers selected models), so it
+  // alone is enough to resolve display names.
   $: hiddenEvalsInfo = hiddenEvalIds
+    .filter((id) => id !== "kiln_cost_section")
     .map((evalId) => {
-      const fromChart = chartComparisonFeatures.find(
-        (s) => s.eval_id === evalId,
-      )
-      const fromSelected = comparisonFeatures.find((s) => s.eval_id === evalId)
-      const category =
-        fromChart?.category ?? fromSelected?.category ?? "Unknown eval"
-      return { eval_id: evalId, category }
+      const feature = chartComparisonFeatures.find((s) => s.eval_id === evalId)
+      return { eval_id: evalId, category: feature?.category ?? "Unknown eval" }
     })
-    .filter((info) => info.eval_id !== "kiln_cost_section")
 
   function hideEval(evalId: string) {
     if (evalId === "kiln_cost_section") return

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -99,13 +99,17 @@
     selectedModels = new Array(columns).fill(null)
 
     // Hidden evals can be restored before run configs are loaded - they are just IDs.
-    // Defensive: drop the cost section ID in case a hand-edited URL sneaks it in.
+    // Defensive: drop the cost section ID + dedupe in case a hand-edited URL is messy.
     const urlHidden = urlParams.get("hidden_evals")
     if (urlHidden) {
-      hiddenEvalIds = urlHidden
-        .split(",")
-        .map((id) => id.trim())
-        .filter((id) => id.length > 0 && id !== "kiln_cost_section")
+      hiddenEvalIds = [
+        ...new Set(
+          urlHidden
+            .split(",")
+            .map((id) => id.trim())
+            .filter((id) => id.length > 0 && id !== "kiln_cost_section"),
+        ),
+      ]
     }
   }
 
@@ -392,15 +396,17 @@
     hiddenEvalIds = []
   }
 
+  // Item styling (all-caps, right-aligned, divider before "Show all hidden")
+  // is handled by the scoped style block at the bottom of this component.
   $: hiddenEvalsMenuItems = [
     ...hiddenEvalsInfo.map(
       (info): FloatingMenuItem => ({
-        label: `Show: ${info.category}`,
+        label: info.category,
         onclick: () => showEval(info.eval_id),
       }),
     ),
     ...(hiddenEvalsInfo.length > 1
-      ? [{ label: "Show all", onclick: showAllHiddenEvals }]
+      ? [{ label: "Show all hidden", onclick: showAllHiddenEvals }]
       : []),
   ] as FloatingMenuItem[]
 
@@ -772,17 +778,17 @@
         <!-- Table action buttons - positioned above table on the right -->
         <div class="flex justify-end gap-2 mb-4">
           {#if hiddenEvalsInfo.length > 0}
-            <FloatingMenu items={hiddenEvalsMenuItems} width="w-72">
-              <button
-                slot="trigger"
-                type="button"
-                class="btn btn-sm btn-outline"
-              >
-                {hiddenEvalsInfo.length} eval{hiddenEvalsInfo.length === 1
-                  ? ""
-                  : "s"} hidden
-              </button>
-            </FloatingMenu>
+            <div class="hidden-evals-dropdown">
+              <FloatingMenu items={hiddenEvalsMenuItems} width="w-72">
+                <button
+                  slot="trigger"
+                  type="button"
+                  class="btn btn-sm btn-outline"
+                >
+                  Hidden Evals ({hiddenEvalsInfo.length})
+                </button>
+              </FloatingMenu>
+            </div>
           {/if}
           {#if columns < MAX_COLUMNS}
             <button
@@ -1189,3 +1195,27 @@
     }
   }}
 />
+
+<style>
+  /* Style FloatingMenu items to match the all-caps eval section headers below.
+     Uses :global() because the menu list lives inside FloatingMenu's slot. */
+  .hidden-evals-dropdown :global(ul.menu li > button),
+  .hidden-evals-dropdown :global(ul.menu li > a) {
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.025em;
+    color: rgb(17 24 39);
+    text-align: right;
+    justify-content: end;
+    justify-items: end;
+  }
+
+  /* Divider between the eval list and the "Show all hidden" footer item.
+     :not(:only-child) keeps this off when there's only one hidden eval. */
+  .hidden-evals-dropdown :global(ul.menu li:not(:only-child):last-child) {
+    border-top: 1px solid rgb(229 231 235);
+    margin-top: 0.25rem;
+    padding-top: 0.25rem;
+  }
+</style>

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -396,9 +396,8 @@
     hiddenEvalIds = []
   }
 
-  // Item styling (all-caps, right-aligned, divider before "Show all hidden")
-  // is handled by the scoped style block at the bottom of this component.
   $: hiddenEvalsMenuItems = [
+    { label: "Show Eval", header: true },
     ...hiddenEvalsInfo.map(
       (info): FloatingMenuItem => ({
         label: info.category,
@@ -406,7 +405,7 @@
       }),
     ),
     ...(hiddenEvalsInfo.length > 1
-      ? [{ label: "Show all hidden", onclick: showAllHiddenEvals }]
+      ? [{ label: "Show All", onclick: showAllHiddenEvals }]
       : []),
   ] as FloatingMenuItem[]
 
@@ -1197,25 +1196,38 @@
 />
 
 <style>
-  /* Style FloatingMenu items to match the all-caps eval section headers below.
-     Uses :global() because the menu list lives inside FloatingMenu's slot. */
   .hidden-evals-dropdown :global(ul.menu li > button),
   .hidden-evals-dropdown :global(ul.menu li > a) {
     font-size: 0.875rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.025em;
+    font-weight: 500;
     color: rgb(17 24 39);
-    text-align: right;
-    justify-content: end;
-    justify-items: end;
   }
 
-  /* Divider between the eval list and the "Show all hidden" footer item.
-     :not(:only-child) keeps this off when there's only one hidden eval. */
-  .hidden-evals-dropdown :global(ul.menu li:not(:only-child):last-child) {
-    border-top: 1px solid rgb(229 231 235);
-    margin-top: 0.25rem;
-    padding-top: 0.25rem;
+  /* Render a gray "+" prefix on eval rows only. Excludes the header
+     (first-child) and the "Restore All" footer (last-child at position 4+). */
+  .hidden-evals-dropdown
+    :global(
+      ul.menu
+        li:not(:first-child):not(:last-child:nth-child(n + 4))
+        > button::before
+    ) {
+    content: "+";
+    color: rgb(107 114 128);
+    margin-right: 0.375rem;
+    font-weight: 400;
+  }
+
+  /* "Restore All" footer styling — gray-500. */
+  .hidden-evals-dropdown
+    :global(ul.menu li:last-child:nth-child(n + 4) > button) {
+    color: rgb(107 114 128);
+  }
+
+  /* Divider before the "Show all hidden" footer. nth-child(n+4) ensures we
+     only render it when the list has header + 2+ evals + show-all footer. */
+  .hidden-evals-dropdown :global(ul.menu li:last-child:nth-child(n + 4)) {
+    border-top: 1px solid rgb(209 213 219);
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
   }
 </style>

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -40,6 +40,8 @@
   import CreateNewRunConfigDialog from "$lib/ui/run_config_component/create_new_run_config_dialog.svelte"
   import SavedRunConfigurationsDropdown from "$lib/ui/run_config_component/saved_run_configs_dropdown.svelte"
   import RunEval from "$lib/components/run_eval.svelte"
+  import FloatingMenu from "$lib/ui/floating_menu.svelte"
+  import type { FloatingMenuItem } from "$lib/ui/floating_menu_types"
 
   import { agentInfo } from "$lib/agent"
   $: project_id = $page.params.project_id!
@@ -387,6 +389,18 @@
   function showAllHiddenEvals() {
     hiddenEvalIds = []
   }
+
+  $: hiddenEvalsMenuItems = [
+    ...hiddenEvalsInfo.map(
+      (info): FloatingMenuItem => ({
+        label: `Show: ${info.category}`,
+        onclick: () => showEval(info.eval_id),
+      }),
+    ),
+    ...(hiddenEvalsInfo.length > 1
+      ? [{ label: "Show all", onclick: showAllHiddenEvals }]
+      : []),
+  ] as FloatingMenuItem[]
 
   // Reactively fetch eval templates for sections
   $: {
@@ -756,73 +770,17 @@
         <!-- Table action buttons - positioned above table on the right -->
         <div class="flex justify-end gap-2 mb-4">
           {#if hiddenEvalsInfo.length > 0}
-            <div class="dropdown dropdown-end">
-              <!-- svelte-ignore a11y-label-has-associated-control -->
-              <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-              <label tabindex="0" class="btn btn-sm btn-outline gap-2">
-                <svg
-                  class="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                  />
-                </svg>
+            <FloatingMenu items={hiddenEvalsMenuItems} width="w-72">
+              <button
+                slot="trigger"
+                type="button"
+                class="btn btn-sm btn-outline"
+              >
                 {hiddenEvalsInfo.length} eval{hiddenEvalsInfo.length === 1
                   ? ""
                   : "s"} hidden
-                <svg
-                  class="w-3 h-3"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
-              </label>
-              <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
-              <ul
-                tabindex="0"
-                class="dropdown-content menu menu-sm p-2 shadow bg-base-100 rounded-box w-72 z-10 border border-gray-200"
-              >
-                <li class="menu-title">
-                  <span class="text-xs">Hidden evals</span>
-                </li>
-                {#each hiddenEvalsInfo as info}
-                  <li>
-                    <button
-                      on:click={() => showEval(info.eval_id)}
-                      class="flex items-center justify-between gap-2"
-                    >
-                      <span class="truncate flex-1 text-left">
-                        {info.category}
-                      </span>
-                      <span class="text-xs text-primary">Show</span>
-                    </button>
-                  </li>
-                {/each}
-                {#if hiddenEvalsInfo.length > 1}
-                  <li class="border-t border-gray-200 mt-1 pt-1">
-                    <button
-                      on:click={showAllHiddenEvals}
-                      class="text-primary font-medium"
-                    >
-                      Show all
-                    </button>
-                  </li>
-                {/if}
-              </ul>
-            </div>
+              </button>
+            </FloatingMenu>
           {/if}
           {#if columns < MAX_COLUMNS}
             <button
@@ -955,23 +913,10 @@
                 {#if section.eval_id !== "kiln_cost_section"}
                   <button
                     on:click={() => hideEval(section.eval_id)}
-                    class="text-xs text-gray-500 hover:text-gray-900 flex items-center gap-1 px-2 py-1 rounded hover:bg-gray-200 transition-colors"
-                    title="Hide this eval from the comparison"
+                    class="w-6 h-6 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 transition-colors"
+                    title="Hide this eval"
                   >
-                    <svg
-                      class="w-3.5 h-3.5"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                      />
-                    </svg>
-                    Hide
+                    ✕
                   </button>
                 {/if}
               </div>

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -342,25 +342,29 @@
     eval_scores_cache,
   )
 
-  // Filter out user-hidden evals (cost section is never hideable).
-  // hiddenEvalIds is referenced directly in these reactive statements so that
-  // Svelte tracks it as a dependency and re-runs the filter when it changes.
-  $: visibleComparisonFeatures =
-    hiddenEvalIds.length === 0
-      ? comparisonFeatures
-      : comparisonFeatures.filter(
-          (section) =>
-            section.eval_id === "kiln_cost_section" ||
-            !hiddenEvalIds.includes(section.eval_id),
-        )
-  $: visibleChartComparisonFeatures =
-    hiddenEvalIds.length === 0
-      ? chartComparisonFeatures
-      : chartComparisonFeatures.filter(
-          (section) =>
-            section.eval_id === "kiln_cost_section" ||
-            !hiddenEvalIds.includes(section.eval_id),
-        )
+  // Filter out user-hidden evals (cost section is never hideable). hiddenEvalIds is
+  // passed in as a parameter (rather than read via closure) so that Svelte's reactive
+  // `$:` statements track it as a dependency and re-run when it changes.
+  function filterVisibleFeatures<T extends { eval_id: string }>(
+    features: T[],
+    hidden: string[],
+  ): T[] {
+    if (hidden.length === 0) return features
+    return features.filter(
+      (section) =>
+        section.eval_id === "kiln_cost_section" ||
+        !hidden.includes(section.eval_id),
+    )
+  }
+
+  $: visibleComparisonFeatures = filterVisibleFeatures(
+    comparisonFeatures,
+    hiddenEvalIds,
+  )
+  $: visibleChartComparisonFeatures = filterVisibleFeatures(
+    chartComparisonFeatures,
+    hiddenEvalIds,
+  )
 
   // Names of currently-hidden evals (used for the "show hidden" dropdown).
   // Prefer chartComparisonFeatures so we still show names when no models are selected.

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -53,6 +53,7 @@
   // State management
   let columns = 2 // Start with 2 columns
   let selectedModels: (string | null)[] = [null, null] // Track selected model for each column
+  let hiddenEvalIds: string[] = [] // Eval IDs hidden by the user (kiln_cost_section is never hideable)
 
   // Run configs state
   let loading_run_configs = true
@@ -94,6 +95,15 @@
 
     // Initialize selectedModels array with correct length
     selectedModels = new Array(columns).fill(null)
+
+    // Hidden evals can be restored before run configs are loaded - they are just IDs
+    const urlHidden = urlParams.get("hidden_evals")
+    if (urlHidden) {
+      hiddenEvalIds = urlHidden
+        .split(",")
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0)
+    }
   }
 
   // Restore model selections from URL after data is loaded
@@ -137,13 +147,20 @@
     )
     urlParams.set("models", modelIds.join(","))
 
+    // Update hidden evals (omit param when none are hidden to keep URL clean)
+    if (hiddenEvalIds.length > 0) {
+      urlParams.set("hidden_evals", hiddenEvalIds.join(","))
+    } else {
+      urlParams.delete("hidden_evals")
+    }
+
     // Use replace to avoid creating new history entries
     const newURL = `${$page.url.pathname}?${urlParams.toString()}`
     goto(newURL, { replaceState: true })
   }
 
   // Reactive statements to update URL when state changes
-  $: if (!isInitializing && (columns || selectedModels)) {
+  $: if (!isInitializing && (columns || selectedModels || hiddenEvalIds)) {
     updateURL()
   }
 
@@ -322,6 +339,54 @@
     allRunConfigIds,
     eval_scores_cache,
   )
+
+  // Filter out user-hidden evals (cost section is never hideable).
+  // hiddenEvalIds is referenced directly in these reactive statements so that
+  // Svelte tracks it as a dependency and re-runs the filter when it changes.
+  $: visibleComparisonFeatures =
+    hiddenEvalIds.length === 0
+      ? comparisonFeatures
+      : comparisonFeatures.filter(
+          (section) =>
+            section.eval_id === "kiln_cost_section" ||
+            !hiddenEvalIds.includes(section.eval_id),
+        )
+  $: visibleChartComparisonFeatures =
+    hiddenEvalIds.length === 0
+      ? chartComparisonFeatures
+      : chartComparisonFeatures.filter(
+          (section) =>
+            section.eval_id === "kiln_cost_section" ||
+            !hiddenEvalIds.includes(section.eval_id),
+        )
+
+  // Names of currently-hidden evals (used for the "show hidden" dropdown).
+  // Prefer chartComparisonFeatures so we still show names when no models are selected.
+  $: hiddenEvalsInfo = hiddenEvalIds
+    .map((evalId) => {
+      const fromChart = chartComparisonFeatures.find(
+        (s) => s.eval_id === evalId,
+      )
+      const fromSelected = comparisonFeatures.find((s) => s.eval_id === evalId)
+      const category =
+        fromChart?.category ?? fromSelected?.category ?? "Unknown eval"
+      return { eval_id: evalId, category }
+    })
+    .filter((info) => info.eval_id !== "kiln_cost_section")
+
+  function hideEval(evalId: string) {
+    if (evalId === "kiln_cost_section") return
+    if (hiddenEvalIds.includes(evalId)) return
+    hiddenEvalIds = [...hiddenEvalIds, evalId]
+  }
+
+  function showEval(evalId: string) {
+    hiddenEvalIds = hiddenEvalIds.filter((id) => id !== evalId)
+  }
+
+  function showAllHiddenEvals() {
+    hiddenEvalIds = []
+  }
 
   // Reactively fetch eval templates for sections
   $: {
@@ -688,8 +753,77 @@
           <div class="text-gray-600">Loading evaluation scores...</div>
         </div>
       {:else}
-        <!-- Add Column Button - positioned above table on the right -->
-        <div class="flex justify-end mb-4">
+        <!-- Table action buttons - positioned above table on the right -->
+        <div class="flex justify-end gap-2 mb-4">
+          {#if hiddenEvalsInfo.length > 0}
+            <div class="dropdown dropdown-end">
+              <!-- svelte-ignore a11y-label-has-associated-control -->
+              <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+              <label tabindex="0" class="btn btn-sm btn-outline gap-2">
+                <svg
+                  class="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                  />
+                </svg>
+                {hiddenEvalsInfo.length} eval{hiddenEvalsInfo.length === 1
+                  ? ""
+                  : "s"} hidden
+                <svg
+                  class="w-3 h-3"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </label>
+              <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
+              <ul
+                tabindex="0"
+                class="dropdown-content menu menu-sm p-2 shadow bg-base-100 rounded-box w-72 z-10 border border-gray-200"
+              >
+                <li class="menu-title">
+                  <span class="text-xs">Hidden evals</span>
+                </li>
+                {#each hiddenEvalsInfo as info}
+                  <li>
+                    <button
+                      on:click={() => showEval(info.eval_id)}
+                      class="flex items-center justify-between gap-2"
+                    >
+                      <span class="truncate flex-1 text-left">
+                        {info.category}
+                      </span>
+                      <span class="text-xs text-primary">Show</span>
+                    </button>
+                  </li>
+                {/each}
+                {#if hiddenEvalsInfo.length > 1}
+                  <li class="border-t border-gray-200 mt-1 pt-1">
+                    <button
+                      on:click={showAllHiddenEvals}
+                      class="text-primary font-medium"
+                    >
+                      Show all
+                    </button>
+                  </li>
+                {/if}
+              </ul>
+            </div>
+          {/if}
           {#if columns < MAX_COLUMNS}
             <button
               on:click={addColumn}
@@ -808,14 +942,38 @@
 
           <!-- Comparison Data - only show if models are selected -->
           {#if validSelectedModels.length > 0}
-            {#each comparisonFeatures as section}
+            {#each visibleComparisonFeatures as section}
               <!-- Section Header -->
-              <div class="bg-gray-50 px-6 py-3 border-b border-gray-200">
+              <div
+                class="bg-gray-50 px-6 py-3 border-b border-gray-200 flex items-center justify-between gap-2"
+              >
                 <h4
                   class="text-sm font-semibold text-gray-900 uppercase tracking-wide"
                 >
                   {section.category}
                 </h4>
+                {#if section.eval_id !== "kiln_cost_section"}
+                  <button
+                    on:click={() => hideEval(section.eval_id)}
+                    class="text-xs text-gray-500 hover:text-gray-900 flex items-center gap-1 px-2 py-1 rounded hover:bg-gray-200 transition-colors"
+                    title="Hide this eval from the comparison"
+                  >
+                    <svg
+                      class="w-3.5 h-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                      />
+                    </svg>
+                    Hide
+                  </button>
+                {/if}
               </div>
 
               {#if section.items.length == 0}
@@ -1032,7 +1190,7 @@
         {#if validSelectedModels.length > 0}
           <div class="mt-16">
             <CompareRadarChart
-              {comparisonFeatures}
+              comparisonFeatures={visibleComparisonFeatures}
               {getModelValueRaw}
               run_configs={current_task_run_configs || []}
               model_info={$model_info}
@@ -1046,7 +1204,7 @@
 
         <div class="mt-16">
           <CompareChart
-            comparisonFeatures={chartComparisonFeatures}
+            comparisonFeatures={visibleChartComparisonFeatures}
             {getModelValueRaw}
             run_configs={current_task_run_configs || []}
             model_info={$model_info}


### PR DESCRIPTION
## Summary

Adds a per-eval Hide button on the spec/eval compare screen, plus a "N evals hidden" dropdown to restore individual evals or show all. Hidden eval IDs persist in the URL (`?hidden_evals=...`) so the view stays shareable, and the filter applies to the table, radar chart, and bar chart.

Uses the existing `FloatingMenu` primitive (per `frontend_controls.md`, which calls out that DaisyUI's `dropdown-content` breaks inside tables/scroll areas) and the file's existing `✕` button pattern from "Remove column" to keep new code minimal.

Little x's now on each row
<img width="1258" height="598" alt="Screenshot 2026-05-14 at 12 01 50 PM" src="https://github.com/user-attachments/assets/ecc1264b-6342-4178-9f63-07676ebd8493" />

clicking the x will move them up to a button on the top 
<img width="1258" height="530" alt="Screenshot 2026-05-14 at 12 01 57 PM" src="https://github.com/user-attachments/assets/0417eb34-2b29-4303-a57c-adba78777051" />

dropdown to re-enable them
<img width="1241" height="512" alt="Screenshot 2026-05-14 at 12 02 01 PM" src="https://github.com/user-attachments/assets/942c09c1-fe80-4362-ac6b-cfba1edfefbc" />


## Test plan

- [ ] Open `/specs/<project>/<task>/compare`, click Hide on an eval — table, radar, and bar chart all drop that eval immediately (no refresh required).
- [ ] "N evals hidden" dropdown appears; clicking an entry restores that eval; "Show all" appears when >1 is hidden.
- [ ] URL updates with `hidden_evals=…` and reloading the page preserves the hidden set.
- [ ] Cost section can't be hidden.

Made with [Cursor](https://cursor.com)