### PR TITLE
KIL-688 Polish Available Tools/Skills lists with "+N more" modal

### DIFF
--- a/app/web_ui/src/lib/ui/badge_list.svelte
+++ b/app/web_ui/src/lib/ui/badge_list.svelte
@@ -1,11 +1,25 @@
 <script lang="ts">
+  import Dialog from "./dialog.svelte"
+
   export let items: string | string[]
   export let links: (string | null)[] | undefined = undefined
+  // When true and there is more than one item, only the first badge is shown
+  // inline alongside a "+N more" badge that opens a modal with the full list.
+  // Keeps long lists (e.g. tools/skills) from overflowing in tight spaces.
+  export let collapse: boolean = false
+  // Title shown on the "+N more" modal.
+  export let modal_title: string = ""
+
+  let dialog: Dialog
+
+  $: all_items = Array.isArray(items) ? items : []
+  $: should_collapse = collapse && all_items.length > 1
+  $: visible_items = should_collapse ? all_items.slice(0, 1) : all_items
 </script>
 
 {#if Array.isArray(items)}
-  <div class="flex flex-wrap gap-1">
-    {#each items as name, i}
+  <div class="flex flex-wrap gap-1 items-center">
+    {#each visible_items as name, i}
       {@const link = links?.[i]}
       {#if link}
         <a
@@ -19,7 +33,47 @@
         <span class="badge badge-outline">{name}</span>
       {/if}
     {/each}
+    {#if should_collapse}
+      <button
+        class="badge badge-outline hover:bg-base-200"
+        on:click|stopPropagation={() => dialog?.show()}
+      >
+        +{all_items.length - 1} more
+      </button>
+    {/if}
   </div>
+
+  {#if should_collapse}
+    <div
+      on:click|stopPropagation
+      on:keydown|stopPropagation
+      role="presentation"
+    >
+      <Dialog
+        bind:this={dialog}
+        title={modal_title}
+        width="wide"
+        action_buttons={[{ label: "Close", isCancel: true }]}
+      >
+        <div class="flex flex-wrap gap-1 text-sm text-gray-500">
+          {#each all_items as name, i}
+            {@const link = links?.[i]}
+            {#if link}
+              <a
+                href={link}
+                class="badge badge-outline hover:bg-base-200"
+                on:click|stopPropagation
+              >
+                {name}
+              </a>
+            {:else}
+              <span class="badge badge-outline">{name}</span>
+            {/if}
+          {/each}
+        </div>
+      </Dialog>
+    </div>
+  {/if}
 {:else}
   {items}
 {/if}

--- a/app/web_ui/src/lib/ui/badge_list.test.ts
+++ b/app/web_ui/src/lib/ui/badge_list.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterEach } from "vitest"
+import { render, fireEvent, cleanup } from "@testing-library/svelte"
+import BadgeList from "./badge_list.svelte"
+
+// jsdom does not implement HTMLDialogElement.showModal/close. The "+N more"
+// modal relies on them, so polyfill with no-ops that track the open state.
+beforeAll(() => {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function () {
+      this.open = true
+    }
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function () {
+      this.open = false
+    }
+  }
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("BadgeList", () => {
+  it("renders a plain string as-is", () => {
+    const { container } = render(BadgeList, { props: { items: "None" } })
+    expect(container.textContent?.trim()).toBe("None")
+  })
+
+  it("renders all badges by default (no collapse)", () => {
+    const { container } = render(BadgeList, {
+      props: { items: ["alpha", "beta", "gamma"] },
+    })
+    expect(container.textContent).toContain("alpha")
+    expect(container.textContent).toContain("beta")
+    expect(container.textContent).toContain("gamma")
+    expect(container.textContent).not.toContain("more")
+  })
+
+  it("collapses to the first badge plus a '+N more' badge", () => {
+    const { container } = render(BadgeList, {
+      props: { items: ["alpha", "beta", "gamma"], collapse: true },
+    })
+    // The inline row (distinguished by `items-center`) shows only the first
+    // item plus the "+N more" badge; the rest live in the (hidden) modal.
+    const inline = container.querySelector(".items-center")
+    expect(inline?.textContent).toContain("alpha")
+    expect(inline?.textContent).toContain("+2 more")
+    expect(inline?.textContent).not.toContain("beta")
+    expect(inline?.textContent).not.toContain("gamma")
+  })
+
+  it("does not collapse a single item", () => {
+    const { container } = render(BadgeList, {
+      props: { items: ["alpha"], collapse: true },
+    })
+    expect(container.textContent).toContain("alpha")
+    expect(container.textContent).not.toContain("more")
+  })
+
+  it("opens a titled modal with the full list when '+N more' is clicked", async () => {
+    const { container, getByText } = render(BadgeList, {
+      props: {
+        items: ["alpha", "beta", "gamma"],
+        links: ["/t/a", "/t/b", "/t/c"],
+        collapse: true,
+        modal_title: "Available Tools",
+      },
+    })
+    await fireEvent.click(getByText("+2 more"))
+    const dialog = container.querySelector("dialog")
+    expect(dialog?.textContent).toContain("Available Tools")
+    expect(dialog?.textContent).toContain("beta")
+    expect(dialog?.textContent).toContain("gamma")
+    // Links render as anchors in the modal.
+    const anchors = dialog?.querySelectorAll("a.badge")
+    expect(anchors?.length).toBe(3)
+    expect(anchors?.[2].getAttribute("href")).toBe("/t/c")
+  })
+})

--- a/app/web_ui/src/lib/ui/dialog.svelte
+++ b/app/web_ui/src/lib/ui/dialog.svelte
@@ -89,7 +89,11 @@
   on:close={() => dispatch("close")}
   on:cancel={(e) => dispatch("cancel", e)}
 >
-  <div class="modal-box {width === 'wide' ? 'w-11/12 max-w-3xl' : ''}">
+  <div
+    class="modal-box text-base-content {width === 'wide'
+      ? 'w-11/12 max-w-3xl'
+      : ''}"
+  >
     <!-- Hidden div to force the compiler to find these classes -->
     <div class="hidden w-11/12 max-w-3xl"></div>
     <div class="flex flex-row gap-2 items-start">

--- a/app/web_ui/src/lib/ui/property_list.svelte
+++ b/app/web_ui/src/lib/ui/property_list.svelte
@@ -3,9 +3,28 @@
   import InfoTooltip from "./info_tooltip.svelte"
   import type { UiProperty } from "./property_list"
   import Warning from "./warning.svelte"
+  import Dialog from "./dialog.svelte"
 
   export let properties: UiProperty[]
   export let title: string | null = null
+
+  let badges_dialog: Dialog
+  let modal_title = ""
+  let modal_values: string[] = []
+  let modal_links: (string | null)[] | undefined = undefined
+
+  function open_badges_modal(property: UiProperty) {
+    if (!Array.isArray(property.value)) {
+      return
+    }
+    modal_title = property.name
+    modal_values = property.value
+    modal_links =
+      property.links && property.links.length === property.value.length
+        ? property.links
+        : undefined
+    badges_dialog?.show()
+  }
 </script>
 
 <div>
@@ -37,15 +56,17 @@
           <slot name="custom_value" {property} />
         {:else if Array.isArray(property.value)}
           {#if property.badge}
-            <div class="flex flex-wrap gap-1">
-              {#each property.value as value, i}
+            {@const collapse =
+              property.collapse_badges && property.value.length > 1}
+            <div class="flex flex-wrap gap-1 items-center">
+              {#each collapse ? property.value.slice(0, 1) : property.value as value, i}
                 {@const link = property.links
                   ? property.links.length == property.value.length
                     ? property.links[i]
                     : null
                   : null}
                 <button
-                  class="badge badge-outline h-auto"
+                  class="badge badge-outline h-auto hover:bg-base-200"
                   on:click={() => {
                     if (link) {
                       goto(link)
@@ -55,6 +76,14 @@
                   {value}
                 </button>
               {/each}
+              {#if collapse}
+                <button
+                  class="badge badge-outline h-auto hover:bg-base-200"
+                  on:click={() => open_badges_modal(property)}
+                >
+                  +{property.value.length - 1} more
+                </button>
+              {/if}
             </div>
           {:else}
             <div class="flex flex-wrap gap-1">
@@ -100,3 +129,29 @@
     {/each}
   </div>
 </div>
+
+<Dialog
+  bind:this={badges_dialog}
+  title={modal_title}
+  width="wide"
+  action_buttons={[{ label: "Close", isCancel: true }]}
+>
+  <div class="flex flex-wrap gap-1 text-sm text-gray-500">
+    {#each modal_values as value, i}
+      {@const link =
+        modal_links && modal_links.length === modal_values.length
+          ? modal_links[i]
+          : null}
+      <button
+        class="badge badge-outline h-auto hover:bg-base-200"
+        on:click={() => {
+          if (link) {
+            goto(link)
+          }
+        }}
+      >
+        {value}
+      </button>
+    {/each}
+  </div>
+</Dialog>

--- a/app/web_ui/src/lib/ui/property_list.svelte
+++ b/app/web_ui/src/lib/ui/property_list.svelte
@@ -65,16 +65,16 @@
                     ? property.links[i]
                     : null
                   : null}
-                <button
-                  class="badge badge-outline h-auto hover:bg-base-200"
-                  on:click={() => {
-                    if (link) {
-                      goto(link)
-                    }
-                  }}
-                >
-                  {value}
-                </button>
+                {#if link}
+                  <a
+                    href={link}
+                    class="badge badge-outline h-auto hover:bg-base-200"
+                  >
+                    {value}
+                  </a>
+                {:else}
+                  <span class="badge badge-outline h-auto">{value}</span>
+                {/if}
               {/each}
               {#if collapse}
                 <button
@@ -142,16 +142,13 @@
         modal_links && modal_links.length === modal_values.length
           ? modal_links[i]
           : null}
-      <button
-        class="badge badge-outline h-auto hover:bg-base-200"
-        on:click={() => {
-          if (link) {
-            goto(link)
-          }
-        }}
-      >
-        {value}
-      </button>
+      {#if link}
+        <a href={link} class="badge badge-outline h-auto hover:bg-base-200">
+          {value}
+        </a>
+      {:else}
+        <span class="badge badge-outline h-auto">{value}</span>
+      {/if}
     {/each}
   </div>
 </Dialog>

--- a/app/web_ui/src/lib/ui/property_list.test.ts
+++ b/app/web_ui/src/lib/ui/property_list.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest"
+import { render, fireEvent, cleanup } from "@testing-library/svelte"
+import { goto } from "$app/navigation"
+import PropertyList from "./property_list.svelte"
+import type { UiProperty } from "./property_list"
+
+vi.mock("$app/navigation", () => ({
+  goto: vi.fn(),
+}))
+
+// jsdom does not implement HTMLDialogElement.showModal/close. The Dialog
+// component used for the "+N more" modal calls them, so polyfill with no-ops
+// that just track the open state.
+beforeAll(() => {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function () {
+      this.open = true
+    }
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function () {
+      this.open = false
+    }
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function render_props(properties: UiProperty[]) {
+  return render(PropertyList, { props: { properties } })
+}
+
+describe("PropertyList collapse_badges", () => {
+  it("renders all badges when collapse_badges is not set", () => {
+    const { container } = render_props([
+      {
+        name: "Available Tools",
+        value: ["alpha", "beta", "gamma"],
+        badge: true,
+      },
+    ])
+    expect(container.textContent).toContain("alpha")
+    expect(container.textContent).toContain("beta")
+    expect(container.textContent).toContain("gamma")
+    expect(container.textContent).not.toContain("more")
+  })
+
+  it("collapses to first badge plus a '+N more' badge", () => {
+    const { container } = render_props([
+      {
+        name: "Available Tools",
+        value: ["alpha", "beta", "gamma"],
+        badge: true,
+        collapse_badges: true,
+      },
+    ])
+    // First badge shown inline, the rest hidden until the modal is opened.
+    expect(container.textContent).toContain("alpha")
+    expect(container.textContent).toContain("+2 more")
+    expect(container.textContent).not.toContain("beta")
+    expect(container.textContent).not.toContain("gamma")
+  })
+
+  it("does not collapse when there is only one value", () => {
+    const { container } = render_props([
+      {
+        name: "Available Tools",
+        value: ["alpha"],
+        badge: true,
+        collapse_badges: true,
+      },
+    ])
+    expect(container.textContent).toContain("alpha")
+    expect(container.textContent).not.toContain("more")
+  })
+
+  it("opens a modal listing the full set when '+N more' is clicked", async () => {
+    const { container, getByText } = render_props([
+      {
+        name: "Available Tools",
+        value: ["alpha", "beta", "gamma"],
+        badge: true,
+        collapse_badges: true,
+      },
+    ])
+    await fireEvent.click(getByText("+2 more"))
+    // The wide modal renders the full list (including the collapsed values).
+    expect(container.textContent).toContain("beta")
+    expect(container.textContent).toContain("gamma")
+    // Modal is titled by the property name.
+    expect(container.querySelector("dialog")?.textContent).toContain(
+      "Available Tools",
+    )
+  })
+
+  it("renders the same badge pills in the modal and navigates on click", async () => {
+    const { getByText, container } = render_props([
+      {
+        name: "Available Tools",
+        value: ["alpha", "beta"],
+        links: ["/tools/a", "/tools/b"],
+        badge: true,
+        collapse_badges: true,
+      },
+    ])
+    await fireEvent.click(getByText("+1 more"))
+    // Modal pills use the same badge markup as the inline list.
+    const pills = container.querySelectorAll(
+      "dialog button.badge.badge-outline",
+    )
+    expect(pills.length).toBe(2)
+    expect(pills[1].textContent?.trim()).toBe("beta")
+    // Clicking a pill navigates to its tool link.
+    await fireEvent.click(pills[1])
+    expect(goto).toHaveBeenCalledWith("/tools/b")
+  })
+})

--- a/app/web_ui/src/lib/ui/property_list.test.ts
+++ b/app/web_ui/src/lib/ui/property_list.test.ts
@@ -1,13 +1,8 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeAll, afterEach, vi } from "vitest"
+import { describe, it, expect, beforeAll, afterEach } from "vitest"
 import { render, fireEvent, cleanup } from "@testing-library/svelte"
-import { goto } from "$app/navigation"
 import PropertyList from "./property_list.svelte"
 import type { UiProperty } from "./property_list"
-
-vi.mock("$app/navigation", () => ({
-  goto: vi.fn(),
-}))
 
 // jsdom does not implement HTMLDialogElement.showModal/close. The Dialog
 // component used for the "+N more" modal calls them, so polyfill with no-ops
@@ -27,7 +22,6 @@ beforeAll(() => {
 
 afterEach(() => {
   cleanup()
-  vi.clearAllMocks()
 })
 
 function render_props(properties: UiProperty[]) {
@@ -97,7 +91,7 @@ describe("PropertyList collapse_badges", () => {
     )
   })
 
-  it("renders the same badge pills in the modal and navigates on click", async () => {
+  it("renders the same badge pills (semantic links) in the modal", async () => {
     const { getByText, container } = render_props([
       {
         name: "Available Tools",
@@ -108,14 +102,11 @@ describe("PropertyList collapse_badges", () => {
       },
     ])
     await fireEvent.click(getByText("+1 more"))
-    // Modal pills use the same badge markup as the inline list.
-    const pills = container.querySelectorAll(
-      "dialog button.badge.badge-outline",
-    )
+    // Modal pills use the same badge markup as the inline list: semantic
+    // anchors for links pointing at the tool's page.
+    const pills = container.querySelectorAll("dialog a.badge.badge-outline")
     expect(pills.length).toBe(2)
     expect(pills[1].textContent?.trim()).toBe("beta")
-    // Clicking a pill navigates to its tool link.
-    await fireEvent.click(pills[1])
-    expect(goto).toHaveBeenCalledWith("/tools/b")
+    expect(pills[1].getAttribute("href")).toBe("/tools/b")
   })
 })

--- a/app/web_ui/src/lib/ui/property_list.ts
+++ b/app/web_ui/src/lib/ui/property_list.ts
@@ -7,6 +7,10 @@ export type UiProperty = {
   error?: boolean
   warn_icon?: boolean
   badge?: boolean
+  // Only applies to badge + string[] values. When true and there is more than
+  // one value, show the first badge plus a "+N more" badge that opens a modal
+  // with the full list. Keeps long lists (e.g. tools/skills) from overflowing.
+  collapse_badges?: boolean
   value_with_link?: {
     prefix: string
     link_text: string

--- a/app/web_ui/src/lib/utils/run_config_formatters.ts
+++ b/app/web_ui/src/lib/utils/run_config_formatters.ts
@@ -234,12 +234,14 @@ export function getRunConfigUiProperties(
           value: tools_property_info.value,
           links: tools_property_info.links,
           badge: Array.isArray(tools_property_info.value) ? true : false,
+          collapse_badges: true,
         },
         {
           name: "Available Skills",
           value: skills_property_info.value,
           links: skills_property_info.links,
           badge: Array.isArray(skills_property_info.value) ? true : false,
+          collapse_badges: true,
         },
         {
           name: "Temperature",

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
@@ -691,8 +691,7 @@
                       <span class="truncate">{tagDisplay.firstTag}</span>
                       {#if tagDisplay.othersCount > 0}
                         <span class="ml-1 font-medium text-nowrap">
-                          +{tagDisplay.othersCount}
-                          {tagDisplay.othersCount === 1 ? "other" : "others"}
+                          +{tagDisplay.othersCount} more
                         </span>
                       {/if}
                     </div>

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/[run_id]/run/+page.svelte
@@ -140,12 +140,14 @@
       value: tools_property_value,
       links: tool_links,
       badge: Array.isArray(tools_property_value) ? true : false,
+      collapse_badges: true,
     })
     properties.push({
       name: "Available Skills",
       value: skills_property_value,
       links: skill_links,
       badge: Array.isArray(skills_property_value) ? true : false,
+      collapse_badges: true,
     })
     return properties
   }

--- a/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/optimize/[project_id]/[task_id]/+page.svelte
@@ -510,12 +510,16 @@
                     <BadgeList
                       items={tools_info.value}
                       links={tools_info.links}
+                      collapse
+                      modal_title="Tools"
                     />
                   </td>
                   <td class="text-gray-500">
                     <BadgeList
                       items={skills_info.value}
                       links={skills_info.links}
+                      collapse
+                      modal_title="Skills"
                     />
                   </td>
                   <td>

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/+page.svelte
@@ -981,10 +981,7 @@
                           <span class="truncate">{tagDisplay.firstTag}</span>
                           {#if tagDisplay.othersCount > 0}
                             <span class="ml-1 font-medium text-nowrap">
-                              +{tagDisplay.othersCount}
-                              {tagDisplay.othersCount === 1
-                                ? "other"
-                                : "others"}
+                              +{tagDisplay.othersCount} more
                             </span>
                           {/if}
                         </div>


### PR DESCRIPTION
BEFORE:
<img width="288" height="827" alt="Screenshot 2026-06-02 at 9 07 33 PM" src="https://github.com/user-attachments/assets/680331d9-ba25-4867-8441-73aee9aae6eb" />

AFTER:
<img width="383" height="317" alt="Screenshot 2026-06-02 at 11 46 27 PM" src="https://github.com/user-attachments/assets/a8ff3238-2396-448f-ba20-577c5ea1bc4b" />

<img width="796" height="531" alt="Screenshot 2026-06-02 at 11 46 32 PM" src="https://github.com/user-attachments/assets/69a8caee-d9c2-4c92-bf3d-f5c8e429dfa6" />

Linear ticket: https://linear.app/kiln_ai/issue/KIL-688/available-tools-in-property-list-needs-polish-for-many-tools

## Description

The **Available Tools** and **Available Skills** lists overflowed and looked messy when a run config had many tools/skills. This caps each list at one badge plus a **`+N more`** badge that opens a `width="wide"` modal with the full set — the same paradigm we already use for tags in tables.

### Changes

- **`property_list.svelte` / `property_list.ts`** — add opt-in `collapse_badges`. The tools/skills rows on the run-config detail and run detail pages now collapse to the first pill + `+N more`, opening a wide modal titled by the property name (`Available Tools` / `Available Skills`). Modal pills use the exact same `badge badge-outline hover:bg-base-200` markup as the inline pills, and stay individually clickable links.
- **`badge_list.svelte`** — add opt-in `collapse` + `modal_title`. The **Optimize run-config table** Tools/Skills columns now collapse, opening a modal titled `Tools` / `Skills` to match the column headers. `+N more` and the dialog stop click propagation so they don't trigger the row's navigate-on-click.
- **`dialog.svelte`** — give `modal-box` its own `text-base-content` so a dialog title no longer inherits color from its trigger context (the tools/skills modals open from inside `text-gray-500` table cells, which previously washed out their titles).
- **Copy unification** — the tag truncation on the specs/dataset tables now reads `+N more` (was `+N other(s)`) to match the tools/skills wording. Distinct pill styles are intentionally kept (tag = single filled pill; tools/skills = outline link-pills).

### Audit

Audited the app for other long inline badge/pill lists in constrained spaces. The only actionable spot beyond the above was the Optimize table (fixed here). The kiln-task-tools list in `tools/[project_id]/+page.svelte` is already hidden behind an `InfoTooltip`, so it was left as-is.

### Tests

- `property_list.test.ts` (5) and `badge_list.test.ts` (5) covering: all-badges default, collapse to `+N more`, single-item no-collapse, modal opens with the full list + title, and link navigation.
- Full web suite green (927 tests), build passes, lint/format/svelte-check clean.

> Note: the local pre-commit OpenAPI schema check flagged drift, but it compares against a **stale running dev server**, not the branch code — this change is purely frontend and touches no API. CI regenerates the schema from source and is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)