### PR TITLE
KIL-714 Show thinking level in run config details

### DIFF
--- a/app/web_ui/src/lib/ui/run_config_component/advanced_run_options.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/advanced_run_options.svelte
@@ -3,6 +3,7 @@
   import type { OptionGroup } from "$lib/ui/fancy_select_types"
   import type { StructuredOutputMode, InputTransform } from "$lib/types"
   import { structuredOutputModeToString } from "$lib/utils/formatters"
+  import { THINKING_LEVEL_INFO_DESCRIPTION } from "$lib/utils/run_config_formatters"
   import InputTransformSelector from "./input_transform_selector.svelte"
 
   export let temperature: number
@@ -170,7 +171,7 @@
       inputType="fancy_select"
       bind:value={thinking_level}
       fancy_select_options={thinking_level_options}
-      info_description="Thinking level controls the model’s internal reasoning effort for supported models. Higher effort uses more tokens and is slower; lower effort is faster."
+      info_description={THINKING_LEVEL_INFO_DESCRIPTION}
       optional={true}
     />
   {/if}

--- a/app/web_ui/src/lib/utils/run_config_formatters.test.ts
+++ b/app/web_ui/src/lib/utils/run_config_formatters.test.ts
@@ -8,6 +8,7 @@ import {
   getRunConfigInputTransformSummaryLabel,
   buildJinjaInputTransform,
   inputTransformsEqual,
+  getThinkingLevelDisplayName,
 } from "./run_config_formatters"
 
 const JINJA_TRANSFORM: InputTransform = {
@@ -18,9 +19,10 @@ const JINJA_TRANSFORM: InputTransform = {
 function makeKilnAgentConfig(
   overrides: Partial<TaskRunConfig> & {
     input_transform?: InputTransform | null
+    thinking_level?: string | null
   } = {},
 ): TaskRunConfig {
-  const { input_transform, ...rest } = overrides
+  const { input_transform, thinking_level, ...rest } = overrides
   return {
     v: 1,
     id: "rc-agent",
@@ -37,6 +39,7 @@ function makeKilnAgentConfig(
       top_p: 1,
       structured_output_mode: "default",
       input_transform: input_transform ?? null,
+      thinking_level: thinking_level ?? null,
     },
     prompt: null,
     model_type: "task_run_config",
@@ -197,6 +200,57 @@ describe("getRunConfigUiProperties (kiln_agent input transformer row)", () => {
     const transformIdx = names.indexOf("Input Transformer")
     expect(promptIdx).toBeGreaterThanOrEqual(0)
     expect(transformIdx).toBe(promptIdx + 1)
+  })
+})
+
+describe("getThinkingLevelDisplayName", () => {
+  it("maps known thinking level values to friendly labels", () => {
+    expect(getThinkingLevelDisplayName("none")).toBe("None")
+    expect(getThinkingLevelDisplayName("minimal")).toBe("Minimal")
+    expect(getThinkingLevelDisplayName("low")).toBe("Low")
+    expect(getThinkingLevelDisplayName("medium")).toBe("Medium")
+    expect(getThinkingLevelDisplayName("high")).toBe("High")
+    expect(getThinkingLevelDisplayName("xhigh")).toBe("Extra High")
+    expect(getThinkingLevelDisplayName("max")).toBe("Max")
+  })
+
+  it("capitalizes unknown values as a fallback", () => {
+    expect(getThinkingLevelDisplayName("ultra")).toBe("Ultra")
+  })
+})
+
+describe("getRunConfigUiProperties (kiln_agent thinking level row)", () => {
+  it("shows the Thinking Level row when a value is set", () => {
+    const config = makeKilnAgentConfig({ thinking_level: "high" })
+    const props = getRunConfigUiProperties("p1", "t1", config, null, null, null)
+    const row = props.find((p) => p.name === "Thinking Level")
+    expect(row).toBeDefined()
+    expect(row?.value).toBe("High")
+  })
+
+  it('shows "None" when thinking level is explicitly "none"', () => {
+    const config = makeKilnAgentConfig({ thinking_level: "none" })
+    const props = getRunConfigUiProperties("p1", "t1", config, null, null, null)
+    const row = props.find((p) => p.name === "Thinking Level")
+    expect(row).toBeDefined()
+    expect(row?.value).toBe("None")
+  })
+
+  it("omits the Thinking Level row when thinking level is null", () => {
+    const config = makeKilnAgentConfig({ thinking_level: null })
+    const props = getRunConfigUiProperties("p1", "t1", config, null, null, null)
+    const names = props.map((p) => p.name)
+    expect(names).not.toContain("Thinking Level")
+  })
+
+  it("places the Thinking Level row after Top P", () => {
+    const config = makeKilnAgentConfig({ thinking_level: "medium" })
+    const props = getRunConfigUiProperties("p1", "t1", config, null, null, null)
+    const names = props.map((p) => p.name)
+    const topPIdx = names.indexOf("Top P")
+    const thinkingIdx = names.indexOf("Thinking Level")
+    expect(topPIdx).toBeGreaterThanOrEqual(0)
+    expect(thinkingIdx).toBe(topPIdx + 1)
   })
 })
 

--- a/app/web_ui/src/lib/utils/run_config_formatters.test.ts
+++ b/app/web_ui/src/lib/utils/run_config_formatters.test.ts
@@ -243,6 +243,15 @@ describe("getRunConfigUiProperties (kiln_agent thinking level row)", () => {
     expect(names).not.toContain("Thinking Level")
   })
 
+  it("omits the Thinking Level row when thinking_level is undefined/absent", () => {
+    const config = makeKilnAgentConfig()
+    delete (config.run_config_properties as Record<string, unknown>)
+      .thinking_level
+    const props = getRunConfigUiProperties("p1", "t1", config, null, null, null)
+    const names = props.map((p) => p.name)
+    expect(names).not.toContain("Thinking Level")
+  })
+
   it("places the Thinking Level row after Top P", () => {
     const config = makeKilnAgentConfig({ thinking_level: "medium" })
     const props = getRunConfigUiProperties("p1", "t1", config, null, null, null)

--- a/app/web_ui/src/lib/utils/run_config_formatters.ts
+++ b/app/web_ui/src/lib/utils/run_config_formatters.ts
@@ -308,7 +308,7 @@ export function getRunConfigUiProperties(
           name: "Top P",
           value: run_config.run_config_properties.top_p.toString(),
         },
-        ...(run_config.run_config_properties.thinking_level
+        ...(run_config.run_config_properties.thinking_level != null
           ? [
               {
                 name: "Thinking Level",

--- a/app/web_ui/src/lib/utils/run_config_formatters.ts
+++ b/app/web_ui/src/lib/utils/run_config_formatters.ts
@@ -315,8 +315,7 @@ export function getRunConfigUiProperties(
                 value: getThinkingLevelDisplayName(
                   run_config.run_config_properties.thinking_level,
                 ),
-                tooltip:
-                  "The reasoning effort used for this run config. Higher levels use more tokens and are slower.",
+                tooltip: THINKING_LEVEL_INFO_DESCRIPTION,
               },
             ]
           : []),
@@ -328,6 +327,9 @@ export function getRunConfigUiProperties(
     }
   }
 }
+
+export const THINKING_LEVEL_INFO_DESCRIPTION =
+  "Thinking level controls the model's internal reasoning effort for supported models. Higher effort uses more tokens and is slower; lower effort is faster."
 
 const THINKING_LEVEL_DISPLAY_NAMES: Record<string, string> = {
   none: "None",

--- a/app/web_ui/src/lib/utils/run_config_formatters.ts
+++ b/app/web_ui/src/lib/utils/run_config_formatters.ts
@@ -308,6 +308,18 @@ export function getRunConfigUiProperties(
           name: "Top P",
           value: run_config.run_config_properties.top_p.toString(),
         },
+        ...(run_config.run_config_properties.thinking_level
+          ? [
+              {
+                name: "Thinking Level",
+                value: getThinkingLevelDisplayName(
+                  run_config.run_config_properties.thinking_level,
+                ),
+                tooltip:
+                  "The reasoning effort used for this run config. Higher levels use more tokens and are slower.",
+              },
+            ]
+          : []),
       ]
     }
     default: {
@@ -315,6 +327,25 @@ export function getRunConfigUiProperties(
       throw new Error(`Unknown run config type: ${_exhaustive}`)
     }
   }
+}
+
+const THINKING_LEVEL_DISPLAY_NAMES: Record<string, string> = {
+  none: "None",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+  max: "Max",
+}
+
+export function getThinkingLevelDisplayName(value: string): string {
+  const known = THINKING_LEVEL_DISPLAY_NAMES[value]
+  if (known) {
+    return known
+  }
+  // Fallback for unknown values: capitalize the first letter.
+  return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
 export function buildJinjaInputTransform(template: string): InputTransform {


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-714/thinking-level-is-not-shown-in-run-config-details

## Description

When selecting run config options, some models support selecting a thinking level. For these run configs, we now show the thinking level back when viewing the run config details. There are multiple places we show run config details (evals compare run configs, run config details page, etc.) — all of these render through the shared `getRunConfigUiProperties()`, so a single change covers them all.

### Handling of `thinking_level: str | None`
The ticket raised a question about what `None` means. Resolution:
- **`null`/`undefined`** → the row is omitted entirely. This covers both legacy run configs and models that don't support thinking levels — there is no meaningful value to show.
- **A stored value** (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`) → shown with a friendly label. Note that `none` is an explicit 'Off/None' choice the user made in the selector, so it is displayed as **None** rather than hidden.

### Changes
- Added `getThinkingLevelDisplayName(value)` mapping canonical values to friendly labels (None / Minimal / Low / Medium / High / Extra High / Max), with a capitalized fallback for unknown values.
- Added a **Thinking Level** row in the `kiln_agent` branch of `getRunConfigUiProperties`, placed after **Top P**, rendered only when `thinking_level` is non-null, with an explanatory tooltip.
- Added unit tests for the label mapping and the row behavior (shown with a value, `none` → None, omitted when null, ordering).

No backend changes; no schema regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)