### PR TITLE
Update SDK with multipart boundary fix

### DIFF
--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/api/jobs/start_sample_job_v1_jobs_sample_job_start_post.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/api/jobs/start_sample_job_v1_jobs_sample_job_start_post.py
@@ -23,7 +23,6 @@ def _get_kwargs(
     }
 
     _kwargs["data"] = body.to_dict()
-
     headers["Content-Type"] = "application/x-www-form-urlencoded"
 
     _kwargs["headers"] = headers

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/__init__.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/__init__.py
@@ -83,6 +83,7 @@ from .mcp_run_config_properties import McpRunConfigProperties
 from .mcp_tool_reference import MCPToolReference
 from .mcp_tool_reference_input_schema_type_0 import MCPToolReferenceInputSchemaType0
 from .mcp_tool_reference_output_schema_type_0 import MCPToolReferenceOutputSchemaType0
+from .message_usage import MessageUsage
 from .model_provider_name import ModelProviderName
 from .new_proposed_spec_edit_api import NewProposedSpecEditApi
 from .output_file_info import OutputFileInfo
@@ -194,6 +195,7 @@ __all__ = (
     "MCPToolReference",
     "MCPToolReferenceInputSchemaType0",
     "MCPToolReferenceOutputSchemaType0",
+    "MessageUsage",
     "ModelProviderName",
     "NewProposedSpecEditApi",
     "OutputFileInfo",

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/chat_completion_assistant_message_param_wrapper.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/chat_completion_assistant_message_param_wrapper.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from ..models.chat_completion_content_part_text_param import ChatCompletionContentPartTextParam
     from ..models.chat_completion_message_function_tool_call_param import ChatCompletionMessageFunctionToolCallParam
     from ..models.function_call import FunctionCall
+    from ..models.message_usage import MessageUsage
 
 
 T = TypeVar("T", bound="ChatCompletionAssistantMessageParamWrapper")
@@ -37,6 +38,8 @@ class ChatCompletionAssistantMessageParamWrapper:
             name (str | Unset):
             refusal (None | str | Unset):
             tool_calls (list[ChatCompletionMessageFunctionToolCallParam] | Unset):
+            latency_ms (int | None | Unset):
+            usage (MessageUsage | None | Unset):
     """
 
     role: Literal["assistant"]
@@ -49,12 +52,15 @@ class ChatCompletionAssistantMessageParamWrapper:
     name: str | Unset = UNSET
     refusal: None | str | Unset = UNSET
     tool_calls: list[ChatCompletionMessageFunctionToolCallParam] | Unset = UNSET
+    latency_ms: int | None | Unset = UNSET
+    usage: MessageUsage | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         from ..models.audio import Audio
         from ..models.chat_completion_content_part_text_param import ChatCompletionContentPartTextParam
         from ..models.function_call import FunctionCall
+        from ..models.message_usage import MessageUsage
 
         role = self.role
 
@@ -112,6 +118,20 @@ class ChatCompletionAssistantMessageParamWrapper:
                 tool_calls_item = tool_calls_item_data.to_dict()
                 tool_calls.append(tool_calls_item)
 
+        latency_ms: int | None | Unset
+        if isinstance(self.latency_ms, Unset):
+            latency_ms = UNSET
+        else:
+            latency_ms = self.latency_ms
+
+        usage: dict[str, Any] | None | Unset
+        if isinstance(self.usage, Unset):
+            usage = UNSET
+        elif isinstance(self.usage, MessageUsage):
+            usage = self.usage.to_dict()
+        else:
+            usage = self.usage
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -133,6 +153,10 @@ class ChatCompletionAssistantMessageParamWrapper:
             field_dict["refusal"] = refusal
         if tool_calls is not UNSET:
             field_dict["tool_calls"] = tool_calls
+        if latency_ms is not UNSET:
+            field_dict["latency_ms"] = latency_ms
+        if usage is not UNSET:
+            field_dict["usage"] = usage
 
         return field_dict
 
@@ -143,6 +167,7 @@ class ChatCompletionAssistantMessageParamWrapper:
         from ..models.chat_completion_content_part_text_param import ChatCompletionContentPartTextParam
         from ..models.chat_completion_message_function_tool_call_param import ChatCompletionMessageFunctionToolCallParam
         from ..models.function_call import FunctionCall
+        from ..models.message_usage import MessageUsage
 
         d = dict(src_dict)
         role = cast(Literal["assistant"], d.pop("role"))
@@ -257,6 +282,32 @@ class ChatCompletionAssistantMessageParamWrapper:
 
                 tool_calls.append(tool_calls_item)
 
+        def _parse_latency_ms(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        latency_ms = _parse_latency_ms(d.pop("latency_ms", UNSET))
+
+        def _parse_usage(data: object) -> MessageUsage | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                usage_type_0 = MessageUsage.from_dict(data)
+
+                return usage_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MessageUsage | None | Unset, data)
+
+        usage = _parse_usage(d.pop("usage", UNSET))
+
         chat_completion_assistant_message_param_wrapper = cls(
             role=role,
             audio=audio,
@@ -266,6 +317,8 @@ class ChatCompletionAssistantMessageParamWrapper:
             name=name,
             refusal=refusal,
             tool_calls=tool_calls,
+            latency_ms=latency_ms,
+            usage=usage,
         )
 
         chat_completion_assistant_message_param_wrapper.additional_properties = d

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/chat_session_list_item.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/chat_session_list_item.py
@@ -6,7 +6,6 @@ from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-from dateutil.parser import isoparse
 
 T = TypeVar("T", bound="ChatSessionListItem")
 
@@ -54,7 +53,7 @@ class ChatSessionListItem:
         d = dict(src_dict)
         id = d.pop("id")
 
-        updated_at = isoparse(d.pop("updated_at"))
+        updated_at = datetime.datetime.fromisoformat(d.pop("updated_at"))
 
         title = d.pop("title")
 

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/kiln_base_model.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/kiln_base_model.py
@@ -6,7 +6,6 @@ from typing import Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
 
@@ -115,7 +114,7 @@ class KilnBaseModel:
         if isinstance(_created_at, Unset):
             created_at = UNSET
         else:
-            created_at = isoparse(_created_at)
+            created_at = datetime.datetime.fromisoformat(_created_at)
 
         created_by = d.pop("created_by", UNSET)
 

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/message_usage.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/message_usage.py
@@ -8,18 +8,22 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="Usage")
+T = TypeVar("T", bound="MessageUsage")
 
 
 @_attrs_define
-class Usage:
-    """Token usage, cost, and aggregate LLM latency for a per-run accumulator.
+class MessageUsage:
+    """Token usage and cost for a single LLM call or a multi-message sum.
 
-    Extends :class:`MessageUsage` with ``total_llm_latency_ms``, which is
-    only meaningful while a single run is in flight (its model calls run
-    sequentially in real time). For per-message records and full-trace
-    sums use :class:`MessageUsage` — those values would mix latencies
-    from different points in time, so the field doesn't apply.
+    Carries only the fields that are meaningfully aggregatable across
+    messages: token counts and cost. Per-call latency lives on the
+    individual message's ``latency_ms`` field; aggregating it across the
+    full trace would mix latencies from different points in time, so
+    ``MessageUsage`` does NOT carry ``total_llm_latency_ms``.
+
+    The :class:`Usage` subclass adds ``total_llm_latency_ms`` for the
+    in-flight per-run accumulator that tracks how long this run spent
+    waiting on LLM calls.
 
         Attributes:
             input_tokens (int | None | Unset): The number of input tokens used.
@@ -27,8 +31,6 @@ class Usage:
             total_tokens (int | None | Unset): The total number of tokens used.
             cost (float | None | Unset): The cost in US dollars, saved at runtime (prices can change over time).
             cached_tokens (int | None | Unset): Number of tokens served from prompt cache. None if not reported.
-            total_llm_latency_ms (int | None | Unset): Total time spent waiting on LLM API calls in milliseconds. Sum of
-                per-call latencies, excludes tool execution time.
     """
 
     input_tokens: int | None | Unset = UNSET
@@ -36,7 +38,6 @@ class Usage:
     total_tokens: int | None | Unset = UNSET
     cost: float | None | Unset = UNSET
     cached_tokens: int | None | Unset = UNSET
-    total_llm_latency_ms: int | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -70,12 +71,6 @@ class Usage:
         else:
             cached_tokens = self.cached_tokens
 
-        total_llm_latency_ms: int | None | Unset
-        if isinstance(self.total_llm_latency_ms, Unset):
-            total_llm_latency_ms = UNSET
-        else:
-            total_llm_latency_ms = self.total_llm_latency_ms
-
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -89,8 +84,6 @@ class Usage:
             field_dict["cost"] = cost
         if cached_tokens is not UNSET:
             field_dict["cached_tokens"] = cached_tokens
-        if total_llm_latency_ms is not UNSET:
-            field_dict["total_llm_latency_ms"] = total_llm_latency_ms
 
         return field_dict
 
@@ -143,26 +136,16 @@ class Usage:
 
         cached_tokens = _parse_cached_tokens(d.pop("cached_tokens", UNSET))
 
-        def _parse_total_llm_latency_ms(data: object) -> int | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(int | None | Unset, data)
-
-        total_llm_latency_ms = _parse_total_llm_latency_ms(d.pop("total_llm_latency_ms", UNSET))
-
-        usage = cls(
+        message_usage = cls(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             total_tokens=total_tokens,
             cost=cost,
             cached_tokens=cached_tokens,
-            total_llm_latency_ms=total_llm_latency_ms,
         )
 
-        usage.additional_properties = d
-        return usage
+        message_usage.additional_properties = d
+        return message_usage
 
     @property
     def additional_keys(self) -> list[str]:

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/task_output.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/task_output.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
 
@@ -153,7 +152,7 @@ class TaskOutput:
         if isinstance(_created_at, Unset):
             created_at = UNSET
         else:
-            created_at = isoparse(_created_at)
+            created_at = datetime.datetime.fromisoformat(_created_at)
 
         created_by = d.pop("created_by", UNSET)
 

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/task_output_rating.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/task_output_rating.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-from dateutil.parser import isoparse
 
 from ..models.task_output_rating_type import TaskOutputRatingType
 from ..types import UNSET, Unset
@@ -151,7 +150,7 @@ class TaskOutputRating:
         if isinstance(_created_at, Unset):
             created_at = UNSET
         else:
-            created_at = isoparse(_created_at)
+            created_at = datetime.datetime.fromisoformat(_created_at)
 
         created_by = d.pop("created_by", UNSET)
 

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/task_run.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/task_run.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
 
@@ -18,6 +17,7 @@ if TYPE_CHECKING:
     from ..models.chat_completion_tool_message_param_wrapper import ChatCompletionToolMessageParamWrapper
     from ..models.chat_completion_user_message_param import ChatCompletionUserMessageParam
     from ..models.data_source import DataSource
+    from ..models.message_usage import MessageUsage
     from ..models.task_output import TaskOutput
     from ..models.task_run_intermediate_outputs_type_0 import TaskRunIntermediateOutputsType0
     from ..models.usage import Usage
@@ -59,6 +59,9 @@ class TaskRun:
                 reporting.
             usage (None | Unset | Usage): Usage information for the task run. This includes the number of input tokens,
                 output tokens, and total tokens used.
+            cumulative_usage (MessageUsage | None | Unset): Sum of per-message token usage and cost across the entire trace,
+                including any seeded prior trace. None on records created before this field existed. For a fresh (non-seeded)
+                run, the token / cost fields equal those of `usage`.
             trace (list[ChatCompletionAssistantMessageParamWrapper | ChatCompletionDeveloperMessageParam |
                 ChatCompletionFunctionMessageParam | ChatCompletionSystemMessageParam | ChatCompletionToolMessageParamWrapper |
                 ChatCompletionUserMessageParam] | None | Unset): The trace of the task run in OpenAI format. This is the list of
@@ -81,6 +84,7 @@ class TaskRun:
     intermediate_outputs: None | TaskRunIntermediateOutputsType0 | Unset = UNSET
     tags: list[str] | Unset = UNSET
     usage: None | Unset | Usage = UNSET
+    cumulative_usage: MessageUsage | None | Unset = UNSET
     trace: (
         list[
             ChatCompletionAssistantMessageParamWrapper
@@ -103,6 +107,7 @@ class TaskRun:
         from ..models.chat_completion_tool_message_param_wrapper import ChatCompletionToolMessageParamWrapper
         from ..models.chat_completion_user_message_param import ChatCompletionUserMessageParam
         from ..models.data_source import DataSource
+        from ..models.message_usage import MessageUsage
         from ..models.task_output import TaskOutput
         from ..models.task_run_intermediate_outputs_type_0 import TaskRunIntermediateOutputsType0
         from ..models.usage import Usage
@@ -175,6 +180,14 @@ class TaskRun:
         else:
             usage = self.usage
 
+        cumulative_usage: dict[str, Any] | None | Unset
+        if isinstance(self.cumulative_usage, Unset):
+            cumulative_usage = UNSET
+        elif isinstance(self.cumulative_usage, MessageUsage):
+            cumulative_usage = self.cumulative_usage.to_dict()
+        else:
+            cumulative_usage = self.cumulative_usage
+
         trace: list[dict[str, Any]] | None | Unset
         if isinstance(self.trace, Unset):
             trace = UNSET
@@ -237,6 +250,8 @@ class TaskRun:
             field_dict["tags"] = tags
         if usage is not UNSET:
             field_dict["usage"] = usage
+        if cumulative_usage is not UNSET:
+            field_dict["cumulative_usage"] = cumulative_usage
         if trace is not UNSET:
             field_dict["trace"] = trace
         if parent_task_run_id is not UNSET:
@@ -253,6 +268,7 @@ class TaskRun:
         from ..models.chat_completion_tool_message_param_wrapper import ChatCompletionToolMessageParamWrapper
         from ..models.chat_completion_user_message_param import ChatCompletionUserMessageParam
         from ..models.data_source import DataSource
+        from ..models.message_usage import MessageUsage
         from ..models.task_output import TaskOutput
         from ..models.task_run_intermediate_outputs_type_0 import TaskRunIntermediateOutputsType0
         from ..models.usage import Usage
@@ -289,7 +305,7 @@ class TaskRun:
         if isinstance(_created_at, Unset):
             created_at = UNSET
         else:
-            created_at = isoparse(_created_at)
+            created_at = datetime.datetime.fromisoformat(_created_at)
 
         created_by = d.pop("created_by", UNSET)
 
@@ -371,6 +387,23 @@ class TaskRun:
             return cast(None | Unset | Usage, data)
 
         usage = _parse_usage(d.pop("usage", UNSET))
+
+        def _parse_cumulative_usage(data: object) -> MessageUsage | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                cumulative_usage_type_0 = MessageUsage.from_dict(data)
+
+                return cumulative_usage_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MessageUsage | None | Unset, data)
+
+        cumulative_usage = _parse_cumulative_usage(d.pop("cumulative_usage", UNSET))
 
         def _parse_trace(
             data: object,
@@ -500,6 +533,7 @@ class TaskRun:
             intermediate_outputs=intermediate_outputs,
             tags=tags,
             usage=usage,
+            cumulative_usage=cumulative_usage,
             trace=trace,
             parent_task_run_id=parent_task_run_id,
         )

--- a/app/desktop/studio_server/test_multipart_boundary.py
+++ b/app/desktop/studio_server/test_multipart_boundary.py
@@ -1,0 +1,158 @@
+import io
+import zipfile
+
+import httpx
+import pytest
+from python_multipart.multipart import parse_options_header
+
+from app.desktop.studio_server.api_client.kiln_ai_server_client.api.jobs.start_prompt_optimization_job_v1_jobs_prompt_optimization_job_start_post import (
+    _get_kwargs,
+)
+from app.desktop.studio_server.api_client.kiln_ai_server_client.models.body_start_prompt_optimization_job_v1_jobs_prompt_optimization_job_start_post import (
+    BodyStartPromptOptimizationJobV1JobsPromptOptimizationJobStartPost,
+)
+from app.desktop.studio_server.api_client.kiln_ai_server_client.types import File
+
+
+def _make_zip_with_content(text: str) -> bytes:
+    """Create a zip file in memory containing a single text file with the given content."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("marker.txt", text)
+    return buf.getvalue()
+
+
+def _read_httpx_stream(request: httpx.Request) -> bytes:
+    """Read all bytes from an httpx Request's streaming body."""
+    return b"".join(request.stream)
+
+
+def _build_multipart_request(
+    zip_bytes: bytes,
+    task_id: str = "task-1",
+    run_config_id: str = "rc-1",
+    eval_ids: list[str] | None = None,
+) -> httpx.Request:
+    """Build a real httpx Request from the SDK's multipart body."""
+    body = BodyStartPromptOptimizationJobV1JobsPromptOptimizationJobStartPost(
+        task_id=task_id,
+        target_run_config_id=run_config_id,
+        eval_ids=eval_ids or ["eval-1"],
+        project_zip=File(
+            payload=io.BytesIO(zip_bytes),
+            file_name="project.zip",
+            mime_type="application/zip",
+        ),
+    )
+    kwargs = _get_kwargs(body=body)
+    return httpx.Request(
+        method=kwargs["method"],
+        url=f"http://localhost{kwargs['url']}",
+        files=kwargs["files"],
+        headers=kwargs.get("headers", {}),
+    )
+
+
+def _extract_zip_from_multipart(request: httpx.Request) -> bytes:
+    """Extract the project_zip file bytes from a multipart httpx Request."""
+    content_type = request.headers["content-type"]
+    _, params = parse_options_header(content_type.encode())
+    boundary = params[b"boundary"]
+    raw_body = _read_httpx_stream(request)
+    parts = raw_body.split(b"--" + boundary)
+
+    for part in parts:
+        if b'name="project_zip"' in part:
+            header_end = part.find(b"\r\n\r\n")
+            assert header_end != -1
+            file_data = part[header_end + 4 :]
+            if file_data.endswith(b"\r\n"):
+                file_data = file_data[:-2]
+            return file_data
+
+    raise AssertionError("project_zip part not found in multipart body")
+
+
+def test_get_kwargs_does_not_hardcode_content_type():
+    """Regression: _get_kwargs must not set a Content-Type header.
+
+    When a Content-Type header is hardcoded (e.g. with boundary=+++) httpx
+    cannot negotiate its own boundary, which corrupts multipart parsing
+    whenever the payload contains the same boundary string.
+    """
+    zip_bytes = _make_zip_with_content("+++ test marker +++")
+    body = BodyStartPromptOptimizationJobV1JobsPromptOptimizationJobStartPost(
+        task_id="t1",
+        target_run_config_id="rc1",
+        eval_ids=["e1"],
+        project_zip=File(
+            payload=io.BytesIO(zip_bytes),
+            file_name="project.zip",
+            mime_type="application/zip",
+        ),
+    )
+
+    kwargs = _get_kwargs(body=body)
+
+    headers = kwargs.get("headers", {})
+    assert "Content-Type" not in headers, (
+        f"SDK must not hardcode a Content-Type header on multipart endpoints, "
+        f"but found: {headers.get('Content-Type')}"
+    )
+    assert "files" in kwargs, "_get_kwargs should set 'files' for multipart upload"
+
+
+def test_multipart_roundtrip_with_triple_plus_content():
+    """Upload a zip whose contents include '+++' and verify the multipart body
+    can be parsed without corruption.
+
+    This is the core regression test: a hardcoded boundary=+++ would make the
+    multipart parser split on the '+++' inside the zip, producing a 400 error.
+    """
+    marker = "+++ test marker +++"
+    zip_bytes = _make_zip_with_content(marker)
+
+    request = _build_multipart_request(zip_bytes, eval_ids=["eval-1", "eval-2"])
+
+    content_type = request.headers["content-type"]
+    assert "multipart/form-data" in content_type
+    assert "boundary=+++" not in content_type
+
+    file_data = _extract_zip_from_multipart(request)
+    zf = zipfile.ZipFile(io.BytesIO(file_data))
+    extracted = zf.read("marker.txt").decode()
+    assert extracted == marker
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "+++",
+        "------",
+        "boundary=+++",
+        "--boundary\r\n",
+        'Content-Disposition: form-data; name="inject"',
+    ],
+    ids=[
+        "triple-plus",
+        "dashes",
+        "fake-boundary-header",
+        "boundary-line",
+        "header-injection",
+    ],
+)
+def test_multipart_encoding_resilient_to_adversarial_content(content: str):
+    """Verify multipart encoding stays correct even when zip content contains
+    strings that look like multipart delimiters or headers."""
+    zip_bytes = _make_zip_with_content(content)
+
+    request = _build_multipart_request(zip_bytes)
+
+    content_type = request.headers["content-type"]
+    assert "multipart/form-data" in content_type
+    assert "boundary=+++" not in content_type
+
+    file_data = _extract_zip_from_multipart(request)
+    zf = zipfile.ZipFile(io.BytesIO(file_data))
+    extracted = zf.read("marker.txt").decode()
+    assert extracted == content


### PR DESCRIPTION
Copies the patched generated SDK from kiln_server PR https://github.com/Kiln-AI/kiln_server/pull/211 and adds regression tests for the multipart boundary fix.

The regenerated SDK no longer hardcodes Content-Type headers on multipart endpoints, letting httpx auto-generate a safe boundary. This prevents multipart parse failures when zip payloads happen to contain the boundary string.

New test file with 7 tests that build real httpx multipart requests through the SDK and verify the zip content survives a round-trip even with adversarial payloads like `+++`, `------`, and fake Content-Disposition headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)