### PR TITLE
fix: make KilnApiCallTool.run match the tool interface calling convention

### DIFF
--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -7,7 +7,7 @@ import httpx
 import jq
 
 from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
-from kiln_ai.tools.base_tool import KilnTool, ToolCallResult
+from kiln_ai.tools.base_tool import KilnTool, ToolCallContext, ToolCallResult
 
 
 class KilnApiCallTool(KilnTool):
@@ -55,11 +55,12 @@ Endpoint paths, request schemas, response fields, and jq filters are defined in 
 
     async def run(  # type: ignore[override]
         self,
+        context: ToolCallContext | None = None,
+        *,
         method: str,
         url_path: str,
         body: str | dict | list | None = None,
         jq_filter: str | None = None,
-        context=None,
     ) -> ToolCallResult:
         body_str: str | None = None
         if isinstance(body, (dict, list)):

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -41,6 +41,20 @@ class TestRunCallingConvention:
             result = await tool.run(method="GET", url_path="/test")
             assert json.loads(result.output)["status_code"] == 200
 
+    @pytest.mark.asyncio
+    async def test_run_with_positional_context_and_jq(self, tool):
+        # jq_filter must still bind as a keyword-only arg when context is passed
+        # positionally — i.e. the adapter convention with the full set of args.
+        with respx.mock:
+            respx.get("http://test-server:8757/test").mock(
+                return_value=httpx.Response(200, json={"name": "v", "extra": 1})
+            )
+            args = {"method": "GET", "url_path": "/test", "jq_filter": ".name"}
+            result = await tool.run(ToolCallContext(allow_saving=False), **args)
+            parsed = json.loads(result.output)
+            assert parsed["status_code"] == 200
+            assert parsed["body"] == "v"
+
 
 class TestKilnApiCallToolInit:
     def test_custom_base_url(self):

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -5,12 +5,41 @@ import pytest
 import respx
 
 from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
+from kiln_ai.tools.base_tool import ToolCallContext
 from kiln_ai.tools.built_in_tools.kiln_api_call_tool import KilnApiCallTool
 
 
 @pytest.fixture
 def tool():
     return KilnApiCallTool(api_base_url="http://test-server:8757")
+
+
+class TestRunCallingConvention:
+    """run() must work via both tool-execution paths: the adapter's
+    ``tool.run(context, **args)`` (LiteLlmAdapter.process_tool_calls) and the
+    studio_server executor's ``tool.run(**args)`` (no context)."""
+
+    @pytest.mark.asyncio
+    async def test_run_with_positional_context(self, tool):
+        # Mirrors LiteLlmAdapter.process_tool_calls: context passed positionally,
+        # call args expanded as keywords.
+        with respx.mock:
+            respx.get("http://test-server:8757/test").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            args = {"method": "GET", "url_path": "/test"}
+            result = await tool.run(ToolCallContext(allow_saving=False), **args)
+            assert json.loads(result.output)["status_code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_run_without_context(self, tool):
+        # Mirrors studio_server.chat.stream_session.execute_tool: tool.run(**args).
+        with respx.mock:
+            respx.get("http://test-server:8757/test").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            result = await tool.run(method="GET", url_path="/test")
+            assert json.loads(result.output)["status_code"] == 200
 
 
 class TestKilnApiCallToolInit:


### PR DESCRIPTION
## Problem

`KilnApiCallTool.run` declares `context` as its **last** positional parameter:

```python
async def run(self, method, url_path, body=None, jq_filter=None, context=None): ...
```

Every other `KilnTool` (and the `KilnToolInterface` base) uses `run(self, context=None, **kwargs)` — `context` **first**. `LiteLlmAdapter.process_tool_calls` invokes tools accordingly:

```python
result = await t.run(c, **args)   # litellm_adapter.py:876 — context positional-first
```

For the API tool, `c` binds to `method` and `**args` then re-supplies `method`, raising:

```
TypeError: KilnApiCallTool.run() got multiple values for argument 'method'
```

## Fix

Move `context` to the first parameter and make the call args keyword-only, matching the interface convention so `run()` works via **both** execution paths:

```python
async def run(self, context: ToolCallContext | None = None, *, method, url_path, body=None, jq_filter=None): ...
```

## Tests

Added `TestRunCallingConvention` covering both call sites:
- `test_run_with_positional_context` — mirrors `process_tool_calls` (`tool.run(context, **args)`); fails pre-fix with the `TypeError` above.
- `test_run_without_context` — mirrors `studio_server` `execute_tool` (`tool.run(**args)`).

Full `checks.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)