### PR TITLE
KIL-713 Open GEPA run-config links in new tab to avoid unsaved-changes warning

### DIFF
--- a/app/web_ui/src/lib/ui/property_list.svelte
+++ b/app/web_ui/src/lib/ui/property_list.svelte
@@ -7,6 +7,13 @@
 
   export let properties: UiProperty[]
   export let title: string | null = null
+  // When true, links open in a new tab. Useful when the list is rendered inside
+  // a form with an unsaved-changes warning, so following a link doesn't trigger
+  // a same-tab navigation (and the warning popup).
+  export let open_links_in_new_tab: boolean = false
+
+  $: link_target = open_links_in_new_tab ? "_blank" : undefined
+  $: link_rel = open_links_in_new_tab ? "noopener noreferrer" : undefined
 
   let badges_dialog: Dialog
   let modal_title = ""
@@ -68,6 +75,8 @@
                 {#if link}
                   <a
                     href={link}
+                    target={link_target}
+                    rel={link_rel}
                     class="badge badge-outline h-auto hover:bg-base-200"
                   >
                     {value}
@@ -95,7 +104,12 @@
                     : null}
 
                 {#if link}
-                  <a href={link} class="link">{value}</a>
+                  <a
+                    href={link}
+                    target={link_target}
+                    rel={link_rel}
+                    class="link">{value}</a
+                  >
                 {:else}
                   <span>{value}</span>
                 {/if}
@@ -116,7 +130,12 @@
         {:else if property.value_with_link}
           <span>
             {property.value_with_link.prefix}
-            <a href={property.value_with_link.link} class="link">
+            <a
+              href={property.value_with_link.link}
+              target={link_target}
+              rel={link_rel}
+              class="link"
+            >
               {property.value_with_link.link_text}
             </a>
           </span>
@@ -125,7 +144,12 @@
             >{property.value}</button
           >
         {:else if property.link}
-          <a href={property.link} class="link">{property.value}</a>
+          <a
+            href={property.link}
+            target={link_target}
+            rel={link_rel}
+            class="link">{property.value}</a
+          >
         {:else}
           {property.value}
         {/if}
@@ -147,7 +171,12 @@
           ? modal_links[i]
           : null}
       {#if link}
-        <a href={link} class="badge badge-outline h-auto hover:bg-base-200">
+        <a
+          href={link}
+          target={link_target}
+          rel={link_rel}
+          class="badge badge-outline h-auto hover:bg-base-200"
+        >
           {value}
         </a>
       {:else}

--- a/app/web_ui/src/lib/ui/property_list.test.ts
+++ b/app/web_ui/src/lib/ui/property_list.test.ts
@@ -28,6 +28,15 @@ function render_props(properties: UiProperty[]) {
   return render(PropertyList, { props: { properties } })
 }
 
+function render_props_with_options(
+  properties: UiProperty[],
+  open_links_in_new_tab: boolean,
+) {
+  return render(PropertyList, {
+    props: { properties, open_links_in_new_tab },
+  })
+}
+
 describe("PropertyList collapse_badges", () => {
   it("renders all badges when collapse_badges is not set", () => {
     const { container } = render_props([
@@ -108,5 +117,110 @@ describe("PropertyList collapse_badges", () => {
     expect(pills.length).toBe(2)
     expect(pills[1].textContent?.trim()).toBe("beta")
     expect(pills[1].getAttribute("href")).toBe("/tools/b")
+  })
+})
+
+describe("PropertyList open_links_in_new_tab", () => {
+  it("renders a single link in the same tab by default", () => {
+    const { container } = render_props([
+      { name: "Prompt", value: "My Prompt", link: "/prompts/p1" },
+    ])
+    const anchor = container.querySelector("a.link")
+    expect(anchor?.getAttribute("href")).toBe("/prompts/p1")
+    expect(anchor?.getAttribute("target")).toBeNull()
+    expect(anchor?.getAttribute("rel")).toBeNull()
+  })
+
+  it("opens a single link in a new tab when enabled", () => {
+    const { container } = render_props_with_options(
+      [{ name: "Prompt", value: "My Prompt", link: "/prompts/p1" }],
+      true,
+    )
+    const anchor = container.querySelector("a.link")
+    expect(anchor?.getAttribute("href")).toBe("/prompts/p1")
+    expect(anchor?.getAttribute("target")).toBe("_blank")
+    expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer")
+  })
+
+  it("opens badge links in a new tab when enabled", () => {
+    const { container } = render_props_with_options(
+      [
+        {
+          name: "Available Tools",
+          value: ["alpha", "beta"],
+          links: ["/tools/a", "/tools/b"],
+          badge: true,
+        },
+      ],
+      true,
+    )
+    const anchors = container.querySelectorAll("a.badge")
+    expect(anchors.length).toBe(2)
+    anchors.forEach((anchor) => {
+      expect(anchor.getAttribute("target")).toBe("_blank")
+      expect(anchor.getAttribute("rel")).toBe("noopener noreferrer")
+    })
+  })
+
+  it("opens non-badge array links in a new tab when enabled", () => {
+    const { container } = render_props_with_options(
+      [
+        {
+          name: "Evals",
+          value: ["eval one", "eval two"],
+          links: ["/evals/1", "/evals/2"],
+        },
+      ],
+      true,
+    )
+    const anchors = container.querySelectorAll("a.link")
+    expect(anchors.length).toBe(2)
+    anchors.forEach((anchor) => {
+      expect(anchor.getAttribute("target")).toBe("_blank")
+      expect(anchor.getAttribute("rel")).toBe("noopener noreferrer")
+    })
+  })
+
+  it("opens value_with_link in a new tab when enabled", () => {
+    const { container } = render_props_with_options(
+      [
+        {
+          name: "Source",
+          value: "ignored",
+          value_with_link: {
+            prefix: "From ",
+            link_text: "dataset",
+            link: "/dataset/1",
+          },
+        },
+      ],
+      true,
+    )
+    const anchor = container.querySelector("a.link")
+    expect(anchor?.getAttribute("href")).toBe("/dataset/1")
+    expect(anchor?.getAttribute("target")).toBe("_blank")
+    expect(anchor?.getAttribute("rel")).toBe("noopener noreferrer")
+  })
+
+  it("opens links inside the '+N more' modal in a new tab when enabled", async () => {
+    const { container, getByText } = render_props_with_options(
+      [
+        {
+          name: "Available Tools",
+          value: ["alpha", "beta"],
+          links: ["/tools/a", "/tools/b"],
+          badge: true,
+          collapse_badges: true,
+        },
+      ],
+      true,
+    )
+    await fireEvent.click(getByText("+1 more"))
+    const pills = container.querySelectorAll("dialog a.badge.badge-outline")
+    expect(pills.length).toBe(2)
+    pills.forEach((pill) => {
+      expect(pill.getAttribute("target")).toBe("_blank")
+      expect(pill.getAttribute("rel")).toBe("noopener noreferrer")
+    })
   })
 })

--- a/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/create_prompt_optimization_job/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/create_prompt_optimization_job/+page.svelte
@@ -868,7 +868,10 @@
                     <div class="text-md font-semibold text-left mb-4">
                       Details
                     </div>
-                    <PropertyList properties={run_config_properties} />
+                    <PropertyList
+                      properties={run_config_properties}
+                      open_links_in_new_tab={true}
+                    />
                   </div>
                 </div>
               {/if}


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-713

## Description

In the form where the user creates a new prompt optimization (GEPA) job, but before kicking it off, clicking the prompt link in the run config details opened in the same tab — triggering the form's unsaved-changes warning popup.

## Root cause

The run-config details are rendered via `PropertyList`. Its links (prompt, tools, skills) rendered as plain same-tab `<a href>` elements. The form wraps everything in `FormContainer` with `warn_before_unload`, which uses SvelteKit's `beforeNavigate`. Clicking the prompt link triggered a client-side navigation → unsaved-changes warning.

## Fix

- Added an opt-in `open_links_in_new_tab` boolean prop to `property_list.svelte` (default `false`). When enabled, all link variants (single link, badge links, array links, `value_with_link`, and the "+N more" modal pills) get `target="_blank"` + `rel="noopener noreferrer"`, opening a new tab and avoiding the same-tab navigation/warning.
- Enabled `open_links_in_new_tab` on the `PropertyList` in the GEPA create-job form.
- Added unit tests covering default same-tab behavior and new-tab behavior across all link types.

Scoped so every other `PropertyList` usage is unaffected (default off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
