### PR TITLE
KIL-712 Use default run config's prompt in eval/spec builder

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -204,9 +204,11 @@ export interface paths {
         put?: never;
         /**
          * Build Prompt With Examples
-         * @description Build a prompt with task instruction, requirements, and optional custom examples.
+         * @description Build a prompt with the task's prompt, requirements, and optional custom examples.
          *
          *     Uses the same formatting as the FewShotPromptBuilder but with user-provided examples.
+         *     When the task has a default run config, that run config's prompt is used as the base
+         *     (so synthetic data reflects the production prompt) instead of the task instruction.
          */
         post: operations["build_prompt_with_examples_api_projects__project_id__tasks__task_id__build_prompt_with_examples_post"];
         delete?: never;

--- a/libs/core/kiln_ai/adapters/prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/prompt_builders.py
@@ -247,21 +247,37 @@ class FewShotPromptBuilder(MultiShotPromptBuilder):
 
 
 class CustomExamplePromptBuilder(FewShotPromptBuilder):
-    """A prompt builder that uses custom examples instead of collecting from the dataset."""
+    """A prompt builder that uses custom examples instead of collecting from the dataset.
 
-    def __init__(self, task: Task, examples: list[PromptExample] | None = None):
+    The base prompt is normally built from the task's instruction and requirements. A
+    base_prompt_override can be supplied (e.g. the task's default run config prompt) to
+    use the real production prompt as the base instead, with the custom examples appended.
+    """
+
+    def __init__(
+        self,
+        task: Task,
+        examples: list[PromptExample] | None = None,
+        base_prompt_override: str | None = None,
+    ):
         super().__init__(task)
         self._custom_examples = examples or []
+        self._base_prompt_override = base_prompt_override
 
     def collect_examples(self) -> list[TaskRun]:
         """Override to return an empty list - we handle examples separately."""
         return []
 
     def build_base_prompt(self) -> str:
-        """Build a prompt with instruction, requirements, and custom examples."""
-        base_prompt = self.build_instruction_and_requirements()
+        """Build a prompt with instruction (or override), requirements, and custom examples."""
+        if self._base_prompt_override is not None:
+            base_prompt = self._base_prompt_override
+        else:
+            base_prompt = self.build_instruction_and_requirements()
 
         if self._custom_examples:
+            if not base_prompt.endswith("\n\n"):
+                base_prompt = base_prompt.rstrip("\n") + "\n\n"
             base_prompt += "# Example Outputs\n\n"
             for i, example in enumerate(self._custom_examples):
                 base_prompt += f"## Example {i + 1}\n\nInput: {example.input}\nOutput: {example.output}\n\n"

--- a/libs/core/kiln_ai/adapters/test_prompt_builders.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_builders.py
@@ -8,11 +8,13 @@ from kiln_ai.adapters.model_adapters.test_structured_output import (
     build_structured_output_test_task,
 )
 from kiln_ai.adapters.prompt_builders import (
+    CustomExamplePromptBuilder,
     FewShotChainOfThoughtPromptBuilder,
     FewShotPromptBuilder,
     FineTunePromptBuilder,
     MultiShotChainOfThoughtPromptBuilder,
     MultiShotPromptBuilder,
+    PromptExample,
     RepairsPromptBuilder,
     SavedPromptBuilder,
     SimpleChainOfThoughtPromptBuilder,
@@ -685,3 +687,56 @@ def test_build_prompt_for_ui_with_skills(tmp_path):
     ui_prompt = builder.build_prompt_for_ui(skills=skills)
     assert "my-skill" in ui_prompt
     assert "Does something" in ui_prompt
+
+
+def test_custom_example_prompt_builder_uses_instruction(tmp_path):
+    task = build_test_task(tmp_path)
+    examples = [PromptExample(input="2 + 2", output="[4]")]
+    builder = CustomExamplePromptBuilder(task, examples)
+    prompt = builder.build_prompt(include_json_instructions=False)
+
+    assert "# Instruction" in prompt
+    assert task.instruction in prompt
+    # Requirements are included from the task
+    assert task.requirements[0].instruction in prompt
+    assert "# Example Outputs" in prompt
+    assert "Input: 2 + 2" in prompt
+    assert "Output: [4]" in prompt
+
+
+def test_custom_example_prompt_builder_no_examples(tmp_path):
+    task = build_test_task(tmp_path)
+    builder = CustomExamplePromptBuilder(task)
+    prompt = builder.build_prompt(include_json_instructions=False)
+
+    assert task.instruction in prompt
+    assert "# Example Outputs" not in prompt
+
+
+def test_custom_example_prompt_builder_base_prompt_override(tmp_path):
+    task = build_test_task(tmp_path)
+    override = "PRODUCTION PROMPT: translate the input to French."
+    examples = [PromptExample(input="hello", output="bonjour")]
+    builder = CustomExamplePromptBuilder(task, examples, base_prompt_override=override)
+    prompt = builder.build_prompt(include_json_instructions=False)
+
+    # Override replaces the task instruction and requirements
+    assert override in prompt
+    assert "# Instruction" not in prompt
+    assert task.instruction not in prompt
+    assert task.requirements[0].instruction not in prompt
+    # Examples are still appended, with separation
+    assert "# Example Outputs" in prompt
+    assert "Input: hello" in prompt
+    assert "Output: bonjour" in prompt
+    assert override + "\n\n# Example Outputs" in prompt
+
+
+def test_custom_example_prompt_builder_override_no_examples(tmp_path):
+    task = build_test_task(tmp_path)
+    override = "PRODUCTION PROMPT: do the thing."
+    builder = CustomExamplePromptBuilder(task, base_prompt_override=override)
+    prompt = builder.build_prompt(include_json_instructions=False)
+
+    assert prompt == override
+    assert "# Example Outputs" not in prompt

--- a/libs/server/kiln_server/prompt_api.py
+++ b/libs/server/kiln_server/prompt_api.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from typing import Annotated
 
@@ -17,6 +18,8 @@ from kiln_server.utils.agent_checks.policy import (
     DENY_AGENT,
     agent_policy_require_approval,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def default_run_config_prompt(task: Task) -> str | None:
@@ -47,9 +50,16 @@ def default_run_config_prompt(task: Task) -> str | None:
     try:
         builder = prompt_builder_from_id(prompt_id, task)
         return builder.build_prompt(include_json_instructions=False)
-    except ValueError:
+    except Exception:
         # A misconfigured run config (e.g. a frozen prompt that no longer resolves)
         # should not break the builder - fall back to the task instruction.
+        logger.warning(
+            "Failed to resolve default run config prompt %s for task %s; "
+            "falling back to task instruction.",
+            prompt_id,
+            task.id,
+            exc_info=True,
+        )
         return None
 
 

--- a/libs/server/kiln_server/prompt_api.py
+++ b/libs/server/kiln_server/prompt_api.py
@@ -2,8 +2,12 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import FastAPI, HTTPException, Path
-from kiln_ai.adapters.prompt_builders import CustomExamplePromptBuilder, PromptExample
-from kiln_ai.datamodel import BasePrompt, Prompt, PromptId
+from kiln_ai.adapters.prompt_builders import (
+    CustomExamplePromptBuilder,
+    PromptExample,
+    prompt_builder_from_id,
+)
+from kiln_ai.datamodel import BasePrompt, Prompt, PromptId, Task
 from kiln_ai.datamodel.prompt_type import prompt_type_label
 from pydantic import BaseModel, Field
 
@@ -13,6 +17,40 @@ from kiln_server.utils.agent_checks.policy import (
     DENY_AGENT,
     agent_policy_require_approval,
 )
+
+
+def default_run_config_prompt(task: Task) -> str | None:
+    """Resolve the prompt text from the task's default run config.
+
+    Returns None when the task has no default run config, the config can't be found,
+    it has no prompt_id (e.g. an MCP run config), or the prompt can't be resolved. In
+    those cases callers should fall back to the task instruction.
+    """
+    if not task.default_run_config_id:
+        return None
+
+    run_config = next(
+        (
+            rc
+            for rc in task.run_configs(readonly=True)
+            if rc.id == task.default_run_config_id
+        ),
+        None,
+    )
+    if run_config is None:
+        return None
+
+    prompt_id = getattr(run_config.run_config_properties, "prompt_id", None)
+    if not prompt_id:
+        return None
+
+    try:
+        builder = prompt_builder_from_id(prompt_id, task)
+        return builder.build_prompt(include_json_instructions=False)
+    except ValueError:
+        # A misconfigured run config (e.g. a frozen prompt that no longer resolves)
+        # should not break the builder - fall back to the task instruction.
+        return None
 
 
 def editable_prompt_from_id(project_id: str, task_id: str, prompt_id: str) -> Prompt:
@@ -274,15 +312,20 @@ def connect_prompt_api(app: FastAPI):
         ],
         request: BuildPromptRequest,
     ) -> BuildPromptResponse:
-        """Build a prompt with task instruction, requirements, and optional custom examples.
+        """Build a prompt with the task's prompt, requirements, and optional custom examples.
 
         Uses the same formatting as the FewShotPromptBuilder but with user-provided examples.
+        When the task has a default run config, that run config's prompt is used as the base
+        (so synthetic data reflects the production prompt) instead of the task instruction.
         """
         task = task_from_id(project_id, task_id)
         examples = [
             PromptExample(input=e.input, output=e.output) for e in request.examples
         ]
-        builder = CustomExamplePromptBuilder(task, examples)
+        base_prompt_override = default_run_config_prompt(task)
+        builder = CustomExamplePromptBuilder(
+            task, examples, base_prompt_override=base_prompt_override
+        )
         prompt = builder.build_prompt(include_json_instructions=False)
         return BuildPromptResponse(prompt=prompt)
 

--- a/libs/server/kiln_server/test_prompt_api.py
+++ b/libs/server/kiln_server/test_prompt_api.py
@@ -236,3 +236,109 @@ def test_delete_prompt_success(client, project_and_task):
     # Verify the file was actually deleted, including the parent directory
     assert not prompt_path.exists()
     assert not prompt_path.parent.exists()
+
+
+def _add_default_run_config(task, prompt_id):
+    from kiln_ai.datamodel import StructuredOutputMode
+    from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
+    from kiln_ai.datamodel.task import TaskRunConfig
+
+    run_config = TaskRunConfig(
+        name="Default Config",
+        run_config_properties=KilnAgentRunConfigProperties(
+            model_name="gpt-4o",
+            model_provider_name="openai",
+            prompt_id=prompt_id,
+            structured_output_mode=StructuredOutputMode.default,
+        ),
+        parent=task,
+    )
+    run_config.save_to_file()
+    task.default_run_config_id = run_config.id
+    task.save_to_file()
+    return run_config
+
+
+def test_build_prompt_with_examples_uses_instruction(client, project_and_task):
+    project, task = project_and_task
+
+    with patch("kiln_server.prompt_api.task_from_id") as mock_task_from_id:
+        mock_task_from_id.return_value = task
+        response = client.post(
+            f"/api/projects/{project.id}/tasks/{task.id}/build_prompt_with_examples",
+            json={"examples": [{"input": "in", "output": "out"}]},
+        )
+
+    assert response.status_code == 200
+    prompt = response.json()["prompt"]
+    assert task.instruction in prompt
+    assert "# Example Outputs" in prompt
+    assert "Input: in" in prompt
+    assert "Output: out" in prompt
+
+
+def test_build_prompt_with_examples_uses_default_run_config_prompt(
+    client, project_and_task
+):
+    project, task = project_and_task
+
+    saved_prompt = Prompt(
+        name="Production Prompt",
+        prompt="PRODUCTION PROMPT: translate to French.",
+        parent=task,
+    )
+    saved_prompt.save_to_file()
+    _add_default_run_config(task, f"id::{saved_prompt.id}")
+
+    with patch("kiln_server.prompt_api.task_from_id") as mock_task_from_id:
+        mock_task_from_id.return_value = task
+        response = client.post(
+            f"/api/projects/{project.id}/tasks/{task.id}/build_prompt_with_examples",
+            json={"examples": [{"input": "hello", "output": "bonjour"}]},
+        )
+
+    assert response.status_code == 200
+    prompt = response.json()["prompt"]
+    # The default run config prompt is used, not the task instruction
+    assert "PRODUCTION PROMPT: translate to French." in prompt
+    assert task.instruction not in prompt
+    # Examples are still appended
+    assert "# Example Outputs" in prompt
+    assert "Input: hello" in prompt
+    assert "Output: bonjour" in prompt
+
+
+def test_build_prompt_with_examples_missing_default_run_config_falls_back(
+    client, project_and_task
+):
+    project, task = project_and_task
+    # Point at a run config that doesn't exist
+    task.default_run_config_id = "nonexistent"
+    task.save_to_file()
+
+    with patch("kiln_server.prompt_api.task_from_id") as mock_task_from_id:
+        mock_task_from_id.return_value = task
+        response = client.post(
+            f"/api/projects/{project.id}/tasks/{task.id}/build_prompt_with_examples",
+            json={"examples": []},
+        )
+
+    assert response.status_code == 200
+    prompt = response.json()["prompt"]
+    assert task.instruction in prompt
+
+
+def test_default_run_config_prompt_none_without_default(project_and_task):
+    from kiln_server.prompt_api import default_run_config_prompt
+
+    _, task = project_and_task
+    assert default_run_config_prompt(task) is None
+
+
+def test_default_run_config_prompt_unresolvable_returns_none(project_and_task):
+    from kiln_server.prompt_api import default_run_config_prompt
+
+    _, task = project_and_task
+    # Saved-prompt id that doesn't exist -> SavedPromptBuilder raises ValueError
+    _add_default_run_config(task, "id::does-not-exist")
+    assert default_run_config_prompt(task) is None

--- a/libs/server/kiln_server/test_prompt_api.py
+++ b/libs/server/kiln_server/test_prompt_api.py
@@ -342,3 +342,25 @@ def test_default_run_config_prompt_unresolvable_returns_none(project_and_task):
     # Saved-prompt id that doesn't exist -> SavedPromptBuilder raises ValueError
     _add_default_run_config(task, "id::does-not-exist")
     assert default_run_config_prompt(task) is None
+
+
+def test_default_run_config_prompt_mcp_config_returns_none(project_and_task):
+    from kiln_ai.datamodel.run_config import McpRunConfigProperties, MCPToolReference
+    from kiln_ai.datamodel.task import TaskRunConfig
+
+    from kiln_server.prompt_api import default_run_config_prompt
+
+    _, task = project_and_task
+    # An MCP run config has no prompt_id -> fall back to the task instruction.
+    run_config = TaskRunConfig(
+        name="MCP Config",
+        run_config_properties=McpRunConfigProperties(
+            tool_reference=MCPToolReference(tool_id="mcp::local::server_id::tool_name"),
+        ),
+        parent=task,
+    )
+    run_config.save_to_file()
+    task.default_run_config_id = run_config.id
+    task.save_to_file()
+
+    assert default_run_config_prompt(task) is None


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-712/eval-builder-should-use-default-run-configs-prompt-and-fallback-to

## Description

The eval builder always sent `task.instruction` to copilot's `clarify_spec` / `generate_batch` as `target_task_info.task_prompt`. For users whose real production prompt lives in a saved prompt or a run-config-linked prompt, SDG generated topics/inputs/outputs against a stub instruction — so the synthetic data didn't reflect what production actually does.

This PR checks whether the task has a default run config set and uses that run config's prompt, otherwise falls back to `task.instruction` as before. (A full prompt picker is future work.)

## Changes

- **`build_prompt_with_examples` endpoint** (`libs/server/kiln_server/prompt_api.py`): resolves the task's default run config and uses its prompt as the base via `prompt_builder_from_id(...).build_prompt(...)`. New helper `default_run_config_prompt(task)` returns `None` (→ fall back to instruction) when there is no default run config, the config can't be found, it has no `prompt_id` (e.g. an MCP run config), or the prompt can't be resolved.
- **`CustomExamplePromptBuilder`** (`libs/core/.../prompt_builders.py`): gains an optional `base_prompt_override` param. When provided, it bypasses `build_instruction_and_requirements` and uses the run config prompt as the base, still appending the custom examples. Behavior is unchanged when no override is passed.

This is backend-only — the spec builder frontend (which calls `build_prompt_with_examples` and sends the result to copilot) benefits transparently. No API request/response schema changes, so no client regen needed.

## Tests

- `CustomExamplePromptBuilder`: instruction path, no-examples path, override replaces instruction/requirements, override with/without examples.
- Endpoint: instruction fallback, default-run-config prompt used, missing/unresolvable run config falls back; `default_run_config_prompt` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
