### PR TITLE
Add deprecated flag to embedding models (KIL-459)

### DIFF
--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -192,6 +192,7 @@ class EmbeddingModelDetails(BaseModel):
     max_input_tokens: int | None
     supports_custom_dimensions: bool
     suggested_for_chunk_embedding: bool
+    deprecated: bool = Field(default=False)
 
 
 class EmbeddingProvider(BaseModel):
@@ -452,6 +453,7 @@ def connect_provider_api(app: FastAPI):
                                 max_input_tokens=provider.max_input_tokens,
                                 supports_custom_dimensions=provider.supports_custom_dimensions,
                                 suggested_for_chunk_embedding=provider.suggested_for_chunk_embedding,
+                                deprecated=provider.deprecated,
                             )
                         )
 

--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -1692,6 +1692,7 @@ async def available_ollama_embedding_models() -> EmbeddingProvider | None:
                             max_input_tokens=ollama_provider.max_input_tokens,
                             supports_custom_dimensions=ollama_provider.supports_custom_dimensions,
                             suggested_for_chunk_embedding=ollama_provider.suggested_for_chunk_embedding,
+                            deprecated=ollama_provider.deprecated,
                         )
                     )
 

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -3554,6 +3554,46 @@ async def test_available_ollama_embedding_models_unit():
     assert model.suggested_for_chunk_embedding is True
 
 
+@patch(
+    "app.desktop.studio_server.provider_api.built_in_embedding_models",
+    [
+        KilnEmbeddingModel(
+            family="gemma",
+            name="embeddinggemma",
+            friendly_name="embeddinggemma",
+            providers=[
+                KilnEmbeddingModelProvider(
+                    name=ModelProviderName.ollama,
+                    model_id="embeddinggemma:300m",
+                    n_dimensions=768,
+                    max_input_tokens=8192,
+                    supports_custom_dimensions=False,
+                    suggested_for_chunk_embedding=True,
+                    ollama_model_aliases=["embeddinggemma"],
+                    deprecated=True,
+                )
+            ],
+        )
+    ],
+)
+@pytest.mark.asyncio
+async def test_available_ollama_embedding_models_surfaces_deprecated():
+    with patch(
+        "app.desktop.studio_server.provider_api.connect_ollama",
+        return_value=OllamaConnection(
+            message="Connected",
+            supported_models=[],
+            untested_models=[],
+            supported_embedding_models=["embeddinggemma:300m"],
+        ),
+    ):
+        provider = await available_ollama_embedding_models()
+
+    assert provider is not None
+    model = next(m for m in provider.models if m.id == "embeddinggemma")
+    assert model.deprecated is True
+
+
 def test_available_embedding_models_endpoint_includes_ollama(client):
     # Return only the Ollama provider, no key-required providers
     fake_provider = {

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -3267,6 +3267,7 @@ async def test_get_embedding_providers(app, client):
                     "max_input_tokens": 8192,
                     "supports_custom_dimensions": True,
                     "suggested_for_chunk_embedding": True,
+                    "deprecated": False,
                 }
             ],
         },
@@ -3281,6 +3282,7 @@ async def test_get_embedding_providers(app, client):
                     "max_input_tokens": None,
                     "supports_custom_dimensions": False,
                     "suggested_for_chunk_embedding": False,
+                    "deprecated": False,
                 }
             ],
         },
@@ -3295,6 +3297,71 @@ async def test_get_embedding_providers(app, client):
                     "max_input_tokens": 8192,
                     "supports_custom_dimensions": False,
                     "suggested_for_chunk_embedding": True,
+                    "deprecated": False,
+                }
+            ],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_available_embedding_models_surfaces_deprecated(app, client):
+    mock_config = MagicMock()
+    mock_config.get_value.return_value = "mock_key"
+
+    mock_provider_warnings = {
+        ModelProviderName.openai: MagicMock(required_config_keys=["key1"]),
+    }
+
+    mock_built_in_embedding_models = [
+        KilnEmbeddingModel(
+            name="model1",
+            friendly_name="Model 1",
+            family="",
+            providers=[
+                KilnEmbeddingModelProvider(
+                    name=ModelProviderName.openai,
+                    model_id="oai1",
+                    n_dimensions=1536,
+                    max_input_tokens=8192,
+                    supports_custom_dimensions=True,
+                    suggested_for_chunk_embedding=True,
+                    deprecated=True,
+                )
+            ],
+        ),
+    ]
+
+    with (
+        patch(
+            "app.desktop.studio_server.provider_api.Config.shared",
+            return_value=mock_config,
+        ),
+        patch(
+            "app.desktop.studio_server.provider_api.provider_warnings",
+            mock_provider_warnings,
+        ),
+        patch(
+            "app.desktop.studio_server.provider_api.built_in_embedding_models",
+            mock_built_in_embedding_models,
+        ),
+    ):
+        response = client.get("/api/available_embedding_models")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "provider_id": "openai",
+            "provider_name": "OpenAI",
+            "models": [
+                {
+                    "id": "model1",
+                    "name": "Model 1",
+                    "n_dimensions": 1536,
+                    "max_input_tokens": 8192,
+                    "supports_custom_dimensions": True,
+                    "suggested_for_chunk_embedding": True,
+                    "deprecated": True,
                 }
             ],
         },

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -5113,6 +5113,11 @@ export interface components {
             supports_custom_dimensions: boolean;
             /** Suggested For Chunk Embedding */
             suggested_for_chunk_embedding: boolean;
+            /**
+             * Deprecated
+             * @default false
+             */
+            deprecated: boolean;
         };
         /**
          * EmbeddingModelName

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/create_embedding_form.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/create_embedding_form.svelte
@@ -58,7 +58,6 @@
 
       // Transform the API response into OptionGroup format
       embeddingModels = data
-        .filter((provider: EmbeddingProvider) => provider.models.length > 0)
         .map((provider: EmbeddingProvider) => ({
           label: provider.provider_name,
           options: provider.models
@@ -80,6 +79,7 @@
               description: `${model.n_dimensions} dimensions${model.max_input_tokens ? ` • ${model.max_input_tokens.toLocaleString()} max tokens` : ""}`,
             })),
         }))
+        .filter((provider) => provider.options.length > 0)
     } catch (err) {
       error = createKilnError(err)
     } finally {

--- a/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/create_embedding_form.svelte
+++ b/app/web_ui/src/routes/(app)/docs/rag_configs/[project_id]/create_rag_config/create_embedding_form.svelte
@@ -61,22 +61,24 @@
         .filter((provider: EmbeddingProvider) => provider.models.length > 0)
         .map((provider: EmbeddingProvider) => ({
           label: provider.provider_name,
-          options: provider.models.map((model: EmbeddingModelDetails) => ({
-            label: model.name,
-            value: {
-              model_name: model.id,
-              model_provider_name: provider.provider_id,
-              n_dimensions: model.n_dimensions,
-              max_input_tokens: model.max_input_tokens,
-              supports_custom_dimensions: model.supports_custom_dimensions,
-              suggested_for_chunk_embedding:
-                model.suggested_for_chunk_embedding,
-            },
-            badge: model.suggested_for_chunk_embedding
-              ? "Recommended"
-              : undefined,
-            description: `${model.n_dimensions} dimensions${model.max_input_tokens ? ` • ${model.max_input_tokens.toLocaleString()} max tokens` : ""}`,
-          })),
+          options: provider.models
+            .filter((model: EmbeddingModelDetails) => !model.deprecated)
+            .map((model: EmbeddingModelDetails) => ({
+              label: model.name,
+              value: {
+                model_name: model.id,
+                model_provider_name: provider.provider_id,
+                n_dimensions: model.n_dimensions,
+                max_input_tokens: model.max_input_tokens,
+                supports_custom_dimensions: model.supports_custom_dimensions,
+                suggested_for_chunk_embedding:
+                  model.suggested_for_chunk_embedding,
+              },
+              badge: model.suggested_for_chunk_embedding
+                ? "Recommended"
+                : undefined,
+              description: `${model.n_dimensions} dimensions${model.max_input_tokens ? ` • ${model.max_input_tokens.toLocaleString()} max tokens` : ""}`,
+            })),
         }))
     } catch (err) {
       error = createKilnError(err)

--- a/libs/core/kiln_ai/adapters/ml_embedding_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_embedding_model_list.py
@@ -121,6 +121,9 @@ class KilnEmbeddingModelProvider(BaseModel):
 
     ollama_model_aliases: List[str] | None = None
 
+    # The model is deprecated and no longer supported on a specific provider
+    deprecated: bool = False
+
 
 class KilnEmbeddingModel(BaseModel):
     """


### PR DESCRIPTION
Adds a per-provider deprecated flag to embedding models, mirroring the existing ml_model_list pattern.

The flag is passed through the provider API and used to filter deprecated models out of the RAG embedding selection dropdown, so they can no longer be newly selected. Existing configs still resolve for display, and the flag round-trips through remote config automatically, so a model can be deprecated without a Kiln release.

No embedding model is marked deprecated yet; this is groundwork. Backward compatible: the field defaults to false and old clients ignore it.

Closes KIL-459

🤖 Generated with [Claude Code](https://claude.com/claude-code)