### PR TITLE
feat: enable Kiln API tool to call SSE endpoints

### DIFF
--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -41,7 +41,7 @@ class KilnApiCallTool(KilnTool):
 
 Endpoint paths, request schemas, response fields, and jq filters are defined in per-endpoint documentation — not here. Load the endpoint doc before calling.
 
-For SSE endpoints (text/event-stream), the tool consumes the stream until it closes (or a `data: complete` sentinel) and returns body = {"event_count": N, "complete": bool}. Individual event payloads are not returned."""
+For SSE endpoints (text/event-stream), the tool consumes the stream until it closes (or a `data: complete` sentinel) and returns body = {"event_count": N, "stream_complete": bool, "message": str}. stream_complete only means the stream ended — not that the underlying job succeeded; check the flow's status afterward. Individual event payloads are not returned."""
 
     @staticmethod
     def _build_parameters_schema() -> dict[str, Any]:
@@ -151,8 +151,10 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
                         response_text = json.dumps(
                             {
                                 "event_count": event_count,
-                                "complete": complete,
-                            }
+                                "stream_complete": complete,
+                                "message": "The stream has completed. Note this is not a guarantee that the job has completed with zero errors - check the status of the flow you were triggering after this.",
+                            },
+                            ensure_ascii=False,
                         )
                     else:
                         raw = await response.aread()

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -97,9 +97,10 @@ For SSE endpoints (text/event-stream), the tool collects emitted events until th
         if not url_path.startswith("/"):
             raise ValueError(f"url_path must start with '/', got: {url_path}")
 
-        if "?" in url_path:
+        if "?" in url_path or "#" in url_path:
             raise ValueError(
-                "url_path must not contain a query string. Pass query args via query_params."
+                "url_path must not contain a query string or fragment ('?' or '#'). "
+                "Pass query args via query_params."
             )
 
         if body_str is not None and method in {"GET", "DELETE"}:
@@ -148,9 +149,15 @@ For SSE endpoints (text/event-stream), the tool collects emitted events until th
                     else:
                         raw = await response.aread()
                         response_text = raw.decode("utf-8", errors="replace")
-            except httpx.TimeoutException:
+            except httpx.TimeoutException as e:
+                # Read timeouts use the long SSE bound; connect/write/pool use
+                # the short one. Report whichever actually fired.
+                if isinstance(e, httpx.ReadTimeout):
+                    timeout_seconds = SSE_READ_TIMEOUT_SECONDS
+                else:
+                    timeout_seconds = SSE_CONNECT_TIMEOUT_SECONDS
                 raise TimeoutError(
-                    f"Request to {url_path} timed out after {SSE_READ_TIMEOUT_SECONDS}s"
+                    f"Request to {url_path} timed out after {timeout_seconds}s"
                 )
             except httpx.ConnectError:
                 raise ConnectionError(f"Could not connect to server for {url_path}")
@@ -188,9 +195,12 @@ async def _consume_sse(response: httpx.Response) -> tuple[list[Any], bool]:
 
     Each event's ``data:`` lines are joined with newlines per the SSE spec,
     JSON-decoded when possible, and appended. Non-data lines (``id:``,
-    ``event:``, ``retry:``, comments) are ignored. ``complete`` is True when
-    we observe the Kiln-specific ``data: complete`` sentinel or the stream
-    ends cleanly.
+    ``event:``, ``retry:``, comments) are ignored. ``complete`` is True only
+    when we observe an explicit ``data: complete`` sentinel — a clean stream
+    end does NOT set it. That sentinel is emitted by some Kiln endpoints
+    (eval runs, RAG indexing) but not others (chat, which has no such marker),
+    so ``complete=False`` is normal for streams that don't use it and does not
+    by itself imply truncation.
     """
     events: list[Any] = []
     data_lines: list[str] = []

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -9,7 +9,10 @@ import jq
 from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
 from kiln_ai.tools.base_tool import KilnTool, ToolCallContext, ToolCallResult
 
-# Long enough for SSE streams (e.g. eval runs) that emit progress events.
+# httpx read timeout is per-read (idle), not a wall-clock cap: it resets every
+# time a chunk arrives. So this bounds the gap *between* events, not total
+# stream duration — a multi-hour eval that emits progress regularly never trips
+# it; only ~30 min of total silence (no events, no keepalive) does.
 SSE_READ_TIMEOUT_SECONDS = 1800.0
 # Short connection/setup timeout — server should accept quickly even when the
 # body will then stream for a long time.
@@ -34,7 +37,7 @@ class KilnApiCallTool(KilnTool):
 
 Endpoint paths, request schemas, response fields, and jq filters are defined in per-endpoint documentation — not here. Load the endpoint doc before calling.
 
-For SSE endpoints (text/event-stream), the tool collects emitted events until the stream closes and returns body = {"events": [...], "event_count": N, "complete": bool}. Each event is parsed as JSON when possible, otherwise kept as a string."""
+For SSE endpoints (text/event-stream), the tool consumes the stream until it closes (or a `data: complete` sentinel) and returns body = {"event_count": N, "complete": bool}. Individual event payloads are not returned."""
 
     @staticmethod
     def _build_parameters_schema() -> dict[str, Any]:
@@ -139,11 +142,10 @@ For SSE endpoints (text/event-stream), the tool collects emitted events until th
                     is_sse = content_type.startswith("text/event-stream")
 
                     if is_sse:
-                        events, complete = await _consume_sse(response)
+                        event_count, complete = await _consume_sse(response)
                         response_text = json.dumps(
                             {
-                                "events": events,
-                                "event_count": len(events),
+                                "event_count": event_count,
                                 "complete": complete,
                             }
                         )
@@ -191,19 +193,20 @@ For SSE endpoints (text/event-stream), the tool collects emitted events until th
         return ToolCallResult(output=json.dumps(result, ensure_ascii=False))
 
 
-async def _consume_sse(response: httpx.Response) -> tuple[list[Any], bool]:
-    """Iterate an SSE response, returning (events, complete).
+async def _consume_sse(response: httpx.Response) -> tuple[int, bool]:
+    """Drain an SSE response, returning (event_count, complete).
 
-    Each event's ``data:`` lines are joined with newlines per the SSE spec,
-    JSON-decoded when possible, and appended. Non-data lines (``id:``,
-    ``event:``, ``retry:``, comments) are ignored. ``complete`` is True only
-    when we observe an explicit ``data: complete`` sentinel — a clean stream
-    end does NOT set it. That sentinel is emitted by some Kiln endpoints
-    (eval runs, RAG indexing) but not others (chat, which has no such marker),
-    so ``complete=False`` is normal for streams that don't use it and does not
-    by itself imply truncation.
+    Event payloads are intentionally not retained — a long stream (e.g. an eval
+    run) can emit thousands of events, and the caller only needs to know it
+    finished, not replay every progress update. We count events and detect the
+    explicit ``data: complete`` sentinel. ``complete`` is True only on that
+    sentinel — a clean stream end does NOT set it. The sentinel is emitted by
+    some Kiln endpoints (eval runs, RAG indexing) but not others (chat), so
+    ``complete=False`` is normal for streams that don't use it and does not by
+    itself imply truncation. Draining still blocks until the stream closes, so
+    the tool call returns only once the underlying operation has finished.
     """
