### PR TITLE
fix: audio/video document extraction on OpenRouter

### DIFF
--- a/libs/core/kiln_ai/adapters/extractors/encoding.py
+++ b/libs/core/kiln_ai/adapters/extractors/encoding.py
@@ -1,8 +1,12 @@
 import base64
 
 
+def to_base64(bytes: bytes) -> str:
+    return base64.b64encode(bytes).decode("utf-8")
+
+
 def to_base64_url(mime_type: str, bytes: bytes) -> str:
-    base64_url = f"data:{mime_type};base64,{base64.b64encode(bytes).decode('utf-8')}"
+    base64_url = f"data:{mime_type};base64,{to_base64(bytes)}"
     return base64_url
 
 

--- a/libs/core/kiln_ai/adapters/extractors/encoding.py
+++ b/libs/core/kiln_ai/adapters/extractors/encoding.py
@@ -1,12 +1,12 @@
 import base64
 
 
-def to_base64(bytes: bytes) -> str:
-    return base64.b64encode(bytes).decode("utf-8")
+def to_base64(data: bytes) -> str:
+    return base64.b64encode(data).decode("utf-8")
 
 
-def to_base64_url(mime_type: str, bytes: bytes) -> str:
-    base64_url = f"data:{mime_type};base64,{to_base64(bytes)}"
+def to_base64_url(mime_type: str, data: bytes) -> str:
+    base64_url = f"data:{mime_type};base64,{to_base64(data)}"
     return base64_url
 
 

--- a/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py
@@ -13,7 +13,7 @@ from kiln_ai.adapters.extractors.base_extractor import (
     ExtractionInput,
     ExtractionOutput,
 )
-from kiln_ai.adapters.extractors.encoding import to_base64_url
+from kiln_ai.adapters.extractors.encoding import to_base64, to_base64_url
 from kiln_ai.adapters.ml_model_list import (
     KilnModelProvider,
     built_in_models_from_provider,
@@ -55,11 +55,46 @@ MIME_TYPES_SUPPORTED = {
 }
 
 
-def encode_file_litellm_format(path: Path, mime_type: str) -> dict[str, Any]:
+# OpenAI-style `input_audio` blocks take a bare format string, not a MIME type.
+AUDIO_MIME_TO_INPUT_AUDIO_FORMAT = {
+    "audio/wav": "wav",
+    "audio/mpeg": "mp3",
+    "audio/ogg": "ogg",
+}
+
+
+def encode_file_litellm_format(
+    path: Path, mime_type: str, provider_name: ModelProviderName
+) -> dict[str, Any]:
     # There are different formats that LiteLLM supports, the docs are scattered
     # and incomplete:
     # - https://docs.litellm.ai/docs/completion/document_understanding#base64
     # - https://docs.litellm.ai/docs/completion/vision#explicitly-specify-image-type
+
+    # OpenRouter rejects the generic `file` block for audio and video (upstream
+    # providers return a 400 "file type is not supported"). It expects the OpenAI-style
+    # `input_audio` block for audio and a `video_url` block for video. Other providers
+    # (e.g. Gemini/Vertex) work with the generic `file` block via LiteLLM's per-provider
+    # transform, so we only special-case OpenRouter here.
+    if provider_name == ModelProviderName.openrouter:
+        if mime_type.startswith("audio/"):
+            audio_format = AUDIO_MIME_TO_INPUT_AUDIO_FORMAT.get(mime_type)
+            if audio_format is None:
+                raise ValueError(f"Unsupported audio MIME type: {mime_type} for {path}")
+            return {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": to_base64(path.read_bytes()),
+                    "format": audio_format,
+                },
+            }
+        if mime_type.startswith("video/"):
+            return {
+                "type": "video_url",
+                "video_url": {
+                    "url": to_base64_url(mime_type, path.read_bytes()),
+                },
+            }
 
     # this is the most generic format that seems to work for all / most mime types
     if mime_type in [
@@ -317,7 +352,9 @@ class LitellmExtractor(BaseExtractor):
                     "content": [
                         {"type": "text", "text": prompt},
                         encode_file_litellm_format(
-                            Path(extraction_input.path), extraction_input.mime_type
+                            Path(extraction_input.path),
+                            extraction_input.mime_type,
+                            self.model_provider.name,
                         ),
                     ],
                 }

--- a/libs/core/kiln_ai/adapters/extractors/test_litellm_extractor.py
+++ b/libs/core/kiln_ai/adapters/extractors/test_litellm_extractor.py
@@ -6,7 +6,7 @@ import pytest
 from litellm.types.utils import Choices, ModelResponse
 
 from kiln_ai.adapters.extractors.base_extractor import ExtractionInput, OutputFormat
-from kiln_ai.adapters.extractors.encoding import to_base64_url
+from kiln_ai.adapters.extractors.encoding import to_base64, to_base64_url
 from kiln_ai.adapters.extractors.extractor_registry import extractor_adapter_from_type
 from kiln_ai.adapters.extractors.litellm_extractor import (
     ExtractorConfig,
@@ -539,30 +539,95 @@ def paid_litellm_extractor(model_name: str, provider_name: str):
 
 
 @pytest.mark.parametrize(
-    "mime_type, expected_encoding",
+    "provider_name, mime_type, expected_encoding",
     [
+        # Non-OpenRouter providers (e.g. Gemini) use the generic `file` block for
+        # documents, audio and video; images get the dedicated `image_url` block.
         # documents
-        (MockFileFactoryMimeType.PDF, "generic_file_data"),
-        (MockFileFactoryMimeType.TXT, "generic_file_data"),
-        (MockFileFactoryMimeType.MD, "generic_file_data"),
-        (MockFileFactoryMimeType.HTML, "generic_file_data"),
-        (MockFileFactoryMimeType.CSV, "generic_file_data"),
+        (
+            ModelProviderName.gemini_api,
+            MockFileFactoryMimeType.PDF,
+            "generic_file_data",
+        ),
+        (
+            ModelProviderName.gemini_api,
+            MockFileFactoryMimeType.TXT,
+            "generic_file_data",
+        ),
+        (ModelProviderName.gemini_api, MockFileFactoryMimeType.MD, "generic_file_data"),
+        (
+            ModelProviderName.gemini_api,
+            MockFileFactoryMimeType.HTML,
+            "generic_file_data",
+        ),
+        (
+            ModelProviderName.gemini_api,
+            MockFileFactoryMimeType.CSV,
+            "generic_file_data",
+        ),
         # images
-        (MockFileFactoryMimeType.PNG, "image_data"),
-        (MockFileFactoryMimeType.JPEG, "image_data"),
-        (MockFileFactoryMimeType.JPG, "image_data"),
+        (ModelProviderName.gemini_api, MockFileFactoryMimeType.PNG, "image_data"),
+        (ModelProviderName.gemini_api, MockFileFactoryMimeType.JPEG, "image_data"),
+        (ModelProviderName.gemini_api, MockFileFactoryMimeType.JPG, "image_data"),
         # videos
-        (MockFileFactoryMimeType.MP4, "generic_file_data"),
-        (MockFileFactoryMimeType.MOV, "generic_file_data"),
+        (
+            ModelProviderName.gemini_api,
+            MockFileFactoryMimeType.MP4,
+            "generic_file_data",
+        ),
+        (
+            ModelProviderName.gemini_api,
+            MockFileFactoryMimeType.MOV,
+            "generic_file_data",
+        ),
         # audio
-        (MockFileFactoryMimeType.MP3, "generic_file_data"),
-        (MockFileFactoryMimeType.OGG, "generic_file_data"),
-        (MockFileFactoryMimeType.WAV, "generic_file_data"),
+        (
+            ModelProviderName.gemini_api,
+            MockFileFactoryMimeType.MP3,
+            "generic_file_data",
+        ),
+        (
+            ModelProviderName.gemini_api,
+            MockFileFactoryMimeType.OGG,
+            "generic_file_data",
+        ),
+        (
+            ModelProviderName.gemini_api,
+            MockFileFactoryMimeType.WAV,
+            "generic_file_data",
+        ),
+        # OpenRouter rejects the generic `file` block for audio/video, so we use the
+        # OpenAI-style `input_audio` block and a `video_url` block instead. Documents
+        # and images are unchanged.
+        # documents
+        (
+            ModelProviderName.openrouter,
+            MockFileFactoryMimeType.PDF,
+            "generic_file_data",
+        ),
+        (
+            ModelProviderName.openrouter,
+            MockFileFactoryMimeType.CSV,
+            "generic_file_data",
+        ),
+        # images
+        (ModelProviderName.openrouter, MockFileFactoryMimeType.PNG, "image_data"),
+        (ModelProviderName.openrouter, MockFileFactoryMimeType.JPEG, "image_data"),
+        # videos
+        (ModelProviderName.openrouter, MockFileFactoryMimeType.MP4, "video_url"),
+        (ModelProviderName.openrouter, MockFileFactoryMimeType.MOV, "video_url"),
+        # audio
+        (ModelProviderName.openrouter, MockFileFactoryMimeType.MP3, "input_audio_mp3"),
+        (ModelProviderName.openrouter, MockFileFactoryMimeType.OGG, "input_audio_ogg"),
+        (ModelProviderName.openrouter, MockFileFactoryMimeType.WAV, "input_audio_wav"),
     ],
 )
-def test_encode_file_litellm_format(mock_file_factory, mime_type, expected_encoding):
+def test_encode_file_litellm_format(
+    mock_file_factory, provider_name, mime_type, expected_encoding
+):
     test_file = mock_file_factory(mime_type)
-    encoded = encode_file_litellm_format(Path(test_file), mime_type)
+    encoded = encode_file_litellm_format(Path(test_file), mime_type, provider_name)
+    file_bytes = Path(test_file).read_bytes()
 
     # there are two types of ways of including files, image_url is a special case
     # and it also works with the generic file_data encoding, but LiteLLM docs are
@@ -571,14 +636,29 @@ def test_encode_file_litellm_format(mock_file_factory, mime_type, expected_encod
         assert encoded == {
             "type": "image_url",
             "image_url": {
-                "url": to_base64_url(mime_type, Path(test_file).read_bytes()),
+                "url": to_base64_url(mime_type, file_bytes),
             },
         }
     elif expected_encoding == "generic_file_data":
         assert encoded == {
             "type": "file",
             "file": {
-                "file_data": to_base64_url(mime_type, Path(test_file).read_bytes()),
+                "file_data": to_base64_url(mime_type, file_bytes),
+            },
+        }
+    elif expected_encoding == "video_url":
+        assert encoded == {
+            "type": "video_url",
+            "video_url": {
+                "url": to_base64_url(mime_type, file_bytes),
+            },
+        }
+    elif expected_encoding.startswith("input_audio_"):
+        assert encoded == {
+            "type": "input_audio",
+            "input_audio": {
+                "data": to_base64(file_bytes),
+                "format": expected_encoding.removeprefix("input_audio_"),
             },
         }
     else:


### PR DESCRIPTION
## What does this PR do?

Incompatibility with audio / video in OpenRouter - surfaced in https://github.com/Kiln-AI/Kiln/pull/1456 but was there.

Fixes audio and video document extraction for **OpenRouter** models. The LiteLLM extractor was sending every non-image file (including audio and video) as a generic `type: file` content block. OpenRouter's upstream providers reject that for audio/video with `400 "file type is not supported"`, so audio/video extraction silently failed on every OpenRouter model.

The fix sends, **when the provider is OpenRouter**:
- audio → OpenAI-style `input_audio` block (`{data, format}`)
- video → `video_url` block (data URL)

Images, PDFs and text documents are unchanged.

## Is this general to all providers?

No — and this is why the change is scoped to OpenRouter. I tested both formats against Gemini (`gemini_api`):

| Format | OpenRouter | Gemini |
|---|---|---|
| `input_audio` (audio) | ✅ works | ✅ works |
| `video_url` (video) | ✅ works | ❌ **breaks** — model replies *"I cannot access videos"* |

`video_url` is not understood by LiteLLM's Gemini transform, so Gemini/Vertex must keep the generic `file` block (which already works for them). Since video can't be unified, the whole change stays OpenRouter-specific to avoid regressing Gemini. (Audio's `input_audio` does appear general; left scoped for now to only touch the broken provider. Easy to broaden later if we add audio/video models on other OpenAI-compatible providers.)

## Testing

Verified with paid doc-extraction tests using a temporary MiMo-V2.5 entry (not committed):

**MiMo-V2.5 (openrouter) — the fix:**
- ✅ audio/mpeg, ✅ audio/wav, ✅ audio/ogg
- ✅ video/mp4, ✅ video/quicktime (mov)
- ✅ image/jpeg, ✅ image/png, ✅ application/pdf

**Gemini 2.5 Flash Lite (gemini_api) — regression check:**
- ✅ audio/mpeg, ✅ audio/ogg, ✅ audio/wav
- ✅ video/mp4, ✅ video/quicktime
- ✅ image/jpeg, ✅ image/png

Plus the `test_encode_file_litellm_format` unit test now covers both providers and the new `input_audio`/`video_url` shapes. `checks.sh` (ruff, format, project ty, full extractor unit suite — 214 passed) all green.

## Follow-up

Unblocks adding audio/video MIME types back to MiMo-V2.5 (and any future OpenRouter omni models) in a separate PR.

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)