### PR TITLE
fix: Vertex connect check, rebrand into Gemini Enterprise

### DIFF
--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -1280,7 +1280,7 @@ async def connect_gemini(key: str):
 async def connect_vertex(project_id: str, project_location: str):
     try:
         await litellm.acompletion(
-            model="vertex_ai/gemini-2.0-flash",
+            model="vertex_ai/gemini-3.5-flash",
             messages=[{"content": "Hello, how are you?", "role": "user"}],
             vertex_project=project_id,
             vertex_location=project_location,

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -2788,6 +2788,60 @@ async def test_connect_vertex_failure(mock_config_shared, mock_litellm_acompleti
     )
 
 
+@pytest.mark.paid
+@pytest.mark.asyncio
+@patch("app.desktop.studio_server.provider_api.Config.shared")
+async def test_connect_vertex_live(mock_config_shared):
+    """End-to-end check that the Vertex (Gemini Enterprise Agent Platform)
+    Connect button flow still works against the real API. Run before a
+    release: a green run means a user with valid credentials clicking
+    "Connect" in the Kiln UI will succeed.
+
+    Prerequisites for running locally:
+
+    1. A Google Cloud project with the Vertex AI API enabled
+       (``gcloud services enable aiplatform.googleapis.com --project=<id>``).
+    2. Your account has ``roles/aiplatform.user`` on that project.
+    3. Application Default Credentials set up as a plain user credential
+       (NOT impersonating a service account that lacks access). Run
+       ``gcloud auth application-default login`` while a gcloud config
+       without ``auth/impersonate_service_account`` is active. Verify with::
+
+           cat ~/.config/gcloud/application_default_credentials.json | \\
+             jq '{type, service_account_impersonation_url}'
+
+       Want ``type: "authorized_user"`` and no impersonation URL.
+    4. Export the project ID:
+       ``KILN_TEST_VERTEX_PROJECT_ID=<your-project-id>``.
+       Optionally override location with ``KILN_TEST_VERTEX_LOCATION``
+       (defaults to ``global`` — what the UI suggests).
+
+    Skipped if ``KILN_TEST_VERTEX_PROJECT_ID`` is unset so the test doesn't
+    fire blindly in CI without credentials.
+
+    CMD:
+    KILN_TEST_VERTEX_PROJECT_ID=YOUR_PROJECT_ID uv run python3 -m pytest app/desktop/studio_server/test_provider_api.py -k connect_vertex_live --runpaid
+    """
+    import os
+
+    project_id = os.environ.get("KILN_TEST_VERTEX_PROJECT_ID")
+    if not project_id:
+        pytest.skip("KILN_TEST_VERTEX_PROJECT_ID not set")
+    location = os.environ.get("KILN_TEST_VERTEX_LOCATION", "global")
+
+    mock_config = MagicMock()
+    mock_config_shared.return_value = mock_config
+
+    response = await connect_vertex(project_id, location)
+
+    assert response.status_code == 200, (
+        f"Vertex connect failed ({response.status_code}): {response.body.decode()}"
+    )
+    assert "Connected to Vertex" in response.body.decode()
+    assert mock_config.vertex_project_id == project_id
+    assert mock_config.vertex_location == location
+
+
 @pytest.mark.asyncio
 @patch("app.desktop.studio_server.provider_api.requests.get")
 @patch("app.desktop.studio_server.provider_api.Config.shared")

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -43,7 +43,6 @@ from app.desktop.studio_server.provider_api import (
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
-from kiln_server.custom_errors import connect_custom_errors
 from kiln_ai.adapters.ml_embedding_model_list import (
     EmbeddingModelName,
     KilnEmbeddingModel,
@@ -66,6 +65,7 @@ from kiln_ai.adapters.reranker_list import (
     built_in_rerankers,
 )
 from kiln_ai.utils.config import Config
+from kiln_server.custom_errors import connect_custom_errors
 
 
 @pytest.fixture
@@ -2747,7 +2747,7 @@ async def test_connect_vertex_success(mock_config_shared, mock_litellm_acompleti
     assert response.status_code == 200
     assert "Connected to Vertex" in response.body.decode()
     mock_litellm_acompletion.assert_called_once_with(
-        model="vertex_ai/gemini-2.0-flash",
+        model="vertex_ai/gemini-3.5-flash",
         messages=[{"content": "Hello, how are you?", "role": "user"}],
         vertex_project="test-project-id",
         vertex_location="us-central1",
@@ -2772,7 +2772,7 @@ async def test_connect_vertex_failure(mock_config_shared, mock_litellm_acompleti
     assert "Failed to connect to Vertex" in response.body.decode()
     assert "Invalid project ID" in response.body.decode()
     mock_litellm_acompletion.assert_called_once_with(
-        model="vertex_ai/gemini-2.0-flash",
+        model="vertex_ai/gemini-3.5-flash",
         messages=[{"content": "Hello, how are you?", "role": "user"}],
         vertex_project="invalid-project-id",
         vertex_location="us-central1",

--- a/app/web_ui/src/lib/stores.ts
+++ b/app/web_ui/src/lib/stores.ts
@@ -551,7 +551,7 @@ const provider_name_map: Record<ModelProviderName, string> = {
   gemini_api: "Gemini API",
   azure_openai: "Azure OpenAI",
   huggingface: "Hugging Face",
-  vertex: "Google Vertex AI",
+  vertex: "Gemini Enterprise Agent Platform (formerly Vertex AI)",
   together_ai: "Together AI",
   siliconflow_cn: "SiliconFlow CN",
   cerebras: "Cerebras",

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/connect_providers/connect_providers.svelte
@@ -121,7 +121,7 @@
       name: "Google Gemini API",
       id: "gemini_api",
       description:
-        "Google's Gemini API (aka AI Studio). Not to be confused with Vertex AI.",
+        "Google's Gemini API (aka AI Studio). Not to be confused with Gemini Enterprise Agent Platform (formerly Vertex AI).",
       featured: false,
       api_key_steps: [
         "Go to https://aistudio.google.com/app/apikey",
@@ -131,9 +131,10 @@
       api_key_fields: ["API Key"],
     },
     {
-      name: "Google Vertex AI",
+      name: "Gemini Enterprise Agent Platform",
       id: "vertex",
-      description: "Google's Vertex API. Not to be confused with Gemini API.",
+      description:
+        "Google's Gemini Enterprise Agent Platform (formerly Vertex AI). Not to be confused with Gemini API.",
       featured: false,
       pill_text: highlight_finetune ? "Tuneable" : undefined,
       api_key_steps: [

--- a/libs/core/kiln_ai/adapters/provider_tools.py
+++ b/libs/core/kiln_ai/adapters/provider_tools.py
@@ -528,7 +528,7 @@ def provider_name_from_id(id: str) -> str:
             case ModelProviderName.huggingface:
                 return "Hugging Face"
             case ModelProviderName.vertex:
-                return "Google Vertex AI"
+                return "Gemini Enterprise Agent Platform (formerly Vertex AI)"
             case ModelProviderName.together_ai:
                 return "Together AI"
             case ModelProviderName.siliconflow_cn:


### PR DESCRIPTION
## What does this PR do?

Bug: when connecting the Vertex AI provider, we send a request to verify it gets a response. The test request uses Gemini 2.0 Flash, which is now too old.

Changes:
- fix: use Gemini 3.5 Flash
- refactor: rebrand Vertex AI into Gemini Enterprise Agent Platform

<img width="1399" height="1070" alt="image" src="https://github.com/user-attachments/assets/720cf004-62ea-426b-b485-54b6f8478a75" />

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
