### PR TITLE
Switch Claude Sonnet 4.6 OpenRouter to json_schema structured output

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -1844,7 +1844,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 model_id="anthropic/claude-sonnet-4.6",
-                structured_output_mode=StructuredOutputMode.function_calling,
+                structured_output_mode=StructuredOutputMode.json_schema,
                 openrouter_reasoning_object=True,
                 available_thinking_levels=CLAUDE_OPENROUTER_THINKING_LEVELS,
                 default_thinking_level="none",


### PR DESCRIPTION
## Summary

- Switches the `openrouter` provider for `claude_sonnet_4_6` from `structured_output_mode=function_calling` to `json_schema`.
- Aligns the OpenRouter provider with the direct `anthropic` provider for the same model (which already uses `json_schema`). Anthropic now treats `json_schema` as the preferred structured-output path on their newer Claude models.
- No behavioral change in test outcomes: `json_schema` and `function_calling` produced bit-for-bit identical pass/fail/skip counts on the `claude_sonnet_4_6-openrouter` scope.

## Test results (claude_sonnet_4_6 / openrouter, `json_schema`)

21 passed, 1 failed (pre-existing), 10 skipped — paid + ollama suite.

✅ `test_data_gen_all_models_providers[claude_sonnet_4_6-openrouter]`
✅ `test_data_gen_sample_all_models_providers[claude_sonnet_4_6-openrouter]`
✅ `test_data_gen_sample_all_models_providers_with_structured_output[claude_sonnet_4_6-openrouter]`
✅ `test_all_built_in_models_structured_output[claude_sonnet_4_6-openrouter]`
✅ `test_all_built_in_models_structured_input[claude_sonnet_4_6-openrouter]`
✅ `test_structured_output_cot_prompt_builder[claude_sonnet_4_6-openrouter]`
✅ `test_structured_input_cot_prompt_builder[claude_sonnet_4_6-openrouter]`
✅ `test_all_models_providers_plaintext[claude_sonnet_4_6-openrouter]`
✅ `test_cot_prompt_builder[claude_sonnet_4_6-openrouter]`
✅ `test_tools_all_built_in_models[claude_sonnet_4_6-openrouter]`
✅ `test_invoke_openai_stream_chunks[claude_sonnet_4_6-openrouter-medium]`
✅ `test_invoke_openai_stream_non_streaming_still_works[claude_sonnet_4_6-openrouter-medium]`
✅ `test_invoke_openai_stream_with_prior_trace[claude_sonnet_4_6-openrouter-medium]`
✅ `test_invoke_ai_sdk_stream[claude_sonnet_4_6-openrouter-medium]`
✅ `test_ai_sdk_stream_text_ends_before_tool_calls[claude_sonnet_4_6-openrouter-medium]`
✅ `test_provider_bad_request[claude_sonnet_4_6-openrouter]`
✅ `test_supports_vision_is_coherent[claude_sonnet_4_6-openrouter]`
✅ `test_extract_document_success[application/pdf-text_probe0-claude_sonnet_4_6-openrouter]`
✅ `test_extract_document_success[image/png-text_probe5-claude_sonnet_4_6-openrouter]`
✅ `test_extract_document_success[image/jpeg-text_probe6-claude_sonnet_4_6-openrouter]`
✅ `test_extract_document_success[image/jpeg-text_probe7-claude_sonnet_4_6-openrouter]`
❌ `test_all_built_in_models_llm_as_judge[claude_sonnet_4_6-openrouter]` — pre-existing Anthropic-on-OpenRouter issue, see note below

### Note on the g_eval failure

`libs/core/kiln_ai/adapters/eval/g_eval.py` (lines 269-274) explicitly disallows `function_calling` modes for the judge call and falls back to `json_schema` regardless of the provider's configured mode. The Anthropic API then rejects the request with:

> `output_config.format.schema: For 'integer' type, properties maximum, minimum are not supported`

The `task_response` schema uses integer fields with `minimum`/`maximum` (1–5 rating). This failure is **independent of this PR** — it reproduces identically on `claude_sonnet_4_5-openrouter` (which still uses `function_calling` on master), confirming it is a pre-existing baseline Anthropic-on-OpenRouter g_eval issue, not a regression.

## Test plan

- [x] Lint, format, type-check pass (`ruff check`, `ruff format --check`, `ty check`)
- [x] Paid OpenRouter test suite for `claude_sonnet_4_6` shows same results under `json_schema` as it did under `function_calling`
- [x] Confirmed g_eval failure exists on `claude_sonnet_4_5-openrouter` (pre-existing, not caused by this PR)

Made with [Cursor](https://cursor.com)