-    events: list[Any] = []
+    event_count = 0
     data_lines: list[str] = []
     saw_complete_sentinel = False
 
@@ -216,7 +219,7 @@ async def _consume_sse(response: httpx.Response) -> tuple[list[Any], bool]:
                 if payload == "complete":
                     saw_complete_sentinel = True
                     break
-                events.append(_decode_sse_payload(payload))
+                event_count += 1
             continue
         if line.startswith(":"):
             # SSE comment — ignore
@@ -231,14 +234,6 @@ async def _consume_sse(response: httpx.Response) -> tuple[list[Any], bool]:
         if payload == "complete":
             saw_complete_sentinel = True
         else:
-            events.append(_decode_sse_payload(payload))
+            event_count += 1
 
-    return events, saw_complete_sentinel
-
-
-def _decode_sse_payload(payload: str) -> Any:
-    """JSON-decode an SSE data payload, falling back to the raw string."""
-    try:
-        return json.loads(payload)
-    except json.JSONDecodeError:
-        return payload
+    return event_count, saw_complete_sentinel

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -9,6 +9,12 @@ import jq
 from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
 from kiln_ai.tools.base_tool import KilnTool, ToolCallResult
 
+# Long enough for SSE streams (e.g. eval runs) that emit progress events.
+SSE_READ_TIMEOUT_SECONDS = 1800.0
+# Short connection/setup timeout — server should accept quickly even when the
+# body will then stream for a long time.
+SSE_CONNECT_TIMEOUT_SECONDS = 30.0
+
 
 class KilnApiCallTool(KilnTool):
     """Tool for making HTTP requests to the Kiln API server."""
@@ -26,7 +32,9 @@ class KilnApiCallTool(KilnTool):
     def _build_description() -> str:
         return """Call the Kiln REST API. Makes an HTTP request and returns JSON with status_code and body.
 
-Endpoint paths, request schemas, response fields, and jq filters are defined in per-endpoint documentation — not here. Load the endpoint doc before calling."""
+Endpoint paths, request schemas, response fields, and jq filters are defined in per-endpoint documentation — not here. Load the endpoint doc before calling.
+
+For SSE endpoints (text/event-stream), the tool collects emitted events until the stream closes and returns body = {"events": [...], "event_count": N, "complete": bool}. Each event is parsed as JSON when possible, otherwise kept as a string."""
 
     @staticmethod
     def _build_parameters_schema() -> dict[str, Any]:
@@ -40,7 +48,17 @@ Endpoint paths, request schemas, response fields, and jq filters are defined in 
                 },
                 "url_path": {
                     "type": "string",
-                    "description": "API path. Correct paths are in the endpoint documentation.",
+                    "description": "API path with no query string — pass query args via query_params. Correct paths are in the endpoint documentation.",
+                },
+                "query_params": {
+                    "type": "object",
+                    "description": "Query string params. Values are strings or arrays of strings (arrays become repeated keys, e.g. ?ids=a&ids=b). Required and optional params are listed in the endpoint doc.",
+                    "additionalProperties": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "array", "items": {"type": "string"}},
+                        ],
+                    },
                 },
                 "body": {
                     "description": "Request body for POST/PATCH. JSON string, object, or array — auto-serialized. Schema is in the endpoint doc.",
@@ -58,6 +76,7 @@ Endpoint paths, request schemas, response fields, and jq filters are defined in 
         method: str,
         url_path: str,
         body: str | dict | list | None = None,
+        query_params: dict[str, str | list[str]] | None = None,
         jq_filter: str | None = None,
         context=None,
     ) -> ToolCallResult:
@@ -78,44 +97,65 @@ Endpoint paths, request schemas, response fields, and jq filters are defined in 
         if not url_path.startswith("/"):
             raise ValueError(f"url_path must start with '/', got: {url_path}")
 
+        if "?" in url_path:
+            raise ValueError(
+                "url_path must not contain a query string. Pass query args via query_params."
+            )
+
         if body_str is not None and method in {"GET", "DELETE"}:
             raise ValueError(f"body parameter not allowed with {method} method")
 
         # 2. Build full URL
         full_url = f"{self._api_base_url}{url_path}"
 
-        # 3. Make HTTP request
+        # 3. Make HTTP request — use stream() so we can detect SSE responses
+        # from the content-type header and iterate events with a long read
+        # timeout, without giving slow non-SSE responses the same leniency.
         headers = {"Content-Type": "application/json"}
-        # GET/DELETE: 30s, POST/PATCH: 5 minutes (may upload large data)
-        timeout_seconds = 30.0 if method in {"GET", "DELETE"} else 300.0
-        timeout = httpx.Timeout(timeout_seconds)
-
         # Per-request client: tool instances are short-lived (created per call
         # via tool_from_id), so a shared client wouldn't persist across calls anyway.
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            request_funcs = {
-                "GET": lambda: client.get(full_url, headers=headers),
-                "POST": lambda: client.post(
-                    full_url, headers=headers, content=body_str
-                ),
-                "PATCH": lambda: client.patch(
-                    full_url, headers=headers, content=body_str
-                ),
-                "DELETE": lambda: client.delete(full_url, headers=headers),
-            }
+        sse_timeout = httpx.Timeout(
+            connect=SSE_CONNECT_TIMEOUT_SECONDS,
+            read=SSE_READ_TIMEOUT_SECONDS,
+            write=SSE_CONNECT_TIMEOUT_SECONDS,
+            pool=SSE_CONNECT_TIMEOUT_SECONDS,
+        )
+
+        stream_kwargs: dict[str, Any] = {
+            "headers": headers,
+            "params": query_params,
+            "timeout": sse_timeout,
+        }
+        if method in {"POST", "PATCH"}:
+            stream_kwargs["content"] = body_str
+
+        async with httpx.AsyncClient() as client:
             try:
-                response = await request_funcs[method]()
+                async with client.stream(method, full_url, **stream_kwargs) as response:
+                    status_code = response.status_code
+                    content_type = response.headers.get("content-type", "").lower()
+                    is_sse = content_type.startswith("text/event-stream")
+
+                    if is_sse:
+                        events, complete = await _consume_sse(response)
+                        response_text = json.dumps(
+                            {
+                                "events": events,
+                                "event_count": len(events),
+                                "complete": complete,
+                            }
+                        )
+                    else:
+                        raw = await response.aread()
+                        response_text = raw.decode("utf-8", errors="replace")
             except httpx.TimeoutException:
                 raise TimeoutError(
-                    f"Request to {url_path} timed out after {timeout_seconds}s"
+                    f"Request to {url_path} timed out after {SSE_READ_TIMEOUT_SECONDS}s"
                 )
             except httpx.ConnectError:
                 raise ConnectionError(f"Could not connect to server for {url_path}")
 
         # 4. Build response
-        status_code = response.status_code
-        response_text = response.text
-
         if jq_filter and 200 <= status_code < 300:
             # Apply jq filter on successful responses
             try:
@@ -141,3 +181,50 @@ Endpoint paths, request schemas, response fields, and jq filters are defined in 
 
         result = {"status_code": status_code, "body": response_body}
         return ToolCallResult(output=json.dumps(result, ensure_ascii=False))
+
+
+async def _consume_sse(response: httpx.Response) -> tuple[list[Any], bool]:
+    """Iterate an SSE response, returning (events, complete).
+
+    Each event's ``data:`` lines are joined with newlines per the SSE spec,
+    JSON-decoded when possible, and appended. Non-data lines (``id:``,
+    ``event:``, ``retry:``, comments) are ignored. ``complete`` is True when
+    we observe the Kiln-specific ``data: complete`` sentinel or the stream
+    ends cleanly.
+    """
+    events: list[Any] = []
+    data_lines: list[str] = []
+    saw_complete_sentinel = False
+
+    async for line in response.aiter_lines():
+        line = line.rstrip("\r")
+        if line == "":
+            if data_lines:
+                payload = "\n".join(data_lines)
+                data_lines = []
+                if payload == "complete":
+                    saw_complete_sentinel = True
+                    break
+                try:
+                    events.append(json.loads(payload))
+                except json.JSONDecodeError:
+                    events.append(payload)
+            continue
+        if line.startswith(":"):
+            # SSE comment — ignore
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip(" "))
+
+    # Flush a trailing event if the stream closed without a final blank line.
+    if data_lines:
+        payload = "\n".join(data_lines)
+        if payload == "complete":
+            saw_complete_sentinel = True
+        else:
+            try:
+                events.append(json.loads(payload))
+            except json.JSONDecodeError:
+                events.append(payload)
+
+    return events, saw_complete_sentinel

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -41,7 +41,7 @@ class KilnApiCallTool(KilnTool):
 
 Endpoint paths, request schemas, response fields, and jq filters are defined in per-endpoint documentation — not here. Load the endpoint doc before calling.
 
-For SSE endpoints (text/event-stream), the tool consumes the stream until it closes (or a `data: complete` sentinel) and returns body = {"event_count": N, "stream_complete": bool, "message": str}. stream_complete only means the stream ended — not that the underlying job succeeded; check the flow's status afterward. Individual event payloads are not returned."""
+For SSE endpoints (text/event-stream), the tool consumes the stream until it closes (or a `data: complete` sentinel) and returns body = {"event_count": N, "message": str}. The stream ending does not mean the underlying job succeeded — check the flow's status afterward. Individual event payloads are not returned."""
 
     @staticmethod
     def _build_parameters_schema() -> dict[str, Any]:
