### PR TITLE
Add MiMo-V2.5 and MiMo-V2.5-Pro models

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -7962,6 +7962,47 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
+    # MiMo-V2.5-Pro
+    KilnModel(
+        family=ModelFamily.mimo,
+        name=ModelName.mimo_v2_5_pro,
+        friendly_name="MiMo-V2.5-Pro",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="xiaomi/mimo-v2.5-pro",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+            ),
+        ],
+    ),
+    # MiMo-V2.5
+    KilnModel(
+        family=ModelFamily.mimo,
+        name=ModelName.mimo_v2_5,
+        friendly_name="MiMo-V2.5",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="xiaomi/mimo-v2.5",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                supports_doc_extraction=True,
+                multimodal_requires_pdf_as_image=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
     # MiMo-V2-Pro
     KilnModel(
         family=ModelFamily.mimo,
@@ -8007,47 +8048,6 @@ built_in_models: List[KilnModel] = [
                     KilnMimeType.JPG,
                     KilnMimeType.PNG,
                 ],
-            ),
-        ],
-    ),
-    # MiMo-V2.5
-    KilnModel(
-        family=ModelFamily.mimo,
-        name=ModelName.mimo_v2_5,
-        friendly_name="MiMo-V2.5",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.openrouter,
-                model_id="xiaomi/mimo-v2.5",
-                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
-                supports_data_gen=True,
-                supports_vision=True,
-                multimodal_capable=True,
-                supports_doc_extraction=True,
-                multimodal_requires_pdf_as_image=True,
-                multimodal_mime_types=[
-                    # documents
-                    KilnMimeType.PDF,
-                    KilnMimeType.TXT,
-                    KilnMimeType.MD,
-                    # images
-                    KilnMimeType.JPG,
-                    KilnMimeType.PNG,
-                ],
-            ),
-        ],
-    ),
-    # MiMo-V2.5-Pro
-    KilnModel(
-        family=ModelFamily.mimo,
-        name=ModelName.mimo_v2_5_pro,
-        friendly_name="MiMo-V2.5-Pro",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.openrouter,
-                model_id="xiaomi/mimo-v2.5-pro",
-                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
-                supports_data_gen=True,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -8024,8 +8024,16 @@ built_in_models: List[KilnModel] = [
                 supports_vision=True,
                 multimodal_capable=True,
                 multimodal_mime_types=[
+                    # images
                     KilnMimeType.JPG,
                     KilnMimeType.PNG,
+                    # audio
+                    KilnMimeType.MP3,
+                    KilnMimeType.WAV,
+                    KilnMimeType.OGG,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
                 ],
             ),
         ],

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -273,6 +273,8 @@ class ModelName(str, Enum):
     mimo_v2_pro = "mimo_v2_pro"
     mimo_v2_flash = "mimo_v2_flash"
     mimo_v2_omni = "mimo_v2_omni"
+    mimo_v2_5 = "mimo_v2_5"
+    mimo_v2_5_pro = "mimo_v2_5_pro"
 
 
 class ModelParserID(str, Enum):
@@ -8005,6 +8007,40 @@ built_in_models: List[KilnModel] = [
                     KilnMimeType.JPG,
                     KilnMimeType.PNG,
                 ],
+            ),
+        ],
+    ),
+    # MiMo-V2.5
+    KilnModel(
+        family=ModelFamily.mimo,
+        name=ModelName.mimo_v2_5,
+        friendly_name="MiMo-V2.5",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="xiaomi/mimo-v2.5",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+    # MiMo-V2.5-Pro
+    KilnModel(
+        family=ModelFamily.mimo,
+        name=ModelName.mimo_v2_5_pro,
+        friendly_name="MiMo-V2.5-Pro",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="xiaomi/mimo-v2.5-pro",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -8023,17 +8023,16 @@ built_in_models: List[KilnModel] = [
                 supports_data_gen=True,
                 supports_vision=True,
                 multimodal_capable=True,
+                supports_doc_extraction=True,
+                multimodal_requires_pdf_as_image=True,
                 multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
                     # images
                     KilnMimeType.JPG,
                     KilnMimeType.PNG,
-                    # audio
-                    KilnMimeType.MP3,
-                    KilnMimeType.WAV,
-                    KilnMimeType.OGG,
-                    # video
-                    KilnMimeType.MP4,
-                    KilnMimeType.MOV,
                 ],
             ),
         ],


### PR DESCRIPTION
## What does this PR do?

Adds Xiaomi MiMo-V2.5 and MiMo-V2.5-Pro to the built-in model list via OpenRouter, following the existing MiMo-V2 entry pattern.

- **MiMo-V2.5** (`xiaomi/mimo-v2.5`): omnimodal (text, image, audio, video input), vision-capable
- **MiMo-V2.5-Pro** (`xiaomi/mimo-v2.5-pro`): text-only, strong agentic/coding performance

## Related Issues

N/A

## Contributor License Agreement

I, @ianjamesburke, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib