### PR TITLE
Hide structured-only download formats for unstructured tasks

### DIFF
--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
@@ -263,7 +263,7 @@
 
   function build_available_model_select(
     models: FinetuneProvider[] | null,
-    _: Task | null,
+    task: Task | null,
   ) {
     if (!models) {
       return
@@ -330,40 +330,7 @@
       })
     }
 
-    const has_structured_output = !!$current_task?.output_json_schema
-
-    const download_options: Option[] = [
-      {
-        value: "download_jsonl_msg",
-        label: "OpenAI chat format (JSONL)",
-      },
-      {
-        value: "download_jsonl_json_schema_msg",
-        label: "OpenAI chat format with JSON response (JSONL)",
-      },
-      {
-        value: "download_jsonl_toolcall",
-        label: "OpenAI chat format with tool call response (JSONL)",
-      },
-      {
-        value: "download_huggingface_chat_template",
-        label: "HuggingFace chat template (JSONL)",
-      },
-      {
-        value: "download_huggingface_chat_template_toolcall",
-        label: "HuggingFace chat template with tool calls (JSONL)",
-      },
-      {
-        value: "download_vertex_gemini",
-        label: "Google Vertex-AI Gemini format (JSONL)",
-      },
-    ]
-
-    const structured_only_formats = new Set([
-      "download_jsonl_json_schema_msg",
-      "download_jsonl_toolcall",
-      "download_huggingface_chat_template_toolcall",
-    ])
+    const has_structured_output = !!task?.output_json_schema
 
     available_model_select.push({
       label: "Download Dataset",
@@ -393,6 +360,39 @@
       "huggingface_chat_template_toolcall_jsonl",
     download_vertex_gemini: "vertex_gemini",
   }
+
+  const download_options: Option[] = [
+    {
+      value: "download_jsonl_msg",
+      label: "OpenAI chat format (JSONL)",
+    },
+    {
+      value: "download_jsonl_json_schema_msg",
+      label: "OpenAI chat format with JSON response (JSONL)",
+    },
+    {
+      value: "download_jsonl_toolcall",
+      label: "OpenAI chat format with tool call response (JSONL)",
+    },
+    {
+      value: "download_huggingface_chat_template",
+      label: "HuggingFace chat template (JSONL)",
+    },
+    {
+      value: "download_huggingface_chat_template_toolcall",
+      label: "HuggingFace chat template with tool calls (JSONL)",
+    },
+    {
+      value: "download_vertex_gemini",
+      label: "Google Vertex-AI Gemini format (JSONL)",
+    },
+  ]
+
+  const structured_only_formats = new Set([
+    "download_jsonl_json_schema_msg",
+    "download_jsonl_toolcall",
+    "download_huggingface_chat_template_toolcall",
+  ])
 
   $: get_hyperparameters(provider_id)
 

--- a/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
+++ b/app/web_ui/src/routes/(app)/fine_tune/[project_id]/[task_id]/create_finetune/+page.svelte
@@ -10,7 +10,10 @@
   import Warning from "$lib/ui/warning.svelte"
   import Completed from "$lib/ui/completed.svelte"
   import PromptTypeSelector from "$lib/ui/run_config_component/prompt_type_selector.svelte"
-  import { fine_tune_target_model as model_provider } from "$lib/stores"
+  import {
+    fine_tune_target_model as model_provider,
+    current_task,
+  } from "$lib/stores"
   import {
     available_tuning_models,
     available_models_error,
@@ -28,6 +31,7 @@
     FineTuneParameter,
     KilnAgentRunConfigProperties,
     ModelProviderName,
+    Task,
   } from "$lib/types"
   import { isKilnAgentRunConfig } from "$lib/types"
   import SelectFinetuneDataset from "./select_finetune_dataset.svelte"
@@ -255,9 +259,12 @@
     state_initialized = true
   })
 
-  $: build_available_model_select($available_tuning_models)
+  $: build_available_model_select($available_tuning_models, $current_task)
 
-  function build_available_model_select(models: FinetuneProvider[] | null) {
+  function build_available_model_select(
+    models: FinetuneProvider[] | null,
+    _: Task | null,
+  ) {
     if (!models) {
       return
     }
@@ -323,34 +330,48 @@
       })
     }
 
+    const has_structured_output = !!$current_task?.output_json_schema
+
+    const download_options: Option[] = [
+      {
+        value: "download_jsonl_msg",
+        label: "OpenAI chat format (JSONL)",
+      },
+      {
+        value: "download_jsonl_json_schema_msg",
+        label: "OpenAI chat format with JSON response (JSONL)",
+      },
+      {
+        value: "download_jsonl_toolcall",
+        label: "OpenAI chat format with tool call response (JSONL)",
+      },
+      {
+        value: "download_huggingface_chat_template",
+        label: "HuggingFace chat template (JSONL)",
+      },
+      {
+        value: "download_huggingface_chat_template_toolcall",
+        label: "HuggingFace chat template with tool calls (JSONL)",
+      },
+      {
+        value: "download_vertex_gemini",
+        label: "Google Vertex-AI Gemini format (JSONL)",
+      },
+    ]
+
+    const structured_only_formats = new Set([
+      "download_jsonl_json_schema_msg",
+      "download_jsonl_toolcall",
+      "download_huggingface_chat_template_toolcall",
+    ])
+
     available_model_select.push({
       label: "Download Dataset",
-      options: [
-        {
-          value: "download_jsonl_msg",
-          label: "OpenAI chat format (JSONL)",
-        },
-        {
-          value: "download_jsonl_json_schema_msg",
-          label: "OpenAI chat format with JSON response (JSONL)",
-        },
-        {
-          value: "download_jsonl_toolcall",
-          label: "OpenAI chat format with tool call response (JSONL)",
-        },
-        {
-          value: "download_huggingface_chat_template",
-          label: "HuggingFace chat template (JSONL)",
-        },
-        {
-          value: "download_huggingface_chat_template_toolcall",
-          label: "HuggingFace chat template with tool calls (JSONL)",
-        },
-        {
-          value: "download_vertex_gemini",
-          label: "Google Vertex-AI Gemini format (JSONL)",
-        },
-      ],
+      options: has_structured_output
+        ? download_options
+        : download_options.filter(
+            (o) => !structured_only_formats.has(o.value as string),
+          ),
     })
 
     // Check if the model provider is in the available model select


### PR DESCRIPTION
## What this PR is for

When a task has unstructured output (no JSON schema), the fine-tune "Download Dataset" dropdown now hides the 3 formats that require structured data: JSON response, OpenAI tool call, and HuggingFace tool call. Previously selecting these would open a new tab with a raw error.

Fixes this by checking current_task.output_json_schema in the create fine-tune page.

## Test plan
- Open create fine-tune page for an unstructured task — should see 3 download formats (OpenAI chat, HuggingFace chat, Vertex Gemini)

<img width="357" height="165" alt="image" src="https://github.com/user-attachments/assets/0ec3641c-0726-4b87-81c6-25ea234a6255" />

- Open create fine-tune page for a structured task — should see all 6 download formats

<img width="404" height="277" alt="image" src="https://github.com/user-attachments/assets/3f2a8be0-bace-4dd0-a890-139cd667b955" />

