### PR TITLE
ci(playwright): add browser cache + step timeouts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,7 +55,29 @@ jobs:
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         timeout-minutes: 5
-        run: npx playwright install chromium
+        run: |
+          BROWSER_DIR="$HOME/.cache/ms-playwright/chromium-1217"
+          HEADLESS_DIR="$HOME/.cache/ms-playwright/chromium_headless_shell-1217"
+          FFMPEG_DIR="$HOME/.cache/ms-playwright/ffmpeg-1011"
+          mkdir -p "$BROWSER_DIR" "$HEADLESS_DIR" "$FFMPEG_DIR"
+
+          echo "Downloading Chrome for Testing..."
+          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip" -o /tmp/chrome.zip
+          unzip -q /tmp/chrome.zip -d "$BROWSER_DIR"
+          rm /tmp/chrome.zip
+
+          echo "Downloading Chrome Headless Shell..."
+          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-headless-shell-linux64.zip" -o /tmp/headless.zip
+          unzip -q /tmp/headless.zip -d "$HEADLESS_DIR"
+          rm /tmp/headless.zip
+
+          echo "Downloading FFmpeg..."
+          curl -sSL --retry 3 "https://cdn.playwright.dev/dbazure/download/playwright/builds/ffmpeg/1011/ffmpeg-linux64.zip" -o /tmp/ffmpeg.zip
+          unzip -q /tmp/ffmpeg.zip -d "$FFMPEG_DIR"
+          rm /tmp/ffmpeg.zip
+
+          echo "Browser install complete"
+          ls -la "$BROWSER_DIR" "$HEADLESS_DIR" "$FFMPEG_DIR"
       - name: Run Playwright tests
         timeout-minutes: 10
         run: npx playwright test

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,15 +41,35 @@ jobs:
         run: uv sync
       - name: Install Node deps
         run: npm ci
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ hashFiles('app/web_ui/package-lock.json') }}
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium
       - name: Install Playwright Browsers
         timeout-minutes: 5
-        run: npx playwright install --with-deps chromium
+        run: |
+          # npx playwright install has been hanging after download in CI.
+          # Download and extract manually, then validate with playwright.
+          BROWSER_DIR="$HOME/.cache/ms-playwright/chromium-1217"
+          HEADLESS_DIR="$HOME/.cache/ms-playwright/chromium_headless_shell-1217"
+          FFMPEG_DIR="$HOME/.cache/ms-playwright/ffmpeg-1011"
+          mkdir -p "$BROWSER_DIR" "$HEADLESS_DIR" "$FFMPEG_DIR"
+
+          echo "Downloading Chrome for Testing..."
+          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip" -o /tmp/chrome.zip
+          unzip -q /tmp/chrome.zip -d "$BROWSER_DIR"
+          rm /tmp/chrome.zip
+
+          echo "Downloading Chrome Headless Shell..."
+          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-headless-shell-linux64.zip" -o /tmp/headless.zip
+          unzip -q /tmp/headless.zip -d "$HEADLESS_DIR"
+          rm /tmp/headless.zip
+
+          echo "Downloading FFmpeg..."
+          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/ffmpeg/1011/ffmpeg-linux64.zip" -o /tmp/ffmpeg.zip
+          unzip -q /tmp/ffmpeg.zip -d "$FFMPEG_DIR"
+          rm /tmp/ffmpeg.zip
+
+          echo "Browser install complete"
+          ls -la "$BROWSER_DIR" "$HEADLESS_DIR" "$FFMPEG_DIR"
       - name: Run Playwright tests
         timeout-minutes: 10
         run: npx playwright test

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,37 +41,9 @@ jobs:
         run: uv sync
       - name: Install Node deps
         run: npm ci
-      - name: Get Playwright version
-        id: pw-version
-        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
-      - name: Install Playwright system deps
-        run: npx playwright install-deps chromium
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - name: Install Playwright Browsers
         timeout-minutes: 5
-        run: |
-          BROWSER_DIR="$HOME/.cache/ms-playwright/chromium-1217"
-          HEADLESS_DIR="$HOME/.cache/ms-playwright/chromium_headless_shell-1217"
-          mkdir -p "$BROWSER_DIR" "$HEADLESS_DIR"
-
-          echo "Downloading Chrome for Testing..."
-          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip" -o /tmp/chrome.zip
-          unzip -q /tmp/chrome.zip -d "$BROWSER_DIR"
-          rm /tmp/chrome.zip
-
-          echo "Downloading Chrome Headless Shell..."
-          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-headless-shell-linux64.zip" -o /tmp/headless.zip
-          unzip -q /tmp/headless.zip -d "$HEADLESS_DIR"
-          rm /tmp/headless.zip
-
-          echo "Browser install complete"
-          ls -la "$BROWSER_DIR" "$HEADLESS_DIR"
+        run: npx playwright install --with-deps chromium
       - name: Run Playwright tests
         timeout-minutes: 10
         run: npx playwright test

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,9 +41,17 @@ jobs:
         run: uv sync
       - name: Install Node deps
         run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ hashFiles('app/web_ui/package-lock.json') }}
       - name: Install Playwright Browsers
