### PR TITLE
Add deprecated flag to reranker models (KIL-460)

### DIFF
--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -203,6 +203,7 @@ class EmbeddingProvider(BaseModel):
 class RerankerModelDetails(BaseModel):
     id: str
     name: str
+    deprecated: bool = Field(default=False)
 
 
 class RerankerProvider(BaseModel):
@@ -514,6 +515,7 @@ def connect_provider_api(app: FastAPI):
                             RerankerModelDetails(
                                 id=model.name,
                                 name=model.friendly_name,
+                                deprecated=provider.deprecated,
                             )
                         )
 

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -3618,10 +3618,12 @@ async def test_get_available_reranker_models(app, client):
                 {
                     "id": "reranker1",
                     "name": "Reranker 1",
+                    "deprecated": False,
                 },
                 {
                     "id": "reranker2",
                     "name": "Reranker 2",
+                    "deprecated": False,
                 },
             ],
         },
@@ -3632,6 +3634,62 @@ async def test_get_available_reranker_models(app, client):
                 {
                     "id": "reranker2",
                     "name": "Reranker 2",
+                    "deprecated": False,
+                }
+            ],
+        },
+    ]
+
+
+async def test_get_available_reranker_models_surfaces_deprecated(app, client):
+    mock_config = MagicMock()
+    mock_config.get_value.return_value = "mock_key"
+
+    mock_provider_warnings = {
+        ModelProviderName.together_ai: MagicMock(required_config_keys=["key1"]),
+    }
+
+    mock_built_in_rerankers = [
+        KilnRerankerModel(
+            name="reranker1",
+            friendly_name="Reranker 1",
+            family="family1",
+            providers=[
+                KilnRerankerModelProvider(
+                    name=ModelProviderName.together_ai,
+                    model_id="together_reranker1",
+                    deprecated=True,
+                )
+            ],
+        ),
+    ]
+
+    with (
+        patch(
+            "app.desktop.studio_server.provider_api.Config.shared",
+            return_value=mock_config,
+        ),
+        patch(
+            "app.desktop.studio_server.provider_api.provider_warnings",
+            mock_provider_warnings,
+        ),
+        patch(
+            "app.desktop.studio_server.provider_api.built_in_rerankers",
+            mock_built_in_rerankers,
+        ),
+    ):
+        response = client.get("/api/available_reranker_models")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "provider_id": "together_ai",
+            "provider_name": "Together AI",
+            "models": [
+                {
+                    "id": "reranker1",
+                    "name": "Reranker 1",
+                    "deprecated": True,
                 }
             ],
         },

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -8469,6 +8469,11 @@ export interface components {
             id: string;
             /** Name */
             name: string;
+            /**
+             * Deprecated
+             * @default false
+             */
+            deprecated: boolean;
         };
         /** RerankerProvider */
         RerankerProvider: {

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/create_reranker_form.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/create_reranker_form.svelte
@@ -53,7 +53,6 @@
 
       // Transform the API response into OptionGroup format
       rerankerModels = data
-        .filter((provider: RerankerProvider) => provider.models.length > 0)
         .map((provider: RerankerProvider) => ({
           label: provider.provider_name,
           options: provider.models
@@ -66,6 +65,7 @@
               },
             })),
         }))
+        .filter((group) => group.options.length > 0)
     } catch (err) {
       error = createKilnError(err)
     } finally {

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/create_reranker_form.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/create_reranker_form.svelte
@@ -56,13 +56,15 @@
         .filter((provider: RerankerProvider) => provider.models.length > 0)
         .map((provider: RerankerProvider) => ({
           label: provider.provider_name,
-          options: provider.models.map((model: RerankerModelDetails) => ({
-            label: model.name,
-            value: {
-              model_name: model.id,
-              model_provider_name: provider.provider_id,
-            },
-          })),
+          options: provider.models
+            .filter((model: RerankerModelDetails) => !model.deprecated)
+            .map((model: RerankerModelDetails) => ({
+              label: model.name,
+              value: {
+                model_name: model.id,
+                model_provider_name: provider.provider_id,
+              },
+            })),
         }))
     } catch (err) {
       error = createKilnError(err)

--- a/libs/core/kiln_ai/adapters/reranker_list.py
+++ b/libs/core/kiln_ai/adapters/reranker_list.py
@@ -35,6 +35,9 @@ class KilnRerankerModelProvider(BaseModel):
         min_length=1,
     )
 
+    # The model is deprecated and no longer supported on a specific provider
+    deprecated: bool = False
+
 
 class KilnRerankerModel(BaseModel):
     """


### PR DESCRIPTION
Adds a per-provider deprecated flag to reranker models, mirroring the existing ml_model_list pattern.

The flag is passed through the provider API and used to filter deprecated models out of the RAG reranker selection dropdown, so they can no longer be newly selected. Existing configs still resolve for display, and the flag round-trips through remote config automatically, so a model can be deprecated without a Kiln release.

No reranker is marked deprecated yet; this is groundwork. Backward compatible: the field defaults to false and old clients ignore it.

Closes KIL-460

🤖 Generated with [Claude Code](https://claude.com/claude-code)