### PR TITLE
Always persist task_run_trace on eval runs

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -232,14 +232,39 @@ class EvalRunner:
                 task_output = result_task_run.output.output
                 task_run_usage = result_task_run.usage
 
-                parent_eval = job.eval_config.parent_eval()
-                if (
-                    parent_eval
-                    and parent_eval.evaluation_data_type == EvalDataType.full_trace
-                    and result_task_run.trace
-                ):
-                    trace = json.dumps(result_task_run.trace, indent=2)
+                # Always persist the full trace when available. The trace is the
+                # only record of what the model actually saw — needed to verify
+                # input_transform rendering, system prompt content, and to debug
+                # eval failures after the fact. EvalDataType still controls
+                # judging behavior; it no longer gates trace persistence.
+                #
+                # Use pydantic_core.to_json so the encoder handles BaseModel
+                # instances and other non-stdlib-serializable types that can
+                # appear in real provider SDK trace objects. Fall back to a
+                # repr-based encoder on the off chance to_json can't handle
+                # something — a degraded trace is still more useful than
+                # crashing the whole eval job.
+                if result_task_run.trace:
+                    try:
+                        from pydantic_core import to_json
 
+                        trace = to_json(result_task_run.trace, indent=2).decode()
+                    except Exception as e:
+                        # Broad catch: pydantic_core.to_json can raise
+                        # PydanticSerializationError (subclass of RuntimeError)
+                        # plus the usual TypeError / ValueError. Falling back
+                        # to a repr-based encoder is always preferable to
+                        # crashing the eval job over an unprintable trace.
+                        logger.warning(
+                            "Falling back to repr trace encoding (%s) for dataset item %s",
+                            type(e).__name__,
+                            job.item.id,
+                        )
+                        trace = json.dumps(
+                            result_task_run.trace, indent=2, default=repr
+                        )
+
+                parent_eval = job.eval_config.parent_eval()
                 if (
                     parent_eval
                     and parent_eval.evaluation_data_type

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -724,7 +724,15 @@ async def test_run_job_with_full_trace_evaluation_data_type(
 async def test_run_job_with_final_answer_evaluation_data_type(
     mock_eval_runner, mock_task, data_source, mock_run_config, mock_eval_config
 ):
-    """Test EvalRunner with final_answer evaluation_data_type (default)"""
+    """Test EvalRunner persists task_run_trace even when evaluation_data_type
+    is not full_trace.
+
+    Trace persistence is independent of evaluation_data_type — the trace is the
+    only record of what the model actually saw, and is needed to verify
+    rendering (input_transform), system prompt content, and to debug failures
+    after the fact. evaluation_data_type still controls judging behavior; it
+    no longer gates trace persistence.
+    """
     # Set the eval config to use final_answer evaluation data type (default)
     mock_eval_config.parent.evaluation_data_type = EvalDataType.final_answer
 
@@ -775,11 +783,16 @@ async def test_run_job_with_final_answer_evaluation_data_type(
 
     assert success is True
 
-    # Verify eval run was saved without trace
+    # Verify the trace is persisted even for final_answer evals
     eval_runs = mock_eval_config.runs()
     assert len(eval_runs) == 1
     saved_run = eval_runs[0]
-    assert saved_run.task_run_trace is None
+    assert saved_run.task_run_trace is not None
+    assert isinstance(saved_run.task_run_trace, str)
+    import json
+
+    parsed_trace = json.loads(saved_run.task_run_trace)
+    assert parsed_trace == mock_trace
 
 
 @pytest.mark.asyncio

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -151,12 +151,12 @@ class EvalRun(KilnParentedModel):
             return self
 
         evaluation_data_type = parent_eval.evaluation_data_type
+        # task_run_trace is persisted for every eval run when available — it is
+        # the only record of what the model actually saw, needed to verify
+        # input_transform rendering and debug eval failures after the fact.
+        # evaluation_data_type still gates judging behavior; it no longer
+        # constrains whether the trace is set.
         if (
-            evaluation_data_type == EvalDataType.final_answer
-            and self.task_run_trace is not None
-        ):
-            raise ValueError("final_answer runs should not set trace")
-        elif (
             not self.eval_config_eval
             and evaluation_data_type == EvalDataType.full_trace
             and self.task_run_trace is None

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -1580,10 +1580,16 @@ def test_validate_output_fields_final_answer_valid_cases(
     assert run.task_run_trace is None
 
 
-def test_validate_output_fields_final_answer_invalid_cases(
+def test_validate_output_fields_final_answer_allows_trace(
     mock_task, valid_eval_config_data
 ):
-    """Test validate_output_fields with final_answer evaluation data type - invalid cases"""
+    """final_answer evals are now allowed to persist task_run_trace.
+
+    The trace is the only record of what the model actually saw — needed to
+    verify input_transform rendering and debug failures after the fact.
+    evaluation_data_type still gates judging behavior; it no longer constrains
+    whether the trace is set.
+    """
     eval = Eval(
         name="Test Eval",
         parent=mock_task,
@@ -1599,20 +1605,16 @@ def test_validate_output_fields_final_answer_invalid_cases(
     )
     config = EvalConfig(parent=eval, **valid_eval_config_data)
 
-    # Invalid case: full_trace is set
-    with pytest.raises(
-        ValueError,
-        match="final_answer runs should not set trace",
-    ):
-        EvalRun(
-            parent=config,
-            dataset_id="dataset123",
-            task_run_config_id="config456",
-            input="test input",
-            output="test output",
-            scores={"accuracy": 0.95},
-            task_run_trace='{"messages": []}',
-        )
+    run = EvalRun(
+        parent=config,
+        dataset_id="dataset123",
+        task_run_config_id="config456",
+        input="test input",
+        output="test output",
+        scores={"accuracy": 0.95},
+        task_run_trace='{"messages": []}',
+    )
+    assert run.task_run_trace == '{"messages": []}'
 
 
 def test_validate_output_fields_full_trace_valid_cases(
@@ -1729,15 +1731,10 @@ def test_validate_output_fields_no_parent_eval_config():
 @pytest.mark.parametrize(
     "evaluation_data_type,trace,should_raise,expected_error",
     [
-        # final_answer cases
+        # final_answer cases — trace is now optional, never forbidden
         (EvalDataType.final_answer, None, False, None),
-        (
-            EvalDataType.final_answer,
-            '{"messages": []}',
-            True,
-            "final_answer runs should not set trace",
-        ),
-        # full_trace cases
+        (EvalDataType.final_answer, '{"messages": []}', False, None),
+        # full_trace cases — trace is still required
         (EvalDataType.full_trace, '{"messages": []}', False, None),
         (
             EvalDataType.full_trace,


### PR DESCRIPTION
## Why

The trace is the only on-disk record of what the model actually saw during an
eval — the rendered system + user message that was sent to the provider. Today
that record is dropped for any eval whose `evaluation_data_type` is not
`full_trace`. So for `final_answer` and `reference_answer` evals (the common
case), `eval_run.kiln` has `task_run_trace: null`.

That gap matters most when something between the dataset item and the model
mutates the input — `input_transform` (the new Jinja2 layer on
`scosman/templates` / #1433) is the immediate example, but any future
provider-side prompt assembly will have the same property. Without the trace,
"did my transform fire?" and "what did the model literally read?" become
unanswerable after the fact; the eval row's `input` field stores the raw
dataset item, not what reached the model.

While debugging an input-feature ablation, I ran an eval, saw an unexpected
result, and had no way to confirm whether the configured Jinja template
actually rendered or was silently bypassed. The trace was being captured in
`result_task_run.trace` — it just wasn't being written.

## What

- `eval_runner.py`: drop the `evaluation_data_type == full_trace` gate. The
  trace is now persisted whenever `result_task_run.trace` is non-empty.
- `eval.py`: drop the `EvalRun` validator that rejected setting
  `task_run_trace` on `final_answer` evals. The full_trace-requires-trace
  invariant is preserved.
- `eval_runner.py`: use `pydantic_core.to_json` instead of `json.dumps` so
  real provider-SDK trace objects (which contain Pydantic `BaseModel`
  instances — litellm's `Message`, `Choices`, etc.) serialize correctly. The
  stdlib encoder choked on these the first time real data hit the path;
  Pydantic's encoder handles them, with a `default=repr` fallback that logs
  a warning and writes a degraded trace if even `to_json` can't.
- Tests updated to assert traces are preserved on `final_answer` evals; the
  parametrized matrix in `test_validate_output_fields_parametrized` reflects
  the relaxed validator.

`EvalDataType` still controls judging behavior (full_trace evals still
require the trace; reference_answer evals still write the reference answer
field). The change is scoped narrowly to "the trace gets written if we have
one to write."

## Notes

- Storage: traces are typically 5–15 KB each. On a 1000-row dataset across
  several Specs and run-configs this adds up, but evals already persist
  `intermediate_outputs`, `input`, `output`, and `task_run_usage` per row,
  and a trace is in the same order of magnitude. The verification value
  more than pays the disk cost.
- The two pre-existing pre-commit failures on this branch
  (`test_benchmark_get_model` timing-sensitive perf test,
  `test_adapter_reuse_preserves_data` depending on the lancedb/pandas
  transitive issue) are unrelated to this change and not affected by it.
  138 eval-related tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)