### PR TITLE
KIL-715 Allow renaming eval score display names for spec evals

### DIFF
--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from collections import defaultdict
 from typing import Annotated, Any, Dict, List, Set, Tuple
 
@@ -25,6 +26,7 @@ from kiln_ai.datamodel.eval import (
     EvalTemplateId,
 )
 from kiln_ai.datamodel.json_schema import string_to_json_key
+from kiln_ai.datamodel.model_cache import ModelCache
 from kiln_ai.datamodel.prompt_id import is_frozen_prompt
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.spec import SpecStatus
@@ -38,13 +40,15 @@ from kiln_server.utils.agent_checks.policy import (
     DENY_AGENT,
     agent_policy_require_approval,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from .correlation_calculator import (
     CorrelationCalculator,
     CorrelationResult,
     CorrelationScore,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def eval_from_id(project_id: str, task_id: str, eval_id: str) -> Eval:
@@ -57,6 +61,107 @@ def eval_from_id(project_id: str, task_id: str, eval_id: str) -> Eval:
         status_code=404,
         detail=f"Eval not found. ID: {eval_id}",
     )
+
+
+def _save_eval_run_rekeyed(run: EvalRun) -> None:
+    """Persist an EvalRun whose scores were re-keyed during a rename.
+
+    EvalRun.save_to_file() assigns self.path, which (via validate_assignment) re-validates the whole
+    run against its lazily-loaded parent eval. Mid-rename that parent still reflects the old score
+    keys, so the standard save would spuriously fail. The run's new scores are already consistent with
+    the renamed eval, so we serialize and write directly instead.
+    """
+    if run.path is None:
+        raise ValueError("Cannot save EvalRun without a path")
+    json_data = run.model_dump_json(
+        indent=2,
+        exclude={"path"},
+        context={"save_attachments": True, "dest_path": run.path.parent},
+    )
+    run.path.write_text(json_data, encoding="utf-8")
+    ModelCache.shared().invalidate(run.path)
+
+
+def rename_eval_output_scores(eval: Eval, new_names: list[str]) -> None:
+    """Rename the eval's output scores in place and migrate the new keys across all stored eval runs.
+
+    new_names must be positionally aligned with eval.output_scores (same length). Renaming a score
+    that changes its JSON key re-keys that score in every EvalRun under every EvalConfig. The eval and
+    all affected run files are saved atomically: if any save fails, all touched files are restored to
+    their prior on-disk contents.
+    """
+    if len(new_names) != len(eval.output_scores):
+        raise HTTPException(
+            status_code=400,
+            detail=f"output_score_names must have the same length as the eval's output scores. Got {len(new_names)}, expected {len(eval.output_scores)}.",
+        )
+
+    old_keys = [score.json_key() for score in eval.output_scores]
+
+    # Validate each new name (length/charset) and compute the resulting JSON keys.
+    new_keys: list[str] = []
+    for index, name in enumerate(new_names):
+        existing = eval.output_scores[index]
+        try:
+            EvalOutputScore(
+                name=name, type=existing.type, instruction=existing.instruction
+            )
+        except ValidationError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid score name '{name}': {e}",
+            )
+        new_keys.append(string_to_json_key(name))
+
+    if len(set(new_keys)) != len(new_keys):
+        raise HTTPException(
+            status_code=400,
+            detail="Score names must be unique (once normalized to JSON keys).",
+        )
+
+    key_map = {old: new for old, new in zip(old_keys, new_keys)}
+    keys_changed = old_keys != new_keys
+
+    # Load all runs (with the pre-rename eval state, so they validate on load) and re-key the scores
+    # of those that change. We set scores via object.__setattr__ to bypass EvalRun's
+    # validate_assignment: it would otherwise validate the new keys against each run's lazily-reloaded
+    # (pre-rename) parent eval and fail. The new keys are already validated above, and save_to_file
+    # does not re-validate, so the final on-disk state (new run keys + new eval names) is consistent.
+    runs_to_update: list[EvalRun] = []
+    if keys_changed:
+        for config in eval.configs():
+            for run in config.runs():
+                new_scores = {key_map.get(k, k): v for k, v in run.scores.items()}
+                if new_scores != run.scores:
+                    object.__setattr__(run, "scores", new_scores)
+                    runs_to_update.append(run)
+
+    # Apply the new names to the eval in memory.
+    for index, name in enumerate(new_names):
+        eval.output_scores[index].name = name
+
+    # Snapshot the current on-disk contents of every file we will write, for rollback.
+    models_to_save: list[Eval | EvalRun] = [*runs_to_update, eval]
+    snapshots: dict[Any, bytes] = {}
+    for model in models_to_save:
+        if model.path is not None and model.path.exists():
+            snapshots[model.path] = model.path.read_bytes()
+
+    try:
+        for run in runs_to_update:
+            _save_eval_run_rekeyed(run)
+        eval.save_to_file()
+    except Exception as e:
+        for path, content in snapshots.items():
+            try:
+                path.write_bytes(content)
+                ModelCache.shared().invalidate(path)
+            except Exception:
+                logger.exception("Failed to roll back %s after rename failure", path)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to rename eval scores. All changes were rolled back. Error: {e}",
+        )
 
 
 def eval_config_from_id(
@@ -267,6 +372,10 @@ class UpdateEvalRequest(BaseModel):
     )
     train_set_filter_id: str | None = Field(
         default=None, description="The updated train set filter ID."
+    )
+    output_score_names: list[str] | None = Field(
+        default=None,
+        description="Updated names for the eval's output scores. Must be positionally aligned with the eval's existing output_scores (same length). Renaming a score that changes its JSON key migrates the score across all stored eval runs.",
     )
 
 
@@ -691,7 +800,12 @@ def connect_evals_api(app: FastAPI):
                 )
             eval.train_set_filter_id = request.train_set_filter_id
 
-        eval.save_to_file()
+        if request.output_score_names is not None:
+            # Saves the eval (including the name/description/train_set_filter changes above)
+            # atomically with the migrated eval runs.
+            rename_eval_output_scores(eval, request.output_score_names)
+        else:
+            eval.save_to_file()
         return eval
 
     @app.get(

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from collections import defaultdict
 from typing import Annotated, Any, Dict, List, Set, Tuple
 
@@ -26,7 +25,6 @@ from kiln_ai.datamodel.eval import (
     EvalTemplateId,
 )
 from kiln_ai.datamodel.json_schema import string_to_json_key
-from kiln_ai.datamodel.model_cache import ModelCache
 from kiln_ai.datamodel.prompt_id import is_frozen_prompt
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.spec import SpecStatus
@@ -40,15 +38,13 @@ from kiln_server.utils.agent_checks.policy import (
     DENY_AGENT,
     agent_policy_require_approval,
 )
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 
 from .correlation_calculator import (
     CorrelationCalculator,
     CorrelationResult,
     CorrelationScore,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def eval_from_id(project_id: str, task_id: str, eval_id: str) -> Eval:
@@ -63,105 +59,34 @@ def eval_from_id(project_id: str, task_id: str, eval_id: str) -> Eval:
     )
 
 
-def _save_eval_run_rekeyed(run: EvalRun) -> None:
-    """Persist an EvalRun whose scores were re-keyed during a rename.
+def set_output_score_display_names(eval: Eval, display_names: list[str | None]) -> None:
+    """Set the user-facing display name for each of the eval's output scores.
 
-    EvalRun.save_to_file() assigns self.path, which (via validate_assignment) re-validates the whole
-    run against its lazily-loaded parent eval. Mid-rename that parent still reflects the old score
-    keys, so the standard save would spuriously fail. The run's new scores are already consistent with
-    the renamed eval, so we serialize and write directly instead.
+    display_names must be positionally aligned with eval.output_scores (same length). A display name
+    is purely cosmetic: it does not affect the score's name, JSON key, or any stored eval run, so only
+    the single eval file is written. Empty/whitespace entries clear the display name (fall back to
+    the score's name). Only the eval is saved.
     """
-    if run.path is None:
-        raise ValueError("Cannot save EvalRun without a path")
-    json_data = run.model_dump_json(
-        indent=2,
-        exclude={"path"},
-        context={"save_attachments": True, "dest_path": run.path.parent},
-    )
-    run.path.write_text(json_data, encoding="utf-8")
-    ModelCache.shared().invalidate(run.path)
-
-
-def rename_eval_output_scores(eval: Eval, new_names: list[str]) -> None:
-    """Rename the eval's output scores in place and migrate the new keys across all stored eval runs.
-
-    new_names must be positionally aligned with eval.output_scores (same length). Renaming a score
-    that changes its JSON key re-keys that score in every EvalRun under every EvalConfig. The eval and
-    all affected run files are saved atomically: if any save fails, all touched files are restored to
-    their prior on-disk contents.
-    """
-    if len(new_names) != len(eval.output_scores):
+    if len(display_names) != len(eval.output_scores):
         raise HTTPException(
             status_code=400,
-            detail=f"output_score_names must have the same length as the eval's output scores. Got {len(new_names)}, expected {len(eval.output_scores)}.",
+            detail=f"output_score_display_names must have the same length as the eval's output scores. Got {len(display_names)}, expected {len(eval.output_scores)}.",
         )
 
-    old_keys = [score.json_key() for score in eval.output_scores]
-
-    # Validate each new name (length/charset) and compute the resulting JSON keys.
-    new_keys: list[str] = []
-    for index, name in enumerate(new_names):
-        existing = eval.output_scores[index]
-        try:
-            EvalOutputScore(
-                name=name, type=existing.type, instruction=existing.instruction
-            )
-        except ValidationError as e:
+    normalized: list[str | None] = []
+    for display_name in display_names:
+        cleaned = display_name.strip() if display_name is not None else None
+        if cleaned is not None and len(cleaned) > 32:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid score name '{name}': {e}",
+                detail="Score display names must be 32 characters or fewer.",
             )
-        new_keys.append(string_to_json_key(name))
+        normalized.append(cleaned or None)
 
-    if len(set(new_keys)) != len(new_keys):
-        raise HTTPException(
-            status_code=400,
-            detail="Score names must be unique (once normalized to JSON keys).",
-        )
+    for index, display_name in enumerate(normalized):
+        eval.output_scores[index].display_name = display_name
 
-    key_map = {old: new for old, new in zip(old_keys, new_keys)}
-    keys_changed = old_keys != new_keys
-
-    # Load all runs (with the pre-rename eval state, so they validate on load) and re-key the scores
-    # of those that change. We set scores via object.__setattr__ to bypass EvalRun's
-    # validate_assignment: it would otherwise validate the new keys against each run's lazily-reloaded
-    # (pre-rename) parent eval and fail. The new keys are already validated above, and save_to_file
-    # does not re-validate, so the final on-disk state (new run keys + new eval names) is consistent.
-    runs_to_update: list[EvalRun] = []
-    if keys_changed:
-        for config in eval.configs():
-            for run in config.runs():
-                new_scores = {key_map.get(k, k): v for k, v in run.scores.items()}
-                if new_scores != run.scores:
-                    object.__setattr__(run, "scores", new_scores)
-                    runs_to_update.append(run)
-
-    # Apply the new names to the eval in memory.
-    for index, name in enumerate(new_names):
-        eval.output_scores[index].name = name
-
-    # Snapshot the current on-disk contents of every file we will write, for rollback.
-    models_to_save: list[Eval | EvalRun] = [*runs_to_update, eval]
-    snapshots: dict[Any, bytes] = {}
-    for model in models_to_save:
-        if model.path is not None and model.path.exists():
-            snapshots[model.path] = model.path.read_bytes()
-
-    try:
-        for run in runs_to_update:
-            _save_eval_run_rekeyed(run)
-        eval.save_to_file()
-    except Exception as e:
-        for path, content in snapshots.items():
-            try:
-                path.write_bytes(content)
-                ModelCache.shared().invalidate(path)
-            except Exception:
-                logger.exception("Failed to roll back %s after rename failure", path)
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to rename eval scores. All changes were rolled back. Error: {e}",
-        )
+    eval.save_to_file()
 
 
 def eval_config_from_id(
@@ -373,9 +298,9 @@ class UpdateEvalRequest(BaseModel):
     train_set_filter_id: str | None = Field(
         default=None, description="The updated train set filter ID."
     )
-    output_score_names: list[str] | None = Field(
+    output_score_display_names: list[str | None] | None = Field(
         default=None,
-        description="Updated names for the eval's output scores. Must be positionally aligned with the eval's existing output_scores (same length). Renaming a score that changes its JSON key migrates the score across all stored eval runs.",
+        description="Updated user-facing display names for the eval's output scores. Must be positionally aligned with the eval's existing output_scores (same length). Display names are cosmetic only: they do not change the score name, JSON key, or any stored eval run. Empty entries clear the display name.",
     )
 
 
@@ -800,10 +725,10 @@ def connect_evals_api(app: FastAPI):
                 )
             eval.train_set_filter_id = request.train_set_filter_id
 
-        if request.output_score_names is not None:
-            # Saves the eval (including the name/description/train_set_filter changes above)
-            # atomically with the migrated eval runs.
-            rename_eval_output_scores(eval, request.output_score_names)
+        if request.output_score_display_names is not None:
+            # Saves the eval, including the name/description/train_set_filter changes above. Display
+            # names are cosmetic, so no eval run data is touched.
+            set_output_score_display_names(eval, request.output_score_display_names)
         else:
             eval.save_to_file()
         return eval

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -10,6 +10,7 @@ from app.desktop.studio_server.eval_api import (
     connect_evals_api,
     eval_config_from_id,
     get_all_run_configs,
+    rename_eval_output_scores,
     task_run_config_from_id,
 )
 from fastapi import FastAPI, HTTPException
@@ -1556,6 +1557,187 @@ def test_update_eval_empty_request(client, mock_task_from_id, mock_eval, mock_ta
     assert updated_eval["name"] == original_name
     assert updated_eval["description"] == original_description
     assert updated_eval["train_set_filter_id"] == original_train_set_filter_id
+
+
+@pytest.fixture
+def mock_eval_runs(mock_eval_config):
+    """Two eval runs with scores keyed by the json_key of each output score."""
+    runs = []
+    for i in range(2):
+        run = EvalRun(
+            id=f"eval_run{i}",
+            parent=mock_eval_config,
+            dataset_id=f"dataset{i}",
+            task_run_config_id=None,
+            eval_config_eval=True,
+            input="input",
+            output="output",
+            scores={"score1": 4.0, "overall_rating": 3.0},
+        )
+        run.save_to_file()
+        runs.append(run)
+    return runs
+
+
+def _reload_eval(mock_task) -> Eval:
+    from kiln_ai.datamodel.model_cache import ModelCache
+
+    ModelCache.shared().clear()
+    return mock_task.evals()[0]
+
+
+def test_update_eval_rename_score_migrates_runs(
+    client, mock_task_from_id, mock_eval, mock_task, mock_eval_runs
+):
+    """Renaming a score that changes its json_key re-keys the score across all eval runs."""
+    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
+        mock_eval_from_id.return_value = mock_eval
+
+        response = client.patch(
+            "/api/projects/project1/tasks/task1/evals/eval1",
+            json={"output_score_names": ["Quality Check", "overall_rating"]},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["output_scores"][0]["name"] == "Quality Check"
+
+    eval_from_disk = _reload_eval(mock_task)
+    assert eval_from_disk.output_scores[0].name == "Quality Check"
+    assert eval_from_disk.output_scores[0].json_key() == "quality_check"
+    assert eval_from_disk.output_scores[1].name == "overall_rating"
+
+    for config in eval_from_disk.configs():
+        runs = config.runs()
+        assert len(runs) == 2
+        for run in runs:
+            assert "quality_check" in run.scores
+            assert "score1" not in run.scores
+            assert run.scores["quality_check"] == 4.0
+            assert run.scores["overall_rating"] == 3.0
+
+
+def test_update_eval_rename_score_display_only_no_rekey(
+    client, mock_task_from_id, mock_eval, mock_task, mock_eval_runs
+):
+    """Renaming a score without changing its json_key updates the name but leaves run keys intact."""
+    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
+        mock_eval_from_id.return_value = mock_eval
+
+        # "Score1" normalizes to the same json_key "score1"
+        response = client.patch(
+            "/api/projects/project1/tasks/task1/evals/eval1",
+            json={"output_score_names": ["Score1", "overall_rating"]},
+        )
+
+    assert response.status_code == 200
+
+    eval_from_disk = _reload_eval(mock_task)
+    assert eval_from_disk.output_scores[0].name == "Score1"
+    assert eval_from_disk.output_scores[0].json_key() == "score1"
+
+    for config in eval_from_disk.configs():
+        for run in config.runs():
+            assert "score1" in run.scores
+            assert run.scores["score1"] == 4.0
+
+
+def test_update_eval_rename_score_with_name_change(
+    client, mock_task_from_id, mock_eval, mock_task, mock_eval_runs
+):
+    """Eval name and score names can be updated in the same request, atomically."""
+    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
+        mock_eval_from_id.return_value = mock_eval
+
+        response = client.patch(
+            "/api/projects/project1/tasks/task1/evals/eval1",
+            json={
+                "name": "Renamed Eval",
+                "output_score_names": ["Quality Check", "overall_rating"],
+            },
+        )
+
+    assert response.status_code == 200
+
+    eval_from_disk = _reload_eval(mock_task)
+    assert eval_from_disk.name == "Renamed Eval"
+    assert eval_from_disk.output_scores[0].name == "Quality Check"
+
+
+def test_update_eval_rename_score_length_mismatch(client, mock_task_from_id, mock_eval):
+    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
+        mock_eval_from_id.return_value = mock_eval
+
+        response = client.patch(
+            "/api/projects/project1/tasks/task1/evals/eval1",
+            json={"output_score_names": ["only_one"]},
+        )
+
+    assert response.status_code == 400
+    assert "same length" in response.json()["message"]
+
+
+def test_update_eval_rename_score_duplicate_keys(client, mock_task_from_id, mock_eval):
+    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
+        mock_eval_from_id.return_value = mock_eval
+
+        response = client.patch(
+            "/api/projects/project1/tasks/task1/evals/eval1",
+            json={"output_score_names": ["Same Name", "Same Name"]},
+        )
+
+    assert response.status_code == 400
+    assert "unique" in response.json()["message"]
+
+
+@pytest.mark.parametrize("bad_name", ["", "x" * 33])
+def test_update_eval_rename_score_invalid_name(
+    client, mock_task_from_id, mock_eval, bad_name
+):
+    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
+        mock_eval_from_id.return_value = mock_eval
+
+        response = client.patch(
+            "/api/projects/project1/tasks/task1/evals/eval1",
+            json={"output_score_names": [bad_name, "overall_rating"]},
+        )
+
+    assert response.status_code == 400
+    assert "Invalid score name" in response.json()["message"]
+
+
+def test_update_eval_rename_score_rollback_on_save_failure(
+    client, mock_task_from_id, mock_eval, mock_task, mock_eval_runs
+):
+    """If saving the eval fails, run files are restored to their original score keys."""
+    with (
+        patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id,
+        patch.object(Eval, "save_to_file", side_effect=Exception("boom")),
+    ):
+        mock_eval_from_id.return_value = mock_eval
+
+        response = client.patch(
+            "/api/projects/project1/tasks/task1/evals/eval1",
+            json={"output_score_names": ["Quality Check", "overall_rating"]},
+        )
+
+    assert response.status_code == 500
+    assert "rolled back" in response.json()["message"]
+
+    eval_from_disk = _reload_eval(mock_task)
+    # Eval name/scores unchanged on disk
+    assert eval_from_disk.output_scores[0].name == "score1"
+    # Run files restored to original keys
+    for config in eval_from_disk.configs():
+        for run in config.runs():
+            assert "score1" in run.scores
+            assert "quality_check" not in run.scores
+
+
+def test_rename_eval_output_scores_helper_no_runs(mock_eval, mock_task):
+    """The helper works when there are no eval runs to migrate."""
+    rename_eval_output_scores(mock_eval, ["Quality Check", "overall_rating"])
+    eval_from_disk = _reload_eval(mock_task)
+    assert eval_from_disk.output_scores[0].name == "Quality Check"
 
 
 def test_runs_in_filter():

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -10,7 +10,7 @@ from app.desktop.studio_server.eval_api import (
     connect_evals_api,
     eval_config_from_id,
     get_all_run_configs,
-    rename_eval_output_scores,
+    set_output_score_display_names,
     task_run_config_from_id,
 )
 from fastapi import FastAPI, HTTPException
@@ -1586,65 +1586,68 @@ def _reload_eval(mock_task) -> Eval:
     return mock_task.evals()[0]
 
 
-def test_update_eval_rename_score_migrates_runs(
+def test_update_eval_set_display_names(
     client, mock_task_from_id, mock_eval, mock_task, mock_eval_runs
 ):
-    """Renaming a score that changes its json_key re-keys the score across all eval runs."""
+    """Setting display names updates only the eval; score names, keys, and runs are untouched."""
+    run_files = {
+        run.path: run.path.read_bytes()
+        for config in mock_eval.configs()
+        for run in config.runs()
+    }
+    assert len(run_files) == 2
+
     with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
         mock_eval_from_id.return_value = mock_eval
 
         response = client.patch(
             "/api/projects/project1/tasks/task1/evals/eval1",
-            json={"output_score_names": ["Quality Check", "overall_rating"]},
+            json={"output_score_display_names": ["Quality Check", None]},
         )
 
     assert response.status_code == 200
-    assert response.json()["output_scores"][0]["name"] == "Quality Check"
+    body = response.json()
+    assert body["output_scores"][0]["display_name"] == "Quality Check"
+    assert body["output_scores"][1]["display_name"] is None
 
     eval_from_disk = _reload_eval(mock_task)
-    assert eval_from_disk.output_scores[0].name == "Quality Check"
-    assert eval_from_disk.output_scores[0].json_key() == "quality_check"
-    assert eval_from_disk.output_scores[1].name == "overall_rating"
-
-    for config in eval_from_disk.configs():
-        runs = config.runs()
-        assert len(runs) == 2
-        for run in runs:
-            assert "quality_check" in run.scores
-            assert "score1" not in run.scores
-            assert run.scores["quality_check"] == 4.0
-            assert run.scores["overall_rating"] == 3.0
-
-
-def test_update_eval_rename_score_display_only_no_rekey(
-    client, mock_task_from_id, mock_eval, mock_task, mock_eval_runs
-):
-    """Renaming a score without changing its json_key updates the name but leaves run keys intact."""
-    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
-        mock_eval_from_id.return_value = mock_eval
-
-        # "Score1" normalizes to the same json_key "score1"
-        response = client.patch(
-            "/api/projects/project1/tasks/task1/evals/eval1",
-            json={"output_score_names": ["Score1", "overall_rating"]},
-        )
-
-    assert response.status_code == 200
-
-    eval_from_disk = _reload_eval(mock_task)
-    assert eval_from_disk.output_scores[0].name == "Score1"
+    # Underlying names and keys are unchanged
+    assert eval_from_disk.output_scores[0].name == "score1"
     assert eval_from_disk.output_scores[0].json_key() == "score1"
+    assert eval_from_disk.output_scores[0].display_name == "Quality Check"
 
+    # Run files are byte-for-byte unchanged (no migration, clean git history)
     for config in eval_from_disk.configs():
         for run in config.runs():
             assert "score1" in run.scores
-            assert run.scores["score1"] == 4.0
+            assert run.path in run_files
+            assert run.path.read_bytes() == run_files[run.path]
 
 
-def test_update_eval_rename_score_with_name_change(
-    client, mock_task_from_id, mock_eval, mock_task, mock_eval_runs
+def test_update_eval_clear_display_name(
+    client, mock_task_from_id, mock_eval, mock_task
 ):
-    """Eval name and score names can be updated in the same request, atomically."""
+    """An empty/whitespace display name clears it back to None."""
+    mock_eval.output_scores[0].display_name = "Existing"
+    mock_eval.save_to_file()
+
+    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
+        mock_eval_from_id.return_value = mock_eval
+
+        response = client.patch(
+            "/api/projects/project1/tasks/task1/evals/eval1",
+            json={"output_score_display_names": ["   ", None]},
+        )
+
+    assert response.status_code == 200
+    eval_from_disk = _reload_eval(mock_task)
+    assert eval_from_disk.output_scores[0].display_name is None
+
+
+def test_update_eval_display_name_with_eval_name_change(
+    client, mock_task_from_id, mock_eval, mock_task
+):
+    """Eval name and score display names can be updated in the same request."""
     with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
         mock_eval_from_id.return_value = mock_eval
 
@@ -1652,92 +1655,51 @@ def test_update_eval_rename_score_with_name_change(
             "/api/projects/project1/tasks/task1/evals/eval1",
             json={
                 "name": "Renamed Eval",
-                "output_score_names": ["Quality Check", "overall_rating"],
+                "output_score_display_names": ["Quality Check", "Overall"],
             },
         )
 
     assert response.status_code == 200
-
     eval_from_disk = _reload_eval(mock_task)
     assert eval_from_disk.name == "Renamed Eval"
-    assert eval_from_disk.output_scores[0].name == "Quality Check"
+    assert eval_from_disk.output_scores[0].display_name == "Quality Check"
+    assert eval_from_disk.output_scores[1].display_name == "Overall"
 
 
-def test_update_eval_rename_score_length_mismatch(client, mock_task_from_id, mock_eval):
+def test_update_eval_display_names_length_mismatch(
+    client, mock_task_from_id, mock_eval
+):
     with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
         mock_eval_from_id.return_value = mock_eval
 
         response = client.patch(
             "/api/projects/project1/tasks/task1/evals/eval1",
-            json={"output_score_names": ["only_one"]},
+            json={"output_score_display_names": ["only_one"]},
         )
 
     assert response.status_code == 400
     assert "same length" in response.json()["message"]
 
 
-def test_update_eval_rename_score_duplicate_keys(client, mock_task_from_id, mock_eval):
+def test_update_eval_display_name_too_long(client, mock_task_from_id, mock_eval):
     with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
         mock_eval_from_id.return_value = mock_eval
 
         response = client.patch(
             "/api/projects/project1/tasks/task1/evals/eval1",
-            json={"output_score_names": ["Same Name", "Same Name"]},
+            json={"output_score_display_names": ["x" * 33, None]},
         )
 
     assert response.status_code == 400
-    assert "unique" in response.json()["message"]
+    assert "32 characters" in response.json()["message"]
 
 
-@pytest.mark.parametrize("bad_name", ["", "x" * 33])
-def test_update_eval_rename_score_invalid_name(
-    client, mock_task_from_id, mock_eval, bad_name
-):
-    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
-        mock_eval_from_id.return_value = mock_eval
-
-        response = client.patch(
-            "/api/projects/project1/tasks/task1/evals/eval1",
-            json={"output_score_names": [bad_name, "overall_rating"]},
-        )
-
-    assert response.status_code == 400
-    assert "Invalid score name" in response.json()["message"]
-
-
-def test_update_eval_rename_score_rollback_on_save_failure(
-    client, mock_task_from_id, mock_eval, mock_task, mock_eval_runs
-):
-    """If saving the eval fails, run files are restored to their original score keys."""
-    with (
-        patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id,
-        patch.object(Eval, "save_to_file", side_effect=Exception("boom")),
-    ):
-        mock_eval_from_id.return_value = mock_eval
-
-        response = client.patch(
-            "/api/projects/project1/tasks/task1/evals/eval1",
-            json={"output_score_names": ["Quality Check", "overall_rating"]},
-        )
-
-    assert response.status_code == 500
-    assert "rolled back" in response.json()["message"]
-
+def test_set_output_score_display_names_helper(mock_eval, mock_task):
+    """The helper sets display names and saves the eval."""
+    set_output_score_display_names(mock_eval, ["Quality Check", None])
     eval_from_disk = _reload_eval(mock_task)
-    # Eval name/scores unchanged on disk
-    assert eval_from_disk.output_scores[0].name == "score1"
-    # Run files restored to original keys
-    for config in eval_from_disk.configs():
-        for run in config.runs():
-            assert "score1" in run.scores
-            assert "quality_check" not in run.scores
-
-
-def test_rename_eval_output_scores_helper_no_runs(mock_eval, mock_task):
-    """The helper works when there are no eval runs to migrate."""
-    rename_eval_output_scores(mock_eval, ["Quality Check", "overall_rating"])
-    eval_from_disk = _reload_eval(mock_task)
-    assert eval_from_disk.output_scores[0].name == "Quality Check"
+    assert eval_from_disk.output_scores[0].display_name == "Quality Check"
+    assert eval_from_disk.output_scores[1].display_name is None
 
 
 def test_runs_in_filter():

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -5440,6 +5440,11 @@ export interface components {
              */
             name: string;
             /**
+             * Display Name
+             * @description An optional, user-facing display name for the score, shown throughout the UI in place of 'name'. Purely cosmetic: it does not affect the JSON key, stored eval run scores, or the name provided to models. Falls back to 'name' when not set.
+             */
+            display_name?: string | null;
+            /**
              * Instruction
              * @description A description of the score, used to help the model understand the goal of the score. Will be provided to evaluator models, so should be written for the model, not the team/user.
              */
@@ -10226,10 +10231,10 @@ export interface components {
              */
             train_set_filter_id?: string | null;
             /**
-             * Output Score Names
-             * @description Updated names for the eval's output scores. Must be positionally aligned with the eval's existing output_scores (same length). Renaming a score that changes its JSON key migrates the score across all stored eval runs.
+             * Output Score Display Names
+             * @description Updated user-facing display names for the eval's output scores. Must be positionally aligned with the eval's existing output_scores (same length). Display names are cosmetic only: they do not change the score name, JSON key, or any stored eval run. Empty entries clear the display name.
              */
-            output_score_names?: string[] | null;
+            output_score_display_names?: (string | null)[] | null;
         };
         /**
          * UpdateFinetuneRequest

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -10225,6 +10225,11 @@ export interface components {
              * @description The updated train set filter ID.
              */
             train_set_filter_id?: string | null;
+            /**
+             * Output Score Names
+             * @description Updated names for the eval's output scores. Must be positionally aligned with the eval's existing output_scores (same length). Renaming a score that changes its JSON key migrates the score across all stored eval runs.
+             */
+            output_score_names?: string[] | null;
         };
         /**
          * UpdateFinetuneRequest

--- a/app/web_ui/src/lib/components/run_config_comparison_table.svelte
+++ b/app/web_ui/src/lib/components/run_config_comparison_table.svelte
@@ -4,6 +4,7 @@
   import OutputTypeTablePreview from "$lib/components/output_type_table_preview.svelte"
   import RunEval from "$lib/components/run_eval.svelte"
   import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
+  import { score_display_name } from "$lib/utils/formatters"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
   import Warning from "$lib/ui/warning.svelte"
   import type { KilnError } from "$lib/utils/error_handlers"
@@ -141,7 +142,7 @@
           <th class="text-center">Status</th>
           {#each evaluator.output_scores as output_score}
             <th class="text-center">
-              {output_score.name}
+              {score_display_name(output_score)}
               {#if output_score.type}
                 <OutputTypeTablePreview output_score_type={output_score.type} />
               {/if}

--- a/app/web_ui/src/lib/ui/edit_dialog.svelte
+++ b/app/web_ui/src/lib/ui/edit_dialog.svelte
@@ -28,6 +28,9 @@
     placeholder?: string
     optional?: boolean
     max_length?: number
+    // When set, this field is excluded from the main PATCH body and persisted via this
+    // callback instead (e.g. fields that target a different endpoint).
+    custom_setter?: (value: string) => Promise<void>
   }
   export let fields: EditField[]
 
@@ -40,26 +43,35 @@
     try {
       const body = fields.reduce(
         (acc, field) => {
-          acc[field.api_name] = field.value
+          if (!field.custom_setter) {
+            acc[field.api_name] = field.value
+          }
           return acc
         },
         {} as Record<string, string>,
       )
-      const response = await fetch(base_url + patch_url, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-      })
-      if (!response.ok) {
-        let error_body: unknown
-        try {
-          error_body = await response.json()
-        } catch (_) {
-          throw new Error("Failed to save edit. Invalid JSON response.")
+      if (Object.keys(body).length > 0) {
+        const response = await fetch(base_url + patch_url, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(body),
+        })
+        if (!response.ok) {
+          let error_body: unknown
+          try {
+            error_body = await response.json()
+          } catch (_) {
+            throw new Error("Failed to save edit. Invalid JSON response.")
+          }
+          throw createKilnError(error_body)
         }
-        throw createKilnError(error_body)
+      }
+      for (const field of fields) {
+        if (field.custom_setter) {
+          await field.custom_setter(field.value)
+        }
       }
       after_save()
       saved = true

--- a/app/web_ui/src/lib/ui/edit_dialog.svelte
+++ b/app/web_ui/src/lib/ui/edit_dialog.svelte
@@ -68,8 +68,13 @@
           throw createKilnError(error_body)
         }
       }
+      // Invoke each distinct custom_setter once. Multiple fields may share a setter (e.g. all eval
+      // score-name fields persist via a single endpoint call), so we dedupe by function reference to
+      // avoid redundant requests.
+      const called_setters = new Set<(value: string) => Promise<void>>()
       for (const field of fields) {
-        if (field.custom_setter) {
+        if (field.custom_setter && !called_setters.has(field.custom_setter)) {
+          called_setters.add(field.custom_setter)
           await field.custom_setter(field.value)
         }
       }

--- a/app/web_ui/src/lib/ui/edit_dialog.test.ts
+++ b/app/web_ui/src/lib/ui/edit_dialog.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest"
+import { render, fireEvent, cleanup, waitFor } from "@testing-library/svelte"
+import { tick } from "svelte"
+import EditDialog from "./edit_dialog.svelte"
+
+beforeAll(() => {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function () {
+      this.open = true
+    }
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function () {
+      this.open = false
+    }
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+async function submit_form() {
+  const save_button = document.querySelector(
+    'button[type="submit"]',
+  ) as HTMLButtonElement
+  expect(save_button).not.toBeNull()
+  await fireEvent.click(save_button)
+}
+
+describe("EditDialog custom_setter", () => {
+  it("excludes custom_setter fields from the PATCH body and invokes their setter", async () => {
+    const fetch_mock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+    const custom_setter = vi.fn().mockResolvedValue(undefined)
+
+    const { component } = render(EditDialog, {
+      props: {
+        name: "Thing",
+        patch_url: "/api/thing",
+        fields: [
+          {
+            label: "Name",
+            api_name: "name",
+            value: "new name",
+            input_type: "input",
+          },
+          {
+            label: "Score Name",
+            api_name: "output_score_name_0",
+            value: "Quality Check",
+            input_type: "input",
+            custom_setter,
+          },
+        ],
+      },
+    })
+    component.show()
+    await tick()
+
+    await submit_form()
+
+    await waitFor(() => expect(custom_setter).toHaveBeenCalledTimes(1))
+    expect(custom_setter).toHaveBeenCalledWith("Quality Check")
+
+    expect(fetch_mock).toHaveBeenCalledTimes(1)
+    const [, init] = fetch_mock.mock.calls[0]
+    const body = JSON.parse((init?.body as string) ?? "{}")
+    expect(body).toEqual({ name: "new name" })
+  })
+
+  it("does not call after_save when a custom_setter rejects (dialog stays open)", async () => {
+    const fetch_mock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+    const custom_setter = vi
+      .fn()
+      .mockRejectedValue(new Error("migration failed"))
+    const after_save = vi.fn()
+
+    const { component, getAllByText, container } = render(EditDialog, {
+      props: {
+        name: "Thing",
+        patch_url: "/api/thing",
+        after_save,
+        fields: [
+          {
+            label: "Name",
+            api_name: "name",
+            value: "new name",
+            input_type: "input",
+          },
+          {
+            label: "Score Name",
+            api_name: "output_score_name_0",
+            value: "Quality Check",
+            input_type: "input",
+            custom_setter,
+          },
+        ],
+      },
+    })
+    component.show()
+    await tick()
+
+    await submit_form()
+
+    // The main PATCH ran, the setter was attempted and rejected
+    await waitFor(() => expect(custom_setter).toHaveBeenCalledTimes(1))
+    expect(fetch_mock).toHaveBeenCalledTimes(1)
+    // after_save is never called, so the dialog is not dismissed; the error is shown
+    expect(after_save).not.toHaveBeenCalled()
+    await waitFor(() =>
+      expect(getAllByText(/migration failed/).length).toBeGreaterThan(0),
+    )
+    // The dialog remains open
+    expect(container.querySelector("dialog[open]")).not.toBeNull()
+  })
+
+  it("skips the PATCH request entirely when every field has a custom_setter", async () => {
+    const fetch_mock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+    const custom_setter = vi.fn().mockResolvedValue(undefined)
+
+    const { component } = render(EditDialog, {
+      props: {
+        name: "Thing",
+        patch_url: "/api/thing",
+        fields: [
+          {
+            label: "Score Name",
+            api_name: "output_score_name_0",
+            value: "Quality Check",
+            input_type: "input",
+            custom_setter,
+          },
+        ],
+      },
+    })
+    component.show()
+    await tick()
+
+    await submit_form()
+
+    await waitFor(() => expect(custom_setter).toHaveBeenCalledTimes(1))
+    expect(fetch_mock).not.toHaveBeenCalled()
+  })
+})

--- a/app/web_ui/src/lib/ui/edit_dialog.test.ts
+++ b/app/web_ui/src/lib/ui/edit_dialog.test.ts
@@ -72,6 +72,43 @@ describe("EditDialog custom_setter", () => {
     expect(body).toEqual({ name: "new name" })
   })
 
+  it("invokes a shared custom_setter only once across multiple fields", async () => {
+    const fetch_mock = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }))
+    const custom_setter = vi.fn().mockResolvedValue(undefined)
+
+    const { component } = render(EditDialog, {
+      props: {
+        name: "Thing",
+        patch_url: "/api/thing",
+        fields: [
+          {
+            label: "Score 0",
+            api_name: "output_score_name_0",
+            value: "A",
+            input_type: "input",
+            custom_setter,
+          },
+          {
+            label: "Score 1",
+            api_name: "output_score_name_1",
+            value: "B",
+            input_type: "input",
+            custom_setter,
+          },
+        ],
+      },
+    })
+    component.show()
+    await tick()
+
+    await submit_form()
+
+    await waitFor(() => expect(custom_setter).toHaveBeenCalledTimes(1))
+    expect(fetch_mock).not.toHaveBeenCalled()
+  })
+
   it("does not call after_save when a custom_setter rejects (dialog stays open)", async () => {
     const fetch_mock = vi
       .spyOn(global, "fetch")

--- a/app/web_ui/src/lib/utils/formatters.ts
+++ b/app/web_ui/src/lib/utils/formatters.ts
@@ -80,6 +80,15 @@ export function formatSize(byteSize: number | undefined | null): string {
   return `${displaySize} ${units[idx]}`
 }
 
+// The user-facing name for an eval output score: the optional display_name, falling back to the
+// persisted name. Always use this for display; use `name` (not display_name) for json_key lookups.
+export function score_display_name(score: {
+  name: string
+  display_name?: string | null
+}): string {
+  return score.display_name || score.name
+}
+
 export function eval_config_to_ui_name(
   eval_config_type: EvalConfigType,
 ): string {

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
@@ -108,9 +108,9 @@
   let create_new_run_config_dialog: CreateNewRunConfigDialog | null = null
   let edit_dialog: EditDialog | null = null
 
-  // Editable score-name fields for the eval (spec evals usually have a single score).
-  // These persist to the eval endpoint (not the spec endpoint) via a custom setter, since
-  // renaming a score also migrates the score key across all stored eval runs.
+  // Editable score display-name fields for the eval (spec evals usually have a single score).
+  // The display name is cosmetic: it persists to the eval endpoint (not the spec endpoint) via a
+  // custom setter and never changes the underlying score name, JSON key, or stored eval runs.
   type ScoreEditField = {
     label: string
     api_name: string
@@ -124,31 +124,31 @@
     (score, index): ScoreEditField => ({
       label:
         (evaluator?.output_scores?.length || 0) > 1
-          ? `Score Name: ${score.name}`
-          : "Score Name",
-      api_name: `output_score_name_${index}`,
-      value: score.name,
+          ? `Score Display Name: ${score.name}`
+          : "Score Display Name",
+      api_name: `output_score_display_name_${index}`,
+      value: score.display_name || score.name,
       input_type: "input",
       description:
-        "The name of the eval score, shown when comparing run configurations.",
+        "A display name for the eval score, shown throughout the UI (e.g. when comparing run configurations). This is cosmetic and does not change stored eval results.",
       max_length: 32,
-      custom_setter: save_output_score_names,
+      custom_setter: save_output_score_display_names,
     }),
   )
 
-  async function save_output_score_names(): Promise<void> {
+  async function save_output_score_display_names(): Promise<void> {
     const eval_id = spec?.eval_id
     if (!eval_id) {
       return
     }
-    const names = output_score_fields.map((field) => field.value)
+    const display_names = output_score_fields.map((field) => field.value)
     const { error: patch_error } = await client.PATCH(
       "/api/projects/{project_id}/tasks/{task_id}/evals/{eval_id}",
       {
         params: {
           path: { project_id, task_id, eval_id },
         },
-        body: { output_score_names: names },
+        body: { output_score_display_names: display_names },
       },
     )
     if (patch_error) {

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
@@ -124,13 +124,13 @@
     (score, index): ScoreEditField => ({
       label:
         (evaluator?.output_scores?.length || 0) > 1
-          ? `Score Display Name: ${score.name}`
-          : "Score Display Name",
+          ? `Score Name: ${score.name}`
+          : "Score Name",
       api_name: `output_score_display_name_${index}`,
       value: score.display_name || score.name,
       input_type: "input",
       description:
-        "A display name for the eval score, shown throughout the UI (e.g. when comparing run configurations). This is cosmetic and does not change stored eval results.",
+        "The name of the eval score, shown when comparing run configurations.",
       max_length: 32,
       custom_setter: save_output_score_display_names,
     }),

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/+page.svelte
@@ -108,6 +108,54 @@
   let create_new_run_config_dialog: CreateNewRunConfigDialog | null = null
   let edit_dialog: EditDialog | null = null
 
+  // Editable score-name fields for the eval (spec evals usually have a single score).
+  // These persist to the eval endpoint (not the spec endpoint) via a custom setter, since
+  // renaming a score also migrates the score key across all stored eval runs.
+  type ScoreEditField = {
+    label: string
+    api_name: string
+    value: string
+    input_type: "input"
+    description: string
+    max_length: number
+    custom_setter: (value: string) => Promise<void>
+  }
+  $: output_score_fields = (evaluator?.output_scores || []).map(
+    (score, index): ScoreEditField => ({
+      label:
+        (evaluator?.output_scores?.length || 0) > 1
+          ? `Score Name: ${score.name}`
+          : "Score Name",
+      api_name: `output_score_name_${index}`,
+      value: score.name,
+      input_type: "input",
+      description:
+        "The name of the eval score, shown when comparing run configurations.",
+      max_length: 32,
+      custom_setter: save_output_score_names,
+    }),
+  )
+
+  async function save_output_score_names(): Promise<void> {
+    const eval_id = spec?.eval_id
+    if (!eval_id) {
+      return
+    }
+    const names = output_score_fields.map((field) => field.value)
+    const { error: patch_error } = await client.PATCH(
+      "/api/projects/{project_id}/tasks/{task_id}/evals/{eval_id}",
+      {
+        params: {
+          path: { project_id, task_id, eval_id },
+        },
+        body: { output_score_names: names },
+      },
+    )
+    if (patch_error) {
+      throw patch_error
+    }
+  }
+
   $: current_task_run_configs =
     $run_configs_by_task_composite_id[
       get_task_composite_id(project_id, task_id)
@@ -752,6 +800,7 @@
       input_type: "input",
       max_length: 120,
     },
+    ...output_score_fields,
   ]}
 />
 

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
@@ -7,7 +7,10 @@
   import { page } from "$app/stores"
   import type { EvalProgress } from "$lib/types"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
-  import { eval_config_to_ui_name } from "$lib/utils/formatters"
+  import {
+    eval_config_to_ui_name,
+    score_display_name,
+  } from "$lib/utils/formatters"
   import {
     model_info,
     load_model_info,
@@ -431,7 +434,7 @@
     // Goals are setup. Generate friendly names for them.
     goals = []
     for (const output of evaluator.output_scores) {
-      goals.push(output.name + " (" + output.type + ")")
+      goals.push(score_display_name(output) + " (" + output.type + ")")
     }
 
     if (has_default_eval_config) {

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/[eval_config_id]/[run_config_id]/run_result/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/[eval_config_id]/[run_config_id]/run_result/+page.svelte
@@ -15,7 +15,10 @@
   import { onMount, tick } from "svelte"
   import { page } from "$app/stores"
   import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
-  import { eval_config_to_ui_name } from "$lib/utils/formatters"
+  import {
+    eval_config_to_ui_name,
+    score_display_name,
+  } from "$lib/utils/formatters"
   import {
     get_task_composite_id,
     model_info,
@@ -258,7 +261,7 @@
             <th>Thinking</th>
             {#each results.eval.output_scores as score}
               <th class="text-center">
-                {score.name}
+                {score_display_name(score)}
                 {#if score.type}
                   <OutputTypeTablePreview output_score_type={score.type} />
                 {/if}

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_configs/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_configs/+page.svelte
@@ -22,7 +22,10 @@
   import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
   import EvalConfigInstruction from "./eval_config_instruction.svelte"
   import Dialog from "$lib/ui/dialog.svelte"
-  import { eval_config_to_ui_name } from "$lib/utils/formatters"
+  import {
+    eval_config_to_ui_name,
+    score_display_name,
+  } from "$lib/utils/formatters"
   import type { TaskOutputRatingType } from "$lib/types"
   import type { UiProperty } from "$lib/ui/property_list"
   import Intro from "$lib/ui/intro.svelte"
@@ -709,7 +712,7 @@
                 <th> Eval Instructions </th>
                 {#each evaluator.output_scores as output_score}
                   <th class="text-center">
-                    {output_score.name}
+                    {score_display_name(output_score)}
                     {#if output_score.type}
                       <InfoTooltip
                         tooltip_text={info_tooltip_text(

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -65,6 +65,11 @@ class EvalOutputScore(BaseModel):
     name: FilenameStringShort = Field(
         description="The name of the score. Will be provided to the model so use a descriptive name. Should align to the model's TaskRequirement name if you want to use human evals to evaluate the evaluator's performance."
     )
+    display_name: str | None = Field(
+        default=None,
+        max_length=32,
+        description="An optional, user-facing display name for the score, shown throughout the UI in place of 'name'. Purely cosmetic: it does not affect the JSON key, stored eval run scores, or the name provided to models. Falls back to 'name' when not set.",
+    )
     instruction: str | None = Field(
         default=None,
         description="A description of the score, used to help the model understand the goal of the score. Will be provided to evaluator models, so should be written for the model, not the team/user.",
@@ -78,6 +83,9 @@ class EvalOutputScore(BaseModel):
         The JSON key for the score, used when running the evaluator with a LLM and we need JSON output.
 
         For example, "Overall Rating" -> "overall_rating"
+
+        Always derived from 'name' (not 'display_name'), so renaming for display never changes the
+        key used by stored eval runs.
         """
         return string_to_json_key(self.name)
 

--- a/libs/server/kiln_server/spec_api.py
+++ b/libs/server/kiln_server/spec_api.py
@@ -202,6 +202,7 @@ def connect_spec_api(app: FastAPI):
         request: UpdateSpecRequest,
     ) -> Spec:
         spec = spec_from_id(project_id, task_id, spec_id)
+        previous_spec_name = spec.name
 
         # Update all provided fields
         if request.name is not None:
@@ -217,15 +218,30 @@ def connect_spec_api(app: FastAPI):
         if request.tags is not None:
             spec.tags = request.tags
 
-        # Sync eval name when spec name changes
+        # Sync eval name and auto-generated score instructions when the spec name changes
         eval: Eval | None = None
         previous_eval_name: str | None = None
+        previous_score_instructions: list[str | None] | None = None
         if request.name is not None and spec.eval_id:
             parent_task = task_from_id(project_id, task_id)
             eval = Eval.from_id_and_parent_path(spec.eval_id, parent_task.path)
             if eval and eval.name != request.name:
                 previous_eval_name = eval.name
                 eval.name = request.name
+
+                # The score instruction embeds the spec name. Regenerate it for scores that still
+                # use the auto-generated text, without clobbering user-customized instructions.
+                old_auto_instruction = spec_eval_output_score(
+                    previous_spec_name
+                ).instruction
+                new_auto_instruction = spec_eval_output_score(request.name).instruction
+                previous_score_instructions = [
+                    score.instruction for score in eval.output_scores
+                ]
+                for score in eval.output_scores:
+                    if score.instruction == old_auto_instruction:
+                        score.instruction = new_auto_instruction
+
                 eval.save_to_file()
 
         try:
@@ -234,6 +250,11 @@ def connect_spec_api(app: FastAPI):
             if eval is not None and previous_eval_name is not None:
                 try:
                     eval.name = previous_eval_name
+                    if previous_score_instructions is not None:
+                        for score, instruction in zip(
+                            eval.output_scores, previous_score_instructions
+                        ):
+                            score.instruction = instruction
                     eval.save_to_file()
                 except Exception:
                     logger.exception(

--- a/libs/server/kiln_server/test_spec_api.py
+++ b/libs/server/kiln_server/test_spec_api.py
@@ -460,6 +460,75 @@ def test_update_spec_name_syncs_eval_name(
     assert updated_eval.name == "Updated Name"
 
 
+def test_update_spec_name_syncs_auto_generated_score_instruction(
+    client: TestClient,
+    project_and_task: tuple[Project, Task],
+    sample_tone_properties: ToneProperties,
+) -> None:
+    """Renaming a spec regenerates auto-generated score instructions, leaving custom ones intact."""
+    from kiln_server.utils.spec_utils import spec_eval_output_score
+
+    project, task = project_and_task
+
+    auto_instruction = spec_eval_output_score("Original Name").instruction
+    eval = Eval(
+        name="Original Name",
+        description="Test eval",
+        template="rag",
+        eval_set_filter_id="tag::test_eval",
+        output_scores=[
+            EvalOutputScore(
+                name="Original Name",
+                type=TaskOutputRatingType.pass_fail,
+                instruction=auto_instruction,
+            ),
+            EvalOutputScore(
+                name="Custom Score",
+                type=TaskOutputRatingType.five_star,
+                instruction="A custom instruction the user wrote.",
+            ),
+        ],
+        parent=task,
+    )
+    eval.save_to_file()
+
+    spec = Spec(
+        name="Original Name",
+        definition="Original definition",
+        priority=Priority.p2,
+        status=SpecStatus.active,
+        tags=[],
+        eval_id=eval.id,
+        properties=sample_tone_properties,
+        parent=task,
+    )
+    spec.save_to_file()
+
+    with patch("kiln_server.spec_api.task_from_id") as mock_task_from_id:
+        mock_task_from_id.return_value = task
+        response = client.patch(
+            f"/api/projects/{project.id}/tasks/{task.id}/specs/{spec.id}",
+            json={"name": "Updated Name"},
+        )
+
+    assert response.status_code == 200
+
+    updated_eval = Eval.from_id_and_parent_path(eval.id, task.path)
+    assert updated_eval is not None
+    # Auto-generated instruction regenerated with the new name
+    assert (
+        updated_eval.output_scores[0].instruction
+        == spec_eval_output_score("Updated Name").instruction
+    )
+    # Score name itself is left untouched (user-controlled)
+    assert updated_eval.output_scores[0].name == "Original Name"
+    # Custom instruction is not clobbered
+    assert (
+        updated_eval.output_scores[1].instruction
+        == "A custom instruction the user wrote."
+    )
+
+
 def test_update_spec_name_rollback_eval_on_spec_save_failure(
     client: TestClient,
     project_and_task: tuple[Project, Task],


### PR DESCRIPTION
<img width="529" height="632" alt="Screenshot 2026-06-19 at 9 26 14 AM" src="https://github.com/user-attachments/assets/dca49896-73ff-4859-9171-ccdf35cb53b5" />

Linear ticket: https://linear.app/kiln_ai/issue/KIL-715/ability-to-change-eval-score-name

## Description

An eval's score name is shown on the **Compare Run Configurations** page (and elsewhere) and was immutable. This lets users give a score a custom, user-facing **display name** for spec evals.

### Approach (non-destructive)

Following review feedback, this does **not** rename the underlying score or migrate runs (that would touch every eval-run file and pollute git history). Instead the display name is purely cosmetic:

- `EvalOutputScore` gains an optional `display_name` (max 32 chars). `json_key()` still derives from `name`, so stored eval-run scores and all key lookups are unaffected — editing a display name changes only the single `eval.kiln` file.
- `update_eval` accepts `output_score_display_names` (positional, same length as `output_scores`). `set_output_score_display_names` sets the display names and saves just the eval. Empty/whitespace entries clear the display name.
- Frontend: a `score_display_name(score)` helper (`display_name || name`) is applied at every display site — the shared run-config comparison table, eval-configs table, run-result table, and eval goals. `string_to_json_key(score.name)` lookups deliberately stay on `name`.
- The spec-page Edit dialog gains a **Score Display Name** field, clarified as cosmetic, which PATCHes the eval endpoint. `EditDialog` `custom_setter` fields (deduped by reference) keep this separate from the spec-name PATCH.
- Spec rename still propagates to the eval name and regenerates the auto-generated model-facing score instruction (without clobbering custom instructions).

### Tests
- Python: display names set/clear, eval name + display names together, length / length-mismatch `400`s, and a check that **run files are byte-for-byte unchanged** after editing display names.
- Frontend: `custom_setter` excluded from the main PATCH + invoked once (deduped); dialog stays open / `after_save` not called on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)