@@ -147,12 +147,11 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
                     is_sse = content_type.startswith("text/event-stream")
 
                     if is_sse:
-                        event_count, complete = await _consume_sse(response)
+                        event_count = await _consume_sse(response)
                         response_text = json.dumps(
                             {
                                 "event_count": event_count,
-                                "stream_complete": complete,
-                                "message": "The stream has completed. Note this is not a guarantee that the job has completed with zero errors - check the status of the flow you were triggering after this.",
+                                "message": "Stream finished. This does not guarantee the job completed successfully—check the status of the flow you triggered. For Eval or RAG runs, call this again if errors occur; transient failures may be retried. If errors keep happening, we advise running the flow through the web UI instead.",
                             },
                             ensure_ascii=False,
                         )
@@ -200,22 +199,17 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
         return ToolCallResult(output=json.dumps(result, ensure_ascii=False))
 
 
-async def _consume_sse(response: httpx.Response) -> tuple[int, bool]:
-    """Drain an SSE response, returning (event_count, complete).
+async def _consume_sse(response: httpx.Response) -> int:
+    """Drain an SSE response, returning the number of events seen.
 
-    Event payloads are intentionally not retained — a long stream (e.g. an eval
-    run) can emit thousands of events, and the caller only needs to know it
-    finished, not replay every progress update. We count events and detect the
-    explicit ``data: complete`` sentinel. ``complete`` is True only on that
-    sentinel — a clean stream end does NOT set it. The sentinel is emitted by
-    some Kiln endpoints (eval runs, RAG indexing) but not others (chat), so
-    ``complete=False`` is normal for streams that don't use it and does not by
-    itself imply truncation. Draining still blocks until the stream closes, so
-    the tool call returns only once the underlying operation has finished.
+    We count events but don't keep their payloads — a long stream (e.g. an eval
+    run) can emit thousands, and the caller only needs to know it finished.
+    A ``data: complete`` sentinel ends the stream and is not counted as an event.
+    Draining blocks until the stream closes, so the tool call returns only once
+    the underlying operation is done.
     """
     event_count = 0
     data_lines: list[str] = []
-    saw_complete_sentinel = False
 
     async for line in response.aiter_lines():
         line = line.rstrip("\r")
@@ -224,7 +218,6 @@ async def _consume_sse(response: httpx.Response) -> tuple[int, bool]:
                 payload = "\n".join(data_lines)
                 data_lines = []
                 if payload == "complete":
-                    saw_complete_sentinel = True
                     break
                 event_count += 1
             continue
@@ -236,11 +229,7 @@ async def _consume_sse(response: httpx.Response) -> tuple[int, bool]:
             data_lines.append(line[5:].removeprefix(" "))
 
     # Flush a trailing event if the stream closed without a final blank line.
-    if data_lines:
-        payload = "\n".join(data_lines)
-        if payload == "complete":
-            saw_complete_sentinel = True
-        else:
-            event_count += 1
+    if data_lines and "\n".join(data_lines) != "complete":
+        event_count += 1
 
-    return event_count, saw_complete_sentinel
+    return event_count

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -10,13 +10,17 @@ from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
 from kiln_ai.tools.base_tool import KilnTool, ToolCallContext, ToolCallResult
 
 # httpx read timeout is per-read (idle), not a wall-clock cap: it resets every
-# time a chunk arrives. So this bounds the gap *between* events, not total
-# stream duration — a multi-hour eval that emits progress regularly never trips
-# it; only ~30 min of total silence (no events, no keepalive) does.
-SSE_READ_TIMEOUT_SECONDS = 1800.0
+# time a chunk arrives. So this bounds the gap *between* reads, not total
+# request duration. For SSE that's the gap between events; for regular
+# responses it's the gap between body chunks. A multi-hour eval that streams
+# progress regularly never trips it — only this long of total silence does.
+# Kiln's SSE endpoints are chatty (and emit keepalive pings), so a low bound is
+# safe for them while still letting a genuinely stalled request fail reasonably
+# fast.
+READ_TIMEOUT_SECONDS = 120.0
 # Short connection/setup timeout — server should accept quickly even when the
 # body will then stream for a long time.
-SSE_CONNECT_TIMEOUT_SECONDS = 30.0
+CONNECT_TIMEOUT_SECONDS = 30.0
 
 
 class KilnApiCallTool(KilnTool):
@@ -114,22 +118,23 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
         full_url = f"{self._api_base_url}{url_path}"
 
         # 3. Make HTTP request — use stream() so we can detect SSE responses
-        # from the content-type header and iterate events with a long read
-        # timeout, without giving slow non-SSE responses the same leniency.
+        # from the content-type header and drain the event stream. The same
+        # timeout applies to SSE and non-SSE responses: read is per-read (idle),
+        # so it bounds silence on the channel rather than total duration.
         headers = {"Content-Type": "application/json"}
         # Per-request client: tool instances are short-lived (created per call
         # via tool_from_id), so a shared client wouldn't persist across calls anyway.
-        sse_timeout = httpx.Timeout(
-            connect=SSE_CONNECT_TIMEOUT_SECONDS,
-            read=SSE_READ_TIMEOUT_SECONDS,
-            write=SSE_CONNECT_TIMEOUT_SECONDS,
-            pool=SSE_CONNECT_TIMEOUT_SECONDS,
+        timeout = httpx.Timeout(
+            connect=CONNECT_TIMEOUT_SECONDS,
+            read=READ_TIMEOUT_SECONDS,
+            write=CONNECT_TIMEOUT_SECONDS,
+            pool=CONNECT_TIMEOUT_SECONDS,
         )
 
         stream_kwargs: dict[str, Any] = {
             "headers": headers,
             "params": query_params,
-            "timeout": sse_timeout,
+            "timeout": timeout,
         }
         if method in {"POST", "PATCH"}:
             stream_kwargs["content"] = body_str
@@ -153,12 +158,12 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
                         raw = await response.aread()
                         response_text = raw.decode("utf-8", errors="replace")
             except httpx.TimeoutException as e:
-                # Read timeouts use the long SSE bound; connect/write/pool use
-                # the short one. Report whichever actually fired.
+                # Read timeouts use the read bound; connect/write/pool use the
+                # connect one. Report whichever actually fired.
                 if isinstance(e, httpx.ReadTimeout):
-                    timeout_seconds = SSE_READ_TIMEOUT_SECONDS
+                    timeout_seconds = READ_TIMEOUT_SECONDS
                 else:
-                    timeout_seconds = SSE_CONNECT_TIMEOUT_SECONDS
+                    timeout_seconds = CONNECT_TIMEOUT_SECONDS
                 raise TimeoutError(
                     f"Request to {url_path} timed out after {timeout_seconds}s"
                 )

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -215,16 +215,14 @@ async def _consume_sse(response: httpx.Response) -> tuple[list[Any], bool]:
                 if payload == "complete":
                     saw_complete_sentinel = True
                     break
-                try:
-                    events.append(json.loads(payload))
-                except json.JSONDecodeError:
-                    events.append(payload)
+                events.append(_decode_sse_payload(payload))
             continue
         if line.startswith(":"):
             # SSE comment — ignore
             continue
         if line.startswith("data:"):
-            data_lines.append(line[5:].lstrip(" "))
+            # SSE spec: strip exactly one leading space after "data:".
+            data_lines.append(line[5:].removeprefix(" "))
 
     # Flush a trailing event if the stream closed without a final blank line.
     if data_lines:
@@ -232,9 +230,14 @@ async def _consume_sse(response: httpx.Response) -> tuple[list[Any], bool]:
         if payload == "complete":
             saw_complete_sentinel = True
         else:
-            try:
-                events.append(json.loads(payload))
-            except json.JSONDecodeError:
-                events.append(payload)
+            events.append(_decode_sse_payload(payload))
 
     return events, saw_complete_sentinel
+
+
+def _decode_sse_payload(payload: str) -> Any:
+    """JSON-decode an SSE data payload, falling back to the raw string."""
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        return payload

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -17,7 +17,7 @@ from kiln_ai.tools.base_tool import KilnTool, ToolCallContext, ToolCallResult
 # Kiln's SSE endpoints are chatty (and emit keepalive pings), so a low bound is
 # safe for them while still letting a genuinely stalled request fail reasonably
 # fast.
-READ_TIMEOUT_SECONDS = 120.0
+READ_TIMEOUT_SECONDS = 900.0
 # Short connection/setup timeout — server should accept quickly even when the
 # body will then stream for a long time.
 CONNECT_TIMEOUT_SECONDS = 30.0

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -5,7 +5,11 @@ import pytest
 import respx
 
 from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
-from kiln_ai.tools.built_in_tools.kiln_api_call_tool import KilnApiCallTool
+from kiln_ai.tools.built_in_tools.kiln_api_call_tool import (
+    SSE_CONNECT_TIMEOUT_SECONDS,
+    SSE_READ_TIMEOUT_SECONDS,
+    KilnApiCallTool,
+)
 
 
 @pytest.fixture
@@ -59,6 +63,11 @@ class TestInputValidation:
     async def test_url_path_with_query_string_rejected(self, tool):
         with pytest.raises(ValueError, match="must not contain a query string"):
             await tool.run(method="GET", url_path="/test?foo=bar")
+
+    @pytest.mark.asyncio
+    async def test_url_path_with_fragment_rejected(self, tool):
+        with pytest.raises(ValueError, match="query string or fragment"):
+            await tool.run(method="GET", url_path="/test#section")
 
 
 class TestQueryParams:
@@ -315,22 +324,39 @@ class TestHttpErrors:
                 await tool.run(method="GET", url_path="/test")
 
     @pytest.mark.asyncio
-    async def test_timeout(self, tool):
+    async def test_read_timeout_reports_read_bound(self, tool):
         with respx.mock:
             respx.get("http://test-server:8757/test").mock(
-                side_effect=httpx.TimeoutException("timeout")
+                side_effect=httpx.ReadTimeout("timeout")
             )
-            with pytest.raises(TimeoutError, match=r"Request to /test timed out after"):
+            with pytest.raises(
+                TimeoutError,
+                match=rf"Request to /test timed out after {SSE_READ_TIMEOUT_SECONDS}s",
+            ):
                 await tool.run(method="GET", url_path="/test")
 
     @pytest.mark.asyncio
-    async def test_timeout_on_post(self, tool):
+    async def test_read_timeout_on_post(self, tool):
         with respx.mock:
             respx.post("http://test-server:8757/test").mock(
-                side_effect=httpx.TimeoutException("timeout")
+                side_effect=httpx.ReadTimeout("timeout")
             )
-            with pytest.raises(TimeoutError, match=r"timed out after"):
+            with pytest.raises(
+                TimeoutError, match=rf"timed out after {SSE_READ_TIMEOUT_SECONDS}s"
+            ):
                 await tool.run(method="POST", url_path="/test", body="{}")
+
+    @pytest.mark.asyncio
+    async def test_connect_timeout_reports_connect_bound(self, tool):
+        with respx.mock:
+            respx.get("http://test-server:8757/test").mock(
+                side_effect=httpx.ConnectTimeout("timeout")
+            )
+            with pytest.raises(
+                TimeoutError,
+                match=rf"Request to /test timed out after {SSE_CONNECT_TIMEOUT_SECONDS}s",
+            ):
+                await tool.run(method="GET", url_path="/test")
 
 
 class TestResponseConstruction:

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -476,7 +476,7 @@ class TestResponseConstruction:
 
 class TestSSEResponse:
     """SSE responses are drained (events counted, not retained); body returns
