### PR TITLE
feat: typed per-worker progress payload

### DIFF
--- a/app/desktop/studio_server/jobs/models.py
+++ b/app/desktop/studio_server/jobs/models.py
@@ -79,6 +79,12 @@ class JobRecord(BaseModel):
     status: BackgroundJobStatus
     run_id: str | None = None
     progress: JobProgress = Field(default_factory=JobProgress)
+    # Typed, per-worker progress detail (validated against the worker's
+    # `progress_model`). The generic `progress` above is the universal counter;
+    # this carries the rich per-kind shape a worker needs the UI to render
+    # (e.g. RAG's four-phase breakdown). Kept as a dict on the wire so the core
+    # stays worker-agnostic; the frontend casts it to the worker's model.
+    progress_detail: dict[str, Any] | None = None
     params: dict[str, Any] = Field(default_factory=dict)
     result: dict[str, Any] | None = None
     error: JobError | None = None
@@ -92,6 +98,7 @@ class JobRecord(BaseModel):
 
 
 ReportProgress = Callable[["JobProgressUpdate"], Awaitable[None]]
+ReportProgressDetail = Callable[[BaseModel], Awaitable[None]]
 ReportError = Callable[[str, dict[str, Any]], Awaitable[None]]
 
 
@@ -114,11 +121,13 @@ class JobContext:
         job_id: str,
         run_id: str,
         report_progress: ReportProgress,
+        report_progress_detail: ReportProgressDetail,
         report_error: ReportError,
     ) -> None:
         self.job_id = job_id
         self.run_id = run_id
         self._report_progress = report_progress
+        self._report_progress_detail = report_progress_detail
         self._report_error = report_error
 
     async def report_progress(
@@ -142,6 +151,17 @@ class JobContext:
             )
         )
 
+    async def report_progress_detail(self, detail: BaseModel) -> None:
+        """Stamp the job's typed `progress_detail` with a worker-specific model.
+
+        For rich per-kind progress the generic counter can't carry (e.g. RAG's
+        per-phase breakdown). `detail` must be an instance of the worker's
+        declared `progress_model`; the registry validates and serializes it.
+        A UI-smoothing signal only — authoritative progress comes from
+        compute_state(). Cheap to call often.
+        """
+        await self._report_progress_detail(detail)
+
     async def report_error(self, error_message: str, **extra: Any) -> None:
         """Append one structured error entry to this run's error log.
 
@@ -160,6 +180,10 @@ class JobWorker(Generic[TParams, TResult]):
     type_name: ClassVar[str]
     params_model: ClassVar[type[BaseModel]]
     result_model: ClassVar[type[BaseModel]]
+    # Optional typed model for rich per-worker progress reported via
+    # JobContext.report_progress_detail(); stamped on JobRecord.progress_detail.
+    # Leave None for workers whose generic count progress is enough.
+    progress_model: ClassVar[type[BaseModel] | None] = None
     supports_pause: ClassVar[bool] = False
 
     async def compute_state(self, params: TParams) -> JobDerivedState | None:

--- a/app/desktop/studio_server/jobs/registry.py
+++ b/app/desktop/studio_server/jobs/registry.py
@@ -222,7 +222,7 @@ class JobRegistry:
         if job is None:
             return
         params = worker.params_model.model_validate(job.params)
-        ctx = self._build_context(job_id, run_id)
+        ctx = self._build_context(job_id, run_id, worker)
         try:
             try:
                 await self._reconcile(job, emit_on_change=True)
@@ -249,7 +249,9 @@ class JobRegistry:
         finally:
             self._release_slot(job_id)
 
-    def _build_context(self, job_id: str, run_id: str) -> JobContext:
+    def _build_context(
+        self, job_id: str, run_id: str, worker: JobWorker
+    ) -> JobContext:
         async def report_progress(update: JobProgressUpdate) -> None:
             job = self._jobs.get(job_id)
             if job is None or job.run_id != run_id:
@@ -265,10 +267,29 @@ class JobRegistry:
             self._touch(job)
             self._emit(job)
 
+        async def report_progress_detail(detail: BaseModel) -> None:
+            job = self._jobs.get(job_id)
+            if job is None or job.run_id != run_id:
+                return
+            # Guard the worker's contract: the detail must be the model the
+            # worker declared, so progress_detail's shape is predictable for
+            # the frontend that casts it.
+            expected = worker.progress_model
+            if expected is not None and not isinstance(detail, expected):
+                raise TypeError(
+                    f"report_progress_detail expected {expected.__name__}, "
+                    f"got {type(detail).__name__}"
+                )
+            job.progress_detail = detail.model_dump(mode="json")
+            self._touch(job)
+            self._emit(job)
+
         async def report_error(message: str, extra: dict[str, Any]) -> None:
             error_log.append_error(run_id, {"error_message": message, **extra})
 
-        return JobContext(job_id, run_id, report_progress, report_error)
+        return JobContext(
+            job_id, run_id, report_progress, report_progress_detail, report_error
+        )
 
     def _finish_succeeded(self, job: JobRecord, result: BaseModel) -> None:
         job.status = BackgroundJobStatus.SUCCEEDED

--- a/app/desktop/studio_server/jobs/registry.py
+++ b/app/desktop/studio_server/jobs/registry.py
@@ -249,9 +249,7 @@ class JobRegistry:
         finally:
             self._release_slot(job_id)
 
-    def _build_context(
-        self, job_id: str, run_id: str, worker: JobWorker
-    ) -> JobContext:
+    def _build_context(self, job_id: str, run_id: str, worker: JobWorker) -> JobContext:
         async def report_progress(update: JobProgressUpdate) -> None:
             job = self._jobs.get(job_id)
             if job is None or job.run_id != run_id:

--- a/app/desktop/studio_server/jobs/test_registry.py
+++ b/app/desktop/studio_server/jobs/test_registry.py
@@ -810,3 +810,65 @@ async def test_get_unknown_returns_none(registry):
 async def test_lifecycle_op_unknown_raises(registry):
     with pytest.raises(JobNotFoundError):
         await registry.cancel("j_doesnotexist")
+
+
+# -- typed progress detail ---------------------------------------------------
+
+
+class DetailModel(BaseModel):
+    phase: str
+    done: int
+
+
+class DetailWorker(JobWorker[_EmptyParams, _EmptyResult]):
+    type_name = "detail"
+    params_model = _EmptyParams
+    result_model = _EmptyResult
+    progress_model = DetailModel
+    gate: asyncio.Event
+
+    async def run(self, params, ctx):
+        await ctx.report_progress_detail(DetailModel(phase="extract", done=3))
+        await type(self).gate.wait()
+        return _EmptyResult()
+
+
+@pytest.mark.asyncio
+async def test_report_progress_detail_stamps_typed_payload():
+    reg = JobRegistry(max_concurrent=2)
+    reg.register_type(DetailWorker)
+    DetailWorker.gate = asyncio.Event()
+    job = await reg.create("detail", {})
+    await wait_for_status(reg, job.id, BackgroundJobStatus.RUNNING)
+    # Give the worker a tick to report the detail.
+    for _ in range(50):
+        if reg._jobs[job.id].progress_detail is not None:
+            break
+        await asyncio.sleep(0.01)
+    assert reg._jobs[job.id].progress_detail == {"phase": "extract", "done": 3}
+    DetailWorker.gate.set()
+
+
+class WrongModel(BaseModel):
+    other: str
+
+
+class BadDetailWorker(JobWorker[_EmptyParams, _EmptyResult]):
+    type_name = "bad_detail"
+    params_model = _EmptyParams
+    result_model = _EmptyResult
+    progress_model = DetailModel
+
+    async def run(self, params, ctx):
+        await ctx.report_progress_detail(WrongModel(other="x"))
+        return _EmptyResult()
+
+
+@pytest.mark.asyncio
+async def test_report_progress_detail_rejects_wrong_model():
+    reg = JobRegistry(max_concurrent=2)
+    reg.register_type(BadDetailWorker)
+    job = await reg.create("bad_detail", {})
+    # The type guard raises inside run(), routing the job to FAILED.
+    await wait_for_status(reg, job.id, BackgroundJobStatus.FAILED)
+    assert reg._jobs[job.id].error is not None

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -7022,6 +7022,10 @@ export interface components {
             /** Run Id */
             run_id?: string | null;
             progress?: components["schemas"]["JobProgress"];
+            /** Progress Detail */
+            progress_detail?: {
+                [key: string]: unknown;
+            } | null;
             /** Params */
             params?: {
                 [key: string]: unknown;


### PR DESCRIPTION
Stacks on **#1435** (background job system). Gives rich per-worker progress a typed home, replacing the freeform `metadata` escape hatch.

> Scope note: this PR was pared down — the earlier job-group concept and the `compute_state` cost change were dropped to keep it minimal. (The branch name still says "groups"; the content is typed-progress only.)

## What it does
- `JobWorker.progress_model` — an optional per-worker model declaring the shape of rich progress.
- `JobContext.report_progress_detail(model)` — validates against `progress_model` and stamps `JobRecord.progress_detail`. A wrong-type model **fails the job loudly** rather than silently storing garbage.
- `progress_detail` is a `dict` on the wire, so the core stays worker-agnostic; the frontend casts it to the worker's exported model.

This replaces RAG's `report_metadata_patch({"rag_progress": ...})` escape hatch with a first-class, validated field — RAG adopts it (`metadata.rag_progress` → `progress_detail`, `progress_model = RagProgress`) when this lifts into its branch.

## Test plan
- [x] `uv run ruff check` / `ruff format --check`, `uv run ty check` (jobs module)
- [x] `pytest app/desktop/studio_server/jobs/` — 111 passed (incl. the typed-detail stamp + the wrong-model guard)
- [x] `npm run check` (web), client schema regenerated (`progress_detail` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