+        timeout-minutes: 5
         run: npx playwright install --with-deps chromium
       - name: Run Playwright tests
+        timeout-minutes: 10
         run: npx playwright test
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,35 +41,21 @@ jobs:
         run: uv sync
       - name: Install Node deps
         run: npm ci
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
       - name: Install Playwright system deps
         run: npx playwright install-deps chromium
-      - name: Install Playwright Browsers
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         timeout-minutes: 5
-        run: |
-          # npx playwright install has been hanging after download in CI.
-          # Download and extract manually, then validate with playwright.
-          BROWSER_DIR="$HOME/.cache/ms-playwright/chromium-1217"
-          HEADLESS_DIR="$HOME/.cache/ms-playwright/chromium_headless_shell-1217"
-          FFMPEG_DIR="$HOME/.cache/ms-playwright/ffmpeg-1011"
-          mkdir -p "$BROWSER_DIR" "$HEADLESS_DIR" "$FFMPEG_DIR"
-
-          echo "Downloading Chrome for Testing..."
-          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip" -o /tmp/chrome.zip
-          unzip -q /tmp/chrome.zip -d "$BROWSER_DIR"
-          rm /tmp/chrome.zip
-
-          echo "Downloading Chrome Headless Shell..."
-          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-headless-shell-linux64.zip" -o /tmp/headless.zip
-          unzip -q /tmp/headless.zip -d "$HEADLESS_DIR"
-          rm /tmp/headless.zip
-
-          echo "Downloading FFmpeg..."
-          curl -sSL --retry 3 "https://cdn.playwright.dev/builds/ffmpeg/1011/ffmpeg-linux64.zip" -o /tmp/ffmpeg.zip
-          unzip -q /tmp/ffmpeg.zip -d "$FFMPEG_DIR"
-          rm /tmp/ffmpeg.zip
-
-          echo "Browser install complete"
-          ls -la "$BROWSER_DIR" "$HEADLESS_DIR" "$FFMPEG_DIR"
+        run: npx playwright install chromium
       - name: Run Playwright tests
         timeout-minutes: 10
         run: npx playwright test

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -58,8 +58,7 @@ jobs:
         run: |
           BROWSER_DIR="$HOME/.cache/ms-playwright/chromium-1217"
           HEADLESS_DIR="$HOME/.cache/ms-playwright/chromium_headless_shell-1217"
-          FFMPEG_DIR="$HOME/.cache/ms-playwright/ffmpeg-1011"
-          mkdir -p "$BROWSER_DIR" "$HEADLESS_DIR" "$FFMPEG_DIR"
+          mkdir -p "$BROWSER_DIR" "$HEADLESS_DIR"
 
           echo "Downloading Chrome for Testing..."
           curl -sSL --retry 3 "https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip" -o /tmp/chrome.zip
@@ -71,13 +70,8 @@ jobs:
           unzip -q /tmp/headless.zip -d "$HEADLESS_DIR"
           rm /tmp/headless.zip
 
-          echo "Downloading FFmpeg..."
-          curl -sSL --retry 3 "https://cdn.playwright.dev/dbazure/download/playwright/builds/ffmpeg/1011/ffmpeg-linux64.zip" -o /tmp/ffmpeg.zip
-          unzip -q /tmp/ffmpeg.zip -d "$FFMPEG_DIR"
-          rm /tmp/ffmpeg.zip
-
           echo "Browser install complete"
-          ls -la "$BROWSER_DIR" "$HEADLESS_DIR" "$FFMPEG_DIR"
+          ls -la "$BROWSER_DIR" "$HEADLESS_DIR"
       - name: Run Playwright tests
         timeout-minutes: 10
         run: npx playwright test


### PR DESCRIPTION
Playwright CI has been timing out on every branch since ~May 27. The browser install hangs after download completes (extraction never finishes). This adds:

- actions/cache for ~/.cache/ms-playwright so repeated runs skip the download
- 5-min timeout on the install step so it fails fast instead of burning 60 min
- 10-min timeout on the test step (tests take ~2 min locally)