-    {event_count, complete}."""
+    {event_count, stream_complete, message}."""
 
     @pytest.mark.asyncio
     async def test_counts_events_and_marks_complete(self, tool):
@@ -497,7 +497,8 @@ class TestSSEResponse:
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
-            assert parsed["body"] == {"event_count": 3, "complete": True}
+            assert parsed["body"]["event_count"] == 3
+            assert parsed["body"]["stream_complete"] is True
 
     @pytest.mark.asyncio
     async def test_incomplete_stream_marked_not_complete(self, tool):
@@ -512,7 +513,7 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
-            assert parsed["body"]["complete"] is False
+            assert parsed["body"]["stream_complete"] is False
             assert parsed["body"]["event_count"] == 1
 
     @pytest.mark.asyncio
@@ -570,7 +571,8 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
-            assert parsed["body"] == {"event_count": 1, "complete": True}
+            assert parsed["body"]["event_count"] == 1
+            assert parsed["body"]["stream_complete"] is True
 
     @pytest.mark.asyncio
     async def test_trailing_complete_sentinel_without_blank_line(self, tool):
@@ -587,7 +589,7 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
-            assert parsed["body"]["complete"] is True
+            assert parsed["body"]["stream_complete"] is True
             assert parsed["body"]["event_count"] == 1
 
     @pytest.mark.asyncio
@@ -604,7 +606,8 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
-            assert parsed["body"] == {"event_count": 2, "complete": False}
+            assert parsed["body"]["event_count"] == 2
+            assert parsed["body"]["stream_complete"] is False
 
     @pytest.mark.asyncio
     async def test_multiline_data_counted_as_one_event(self, tool):
@@ -635,7 +638,8 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
-            assert parsed["body"] == {"event_count": 0, "complete": False}
+            assert parsed["body"]["event_count"] == 0
+            assert parsed["body"]["stream_complete"] is False
 
     @pytest.mark.asyncio
     async def test_crlf_line_endings(self, tool):
@@ -650,7 +654,8 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
-            assert parsed["body"] == {"event_count": 1, "complete": True}
+            assert parsed["body"]["event_count"] == 1
+            assert parsed["body"]["stream_complete"] is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -691,7 +696,7 @@ class TestSSEResponse:
             )
             parsed = json.loads(result.output)
             assert parsed["body"]["event_count"] == 1
-            assert parsed["body"]["complete"] is True
+            assert parsed["body"]["stream_complete"] is True
 
     @pytest.mark.asyncio
     async def test_sse_with_query_params(self, tool):
@@ -713,7 +718,7 @@ class TestSSEResponse:
             assert "run_config_ids=a" in query
             assert "run_config_ids=b" in query
             parsed = json.loads(result.output)
-            assert parsed["body"]["complete"] is True
+            assert parsed["body"]["stream_complete"] is True
 
     @pytest.mark.asyncio
     async def test_non_2xx_sse_response(self, tool):
@@ -732,7 +737,8 @@ class TestSSEResponse:
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 500
-            assert parsed["body"] == {"event_count": 1, "complete": False}
+            assert parsed["body"]["event_count"] == 1
+            assert parsed["body"]["stream_complete"] is False
 
 
 @contextlib.asynccontextmanager
@@ -783,4 +789,5 @@ class TestSSEReadTimeout:
             result = await tool.run(method="GET", url_path="/stream")
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
-            assert parsed["body"] == {"event_count": 8, "complete": True}
+            assert parsed["body"]["event_count"] == 8
+            assert parsed["body"]["stream_complete"] is True

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -55,6 +55,72 @@ class TestInputValidation:
         with pytest.raises(ValueError, match="body parameter not allowed with DELETE"):
             await tool.run(method="DELETE", url_path="/test", body="data")
 
+    @pytest.mark.asyncio
+    async def test_url_path_with_query_string_rejected(self, tool):
+        with pytest.raises(ValueError, match="must not contain a query string"):
+            await tool.run(method="GET", url_path="/test?foo=bar")
+
+
+class TestQueryParams:
+    @pytest.mark.asyncio
+    async def test_get_with_string_params(self, tool):
+        with respx.mock:
+            route = respx.get("http://test-server:8757/api/items").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            await tool.run(
+                method="GET",
+                url_path="/api/items",
+                query_params={"tag": "v1"},
+            )
+            assert route.calls.last.request.url.query == b"tag=v1"
+
+    @pytest.mark.asyncio
+    async def test_get_with_list_params_repeated_key(self, tool):
+        with respx.mock:
+            route = respx.get("http://test-server:8757/api/eval/run_comparison").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            await tool.run(
+                method="GET",
+                url_path="/api/eval/run_comparison",
+                query_params={"run_config_ids": ["a", "b"], "all_run_configs": "false"},
+            )
+            query = route.calls.last.request.url.query.decode()
+            assert "run_config_ids=a" in query
+            assert "run_config_ids=b" in query
+            assert "all_run_configs=false" in query
+
+    @pytest.mark.asyncio
+    async def test_post_with_query_params_and_body(self, tool):
+        with respx.mock:
+            route = respx.post("http://test-server:8757/api/items").mock(
+                return_value=httpx.Response(201, json={"id": "new"})
+            )
+            await tool.run(
+                method="POST",
+                url_path="/api/items",
+                body={"name": "x"},
+                query_params={"dry_run": "true"},
+            )
+            assert route.calls.last.request.url.query == b"dry_run=true"
+            assert (
+                route.calls.last.request.content == json.dumps({"name": "x"}).encode()
+            )
+
+    @pytest.mark.asyncio
+    async def test_empty_query_params_no_query_string(self, tool):
+        with respx.mock:
+            route = respx.get("http://test-server:8757/api/items").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            await tool.run(
+                method="GET",
+                url_path="/api/items",
+                query_params=None,
+            )
+            assert route.calls.last.request.url.query == b""
+
 
 class TestHappyPath:
     @pytest.mark.asyncio
@@ -254,18 +320,16 @@ class TestHttpErrors:
             respx.get("http://test-server:8757/test").mock(
                 side_effect=httpx.TimeoutException("timeout")
             )
-            with pytest.raises(
-                TimeoutError, match=r"Request to /test timed out after 30\.0s"
-            ):
+            with pytest.raises(TimeoutError, match=r"Request to /test timed out after"):
                 await tool.run(method="GET", url_path="/test")
 
     @pytest.mark.asyncio
-    async def test_timeout_uses_longer_timeout_for_post(self, tool):
+    async def test_timeout_on_post(self, tool):
         with respx.mock:
             respx.post("http://test-server:8757/test").mock(
                 side_effect=httpx.TimeoutException("timeout")
             )
-            with pytest.raises(TimeoutError, match=r"timed out after 300\.0s"):
+            with pytest.raises(TimeoutError, match=r"timed out after"):
                 await tool.run(method="POST", url_path="/test", body="{}")
 
 
@@ -337,3 +401,105 @@ class TestResponseConstruction:
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 404
             assert parsed["body"] == err
