### PR TITLE
feat: model relationship configuration override

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -278,7 +278,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List Runs */
+        /**
+         * List Runs
+         * @description For multiturn tasks, only leaf TaskRuns (those that are not the parent of another run via parent_task_run_id) are returned. Intermediate runs in a chain are filtered out. For single-turn tasks this is equivalent to listing every run.
+         */
         get: operations["get_runs_api_projects__project_id__tasks__task_id__runs_get"];
         put?: never;
         /**
@@ -299,7 +302,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List Run Summaries */
+        /**
+         * List Run Summaries
+         * @description For multiturn tasks, only leaf TaskRuns (those that are not the parent of another run via parent_task_run_id) are summarized.
+         */
         get: operations["get_runs_summary_api_projects__project_id__tasks__task_id__runs_summaries_get"];
         put?: never;
         post?: never;
@@ -387,7 +393,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List Run Tags */
+        /**
+         * List Run Tags
+         * @description Counts only include tags from leaf TaskRuns. For multiturn tasks, tags attached to intermediate runs in a chain are not included.
+         */
         get: operations["get_tags_api_projects__project_id__tasks__task_id__tags_get"];
         put?: never;
         post?: never;

--- a/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
@@ -381,7 +381,7 @@ class DatasetFormatter:
         # Generate formatted output with UTF-8 encoding
         with open(output_path, "w", encoding="utf-8") as f:
             for run_id in self.dataset.split_contents[split_name]:
