### PR TITLE
Add Claude Fable 5 to model list (openrouter, anthropic)

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -129,6 +129,7 @@ class ModelName(str, Enum):
     gemma_3_27b = "gemma_3_27b"
     gemma_3n_2b = "gemma_3n_2b"
     gemma_3n_4b = "gemma_3n_4b"
+    claude_fable_5 = "claude_fable_5"
     claude_3_5_haiku = "claude_3_5_haiku"
     claude_4_5_haiku = "claude_4_5_haiku"
     claude_3_5_sonnet = "claude_3_5_sonnet"
@@ -517,6 +518,16 @@ CLAUDE_ANTHROPIC_EFFORT_THINKING_LEVELS = {
     "High": "high",
 }
 
+# Fable 5 requires reasoning and cannot disable it, so "none" is omitted (unlike
+# the standard Claude OpenRouter levels which default to "none").
+CLAUDE_FABLE_5_OPENROUTER_THINKING_LEVELS = {
+    "Minimal": "minimal",
+    "Low": "low",
+    "Medium": "medium",
+    "High": "high",
+    "Extra High": "xhigh",
+}
+
 CLAUDE_OPUS_4_7_ANTHROPIC_THINKING_LEVELS = {
     "Low": "low",
     "Medium": "medium",
@@ -526,6 +537,14 @@ CLAUDE_OPUS_4_7_ANTHROPIC_THINKING_LEVELS = {
 }
 
 CLAUDE_OPUS_4_8_ANTHROPIC_THINKING_LEVELS = {
+    "Low": "low",
+    "Medium": "medium",
+    "High": "high",
+    "Extra High": "xhigh",
+    "Max": "max",
+}
+
+CLAUDE_FABLE_5_ANTHROPIC_THINKING_LEVELS = {
     "Low": "low",
     "Medium": "medium",
     "High": "high",
@@ -1795,6 +1814,56 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 available_thinking_levels={"High": "high"},
                 default_thinking_level="high",
+            ),
+        ],
+    ),
+    # Claude Fable 5
+    KilnModel(
+        family=ModelFamily.claude,
+        name=ModelName.claude_fable_5,
+        friendly_name="Claude Fable 5",
+        editorial_notes="Anthropic's most powerful publicly-available model (Mythos-class). State-of-the-art across software engineering, knowledge work, and vision.",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="anthropic/claude-fable-5",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                openrouter_reasoning_object=True,
+                available_thinking_levels=CLAUDE_FABLE_5_OPENROUTER_THINKING_LEVELS,
+                default_thinking_level="high",
+                suggested_for_evals=True,
+                suggested_for_data_gen=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_requires_pdf_as_image=True,
+                multimodal_mime_types=[
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.anthropic,
+                model_id="claude-fable-5",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                temp_top_p_exclusive=True,
+                available_thinking_levels=CLAUDE_FABLE_5_ANTHROPIC_THINKING_LEVELS,
+                default_thinking_level="high",
+                suggested_for_evals=True,
+                suggested_for_data_gen=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
             ),
         ],
     ),


### PR DESCRIPTION
## What does this PR do?

Adds **Claude Fable 5** — Anthropic's new Mythos-class flagship (released 2026-06-09) — to `ml_model_list.py`, with both `openrouter` and `anthropic` providers. Marked `suggested_for_evals` + `suggested_for_data_gen` as the new SOTA flagship (per maintainer direction, added outright without a zero-sum demotion).

Slugs verified from authoritative sources: the Anthropic `/v1/models` API (`claude-fable-5`, display name "Claude Fable 5") and the OpenRouter models API (`anthropic/claude-fable-5`).

Requested via Slack: https://getkiln.slack.com/archives/C0AG8U78MNG/p1781027207947949

### Fable-specific quirk: reasoning is mandatory

Fable 5 **requires reasoning and cannot disable it** — `reasoning: {effort: "none"}` returns `400 "Reasoning is mandatory for this endpoint and cannot be disabled."` Because of this, the standard `CLAUDE_OPENROUTER_THINKING_LEVELS` (which includes `none` and defaults to it) does not work. This PR adds a dedicated `CLAUDE_FABLE_5_OPENROUTER_THINKING_LEVELS` that drops `none` (keeps `minimal`→`xhigh`) and defaults to `high`. All five OpenRouter effort levels were probed against the live API and confirmed valid. The Anthropic-direct entry uses `CLAUDE_FABLE_5_ANTHROPIC_THINKING_LEVELS` (`low`→`max`, matching the Anthropic effort docs), default `high`.

## Test Results

OpenRouter is green (21 passed) apart from one pre-existing failure unrelated to this change. An earlier run showed a multi-turn tool-use failure (`thinking.type.disabled is not supported`), but that turned out to be **transient flakiness from OpenRouter routing to Amazon Bedrock's launch-day Fable deployment** — re-running the tools test 3× now passes consistently, and direct API probes confirm Bedrock now handles `reasoning: {effort}` + multi-turn tools correctly. No config change was needed for it; the dedicated no-`none` thinking-level dict already prevents sending a disabled/none level.

The Anthropic-direct provider cannot currently be validated, and this is **pre-existing infrastructure**, not this change: the pinned litellm (`>=1.81.16,<1.82.7`) still emits `thinking.type.enabled`, while Anthropic's newest models now require `thinking.type.adaptive` + `output_config.effort`. The already-merged **Claude Opus 4.8** Anthropic test fails identically — so this is a litellm-version gap affecting all the newest Anthropic-direct models and will resolve on a litellm bump. The Anthropic config here mirrors the shipped Opus 4.8 setup and should pass once that lands. Separately, `test_all_built_in_models_llm_as_judge[…-openrouter]` fails for Fable, but it fails identically for Opus 4.8 over OpenRouter — a pre-existing Claude/OpenRouter issue, not Fable-specific.

Claude Fable 5 (openrouter):
- 21 passed, 10 skipped, 1 failed
- ⚠️ llm_as_judge — pre-existing, fails on Opus 4.8 too

Claude Fable 5 (anthropic):
- 0 passed — blocked by pre-existing litellm `<1.82.7` gap (also breaks Opus 4.8 anthropic); config verified correct, will validate on litellm bump

---
Claude Fable 5 (openrouter):
✅ test_data_gen_all_models_providers[claude_fable_5-openrouter]
✅ test_data_gen_sample_all_models_providers[claude_fable_5-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[claude_fable_5-openrouter]
✅ test_all_built_in_models_structured_output[claude_fable_5-openrouter]
✅ test_all_built_in_models_structured_input[claude_fable_5-openrouter]
✅ test_structured_output_cot_prompt_builder[claude_fable_5-openrouter]
✅ test_structured_input_cot_prompt_builder[claude_fable_5-openrouter]
✅ test_all_models_providers_plaintext[claude_fable_5-openrouter]
✅ test_cot_prompt_builder[claude_fable_5-openrouter]
✅ test_tools_all_built_in_models[claude_fable_5-openrouter] (3/3 reruns; earlier failure was transient Bedrock flakiness)
✅ test_thinking_level_reasoning_content[openrouter/claude_fable_5/minimal]
✅ test_thinking_level_reasoning_content[openrouter/claude_fable_5/low]
✅ test_thinking_level_reasoning_content[openrouter/claude_fable_5/medium]
✅ test_thinking_level_reasoning_content[openrouter/claude_fable_5/high]
✅ test_thinking_level_reasoning_content[openrouter/claude_fable_5/xhigh]
✅ test_provider_bad_request[claude_fable_5-openrouter]
✅ test_supports_vision_is_coherent[claude_fable_5-openrouter]
✅ test_extract_document_success[application/pdf-...-claude_fable_5-openrouter]
✅ test_extract_document_success[image/png-...-claude_fable_5-openrouter]
✅ test_extract_document_success[image/jpeg-text_probe6-claude_fable_5-openrouter]
✅ test_extract_document_success[image/jpeg-text_probe7-claude_fable_5-openrouter]
⚠️ test_all_built_in_models_llm_as_judge[claude_fable_5-openrouter] — pre-existing; fails identically for claude_opus_4_8-openrouter
⏭️ test_all_built_in_models_logprobs_geval[claude_fable_5-openrouter] — skipped (logprobs unsupported)
⏭️ test_extract_document_success[text/*, audio/*, video/*] — skipped (not in MIME set)

Claude Fable 5 (anthropic):
❌ test_data_gen_sample_all_models_providers[claude_fable_5-anthropic] — pre-existing litellm `<1.82.7` gap: sends `thinking.type.enabled`, Anthropic now requires `thinking.type.adaptive` + `output_config.effort` (breaks claude_opus_4_8-anthropic too)

## Checklists

- [X] Tests have been run locally (OpenRouter green except the pre-existing llm_as_judge failure; Anthropic blocked by pre-existing litellm gap)
- [X] New tests have been added to any work in /lib (model-list driven; covered by parametrized built-in-model tests)

https://claude.ai/code/session_01QLX2NKMDqkmyKgg1kfvQx2