+
+
+class TestSSEResponse:
+    """SSE responses are streamed, events collected, body returns
+    {events, event_count, complete}."""
+
+    @pytest.mark.asyncio
+    async def test_collects_events_and_marks_complete(self, tool):
+        body = (
+            'data: {"progress": 1, "total": 3}\n\n'
+            'data: {"progress": 2, "total": 3}\n\n'
+            'data: {"progress": 3, "total": 3}\n\n'
+            "data: complete\n\n"
+        )
+        with respx.mock:
+            respx.get("http://test-server:8757/api/eval/run").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/eval/run")
+            parsed = json.loads(result.output)
+            assert parsed["status_code"] == 200
+            assert parsed["body"]["event_count"] == 3
+            assert parsed["body"]["complete"] is True
+            assert parsed["body"]["events"][0] == {"progress": 1, "total": 3}
+            assert parsed["body"]["events"][-1] == {"progress": 3, "total": 3}
+
+    @pytest.mark.asyncio
+    async def test_incomplete_stream_marked_not_complete(self, tool):
+        body = 'data: {"progress": 1, "total": 3}\n\n'
+        with respx.mock:
+            respx.get("http://test-server:8757/api/eval/run").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/eval/run")
+            parsed = json.loads(result.output)
+            assert parsed["body"]["complete"] is False
+            assert parsed["body"]["event_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_sse_with_jq_filter(self, tool):
+        body = 'data: {"progress": 1}\n\ndata: {"progress": 2}\n\ndata: complete\n\n'
+        with respx.mock:
+            respx.get("http://test-server:8757/api/eval/run").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(
+                method="GET",
+                url_path="/api/eval/run",
+                jq_filter=".events | last | .progress",
+            )
+            parsed = json.loads(result.output)
+            assert parsed["status_code"] == 200
+            assert parsed["body"] == 2
+
+    @pytest.mark.asyncio
+    async def test_non_json_data_lines_kept_as_strings(self, tool):
+        body = "data: hello\n\ndata: world\n\n"
+        with respx.mock:
+            respx.get("http://test-server:8757/api/stream").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/stream")
+            parsed = json.loads(result.output)
+            assert parsed["body"]["events"] == ["hello", "world"]
+
+    @pytest.mark.asyncio
+    async def test_ignores_comments_and_non_data_fields(self, tool):
+        body = (
+            ": keepalive comment\n\n"
+            "event: ping\n\n"
+            'data: {"ok": true}\n\n'
+            "data: complete\n\n"
+        )
+        with respx.mock:
+            respx.get("http://test-server:8757/api/stream").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/stream")
+            parsed = json.loads(result.output)
+            assert parsed["body"]["event_count"] == 1
+            assert parsed["body"]["events"] == [{"ok": True}]
+            assert parsed["body"]["complete"] is True

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -529,3 +529,172 @@ class TestSSEResponse:
             assert parsed["body"]["event_count"] == 1
             assert parsed["body"]["events"] == [{"ok": True}]
             assert parsed["body"]["complete"] is True
+
+    @pytest.mark.asyncio
+    async def test_trailing_complete_sentinel_without_blank_line(self, tool):
+        # Stream ends on "data: complete" with no final blank line, exercising
+        # the post-loop flush branch rather than the in-loop break.
+        body = 'data: {"progress": 1}\n\ndata: complete'
+        with respx.mock:
+            respx.get("http://test-server:8757/api/eval/run").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/eval/run")
+            parsed = json.loads(result.output)
+            assert parsed["body"]["complete"] is True
+            assert parsed["body"]["event_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_trailing_event_flushed_without_blank_line(self, tool):
+        # Last event has no terminating blank line; it must still be emitted.
+        body = 'data: {"progress": 1}\n\ndata: {"progress": 2}'
+        with respx.mock:
+            respx.get("http://test-server:8757/api/eval/run").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/eval/run")
+            parsed = json.loads(result.output)
+            assert parsed["body"]["event_count"] == 2
+            assert parsed["body"]["events"][-1] == {"progress": 2}
+            assert parsed["body"]["complete"] is False
+
+    @pytest.mark.asyncio
+    async def test_multiline_data_joined_with_newlines(self, tool):
+        # Consecutive data: lines in one event join with "\n" (SSE spec). The
+        # joined payload here is valid JSON, so it must also decode correctly.
+        body = 'data: {"a": 1,\ndata: "b": 2}\n\ndata: line1\ndata: line2\n\n'
+        with respx.mock:
+            respx.get("http://test-server:8757/api/stream").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/stream")
+            parsed = json.loads(result.output)
+            assert parsed["body"]["events"][0] == {"a": 1, "b": 2}
+            assert parsed["body"]["events"][1] == "line1\nline2"
+
+    @pytest.mark.asyncio
+    async def test_empty_stream(self, tool):
+        with respx.mock:
+            respx.get("http://test-server:8757/api/stream").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content="",
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/stream")
+            parsed = json.loads(result.output)
+            assert parsed["body"] == {"events": [], "event_count": 0, "complete": False}
+
+    @pytest.mark.asyncio
+    async def test_crlf_line_endings(self, tool):
+        body = 'data: {"progress": 1}\r\n\r\ndata: complete\r\n\r\n'
+        with respx.mock:
+            respx.get("http://test-server:8757/api/eval/run").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/eval/run")
+            parsed = json.loads(result.output)
+            assert parsed["body"]["event_count"] == 1
+            assert parsed["body"]["events"][0] == {"progress": 1}
+            assert parsed["body"]["complete"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "content_type",
+        [
+            "text/event-stream",
+            "text/event-stream; charset=utf-8",
+            "TEXT/EVENT-STREAM",
+        ],
+    )
+    async def test_content_type_variants_detected_as_sse(self, tool, content_type):
+        body = 'data: {"ok": true}\n\ndata: complete\n\n'
+        with respx.mock:
+            respx.get("http://test-server:8757/api/stream").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": content_type},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/stream")
+            parsed = json.loads(result.output)
+            assert parsed["body"]["event_count"] == 1
+            assert parsed["body"]["events"] == [{"ok": True}]
+
+    @pytest.mark.asyncio
+    async def test_post_returns_sse(self, tool):
+        body = 'data: {"progress": 1}\n\ndata: complete\n\n'
+        with respx.mock:
+            respx.post("http://test-server:8757/api/eval/run").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(
+                method="POST", url_path="/api/eval/run", body={"id": "x"}
+            )
+            parsed = json.loads(result.output)
+            assert parsed["body"]["event_count"] == 1
+            assert parsed["body"]["complete"] is True
+
+    @pytest.mark.asyncio
+    async def test_sse_with_query_params(self, tool):
+        body = 'data: {"progress": 1}\n\ndata: complete\n\n'
+        with respx.mock:
+            route = respx.get("http://test-server:8757/api/eval/run").mock(
+                return_value=httpx.Response(
+                    200,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(
+                method="GET",
+                url_path="/api/eval/run",
+                query_params={"run_config_ids": ["a", "b"]},
+            )
+            query = route.calls.last.request.url.query.decode()
+            assert "run_config_ids=a" in query
+            assert "run_config_ids=b" in query
+            parsed = json.loads(result.output)
+            assert parsed["body"]["complete"] is True
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_sse_response(self, tool):
+        # An error status with an event-stream content-type is still parsed as
+        # SSE (detection is content-type based); the partial events surface in
+        # the body and jq is skipped because the status is non-2xx.
+        body = 'data: {"type": "error", "message": "boom"}\n\n'
+        with respx.mock:
+            respx.get("http://test-server:8757/api/eval/run").mock(
+                return_value=httpx.Response(
+                    500,
+                    headers={"content-type": "text/event-stream"},
+                    content=body,
+                )
+            )
+            result = await tool.run(method="GET", url_path="/api/eval/run")
+            parsed = json.loads(result.output)
+            assert parsed["status_code"] == 500
+            assert parsed["body"]["complete"] is False
+            assert parsed["body"]["events"] == [{"type": "error", "message": "boom"}]

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import json
 
 import httpx
@@ -473,11 +475,11 @@ class TestResponseConstruction:
 
 
 class TestSSEResponse:
-    """SSE responses are streamed, events collected, body returns
-    {events, event_count, complete}."""
+    """SSE responses are drained (events counted, not retained); body returns
+    {event_count, complete}."""
 
     @pytest.mark.asyncio
-    async def test_collects_events_and_marks_complete(self, tool):
+    async def test_counts_events_and_marks_complete(self, tool):
         body = (
             'data: {"progress": 1, "total": 3}\n\n'
             'data: {"progress": 2, "total": 3}\n\n'
@@ -495,10 +497,7 @@ class TestSSEResponse:
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
-            assert parsed["body"]["event_count"] == 3
-            assert parsed["body"]["complete"] is True
-            assert parsed["body"]["events"][0] == {"progress": 1, "total": 3}
-            assert parsed["body"]["events"][-1] == {"progress": 3, "total": 3}
+            assert parsed["body"] == {"event_count": 3, "complete": True}
 
     @pytest.mark.asyncio
     async def test_incomplete_stream_marked_not_complete(self, tool):
@@ -530,14 +529,16 @@ class TestSSEResponse:
             result = await tool.run(
                 method="GET",
                 url_path="/api/eval/run",
-                jq_filter=".events | last | .progress",
+                jq_filter=".event_count",
             )
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
             assert parsed["body"] == 2
 
     @pytest.mark.asyncio
-    async def test_non_json_data_lines_kept_as_strings(self, tool):
+    async def test_non_json_data_lines_counted_not_parsed(self, tool):
+        # Non-JSON payloads are still counted as events; we don't parse or keep
+        # them.
         body = "data: hello\n\ndata: world\n\n"
         with respx.mock:
             respx.get("http://test-server:8757/api/stream").mock(
@@ -549,7 +550,7 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
-            assert parsed["body"]["events"] == ["hello", "world"]
+            assert parsed["body"]["event_count"] == 2
 
     @pytest.mark.asyncio
     async def test_ignores_comments_and_non_data_fields(self, tool):
@@ -569,9 +570,7 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
-            assert parsed["body"]["event_count"] == 1
-            assert parsed["body"]["events"] == [{"ok": True}]
-            assert parsed["body"]["complete"] is True
+            assert parsed["body"] == {"event_count": 1, "complete": True}
 
     @pytest.mark.asyncio
     async def test_trailing_complete_sentinel_without_blank_line(self, tool):
@@ -593,7 +592,7 @@ class TestSSEResponse:
 
     @pytest.mark.asyncio
     async def test_trailing_event_flushed_without_blank_line(self, tool):
-        # Last event has no terminating blank line; it must still be emitted.
+        # Last event has no terminating blank line; it must still be counted.
         body = 'data: {"progress": 1}\n\ndata: {"progress": 2}'
         with respx.mock:
             respx.get("http://test-server:8757/api/eval/run").mock(
@@ -605,14 +604,12 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
-            assert parsed["body"]["event_count"] == 2
-            assert parsed["body"]["events"][-1] == {"progress": 2}
-            assert parsed["body"]["complete"] is False
+            assert parsed["body"] == {"event_count": 2, "complete": False}
 
     @pytest.mark.asyncio
-    async def test_multiline_data_joined_with_newlines(self, tool):
-        # Consecutive data: lines in one event join with "\n" (SSE spec). The
-        # joined payload here is valid JSON, so it must also decode correctly.
+    async def test_multiline_data_counted_as_one_event(self, tool):
+        # Consecutive data: lines form a single event (joined per the SSE spec),
+        # so the block below is two events, not four lines.
         body = 'data: {"a": 1,\ndata: "b": 2}\n\ndata: line1\ndata: line2\n\n'
         with respx.mock:
             respx.get("http://test-server:8757/api/stream").mock(
@@ -624,8 +621,7 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
-            assert parsed["body"]["events"][0] == {"a": 1, "b": 2}
-            assert parsed["body"]["events"][1] == "line1\nline2"
+            assert parsed["body"]["event_count"] == 2
 
     @pytest.mark.asyncio
     async def test_empty_stream(self, tool):
@@ -639,7 +635,7 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
-            assert parsed["body"] == {"events": [], "event_count": 0, "complete": False}
+            assert parsed["body"] == {"event_count": 0, "complete": False}
 
     @pytest.mark.asyncio
     async def test_crlf_line_endings(self, tool):
@@ -654,9 +650,7 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
-            assert parsed["body"]["event_count"] == 1
-            assert parsed["body"]["events"][0] == {"progress": 1}
-            assert parsed["body"]["complete"] is True
+            assert parsed["body"] == {"event_count": 1, "complete": True}
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -680,7 +674,6 @@ class TestSSEResponse:
             result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
             assert parsed["body"]["event_count"] == 1
-            assert parsed["body"]["events"] == [{"ok": True}]
 
     @pytest.mark.asyncio
     async def test_post_returns_sse(self, tool):
@@ -724,9 +717,9 @@ class TestSSEResponse:
 
     @pytest.mark.asyncio
     async def test_non_2xx_sse_response(self, tool):
-        # An error status with an event-stream content-type is still parsed as
-        # SSE (detection is content-type based); the partial events surface in
-        # the body and jq is skipped because the status is non-2xx.
+        # An error status with an event-stream content-type is still drained as
+        # SSE (detection is content-type based); jq is skipped because the
+        # status is non-2xx.
         body = 'data: {"type": "error", "message": "boom"}\n\n'
         with respx.mock:
             respx.get("http://test-server:8757/api/eval/run").mock(
@@ -739,5 +732,55 @@ class TestSSEResponse:
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 500
-            assert parsed["body"]["complete"] is False
-            assert parsed["body"]["events"] == [{"type": "error", "message": "boom"}]
+            assert parsed["body"] == {"event_count": 1, "complete": False}
+
+
+@contextlib.asynccontextmanager
+async def _sse_test_server(handler):
+    """Run *handler* as a localhost server on an ephemeral port; yield base URL.
+
+    Used to exercise real read-timeout behavior — respx returns mocked
+    responses without going through httpx's timeout machinery, so it can't
+    simulate inter-event delays.
+    """
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    async with server:
+        yield f"http://127.0.0.1:{port}"
+
+
+class TestSSEReadTimeout:
+    """The read timeout is per-read (idle), not a wall-clock cap on the stream."""
+
+    @pytest.mark.asyncio
+    async def test_slow_steady_stream_does_not_time_out(self, monkeypatch):
+        # Read timeout 0.5s; emit 8 events 0.1s apart so the total (~0.8s)
+        # exceeds the timeout while every gap stays well under it. If the bound
+        # were a total cap this would raise TimeoutError.
+        monkeypatch.setattr(
+            "kiln_ai.tools.built_in_tools.kiln_api_call_tool.SSE_READ_TIMEOUT_SECONDS",
+            0.5,
+        )
+
+        async def handler(reader, writer):
+            await reader.read(65536)
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/event-stream\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            await writer.drain()
+            for i in range(8):
+                await asyncio.sleep(0.1)
+                writer.write(f'data: {{"progress": {i}}}\n\n'.encode())
+                await writer.drain()
+            writer.write(b"data: complete\n\n")
+            await writer.drain()
+            writer.close()
+
+        async with _sse_test_server(handler) as base_url:
+            tool = KilnApiCallTool(api_base_url=base_url)
+            result = await tool.run(method="GET", url_path="/stream")
+            parsed = json.loads(result.output)
+            assert parsed["status_code"] == 200
+            assert parsed["body"] == {"event_count": 8, "complete": True}

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -476,10 +476,10 @@ class TestResponseConstruction:
 
 class TestSSEResponse:
     """SSE responses are drained (events counted, not retained); body returns
-    {event_count, stream_complete, message}."""
+    {event_count, message}."""
 
     @pytest.mark.asyncio
-    async def test_counts_events_and_marks_complete(self, tool):
+    async def test_counts_events_and_excludes_complete_sentinel(self, tool):
         body = (
             'data: {"progress": 1, "total": 3}\n\n'
             'data: {"progress": 2, "total": 3}\n\n'
@@ -498,10 +498,9 @@ class TestSSEResponse:
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
             assert parsed["body"]["event_count"] == 3
-            assert parsed["body"]["stream_complete"] is True
 
     @pytest.mark.asyncio
-    async def test_incomplete_stream_marked_not_complete(self, tool):
+    async def test_incomplete_stream_counts_events(self, tool):
         body = 'data: {"progress": 1, "total": 3}\n\n'
         with respx.mock:
             respx.get("http://test-server:8757/api/eval/run").mock(
@@ -513,7 +512,6 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
-            assert parsed["body"]["stream_complete"] is False
             assert parsed["body"]["event_count"] == 1
 
     @pytest.mark.asyncio
@@ -572,7 +570,6 @@ class TestSSEResponse:
             result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
             assert parsed["body"]["event_count"] == 1
-            assert parsed["body"]["stream_complete"] is True
 
     @pytest.mark.asyncio
     async def test_trailing_complete_sentinel_without_blank_line(self, tool):
@@ -589,7 +586,6 @@ class TestSSEResponse:
             )
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
-            assert parsed["body"]["stream_complete"] is True
             assert parsed["body"]["event_count"] == 1
 
     @pytest.mark.asyncio
@@ -607,7 +603,6 @@ class TestSSEResponse:
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
             assert parsed["body"]["event_count"] == 2
-            assert parsed["body"]["stream_complete"] is False
 
     @pytest.mark.asyncio
     async def test_multiline_data_counted_as_one_event(self, tool):
@@ -639,7 +634,6 @@ class TestSSEResponse:
             result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
             assert parsed["body"]["event_count"] == 0
-            assert parsed["body"]["stream_complete"] is False
 
     @pytest.mark.asyncio
     async def test_crlf_line_endings(self, tool):
@@ -655,7 +649,6 @@ class TestSSEResponse:
             result = await tool.run(method="GET", url_path="/api/eval/run")
             parsed = json.loads(result.output)
             assert parsed["body"]["event_count"] == 1
-            assert parsed["body"]["stream_complete"] is True
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -696,7 +689,6 @@ class TestSSEResponse:
             )
             parsed = json.loads(result.output)
             assert parsed["body"]["event_count"] == 1
-            assert parsed["body"]["stream_complete"] is True
 
     @pytest.mark.asyncio
     async def test_sse_with_query_params(self, tool):
@@ -718,7 +710,7 @@ class TestSSEResponse:
             assert "run_config_ids=a" in query
             assert "run_config_ids=b" in query
             parsed = json.loads(result.output)
-            assert parsed["body"]["stream_complete"] is True
+            assert parsed["body"]["event_count"] == 1
 
     @pytest.mark.asyncio
     async def test_non_2xx_sse_response(self, tool):
@@ -738,7 +730,6 @@ class TestSSEResponse:
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 500
             assert parsed["body"]["event_count"] == 1
-            assert parsed["body"]["stream_complete"] is False
 
 
 @contextlib.asynccontextmanager
@@ -790,4 +781,3 @@ class TestSSEReadTimeout:
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
             assert parsed["body"]["event_count"] == 8
-            assert parsed["body"]["stream_complete"] is True

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -9,8 +9,8 @@ import respx
 from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
 from kiln_ai.tools.base_tool import ToolCallContext
 from kiln_ai.tools.built_in_tools.kiln_api_call_tool import (
-    SSE_CONNECT_TIMEOUT_SECONDS,
-    SSE_READ_TIMEOUT_SECONDS,
+    CONNECT_TIMEOUT_SECONDS,
+    READ_TIMEOUT_SECONDS,
     KilnApiCallTool,
 )
 
@@ -376,7 +376,7 @@ class TestHttpErrors:
             )
             with pytest.raises(
                 TimeoutError,
-                match=rf"Request to /test timed out after {SSE_READ_TIMEOUT_SECONDS}s",
+                match=rf"Request to /test timed out after {READ_TIMEOUT_SECONDS}s",
             ):
                 await tool.run(method="GET", url_path="/test")
 
@@ -387,7 +387,7 @@ class TestHttpErrors:
                 side_effect=httpx.ReadTimeout("timeout")
             )
             with pytest.raises(
-                TimeoutError, match=rf"timed out after {SSE_READ_TIMEOUT_SECONDS}s"
+                TimeoutError, match=rf"timed out after {READ_TIMEOUT_SECONDS}s"
             ):
                 await tool.run(method="POST", url_path="/test", body="{}")
 
@@ -399,7 +399,7 @@ class TestHttpErrors:
             )
             with pytest.raises(
                 TimeoutError,
-                match=rf"Request to /test timed out after {SSE_CONNECT_TIMEOUT_SECONDS}s",
+                match=rf"Request to /test timed out after {CONNECT_TIMEOUT_SECONDS}s",
             ):
                 await tool.run(method="GET", url_path="/test")
 
@@ -758,7 +758,7 @@ class TestSSEReadTimeout:
         # exceeds the timeout while every gap stays well under it. If the bound
         # were a total cap this would raise TimeoutError.
         monkeypatch.setattr(
-            "kiln_ai.tools.built_in_tools.kiln_api_call_tool.SSE_READ_TIMEOUT_SECONDS",
+            "kiln_ai.tools.built_in_tools.kiln_api_call_tool.READ_TIMEOUT_SECONDS",
             0.5,
         )
 


### PR DESCRIPTION
## What does this PR do?

Allow GET query params in Kiln API tool.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
