### PR TITLE
ci(playwright): bump @playwright/test to 1.60.0 to fix CI install hang

### DIFF
--- a/app/web_ui/package-lock.json
+++ b/app/web_ui/package-lock.json
@@ -19,7 +19,7 @@
         "posthog-js": "^1.184.2"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "@redocly/cli": "^2.11.1",
         "@sveltejs/adapter-static": "^3.0.2",
         "@sveltejs/kit": "^2.20.6",
@@ -2231,13 +2231,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8026,13 +8026,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8045,9 +8045,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/app/web_ui/package.json
+++ b/app/web_ui/package.json
@@ -17,7 +17,7 @@
     "format_check": "prettier --check --plugin prettier-plugin-svelte ./"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@redocly/cli": "^2.11.1",
     "@sveltejs/adapter-static": "^3.0.2",
     "@sveltejs/kit": "^2.20.6",


### PR DESCRIPTION
The Playwright CI job was freezing and timing out. It would download the Chrome browser, hit 100%, then hang during the unzip step until CI gave up after 5 minutes.

Nothing in our code changed. Our CI uses "latest stable Node" rather than a pinned version, and GitHub recently bumped that from Node 24.15 to 24.16. Playwright 1.59 has a bug where it can't unzip the browser on Node 24.16+, so the install hangs forever. Playwright fixed it in 1.60.

So this just bumps @playwright/test from 1.59.1 to 1.60.0 (plus the lockfile). Tested locally: browser installs fine, no hang.

Ref: microsoft/playwright#40724. Supersedes the earlier attempts on dchiang/fix-playwright-ci (PR #1440), which were patching the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)