-                task_run = runs_by_id[run_id]
+                task_run = runs_by_id.get(run_id)
                 if task_run is None:
                     raise ValueError(
                         f"Task run {run_id} not found. This is required by this dataset."

--- a/libs/core/kiln_ai/adapters/model_adapters/test_saving_adapter_results.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_saving_adapter_results.py
@@ -457,7 +457,7 @@ def test_generate_run_with_parent_task_run_sets_parent_task_run_id(test_task, ad
     new_run.save_to_file()
 
     reloaded_task = Task.load_from_file(test_task.path)
-    task_runs = reloaded_task.runs()
+    task_runs = reloaded_task.runs(include_intermediate_runs=True)
     assert len(task_runs) == 2
     by_id = {r.id: r for r in task_runs}
     assert by_id[prior_run.id].parent_task_run_id is None
@@ -557,7 +557,7 @@ async def test_invoke_with_parent_task_run_saves_under_task_with_link(
     assert new_run.parent_task_run_id == prior_run.id
 
     reloaded_task = Task.load_from_file(test_task.path)
-    task_runs = reloaded_task.runs()
+    task_runs = reloaded_task.runs(include_intermediate_runs=True)
     assert len(task_runs) == 2
     by_id = {r.id: r for r in task_runs}
     assert by_id[new_run.id].output.output == "More details!"

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -791,22 +791,60 @@ class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
     @classmethod
     def __init_subclass__(
         cls,
-        parent_of: Dict[str, "Type[KilnParentedModel] | ParentOfRelationship"],
+        parent_of: Dict[str, Type[KilnParentedModel] | ParentOfRelationship],
         **kwargs,
     ):
         super().__init_subclass__(**kwargs)
         cls._parent_of = parent_of
+
+        # Reject duplicate child-class registration. `_create_parent_methods`
+        # writes `relationship_name` / `parent_type` onto the child class
+        # itself, so two entries pointing at the same child would silently
+        # overwrite each other - and every on-disk lookup that goes through
+        # `cls.relationship_name()` would target whichever filesystem name was
+        # registered last. That is a corruption-class bug; fail loudly here.
+        seen_child_classes: Dict[Type[KilnParentedModel], str] = {}
+        # Reject filesystem-name collisions. Two relationships writing to the
+        # same on-disk folder would interleave their files and load each
+        # other's children. Same corruption class.
+        seen_filesystem_names: Dict[str, str] = {}
+        filesystem_name_to_python_name: Dict[str, str] = {}
         for python_name, value in parent_of.items():
             child_class: Type[KilnParentedModel]
             filesystem_name: str
             if isinstance(value, ParentOfRelationship):
                 child_class = value.model
                 filesystem_name = value.filesystem_name
+                filesystem_name_to_python_name[filesystem_name] = python_name
             else:
                 child_class = value
                 filesystem_name = python_name
+
+            if child_class in seen_child_classes:
+                raise ValueError(
+                    f"parent_of for {cls.__name__} registers child class "
+                    f"{child_class.__name__} twice (under '{seen_child_classes[child_class]}' "
+                    f"and '{python_name}'). A child class can only appear once - it "
+                    f"holds a single `relationship_name()` / `parent_type()` pair."
+                )
+            seen_child_classes[child_class] = python_name
+
+            if filesystem_name in seen_filesystem_names:
+                raise ValueError(
+                    f"parent_of for {cls.__name__} registers filesystem folder "
+                    f"'{filesystem_name}' twice (under '{seen_filesystem_names[filesystem_name]}' "
+                    f"and '{python_name}'). Each on-disk folder must belong to "
+                    f"exactly one relationship."
+                )
+            seen_filesystem_names[filesystem_name] = python_name
+
             cls._create_child_method(python_name, child_class)
             cls._create_parent_methods(child_class, filesystem_name)
+
+        # Cache the reverse-lookup used by the misuse safeguard in
+        # `_validate_nested`; this is a pure function of `_parent_of` and
+        # never changes after class definition.
+        cls._filesystem_name_to_python_name = filesystem_name_to_python_name
 
     @classmethod
     def validate_and_save_with_subrelations(
@@ -845,6 +883,19 @@ class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
         # Collect all validation errors so we can report them all at once
         validation_errors = []
 
+        # Reject misuse of a relationship's on-disk folder name as a payload
+        # key before any side-effects. ``_parent_of`` is set at class-definition
+        # time, so this check depends only on ``data`` and ``cls`` - running it
+        # before ``save_to_file`` guarantees no half-saved parent on misuse.
+        for key in data:
+            if key not in cls._parent_of and key in cls._filesystem_name_to_python_name:
+                python_name = cls._filesystem_name_to_python_name[key]
+                raise ValueError(
+                    f"Nested payload key '{key}' matches the on-disk folder name "
+                    f"of relationship '{python_name}'. Use the Python attribute "
+                    f"name '{python_name}' instead."
+                )
+
         try:
             instance = cls.model_validate(data)
             if path is not None:
@@ -858,24 +909,7 @@ class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
             for suberror in e.errors():
                 validation_errors.append(suberror)
 
-        # Map on-disk folder names back to their Python attribute name for any
-        # ParentOfRelationship entries, so we can detect mistaken use of the
-        # filesystem name as a data key and fail loudly instead of silently
-        # dropping the nested payload.
-        filesystem_name_to_python_name: Dict[str, str] = {
-            value.filesystem_name: python_name
-            for python_name, value in cls._parent_of.items()
-            if isinstance(value, ParentOfRelationship)
-        }
-
         for key, value_list in data.items():
-            if key not in cls._parent_of and key in filesystem_name_to_python_name:
-                python_name = filesystem_name_to_python_name[key]
-                raise ValueError(
-                    f"Nested payload key '{key}' matches the on-disk folder name "
-                    f"of relationship '{python_name}'. Use the Python attribute "
-                    f"name '{python_name}' instead."
-                )
             if key in cls._parent_of:
                 parent_type_or_rel = cls._parent_of[key]
                 if isinstance(parent_type_or_rel, ParentOfRelationship):

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -858,7 +858,24 @@ class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
             for suberror in e.errors():
                 validation_errors.append(suberror)
 
+        # Map on-disk folder names back to their Python attribute name for any
+        # ParentOfRelationship entries, so we can detect mistaken use of the
+        # filesystem name as a data key and fail loudly instead of silently
+        # dropping the nested payload.
+        filesystem_name_to_python_name: Dict[str, str] = {
+            value.filesystem_name: python_name
+            for python_name, value in cls._parent_of.items()
+            if isinstance(value, ParentOfRelationship)
+        }
+
         for key, value_list in data.items():
+            if key not in cls._parent_of and key in filesystem_name_to_python_name:
+                python_name = filesystem_name_to_python_name[key]
+                raise ValueError(
+                    f"Nested payload key '{key}' matches the on-disk folder name "
+                    f"of relationship '{python_name}'. Use the Python attribute "
+                    f"name '{python_name}' instead."
+                )
             if key in cls._parent_of:
                 parent_type_or_rel = cls._parent_of[key]
                 if isinstance(parent_type_or_rel, ParentOfRelationship):

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -738,7 +738,7 @@ class ParentOfRelationship(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
-    model: type
+    model: Type[KilnParentedModel]
     filesystem_name: str
 
 
@@ -762,7 +762,6 @@ class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
         cls,
         python_name: str,
         child_class: Type[KilnParentedModel],
-        filesystem_name: str,
     ):
         def child_method(self, readonly: bool = False) -> list[child_class]:  # type: ignore[invalid-type-form]
             return child_class.all_children_of_parent_path(self.path, readonly=readonly)
@@ -801,12 +800,12 @@ class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
             child_class: Type[KilnParentedModel]
             filesystem_name: str
             if isinstance(value, ParentOfRelationship):
-                child_class = value.model  # type: ignore[assignment]
+                child_class = value.model
                 filesystem_name = value.filesystem_name
             else:
                 child_class = value
                 filesystem_name = python_name
-            cls._create_child_method(python_name, child_class, filesystem_name)
+            cls._create_child_method(python_name, child_class)
             cls._create_parent_methods(child_class, filesystem_name)
 
     @classmethod

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -723,6 +723,25 @@ class KilnParentedModel(KilnBaseModel, metaclass=ABCMeta):
         return children
 
 
+class ParentOfRelationship(BaseModel):
+    """Specifies a parent-child relationship for KilnParentModel.
+
+    Use this form in ``parent_of`` when the Python attribute name should differ
+    from the on-disk folder name - for example, when a subclass wants to
+    override the auto-generated relationship method with custom filtering
+    logic, the relationship can be registered under a private name like
+    ``"_runs"`` while preserving the public ``runs/`` folder layout on disk.
+
+    For the common case where both names match, pass the child class directly
+    (``parent_of={"foo": FooModel}``).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    model: type
+    filesystem_name: str
+
+
 # Parent create methods for all child relationships
 # You must pass in parent_of in the subclass definition, defining the child relationships
 class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
@@ -732,23 +751,29 @@ class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
     Child relationships must be defined using the parent_of parameter in the class definition.
 
     Args:
-        parent_of (Dict[str, Type[KilnParentedModel]]): Mapping of relationship names to child model types
+        parent_of (Dict[str, Type[KilnParentedModel] | ParentOfRelationship]): Mapping of Python
+            attribute names to either child model classes (where the key is also used as the
+            on-disk folder name) or to ``ParentOfRelationship`` values that decouple the Python
+            attribute name from the on-disk folder name.
     """
 
     @classmethod
     def _create_child_method(
-        cls, relationship_name: str, child_class: Type[KilnParentedModel]
+        cls,
+        python_name: str,
+        child_class: Type[KilnParentedModel],
+        filesystem_name: str,
     ):
         def child_method(self, readonly: bool = False) -> list[child_class]:  # type: ignore[invalid-type-form]
             return child_class.all_children_of_parent_path(self.path, readonly=readonly)
 
-        child_method.__name__ = relationship_name
+        child_method.__name__ = python_name
         child_method.__annotations__ = {"return": List[child_class]}  # type: ignore[invalid-type-form]
-        setattr(cls, relationship_name, child_method)
+        setattr(cls, python_name, child_method)
 
     @classmethod
     def _create_parent_methods(
-        cls, targetCls: Type[KilnParentedModel], relationship_name: str
+        cls, targetCls: Type[KilnParentedModel], filesystem_name: str
     ):
         def parent_class_method() -> Type[KilnParentModel]:
             return cls
@@ -758,19 +783,31 @@ class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
         setattr(targetCls, "parent_type", parent_class_method)
 
         def relationship_name_method() -> str:
-            return relationship_name
+            return filesystem_name
 
         relationship_name_method.__name__ = "relationship_name"
         relationship_name_method.__annotations__ = {"return": str}
         setattr(targetCls, "relationship_name", relationship_name_method)
 
     @classmethod
-    def __init_subclass__(cls, parent_of: Dict[str, Type[KilnParentedModel]], **kwargs):
+    def __init_subclass__(
+        cls,
+        parent_of: Dict[str, "Type[KilnParentedModel] | ParentOfRelationship"],
+        **kwargs,
+    ):
         super().__init_subclass__(**kwargs)
         cls._parent_of = parent_of
-        for relationship_name, child_class in parent_of.items():
-            cls._create_child_method(relationship_name, child_class)
-            cls._create_parent_methods(child_class, relationship_name)
+        for python_name, value in parent_of.items():
+            child_class: Type[KilnParentedModel]
+            filesystem_name: str
+            if isinstance(value, ParentOfRelationship):
+                child_class = value.model  # type: ignore[assignment]
+                filesystem_name = value.filesystem_name
+            else:
+                child_class = value
+                filesystem_name = python_name
+            cls._create_child_method(python_name, child_class, filesystem_name)
+            cls._create_parent_methods(child_class, filesystem_name)
 
     @classmethod
     def validate_and_save_with_subrelations(
@@ -824,7 +861,11 @@ class KilnParentModel(KilnBaseModel, metaclass=ABCMeta):
 
         for key, value_list in data.items():
             if key in cls._parent_of:
-                parent_type = cls._parent_of[key]
+                parent_type_or_rel = cls._parent_of[key]
+                if isinstance(parent_type_or_rel, ParentOfRelationship):
+                    parent_type = parent_type_or_rel.model
+                else:
+                    parent_type = parent_type_or_rel
                 if not isinstance(value_list, list):
                     raise ValueError(
                         f"Expected a list for {key}, but got {type(value_list)}"

--- a/libs/core/kiln_ai/datamodel/task.py
+++ b/libs/core/kiln_ai/datamodel/task.py
@@ -198,13 +198,18 @@ class Task(
         For multiturn tasks, child TaskRuns reference their parent via
         ``parent_task_run_id``. By default we return only the leaves of those
         chains - the runs that aren't a parent of any other run - because that
-        is the right view for the vast majority of consumers (datasets, evals,
-        finetune exports, summary lists, statistics, exports, tags, etc.).
+        is the right view for the vast majority of consumers iterating runs
+        in-process (dataset/eval/finetune sample iteration, summary lists,
+        statistics, tag counts, etc.).
 
         Pass ``include_intermediate_runs=True`` to get every run regardless of
         position in the chain. That is only correct for code that needs the
         complete on-disk set (e.g. walking ancestors, diagnostics). For
         single-turn tasks the two modes are equivalent.
+
+        Note: this filter only affects in-process iteration. Filesystem-level
+        operations that copy the ``runs/`` directory (e.g. project export)
+        copy every run regardless of leaf-ness.
         """
         raw = self._runs(readonly=readonly)  # type: ignore[attr-defined]
         if include_intermediate_runs:

--- a/libs/core/kiln_ai/datamodel/task.py
+++ b/libs/core/kiln_ai/datamodel/task.py
@@ -9,6 +9,7 @@ from kiln_ai.datamodel.basemodel import (
     FilenameStringShort,
     KilnParentedModel,
     KilnParentModel,
+    ParentOfRelationship,
 )
 from kiln_ai.datamodel.data_guide import DataGuide
 from kiln_ai.datamodel.datamodel_enums import (
@@ -127,7 +128,7 @@ class Task(
     KilnParentedModel,
     KilnParentModel,
     parent_of={
-        "runs": TaskRun,
+        "_runs": ParentOfRelationship(model=TaskRun, filesystem_name="runs"),
         "dataset_splits": DatasetSplit,
         "finetunes": Finetune,
         "prompt_optimization_jobs": PromptOptimizationJob,
@@ -188,8 +189,29 @@ class Task(
         return schema_from_json_str(self.input_json_schema, require_object=False)
 
     # These wrappers help for typechecking. We should fix this in KilnParentModel
-    def runs(self, readonly: bool = False) -> list[TaskRun]:
-        return super().runs(readonly=readonly)  # type: ignore
+    def runs(
+        self,
+        readonly: bool = False,
+        include_intermediate_runs: bool = False,
+    ) -> list[TaskRun]:
+        """Return TaskRuns for this task with leaf-only filtering by default.
+
+        For multiturn tasks, child TaskRuns reference their predecessor via
+        ``parent_task_run_id``. By default we return only the leaves of those
+        chains - the runs that aren't a parent of any other run - because that
+        is the right view for the vast majority of consumers (datasets, evals,
+        finetune exports, summary lists, statistics, exports, tags, etc.).
+
+        Pass ``include_intermediate_runs=True`` to get every run regardless of
+        position in the chain. That is only correct for code that needs the
+        complete on-disk set (e.g. walking ancestors, diagnostics). For
+        single-turn tasks the two modes are equivalent.
+        """
+        raw = self._runs(readonly=readonly)  # type: ignore[attr-defined]
+        if include_intermediate_runs:
+            return raw
+        parent_ids = {r.parent_task_run_id for r in raw if r.parent_task_run_id}
+        return [r for r in raw if r.id not in parent_ids]
 
     def dataset_splits(self, readonly: bool = False) -> list[DatasetSplit]:
         return super().dataset_splits(readonly=readonly)  # type: ignore

--- a/libs/core/kiln_ai/datamodel/task.py
+++ b/libs/core/kiln_ai/datamodel/task.py
@@ -188,7 +188,6 @@ class Task(
         # Allow arrays, not just objects
         return schema_from_json_str(self.input_json_schema, require_object=False)
 
-    # These wrappers help for typechecking. We should fix this in KilnParentModel
     def runs(
         self,
         readonly: bool = False,
@@ -196,7 +195,7 @@ class Task(
     ) -> list[TaskRun]:
         """Return TaskRuns for this task with leaf-only filtering by default.
 
-        For multiturn tasks, child TaskRuns reference their predecessor via
+        For multiturn tasks, child TaskRuns reference their parent via
         ``parent_task_run_id``. By default we return only the leaves of those
         chains - the runs that aren't a parent of any other run - because that
         is the right view for the vast majority of consumers (datasets, evals,
@@ -213,6 +212,7 @@ class Task(
         parent_ids = {r.parent_task_run_id for r in raw if r.parent_task_run_id}
         return [r for r in raw if r.id not in parent_ids]
 
+    # These wrappers help for typechecking. We should fix this in KilnParentModel
     def dataset_splits(self, readonly: bool = False) -> list[DatasetSplit]:
         return super().dataset_splits(readonly=readonly)  # type: ignore
 

--- a/libs/core/kiln_ai/datamodel/test_models.py
+++ b/libs/core/kiln_ai/datamodel/test_models.py
@@ -883,7 +883,7 @@ def test_task_runs_multiple_levels_via_parent_task_run_id(task: Task):
 
     assert task.path is not None
     loaded_task = Task.load_from_file(task.path)
-    all_runs = {r.id: r for r in loaded_task.runs()}
+    all_runs = {r.id: r for r in loaded_task.runs(include_intermediate_runs=True)}
     assert len(all_runs) == 3
     assert all_runs[run2.id].parent_task_run_id == run1.id
     assert all_runs[run3.id].parent_task_run_id == run2.id
@@ -1017,7 +1017,7 @@ def test_comprehensive_flat_task_run_hierarchy(tmp_path):
     loaded_project = Project.load_from_file(project_path)
     loaded_task = loaded_project.tasks()[0]
 
-    all_runs = {r.id: r for r in loaded_task.runs()}
+    all_runs = {r.id: r for r in loaded_task.runs(include_intermediate_runs=True)}
     assert len(all_runs) == 8
 
     assert all_runs[run1_l1.id].parent_task_run_id is None
@@ -1087,7 +1087,7 @@ def test_task_run_runs_on_disk(tmp_path):
     child_run.save_to_file()
 
     loaded_task = Task.load_from_file(task.path)
-    children = loaded_task.runs()
+    children = loaded_task.runs(include_intermediate_runs=True)
     assert len(children) == 2
     by_id = {r.id: r for r in children}
     assert by_id[child_run.id].parent_task_run_id == parent_run.id

--- a/libs/core/kiln_ai/datamodel/test_parent_of_relationship.py
+++ b/libs/core/kiln_ai/datamodel/test_parent_of_relationship.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+
+import pytest
+
+from kiln_ai.datamodel.basemodel import (
+    FilenameString,
+    KilnParentedModel,
+    KilnParentModel,
+    ParentOfRelationship,
+)
+
+
+class _TestChild(KilnParentedModel):
+    name: FilenameString
+
+
+class _TestParentLegacy(KilnParentModel, parent_of={"children": _TestChild}):
+    name: FilenameString
+
+
+class _TestChildRel(KilnParentedModel):
+    name: FilenameString
+
+
+class _TestParentRelationship(
+    KilnParentModel,
+    parent_of={
+        "_kids": ParentOfRelationship(model=_TestChildRel, filesystem_name="kids"),
+    },
+):
+    name: FilenameString
+
+
+@pytest.fixture
+def legacy_parent(tmp_path: Path) -> _TestParentLegacy:
+    parent_path = tmp_path / "legacy" / "test_parent_legacy.kiln"
+    parent_path.parent.mkdir(parents=True, exist_ok=True)
+    parent = _TestParentLegacy(name="legacy_parent", path=parent_path)
+    parent.save_to_file()
+    return parent
+
+
+@pytest.fixture
+def relationship_parent(tmp_path: Path) -> _TestParentRelationship:
+    parent_path = tmp_path / "rel" / "test_parent_relationship.kiln"
+    parent_path.parent.mkdir(parents=True, exist_ok=True)
+    parent = _TestParentRelationship(name="rel_parent", path=parent_path)
+    parent.save_to_file()
+    return parent
+
+
+def test_legacy_form_python_attr_matches_filesystem(legacy_parent: _TestParentLegacy):
+    # The Python attr name (key) is used for both attribute access and disk folder.
+    assert callable(getattr(_TestParentLegacy, "children"))
+    assert _TestChild.relationship_name() == "children"
+
+    child = _TestChild(name="kid1", parent=legacy_parent)
+    child.save_to_file()
+
+    # Disk folder should be "children/"
+    assert legacy_parent.path is not None
+    parent_folder = legacy_parent.path.parent
+    assert (parent_folder / "children").is_dir()
+
+    # Round-trip via the auto-generated relationship method.
+    loaded_children = legacy_parent.children()
+    assert len(loaded_children) == 1
+    assert loaded_children[0].name == "kid1"
+
+
+def test_relationship_form_decouples_python_and_filesystem(
+    relationship_parent: _TestParentRelationship,
+):
+    # Python attribute uses the dict key.
+    assert callable(getattr(_TestParentRelationship, "_kids"))
+    # The plain key ("_kids") must NOT be an auto-generated public method on the class.
+    assert not hasattr(_TestParentRelationship, "kids")
+
+    child = _TestChildRel(name="kid_rel", parent=relationship_parent)
+    child.save_to_file()
+
+    assert relationship_parent.path is not None
+    parent_folder = relationship_parent.path.parent
+
+    # On-disk folder must be "kids/" (filesystem_name), not "_kids/".
+    assert (parent_folder / "kids").is_dir()
+    assert not (parent_folder / "_kids").exists()
+
+    # Confirm we can round-trip via the auto-generated method named with the key.
+    loaded = relationship_parent._kids()
+    assert len(loaded) == 1
+    assert loaded[0].name == "kid_rel"
+
+
+def test_relationship_name_returns_filesystem_name():
+    # The child's relationship_name() must return the filesystem name, not the python attr.
+    assert _TestChildRel.relationship_name() == "kids"
+
+
+def test_relationship_form_child_path_uses_filesystem_name(
+    relationship_parent: _TestParentRelationship,
+):
+    # build_path on the child should produce a path containing "kids", not "_kids".
+    child = _TestChildRel(name="path_check", parent=relationship_parent)
+    built_path = child.build_path()
+    assert built_path is not None
+    assert "kids" in built_path.parts
+    assert "_kids" not in built_path.parts
+
+
+def test_parent_of_relationship_is_frozen():
+    rel = ParentOfRelationship(model=_TestChildRel, filesystem_name="kids")
+    with pytest.raises(Exception):
+        rel.filesystem_name = "other"  # type: ignore[misc]

--- a/libs/core/kiln_ai/datamodel/test_parent_of_relationship.py
+++ b/libs/core/kiln_ai/datamodel/test_parent_of_relationship.py
@@ -112,3 +112,32 @@ def test_parent_of_relationship_is_frozen():
     rel = ParentOfRelationship(model=_TestChildRel, filesystem_name="kids")
     with pytest.raises(Exception):
         rel.filesystem_name = "other"  # type: ignore[misc]
+
+
+def test_validate_nested_rejects_filesystem_name_used_as_payload_key(tmp_path: Path):
+    """Passing the on-disk folder name as a nested payload key must fail loudly.
+
+    Previously this would silently drop the nested payload (since the key
+    wasn't in ``_parent_of``), making it easy to miss when migrating callers.
+    """
+    parent_path = tmp_path / "fail_loud" / "test_parent_relationship.kiln"
+    parent_path.parent.mkdir(parents=True, exist_ok=True)
+
+    bad_payload = {
+        "name": "rel_parent_bad",
+        "path": str(parent_path),
+        # "kids" is the filesystem_name; callers must use "_kids" (the python
+        # attr name) for nested payloads.
+        "kids": [{"name": "kid_via_wrong_key"}],
+    }
+
+    with pytest.raises(ValueError, match=r"Use the Python attribute name '_kids'"):
+        _TestParentRelationship.validate_and_save_with_subrelations(bad_payload)
+
+    # And the correct Python attribute name still works.
+    good_payload = {
+        "name": "rel_parent_good",
+        "path": str(parent_path),
+        "_kids": [{"name": "kid_via_correct_key"}],
+    }
+    _TestParentRelationship.validate_and_save_with_subrelations(good_payload)

--- a/libs/core/kiln_ai/datamodel/test_parent_of_relationship.py
+++ b/libs/core/kiln_ai/datamodel/test_parent_of_relationship.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from kiln_ai.datamodel.basemodel import (
     FilenameString,
@@ -110,7 +111,7 @@ def test_relationship_form_child_path_uses_filesystem_name(
 
 def test_parent_of_relationship_is_frozen():
     rel = ParentOfRelationship(model=_TestChildRel, filesystem_name="kids")
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError, match="frozen"):
         rel.filesystem_name = "other"  # type: ignore[misc]
 
 
@@ -120,12 +121,12 @@ def test_validate_nested_rejects_filesystem_name_used_as_payload_key(tmp_path: P
     Previously this would silently drop the nested payload (since the key
     wasn't in ``_parent_of``), making it easy to miss when migrating callers.
     """
-    parent_path = tmp_path / "fail_loud" / "test_parent_relationship.kiln"
-    parent_path.parent.mkdir(parents=True, exist_ok=True)
+    bad_parent_path = tmp_path / "fail_loud" / "test_parent_relationship.kiln"
+    bad_parent_path.parent.mkdir(parents=True, exist_ok=True)
 
     bad_payload = {
         "name": "rel_parent_bad",
-        "path": str(parent_path),
+        "path": str(bad_parent_path),
         # "kids" is the filesystem_name; callers must use "_kids" (the python
         # attr name) for nested payloads.
         "kids": [{"name": "kid_via_wrong_key"}],
@@ -134,10 +135,71 @@ def test_validate_nested_rejects_filesystem_name_used_as_payload_key(tmp_path: P
     with pytest.raises(ValueError, match=r"Use the Python attribute name '_kids'"):
         _TestParentRelationship.validate_and_save_with_subrelations(bad_payload)
 
-    # And the correct Python attribute name still works.
-    good_payload = {
+    # Misuse must not leave any half-saved artifacts on disk.
+    assert not bad_parent_path.exists()
+    assert not (bad_parent_path.parent / "kids").exists()
+    assert not (bad_parent_path.parent / "_kids").exists()
+
+
+def test_validate_nested_with_correct_key_persists_under_filesystem_folder(
+    tmp_path: Path,
+):
+    """A wrapper-form nested payload under the python_name key must persist
+    the child under the filesystem_name folder."""
+    parent_path = tmp_path / "happy_path" / "test_parent_relationship.kiln"
+    parent_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
         "name": "rel_parent_good",
         "path": str(parent_path),
         "_kids": [{"name": "kid_via_correct_key"}],
     }
-    _TestParentRelationship.validate_and_save_with_subrelations(good_payload)
+    _TestParentRelationship.validate_and_save_with_subrelations(payload)
+
+    # The parent .kiln must exist, and the child must live under "kids/" -
+    # not "_kids/" (the python attr name must not leak onto disk).
+    assert parent_path.exists()
+    assert (parent_path.parent / "kids").is_dir()
+    assert not (parent_path.parent / "_kids").exists()
+
+    loaded_parent = _TestParentRelationship.load_from_file(parent_path)
+    kids = loaded_parent._kids()  # type: ignore[attr-defined]
+    assert len(kids) == 1
+    assert kids[0].name == "kid_via_correct_key"
+
+
+def test_init_subclass_rejects_duplicate_child_class():
+    """Registering the same child class twice in parent_of is a foot-gun:
+    `_create_parent_methods` writes onto the child, so the second entry would
+    silently overwrite the first. Class-definition time should reject it."""
+    with pytest.raises(ValueError, match="twice"):
+
+        class _BadParentDuplicateChild(
+            KilnParentModel,
+            parent_of={
+                "first": _TestChildRel,
+                "second": _TestChildRel,
+            },
+        ):
+            name: FilenameString
+
+
+def test_init_subclass_rejects_duplicate_filesystem_name():
+    """Two relationships writing to the same on-disk folder would interleave
+    files. Reject at class-definition time."""
+
+    class _AnotherChild(KilnParentedModel):
+        name: FilenameString
+
+    with pytest.raises(ValueError, match="filesystem folder 'shared'"):
+
+        class _BadParentDuplicateFolder(
+            KilnParentModel,
+            parent_of={
+                "shared": _TestChildRel,
+                "_shared": ParentOfRelationship(
+                    model=_AnotherChild, filesystem_name="shared"
+                ),
+            },
+        ):
+            name: FilenameString

--- a/libs/core/kiln_ai/datamodel/test_task.py
+++ b/libs/core/kiln_ai/datamodel/test_task.py
@@ -752,3 +752,166 @@ def test_is_toolcall_pending_true_when_task_response_mixed_with_unmanaged_tools(
         RunOutput(output="", intermediate_outputs=None, trace=trace).is_toolcall_pending
         is True
     )
+
+
+def _make_task_for_runs_tests(tmp_path) -> Task:
+    task = Task(
+        name="Test Task",
+        instruction="Test instruction",
+        path=tmp_path / "task.kiln",
+    )
+    task.save_to_file()
+    return task
+
+
+def test_task_runs_defaults_to_leaves_only_for_multiturn_chain(tmp_path):
+    task = _make_task_for_runs_tests(tmp_path)
+    output = TaskOutput(output="out")
+
+    run1 = TaskRun(input="in1", output=output, parent=task)
+    run1.save_to_file()
+    run2 = TaskRun(
+        input="in2",
+        output=output,
+        parent=task,
+        parent_task_run_id=run1.id,
+    )
+    run2.save_to_file()
+    run3 = TaskRun(
+        input="in3",
+        output=output,
+        parent=task,
+        parent_task_run_id=run2.id,
+    )
+    run3.save_to_file()
+
+    loaded_task = Task.load_from_file(task.path)
+    leaves = loaded_task.runs()
+    assert len(leaves) == 1
+    assert leaves[0].id == run3.id
+
+
+def test_task_runs_with_include_intermediate_runs_returns_all(tmp_path):
+    task = _make_task_for_runs_tests(tmp_path)
+    output = TaskOutput(output="out")
+
+    run1 = TaskRun(input="in1", output=output, parent=task)
+    run1.save_to_file()
+    run2 = TaskRun(
+        input="in2",
+        output=output,
+        parent=task,
+        parent_task_run_id=run1.id,
+    )
+    run2.save_to_file()
+    run3 = TaskRun(
+        input="in3",
+        output=output,
+        parent=task,
+        parent_task_run_id=run2.id,
+    )
+    run3.save_to_file()
+
+    loaded_task = Task.load_from_file(task.path)
+    all_runs = loaded_task.runs(include_intermediate_runs=True)
+    assert {r.id for r in all_runs} == {run1.id, run2.id, run3.id}
+
+
+def test_task_runs_branching_chain_returns_multiple_leaves(tmp_path):
+    task = _make_task_for_runs_tests(tmp_path)
+    output = TaskOutput(output="out")
+
+    root = TaskRun(input="root", output=output, parent=task)
+    root.save_to_file()
+    leaf_a = TaskRun(
+        input="a",
+        output=output,
+        parent=task,
+        parent_task_run_id=root.id,
+    )
+    leaf_a.save_to_file()
+    leaf_b = TaskRun(
+        input="b",
+        output=output,
+        parent=task,
+        parent_task_run_id=root.id,
+    )
+    leaf_b.save_to_file()
+
+    loaded_task = Task.load_from_file(task.path)
+    leaves = loaded_task.runs()
+    leaf_ids = {r.id for r in leaves}
+    assert leaf_ids == {leaf_a.id, leaf_b.id}
+    assert root.id not in leaf_ids
+
+
+def test_task_runs_readonly_smoke(tmp_path):
+    task = _make_task_for_runs_tests(tmp_path)
+    output = TaskOutput(output="out")
+
+    run1 = TaskRun(input="in1", output=output, parent=task)
+    run1.save_to_file()
+    run2 = TaskRun(
+        input="in2",
+        output=output,
+        parent=task,
+        parent_task_run_id=run1.id,
+    )
+    run2.save_to_file()
+
+    loaded_task = Task.load_from_file(task.path)
+    leaves = loaded_task.runs(readonly=True)
+    assert len(leaves) == 1
+    assert leaves[0].id == run2.id
+    assert leaves[0]._readonly is True
+
+    all_runs = loaded_task.runs(readonly=True, include_intermediate_runs=True)
+    assert {r.id for r in all_runs} == {run1.id, run2.id}
+    assert all(r._readonly for r in all_runs)
+
+
+def test_task_runs_single_turn_modes_equivalent(tmp_path):
+    task = _make_task_for_runs_tests(tmp_path)
+    output = TaskOutput(output="out")
+
+    r1 = TaskRun(input="in1", output=output, parent=task)
+    r1.save_to_file()
+    r2 = TaskRun(input="in2", output=output, parent=task)
+    r2.save_to_file()
+    r3 = TaskRun(input="in3", output=output, parent=task)
+    r3.save_to_file()
+
+    loaded_task = Task.load_from_file(task.path)
+    leaves = loaded_task.runs()
+    all_runs = loaded_task.runs(include_intermediate_runs=True)
+    assert {r.id for r in leaves} == {r.id for r in all_runs}
+    assert {r.id for r in leaves} == {r1.id, r2.id, r3.id}
+
+
+def test_task_runs_persist_under_runs_folder_not_underscore_runs(tmp_path):
+    task = _make_task_for_runs_tests(tmp_path)
+    output = TaskOutput(output="out")
+
+    run = TaskRun(input="in", output=output, parent=task)
+    run.save_to_file()
+
+    runs_folder = tmp_path / "runs"
+    underscore_runs_folder = tmp_path / "_runs"
+    assert runs_folder.is_dir(), (
+        "TaskRun files must live under 'runs/' on disk (filesystem_name)"
+    )
+    assert not underscore_runs_folder.exists(), (
+        "TaskRun files must NOT live under '_runs/' (the Python attribute name)"
+    )
+    assert run.path is not None
+    assert run.path.parent.parent == runs_folder
+    assert run.path.exists()
+
+    # Loading via the auto-generated _runs accessor and the wrapped runs()
+    # method must both find the file on disk.
+    loaded_task = Task.load_from_file(task.path)
+    via_underscore = loaded_task._runs()  # type: ignore[attr-defined]
+    via_wrapped = loaded_task.runs()
+    assert {r.id for r in via_underscore} == {run.id}
+    assert {r.id for r in via_wrapped} == {run.id}
+    assert TaskRun.relationship_name() == "runs"

--- a/libs/server/kiln_server/run_api.py
+++ b/libs/server/kiln_server/run_api.py
@@ -251,6 +251,12 @@ def connect_run_api(app: FastAPI):
     @app.get(
         "/api/projects/{project_id}/tasks/{task_id}/runs",
         summary="List Runs",
+        description=(
+            "For multiturn tasks, only leaf TaskRuns (those that are not the "
+            "parent of another run via parent_task_run_id) are returned. "
+            "Intermediate runs in a chain are filtered out. For single-turn "
+            "tasks this is equivalent to listing every run."
+        ),
         tags=["Runs"],
         openapi_extra=ALLOW_AGENT,
     )
@@ -313,6 +319,10 @@ def connect_run_api(app: FastAPI):
     @app.get(
         "/api/projects/{project_id}/tasks/{task_id}/runs_summaries",
         summary="List Run Summaries",
+        description=(
+            "For multiturn tasks, only leaf TaskRuns (those that are not the "
+            "parent of another run via parent_task_run_id) are summarized."
+        ),
         tags=["Runs"],
         openapi_extra=ALLOW_AGENT,
     )
@@ -580,6 +590,10 @@ def connect_run_api(app: FastAPI):
     @app.get(
         "/api/projects/{project_id}/tasks/{task_id}/tags",
         summary="List Run Tags",
+        description=(
+            "Counts only include tags from leaf TaskRuns. For multiturn tasks, "
+            "tags attached to intermediate runs in a chain are not included."
+        ),
         tags=["Runs"],
         openapi_extra=ALLOW_AGENT,
     )

--- a/libs/server/kiln_server/test_run_api.py
+++ b/libs/server/kiln_server/test_run_api.py
@@ -969,6 +969,92 @@ async def test_get_runs_summaries_task_not_found(client):
     assert response.json()["message"] == "Task not found"
 
 
+def _make_child_run(task, parent_run: TaskRun, **overrides) -> TaskRun:
+    run = TaskRun(
+        parent=task,
+        parent_task_run_id=parent_run.id,
+        input=overrides.get("input", "continuation"),
+        input_source=DataSource(
+            type=DataSourceType.human, properties={"created_by": "Test User"}
+        ),
+        output=TaskOutput(
+            output=overrides.get("output", "continuation output"),
+            source=DataSource(
+                type=DataSourceType.synthetic,
+                properties={
+                    "model_name": "gpt_4o",
+                    "model_provider": "ollama",
+                    "adapter_name": "kiln_langchain_adapter",
+                    "prompt_id": "simple_prompt_builder",
+                },
+            ),
+        ),
+        tags=overrides.get("tags", []),
+    )
+    run.save_to_file()
+    return run
+
+
+@pytest.mark.asyncio
+async def test_get_runs_returns_only_leaf_runs(client, task_run_setup):
+    """GET /runs must hide intermediate runs for multiturn chains.
+
+    Mirrors test_get_runs_summaries_returns_only_leaf_runs against the
+    full-TaskRun endpoint (not the summaries view).
+    """
+    project = task_run_setup["project"]
+    task = task_run_setup["task"]
+    root = task_run_setup["task_run"]
+
+    mid = _make_child_run(task, root)
+    leaf = _make_child_run(task, mid)
+    sib = _make_child_run(task, root)
+
+    with patch("kiln_server.run_api.task_from_id") as mock_task_from_id:
+        mock_task_from_id.return_value = task
+        response = client.get(f"/api/projects/{project.id}/tasks/{task.id}/runs")
+
+    assert response.status_code == 200
+    returned_ids = {entry["id"] for entry in response.json()}
+    assert returned_ids == {leaf.id, sib.id}
+    assert root.id not in returned_ids, "root must be filtered (has children)"
+    assert mid.id not in returned_ids, "mid must be filtered (has children)"
+
+
+@pytest.mark.asyncio
+async def test_get_tags_counts_only_leaf_runs(client, task_run_setup):
+    """GET /tags must not count tags attached to intermediate (non-leaf) runs.
+
+    Setup: root has tag "intermediate" (will be hidden); mid has tag
+    "intermediate" (also hidden); leaf has tags "shared" + "leaf_only"; sib
+    has tag "shared".
+    Expected: only "shared" (count 2) and "leaf_only" (count 1) are returned;
+    "intermediate" is absent.
+    """
+    project = task_run_setup["project"]
+    task = task_run_setup["task"]
+    root = task_run_setup["task_run"]
+
+    # Tag the root in-place and re-save so the on-disk file reflects the tag.
+    root.tags = ["intermediate"]
+    root.save_to_file()
+
+    mid = _make_child_run(task, root, tags=["intermediate"])
+    _leaf = _make_child_run(task, mid, tags=["shared", "leaf_only"])
+    _sib = _make_child_run(task, root, tags=["shared"])
+
+    with patch("kiln_server.run_api.task_from_id") as mock_task_from_id:
+        mock_task_from_id.return_value = task
+        response = client.get(f"/api/projects/{project.id}/tasks/{task.id}/tags")
+
+    assert response.status_code == 200
+    counts = response.json()
+    assert counts == {"shared": 2, "leaf_only": 1}
+    assert "intermediate" not in counts, (
+        "tags on intermediate (filtered) runs must not appear in the counts"
+    )
+
+
 @pytest.mark.asyncio
 async def test_delete_multiple_runs_success(client, task_run_setup):
     project = task_run_setup["project"]

--- a/libs/server/kiln_server/test_run_api.py
+++ b/libs/server/kiln_server/test_run_api.py
@@ -902,6 +902,60 @@ async def test_get_runs_summaries_success(client, task_run_setup):
 
 
 @pytest.mark.asyncio
+async def test_get_runs_summaries_returns_only_leaf_runs(client, task_run_setup):
+    """The endpoint must hide intermediate (non-leaf) runs in multiturn chains.
+
+    Setup: starting from the fixture's lone task_run (no parent), build a
+    linear chain task_run -> mid -> leaf and a sibling branch task_run -> sib.
+    Expected: only `leaf` and `sib` come back; task_run and mid are filtered
+    out because they are parents of other runs.
+    """
+    project = task_run_setup["project"]
+    task = task_run_setup["task"]
+    root = task_run_setup["task_run"]
+
+    def _make_child(parent_run: TaskRun) -> TaskRun:
+        run = TaskRun(
+            parent=task,
+            parent_task_run_id=parent_run.id,
+            input="continuation",
+            input_source=DataSource(
+                type=DataSourceType.human, properties={"created_by": "Test User"}
+            ),
+            output=TaskOutput(
+                output="continuation output",
+                source=DataSource(
+                    type=DataSourceType.synthetic,
+                    properties={
+                        "model_name": "gpt_4o",
+                        "model_provider": "ollama",
+                        "adapter_name": "kiln_langchain_adapter",
+                        "prompt_id": "simple_prompt_builder",
+                    },
+                ),
+            ),
+        )
+        run.save_to_file()
+        return run
+
+    mid = _make_child(root)
+    leaf = _make_child(mid)
+    sib = _make_child(root)
+
+    with patch("kiln_server.run_api.task_from_id") as mock_task_from_id:
+        mock_task_from_id.return_value = task
+        response = client.get(
+            f"/api/projects/{project.id}/tasks/{task.id}/runs_summaries"
+        )
+
+    assert response.status_code == 200
+    returned_ids = {entry["id"] for entry in response.json()}
+    assert returned_ids == {leaf.id, sib.id}
+    assert root.id not in returned_ids, "root must be filtered (has children)"
+    assert mid.id not in returned_ids, "mid must be filtered (has children)"
+
+
+@pytest.mark.asyncio
 async def test_get_runs_summaries_task_not_found(client):
     with patch("kiln_server.run_api.task_from_id") as mock_task_from_id:
         mock_task_from_id.side_effect = HTTPException(


### PR DESCRIPTION
## What does this PR do?

The goal is to allow adding our own logic in relationship getters that get overridden by the parent model class. Specifically, to filter out the non-leaf `TaskRuns` by default - needed for https://github.com/Kiln-AI/Kiln/pull/1409 

---- 
Current system has the Kiln base model override the parent->child relationships with its own default logic. 

When we do this:
```py
class Task(
    KilnParentModel,
    parent_of={
        "child_models": ChildModel,
    },
):
    # this does not do anything and only provides typing to caller
    # actual logic is injected by the parent model class in KilnParentModel.__init_subclass__
    def child_models(self, readonly: bool = False) -> list[ChildModel]:
        return super().child_models(readonly=readonly)  # type: ignore
```

The `child_models` method is there only as a wrapper to provider typing to the caller. If we added logic in it to do post-retrieval filtering for example - e.g. filtering out all the `child_models` that have `color=Blue` - it would not work, because the method's is overriden by the parent class in `KilnParentModel.__init_subclass__`.

For multiturn task runs, `TaskRun` has a reference to its parent `TaskRun` through a field (`parent_task_run_id`). We want to only show the leaf `TaskRuns` as a default since leaves represent the last state of a given conversation (which is just a chain of `TaskRuns`). To do that, we need to filter the task runs to exclude the non-leaf nodes and keep the leaf ones.

After this PR, we can do it like so:
```py
class Task(
    KilnParentedModel,
    KilnParentModel,
    parent_of={
        # the relationship here is named `_runs` and this is where the base class will inject its logic
        # and we keep the folder name `runs` unchanged (parent class by default uses the same name for folder as for the relationship, and we don't want it to name it `_runs/`)
        "_runs": ParentOfRelationship(model=TaskRun, filesystem_name="runs"),
    },
):
    # this method here is a real method, not a typechecking wrapper empty shell - since the parent is not overriding it
    # we can do whatever we want here, it is just a normal method
    def runs(
        self,
        readonly: bool = False,
        include_intermediate_runs: bool = False,
    ) -> list[TaskRun]:
        raw = self._runs(readonly=readonly)  # type: ignore[attr-defined]
        if include_intermediate_runs:
            return raw
        parent_ids = {r.parent_task_run_id for r in raw if r.parent_task_run_id}
        return [r for r in raw if r.id not in parent_ids]
```

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
