### PR TITLE
Filter Fireworks fine-tune dropdown to supported models

### DIFF
--- a/app/desktop/studio_server/finetune_api.py
+++ b/app/desktop/studio_server/finetune_api.py
@@ -798,6 +798,32 @@ def thinking_instructions_from_request(
     return chain_of_thought_prompt(task)
 
 
+# Only models explicitly listed as supported in Fireworks fine-tuning docs:
+# https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro#supported-base-models
+FIREWORKS_SUPPORTED_FINETUNE_MODELS: set[str] = {
+    "gemma-4-26b-a4b-it",
+    "gemma-4-31b-it",
+    "glm-5p1",
+    "kimi-k2p5",
+    "kimi-k2p6",
+    "llama-v3p3-70b-instruct",
+    "minimax-m2p5",
+    "nemotron-nano-3-30b-a3b",
+    "qwen3-235b-a22b-instruct-2507",
+    "qwen3-30b-a3b",
+    "qwen3-30b-a3b-instruct-2507",
+    "qwen3-32b",
+    "qwen3-4b",
+    "qwen3-8b",
+    "qwen3-vl-8b-instruct",
+    "qwen3p5-27b",
+    "qwen3p5-35b-a3b",
+    "qwen3p5-397b-a17b",
+    "qwen3p5-9b",
+    "qwen3p6-27b",
+}
+
+
 async def fetch_fireworks_finetune_models() -> list[FinetuneProviderModel]:
     api_key = Config.shared().fireworks_api_key
     if not api_key:
@@ -841,9 +867,11 @@ async def fetch_fireworks_finetune_models() -> list[FinetuneProviderModel]:
     for model in models:
         if model.get("tunable", False) and "displayName" in model and "name" in model:
             id = model["name"]
+            id_tail = id.split("/")[-1]
+            if id_tail not in FIREWORKS_SUPPORTED_FINETUNE_MODELS:
+                continue
             # Display name is sometimes empty, so use the name from the API name if needed
             display_name = model["displayName"]
-            id_tail = id.split("/")[-1]
             if display_name.strip() == "":
                 name = id_tail
             else:

--- a/app/desktop/studio_server/finetune_api.py
+++ b/app/desktop/studio_server/finetune_api.py
@@ -842,7 +842,10 @@ async def fetch_fireworks_finetune_models() -> list[FinetuneProviderModel]:
 
     tuneable_models = []
     for model in models:
-        if model.get("tunable", False) and "displayName" in model and "name" in model:
+        is_supervised_tunable = model.get("supervisedLoraTunable", False) or model.get(
+            "supervisedFullParameterTunable", False
+        )
+        if is_supervised_tunable and "displayName" in model and "name" in model:
             id = model["name"]
             id_tail = id.split("/")[-1]
             if id_tail not in FIREWORKS_SUPPORTED_FINETUNE_MODELS:

--- a/app/desktop/studio_server/finetune_api.py
+++ b/app/desktop/studio_server/finetune_api.py
@@ -15,6 +15,9 @@ from kiln_ai.adapters.fine_tune.dataset_formatter import (
     DatasetFormatter,
 )
 from kiln_ai.adapters.fine_tune.finetune_registry import finetune_registry
+from kiln_ai.adapters.fine_tune.fireworks_finetune import (
+    FIREWORKS_SUPPORTED_FINETUNE_MODELS,
+)
 from kiln_ai.adapters.ml_model_list import (
     KilnModel,
     KilnModelProvider,
@@ -796,32 +799,6 @@ def thinking_instructions_from_request(
 
     # default for this task
     return chain_of_thought_prompt(task)
-
-
-# Only models explicitly listed as supported in Fireworks fine-tuning docs:
-# https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro#supported-base-models
-FIREWORKS_SUPPORTED_FINETUNE_MODELS: set[str] = {
-    "gemma-4-26b-a4b-it",
-    "gemma-4-31b-it",
-    "glm-5p1",
-    "kimi-k2p5",
-    "kimi-k2p6",
-    "llama-v3p3-70b-instruct",
-    "minimax-m2p5",
-    "nemotron-nano-3-30b-a3b",
-    "qwen3-235b-a22b-instruct-2507",
-    "qwen3-30b-a3b",
-    "qwen3-30b-a3b-instruct-2507",
-    "qwen3-32b",
-    "qwen3-4b",
-    "qwen3-8b",
-    "qwen3-vl-8b-instruct",
-    "qwen3p5-27b",
-    "qwen3p5-35b-a3b",
-    "qwen3p5-397b-a17b",
-    "qwen3p5-9b",
-    "qwen3p6-27b",
-}
 
 
 async def fetch_fireworks_finetune_models() -> list[FinetuneProviderModel]:

--- a/app/desktop/studio_server/test_finetune_api.py
+++ b/app/desktop/studio_server/test_finetune_api.py
@@ -1380,15 +1380,21 @@ async def test_fetch_fireworks_finetune_models_success(mock_config, mock_httpx_c
     first_response.json.return_value = {
         "models": [
             {
-                "name": "accounts/fireworks/models/model1",
-                "displayName": "Model One",
+                "name": "accounts/fireworks/models/qwen3-8b",
+                "displayName": "Qwen3 8B",
                 "tunable": True,
                 "supportsTools": True,
             },
             {
-                "name": "accounts/fireworks/models/model2",
-                "displayName": "Model Two",
-                "tunable": False,  # This should be skipped
+                "name": "accounts/fireworks/models/unsupported-model",
+                "displayName": "Unsupported",
+                "tunable": True,  # tunable but not in allowlist
+                "supportsTools": False,
+            },
+            {
+                "name": "accounts/fireworks/models/llama-v3p3-70b-instruct",
+                "displayName": "Llama 3.3 70B",
+                "tunable": False,  # not tunable, should be skipped
                 "supportsTools": False,
             },
         ],
@@ -1400,14 +1406,14 @@ async def test_fetch_fireworks_finetune_models_success(mock_config, mock_httpx_c
     second_response.json.return_value = {
         "models": [
             {
-                "name": "accounts/fireworks/models/model3",
+                "name": "accounts/fireworks/models/gemma-4-26b-a4b-it",
                 "displayName": "",  # Empty display name
                 "tunable": True,
                 "supportsTools": False,
             },
             {
-                "name": "accounts/fireworks/models/model4",
-                "displayName": "Model Four",
+                "name": "accounts/fireworks/models/qwen3-32b",
+                "displayName": "Qwen3 32B",
                 "tunable": True,
                 "supportsTools": True,
             },
@@ -1441,30 +1447,32 @@ async def test_fetch_fireworks_finetune_models_success(mock_config, mock_httpx_c
         "pageToken": "next-page-token",
     }
 
-    # Check the resulting models - should be 3 tunable models
+    # 3 models: qwen3-8b (supported+tunable), gemma-4-26b-a4b-it (supported+tunable), qwen3-32b (supported+tunable)
+    # Excluded: unsupported-model (not in allowlist), llama-v3p3-70b-instruct (not tunable)
     assert len(result) == 3
 
-    # Check model details
-    assert result[0].name == "Model One (model1)"
-    assert result[0].id == "accounts/fireworks/models/model1"
+    assert result[0].name == "Qwen3 8B (qwen3-8b)"
+    assert result[0].id == "accounts/fireworks/models/qwen3-8b"
     assert result[0].supports_function_calling is True
 
-    # Check that model2 (non-tunable) is not included
-    assert all(model.id != "accounts/fireworks/models/model2" for model in result)
-
-    # Check that empty display name is handled correctly
-    # Should use the last part of the id as the name
-    model3 = next(
-        model for model in result if model.id == "accounts/fireworks/models/model3"
+    # unsupported-model is tunable but not in allowlist
+    assert all(
+        model.id != "accounts/fireworks/models/unsupported-model" for model in result
     )
-    assert model3.name == "model3"
-    assert model3.supports_function_calling is False
 
-    # Check model4 has tool support
-    model4 = next(
-        model for model in result if model.id == "accounts/fireworks/models/model4"
+    # Empty display name falls back to the id tail
+    gemma = next(
+        model
+        for model in result
+        if model.id == "accounts/fireworks/models/gemma-4-26b-a4b-it"
     )
-    assert model4.supports_function_calling is True
+    assert gemma.name == "gemma-4-26b-a4b-it"
+    assert gemma.supports_function_calling is False
+
+    qwen32b = next(
+        model for model in result if model.id == "accounts/fireworks/models/qwen3-32b"
+    )
+    assert qwen32b.supports_function_calling is True
 
 
 @pytest.mark.asyncio

--- a/app/desktop/studio_server/test_finetune_api.py
+++ b/app/desktop/studio_server/test_finetune_api.py
@@ -1382,19 +1382,19 @@ async def test_fetch_fireworks_finetune_models_success(mock_config, mock_httpx_c
             {
                 "name": "accounts/fireworks/models/qwen3-8b",
                 "displayName": "Qwen3 8B",
-                "tunable": True,
+                "supervisedLoraTunable": True,
                 "supportsTools": True,
             },
             {
                 "name": "accounts/fireworks/models/unsupported-model",
                 "displayName": "Unsupported",
-                "tunable": True,  # tunable but not in allowlist
+                "supervisedLoraTunable": True,  # supervised-tunable but not in allowlist
                 "supportsTools": False,
             },
             {
                 "name": "accounts/fireworks/models/llama-v3p3-70b-instruct",
                 "displayName": "Llama 3.3 70B",
-                "tunable": False,  # not tunable, should be skipped
+                "supervisedLoraTunable": False,  # not tunable, should be skipped
                 "supportsTools": False,
             },
         ],
@@ -1408,13 +1408,14 @@ async def test_fetch_fireworks_finetune_models_success(mock_config, mock_httpx_c
             {
                 "name": "accounts/fireworks/models/gemma-4-26b-a4b-it",
                 "displayName": "",  # Empty display name
-                "tunable": True,
+                "supervisedFullParameterTunable": True,
                 "supportsTools": False,
             },
             {
                 "name": "accounts/fireworks/models/qwen3-32b",
                 "displayName": "Qwen3 32B",
-                "tunable": True,
+                "supervisedLoraTunable": True,
+                "supervisedFullParameterTunable": True,
                 "supportsTools": True,
             },
         ]
@@ -1447,15 +1448,15 @@ async def test_fetch_fireworks_finetune_models_success(mock_config, mock_httpx_c
         "pageToken": "next-page-token",
     }
 
-    # 3 models: qwen3-8b (supported+tunable), gemma-4-26b-a4b-it (supported+tunable), qwen3-32b (supported+tunable)
-    # Excluded: unsupported-model (not in allowlist), llama-v3p3-70b-instruct (not tunable)
+    # 3 models: qwen3-8b (supported+supervised), gemma-4-26b-a4b-it (supported+supervised), qwen3-32b (supported+supervised)
+    # Excluded: unsupported-model (not in allowlist), llama-v3p3-70b-instruct (not supervised-tunable)
     assert len(result) == 3
 
     assert result[0].name == "Qwen3 8B (qwen3-8b)"
     assert result[0].id == "accounts/fireworks/models/qwen3-8b"
     assert result[0].supports_function_calling is True
 
-    # unsupported-model is tunable but not in allowlist
+    # unsupported-model is supervised-tunable but not in allowlist
     assert all(
         model.id != "accounts/fireworks/models/unsupported-model" for model in result
     )

--- a/libs/core/kiln_ai/adapters/fine_tune/fireworks_finetune.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/fireworks_finetune.py
@@ -18,6 +18,31 @@ from kiln_ai.utils.wandb_utils import AuthenticationError, get_wandb_default_ent
 
 logger = logging.getLogger(__name__)
 
+# Only models explicitly listed as supported in Fireworks fine-tuning docs:
+# https://docs.fireworks.ai/fine-tuning/managed-finetuning-intro#supported-base-models
+FIREWORKS_SUPPORTED_FINETUNE_MODELS: set[str] = {
+    "gemma-4-26b-a4b-it",
+    "gemma-4-31b-it",
+    "glm-5p1",
+    "kimi-k2p5",
+    "kimi-k2p6",
+    "llama-v3p3-70b-instruct",
+    "minimax-m2p5",
+    "nemotron-nano-3-30b-a3b",
+    "qwen3-235b-a22b-instruct-2507",
+    "qwen3-30b-a3b",
+    "qwen3-30b-a3b-instruct-2507",
+    "qwen3-32b",
+    "qwen3-4b",
+    "qwen3-8b",
+    "qwen3-vl-8b-instruct",
+    "qwen3p5-27b",
+    "qwen3p5-35b-a3b",
+    "qwen3p5-397b-a17b",
+    "qwen3p5-9b",
+    "qwen3p6-27b",
+}
+
 # https://docs.fireworks.ai/fine-tuning/fine-tuning-models#supported-base-models-loras-on-serverless
 serverless_models = [
     "accounts/fireworks/models/llama-v3p1-8b-instruct",


### PR DESCRIPTION
## What does this PR do?

Filter Fireworks fine-tune dropdown to documented supported models.

The Fireworks API marks ~167 models as tunable, but only ~20 are actually supported per their docs. This was flooding the fine-tune dropdown with broken/stale options.

Changes:
- Added FIREWORKS_SUPPORTED_FINETUNE_MODELS allowlist in the core lib (fireworks_finetune.py), sourced from Fireworks docs
- Switched from the stale `tunable` API field to `supervisedLoraTunable`/`supervisedFullParameterTunable`, which accurately reflect fine-tuning support
- Filtered API results against the allowlist so only documented models appear
- Allowlist lives in the core lib so the audit skill in #1408 can share it as a single source of truth

<img width="1012" height="365" alt="image" src="https://github.com/user-attachments/assets/fddd7d74-2306-4af2-b6f8-28d8d0a390a3" />
@tawnymanticore @leonardmq seems like there isn't a single source of truth so I let the "doc" be the final filter. 

## Contributor License Agreement

I confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib