### PR TITLE
KIL-711 Include spec definition in RAG eval judge prompt

### DIFF
--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/create_eval_config/eval_steps_utils.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/create_eval_config/eval_steps_utils.ts
@@ -158,10 +158,20 @@ ${spec.definition}
   }
 
   if (template === "rag") {
-    const steps: string[] = [
-      `Evaluate if the model's output is accurate as per the reference answer.`,
-    ]
-    return steps
+    if (spec !== null) {
+      const steps: string[] = [
+        `Look at the "output" for the task run. Evaluate if the model's output meets the <spec_description>. The eval should pass if the model's output meets all requirements of the spec, and fail if any requirements of the spec are not met.
+<spec_description>
+${spec.definition}
+</spec_description>`,
+      ]
+      return steps
+    } else {
+      const steps: string[] = [
+        `Evaluate if the model's output is accurate as per the reference answer.`,
+      ]
+      return steps
+    }
   }
 
   if (template === "tool_call") {

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/create_eval_config/get_eval_steps.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/create_eval_config/get_eval_steps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import type { EvalTemplateId, Task, Eval } from "$lib/types"
+import type { EvalTemplateId, Task, Eval, Spec } from "$lib/types"
 import { get_eval_steps } from "./eval_steps_utils"
 
 // Test helper functions to create mock objects
@@ -57,6 +57,30 @@ function createMockRequirement(
     instruction,
     priority,
     type: "five_star",
+  }
+}
+
+function createMockSpec(definition: string): Spec {
+  return {
+    v: 1,
+    id: "test-spec-id",
+    name: "Test Spec",
+    definition,
+    properties: {
+      spec_type: "reference_answer_accuracy",
+      core_requirement: "Core requirement",
+      reference_answer_accuracy_description: "Reference answer accuracy",
+      accurate_examples: "Accurate example",
+      inaccurate_examples: "Inaccurate example",
+    },
+    priority: 1,
+    status: "active",
+    tags: [],
+    eval_id: "test-eval-id",
+    model_type: "Spec",
+    path: "/test/spec",
+    created_at: "2024-01-01T00:00:00Z",
+    created_by: "test-user",
   }
 }
 
@@ -330,6 +354,32 @@ describe("get_eval_steps", () => {
         "Is the model's output similar to this example of a failing output: \n<failure_example>\nThis is terrible!\n</failure_example>",
         "Is the model's output similar to this example of a passing output: \n<pass_example>\nThis is good.\n</pass_example>",
         "Considering the above, does the model's output contain the issue described? It should pass if it does not contain the issue, and fail if it does contain the issue.",
+      ])
+    })
+  })
+
+  describe("rag template", () => {
+    it("should return the generic reference-answer step when no spec is provided", () => {
+      const task = createMockTask()
+      const evaluator = createMockEval("rag")
+      const result = get_eval_steps("rag", task, evaluator)
+
+      expect(result).toEqual([
+        "Evaluate if the model's output is accurate as per the reference answer.",
+      ])
+    })
+
+    it("should return a spec-based step embedding the spec definition when a spec is provided", () => {
+      const task = createMockTask()
+      const evaluator = createMockEval("rag")
+      const spec = createMockSpec("The answer must cite the source document.")
+      const result = get_eval_steps("rag", task, evaluator, spec)
+
+      expect(result).toEqual([
+        `Look at the "output" for the task run. Evaluate if the model's output meets the <spec_description>. The eval should pass if the model's output meets all requirements of the spec, and fail if any requirements of the spec are not met.
+<spec_description>
+The answer must cite the source document.
+</spec_description>`,
       ])
     })
   })


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-711/rag-eval-missing-spec-in-judge-prompt

## Description

The `rag` eval template in `get_eval_steps` ignored the spec definition, always returning a generic "accurate as per the reference answer" judge step even when a spec was present. This meant spec-based RAG evals weren't actually evaluating against the spec.

## Changes

- In `eval_steps_utils.ts`, when `template === "rag"` and a spec is present, return a spec-based judge step that embeds `spec.definition` in a `<spec_description>` block (mirroring the spec-based path used by other templates). The generic reference-answer step is preserved for the no-spec/legacy path.
- Added unit tests in `get_eval_steps.test.ts` covering both the rag-with-spec and rag-without-spec cases.

Frontend-only; no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)