### PR TITLE
fix: path traversal in attachment

### DIFF
--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -8,7 +8,7 @@ import uuid
 from abc import ABCMeta
 from builtins import classmethod
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Callable, Dict, List, Optional, Set, Type, TypeVar
 
 from pydantic import (
@@ -145,7 +145,11 @@ class KilnAttachmentModel(BaseModel):
             if isinstance(self.path, str):
                 self.path = Path(self.path)
             self.input_path = None
-            if self.path and (self.path.is_absolute() or ".." in self.path.parts):
+            if self.path and (
+                self.path.is_absolute()
+                or PureWindowsPath(self.path).is_absolute()
+                or ".." in PureWindowsPath(self.path).parts
+            ):
                 raise ValueError(
                     f"Attachment path must be a relative path within the parent: {self.path}"
                 )

--- a/libs/core/kiln_ai/datamodel/basemodel.py
+++ b/libs/core/kiln_ai/datamodel/basemodel.py
@@ -145,6 +145,10 @@ class KilnAttachmentModel(BaseModel):
             if isinstance(self.path, str):
                 self.path = Path(self.path)
             self.input_path = None
+            if self.path and (self.path.is_absolute() or ".." in self.path.parts):
+                raise ValueError(
+                    f"Attachment path must be a relative path within the parent: {self.path}"
+                )
             return self
 
         # when creating a new attachment, the path is not set yet (it is set when the model is saved)
@@ -271,7 +275,15 @@ class KilnAttachmentModel(BaseModel):
             raise ValueError(
                 f"Failed to resolve attachment path for {self.path} because parent path is not absolute: {parent_path}"
             )
-        return (parent_path / self.path).resolve()
+        parent_resolved = parent_path.resolve()
+        resolved = (parent_resolved / self.path).resolve()
+        try:
+            resolved.relative_to(parent_resolved)
+        except ValueError:
+            raise ValueError(
+                f"Attachment path {self.path!r} escapes its parent directory {parent_resolved}"
+            )
+        return resolved
 
 
 # Usage:

--- a/libs/core/kiln_ai/datamodel/test_attachment.py
+++ b/libs/core/kiln_ai/datamodel/test_attachment.py
@@ -519,6 +519,18 @@ def test_loading_from_file_rejects_absolute_path(
         ModelWithAttachment.load_from_file(json_path)
 
 
+def test_loading_from_file_rejects_windows_traversal_path(
+    test_base_kiln_file, mock_file_factory
+):
+    json_path = test_base_kiln_file.parent / "test_model.json"
+    _save_then_tamper_attachment_path(
+        json_path, mock_file_factory, "..\\..\\..\\..\\..\\..\\..\\etc\\passwd"
+    )
+
+    with pytest.raises(ValueError, match="must be a relative path within the parent"):
+        ModelWithAttachment.load_from_file(json_path)
+
+
 def test_resolve_path_rejects_escaping_path(test_base_kiln_file, mock_file_factory):
     test_media_file_document = mock_file_factory(MockFileFactoryMimeType.PDF)
     model = ModelWithAttachment(

--- a/libs/core/kiln_ai/datamodel/test_attachment.py
+++ b/libs/core/kiln_ai/datamodel/test_attachment.py
@@ -478,6 +478,79 @@ def test_loading_from_file(test_base_kiln_file, mock_file_factory):
     assert model.attachment.path is not None
 
 
+def _save_then_tamper_attachment_path(
+    json_path: Path, mock_file_factory, malicious_path: str
+):
+    test_media_file_document = mock_file_factory(MockFileFactoryMimeType.PDF)
+    model = ModelWithAttachment(
+        path=json_path,
+        attachment=KilnAttachmentModel.from_file(test_media_file_document),
+    )
+    model.save_to_file()
+
+    # tamper with the persisted attachment path, simulating a malicious .kiln file
+    # delivered via project import / git sync
+    with open(json_path) as f:
+        data = json.load(f)
+    data["attachment"]["path"] = malicious_path
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+
+
+def test_loading_from_file_rejects_traversal_path(
+    test_base_kiln_file, mock_file_factory
+):
+    json_path = test_base_kiln_file.parent / "test_model.json"
+    _save_then_tamper_attachment_path(
+        json_path, mock_file_factory, "../../../../../../../etc/passwd"
+    )
+
+    with pytest.raises(ValueError, match="must be a relative path within the parent"):
+        ModelWithAttachment.load_from_file(json_path)
+
+
+def test_loading_from_file_rejects_absolute_path(
+    test_base_kiln_file, mock_file_factory
+):
+    json_path = test_base_kiln_file.parent / "test_model.json"
+    _save_then_tamper_attachment_path(json_path, mock_file_factory, "/etc/passwd")
+
+    with pytest.raises(ValueError, match="must be a relative path within the parent"):
+        ModelWithAttachment.load_from_file(json_path)
+
+
+def test_resolve_path_rejects_escaping_path(test_base_kiln_file, mock_file_factory):
+    test_media_file_document = mock_file_factory(MockFileFactoryMimeType.PDF)
+    model = ModelWithAttachment(
+        path=test_base_kiln_file,
+        attachment=KilnAttachmentModel.from_file(test_media_file_document),
+    )
+    model.save_to_file()
+
+    # force a traversal path, bypassing load-time validation, to exercise the
+    # containment guard in resolve_path on its own
+    assert model.attachment is not None
+    model.attachment.input_path = None
+    model.attachment.path = Path("../../../../../../../etc/passwd")
+
+    with pytest.raises(ValueError, match="escapes its parent directory"):
+        model.attachment.resolve_path(test_base_kiln_file.parent)
+
+
+def test_resolve_path_allows_contained_path(test_base_kiln_file, mock_file_factory):
+    test_media_file_document = mock_file_factory(MockFileFactoryMimeType.PDF)
+    model = ModelWithAttachment(
+        path=test_base_kiln_file,
+        attachment=KilnAttachmentModel.from_file(test_media_file_document),
+    )
+    model.save_to_file()
+
+    # a normal relative path inside the parent resolves without error
+    resolved = model.attachment.resolve_path(test_base_kiln_file.parent)
+    assert resolved.exists()
+    assert resolved.is_relative_to(test_base_kiln_file.parent.resolve())
+
+
 class ModelWithAttachmentNameOverride(KilnBaseModel):
     attachment: KilnAttachmentModel = Field(default=None)
 

--- a/libs/server/kiln_server/test_document_api.py
+++ b/libs/server/kiln_server/test_document_api.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -5195,6 +5196,48 @@ async def test_get_documents_filtered_with_document_no_tags(
     assert len(result) == 1
     assert result[0].id == document.id
     assert result[0].id == document.id
+
+
+async def test_download_document_blocks_path_traversal(client, mock_document, tmp_path):
+    """A malicious document.kiln whose attachment path escapes the project dir
+    (e.g. delivered via project import / git sync) must not be served.
+
+    This drives the real attack path with minimal mocks: a tampered document.kiln
+    is written to disk, the real download endpoint loads it from disk via
+    Document.from_id_and_parent_path and resolves the attachment. Only
+    project_from_id is mocked (to avoid touching the global projects config)."""
+    project = mock_document["project"]
+    document = mock_document["document"]
+    assert document.path is not None
+
+    # a secret file living outside the project tree
+    secret_path = tmp_path / "secret.txt"
+    secret_content = b"TOP SECRET root:*:0:0:System Administrator"
+    secret_path.write_bytes(secret_content)
+
+    # relative ../ path from the document folder to the secret file
+    doc_dir = document.path.parent
+    traversal = os.path.relpath(secret_path, doc_dir)
+    # sanity: the path really escapes and really points at the secret, so the
+    # test is not vacuous (pre-fix, this is exactly what got served)
+    assert ".." in Path(traversal).parts
+    assert (doc_dir / traversal).resolve() == secret_path.resolve()
+
+    # tamper the persisted document.kiln to point the attachment at the secret
+    with open(document.path) as f:
+        data = json.load(f)
+    data["original_file"]["attachment"]["path"] = traversal
+    with open(document.path, "w") as f:
+        json.dump(data, f)
+
+    with patch("kiln_server.document_api.project_from_id") as mock_project_from_id:
+        mock_project_from_id.return_value = project
+        response = client.get(
+            f"/api/projects/{project.id}/documents/{document.id}/download"
+        )
+
+    assert response.status_code != 200
+    assert secret_content not in response.content
 
 
 async def test_download_extraction_success(


### PR DESCRIPTION
## What does this PR do?

Security advisory: https://github.com/Kiln-AI/Kiln/security/advisories/GHSA-2cg6-rg2v-xrc4

Prevent Kiln attachment paths from being resolved if they escape the parent dir.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
