### PR TITLE
Fix Anthropic thinking-level vs temperature/top_p interaction

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -516,6 +516,7 @@ CLAUDE_OPENROUTER_THINKING_LEVELS = {
 }
 
 CLAUDE_ANTHROPIC_EFFORT_THINKING_LEVELS = {
+    "Off/None": "none",
     "Low": "low",
     "Medium": "medium",
     "High": "high",
@@ -532,6 +533,7 @@ CLAUDE_FABLE_5_OPENROUTER_THINKING_LEVELS = {
 }
 
 CLAUDE_OPUS_4_7_ANTHROPIC_THINKING_LEVELS = {
+    "Off/None": "none",
     "Low": "low",
     "Medium": "medium",
     "High": "high",
@@ -540,6 +542,7 @@ CLAUDE_OPUS_4_7_ANTHROPIC_THINKING_LEVELS = {
 }
 
 CLAUDE_OPUS_4_8_ANTHROPIC_THINKING_LEVELS = {
+    "Off/None": "none",
     "Low": "low",
     "Medium": "medium",
     "High": "high",

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -547,6 +547,16 @@ class LiteLlmAdapter(BaseAdapter):
                 and provider.openrouter_reasoning_object
             ):
                 extra_body["reasoning"] = {"effort": thinking_level}
+            elif (
+                provider.name == ModelProviderName.anthropic
+                and thinking_level == "none"
+            ):
+                # Anthropic thinking is opt-in via a thinking block; there is no
+                # reasoning_effort="none". Omit the param entirely to disable
+                # thinking (which also frees the user to set a custom temperature
+                # / top_p). litellm errors if we send reasoning_effort="none" to
+                # Anthropic.
+                pass
             else:
                 extra_body["reasoning_effort"] = thinking_level
 
@@ -719,6 +729,28 @@ class LiteLlmAdapter(BaseAdapter):
             if "top_p" in completion_kwargs and "temperature" in completion_kwargs:
                 raise ValueError(
                     "top_p and temperature can not both have custom values for this model. This is a restriction from the model provider. Please set only one of them to a custom value (not 1.0)."
+                )
+
+        # Anthropic disallows custom temperature/top_p while extended thinking is
+        # enabled (temperature must be 1, top_p must be >= 0.95 or unset). Fail
+        # fast with an actionable message instead of an opaque provider 400 -- and
+        # without silently dropping the user's value. Selecting thinking level
+        # "None" disables thinking and lifts this restriction.
+        thinking_enabled = "reasoning_effort" in extra_body or "thinking" in extra_body
+        if provider.name == ModelProviderName.anthropic and thinking_enabled:
+            temperature = completion_kwargs.get("temperature")
+            if isinstance(temperature, (int, float)) and temperature != 1.0:
+                raise ValueError(
+                    "Anthropic requires temperature to be 1 when a thinking level is "
+                    "enabled. Set temperature to 1, or set the thinking level to None "
+                    "to use a custom temperature."
+                )
+            top_p = completion_kwargs.get("top_p")
+            if isinstance(top_p, (int, float)) and top_p < 0.95:
+                raise ValueError(
+                    "Anthropic requires top_p to be 0.95 or higher (or unset) when a "
+                    "thinking level is enabled. Increase top_p to at least 0.95, or "
+                    "set the thinking level to None to use a custom top_p."
                 )
 
         if not skip_response_format:

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -591,7 +591,9 @@ class LiteLlmAdapter(BaseAdapter):
                 "nebius",
             ]
 
-        if provider.anthropic_extended_thinking:
+        # Respect the thinking_level="none" opt-out: don't re-enable thinking via
+        # the extended-thinking block after the level block deliberately skipped it.
+        if provider.anthropic_extended_thinking and thinking_level != "none":
             extra_body["thinking"] = {"type": "enabled", "budget_tokens": 4000}
 
         if provider.r1_openrouter_options:
@@ -736,7 +738,11 @@ class LiteLlmAdapter(BaseAdapter):
         # fast with an actionable message instead of an opaque provider 400 -- and
         # without silently dropping the user's value. Selecting thinking level
         # "None" disables thinking and lifts this restriction.
-        thinking_enabled = "reasoning_effort" in extra_body or "thinking" in extra_body
+        # Check completion_kwargs (not extra_body) so thinking passed via
+        # additional_body_options is also caught -- those merge in directly.
+        thinking_enabled = (
+            "reasoning_effort" in completion_kwargs or "thinking" in completion_kwargs
+        )
         if provider.name == ModelProviderName.anthropic and thinking_enabled:
             temperature = completion_kwargs.get("temperature")
             if isinstance(temperature, (int, float)) and temperature != 1.0:

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -660,6 +660,55 @@ def test_build_extra_body_thinking_level_anthropic_non_none_sets_reasoning_effor
     assert extra_body.get("reasoning_effort") == "high"
 
 
+def test_build_extra_body_anthropic_extended_thinking_respects_none_opt_out(
+    config, mock_task
+):
+    """thinking_level='none' must not be re-enabled by the extended-thinking block."""
+    config.run_config_properties.thinking_level = "none"
+    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+
+    mock_provider = Mock()
+    mock_provider.name = ModelProviderName.anthropic
+    mock_provider.default_thinking_level = "high"
+    mock_provider.openrouter_reasoning_object = False
+    mock_provider.require_openrouter_reasoning = False
+    mock_provider.gemini_reasoning_enabled = False
+    mock_provider.anthropic_extended_thinking = True
+    mock_provider.r1_openrouter_options = False
+    mock_provider.logprobs_openrouter_options = False
+    mock_provider.openrouter_skip_required_parameters = False
+    mock_provider.siliconflow_enable_thinking = None
+
+    extra_body = adapter.build_extra_body(mock_provider)
+
+    assert "thinking" not in extra_body
+    assert "reasoning_effort" not in extra_body
+
+
+def test_build_extra_body_anthropic_extended_thinking_enabled_when_not_none(
+    config, mock_task
+):
+    """The extended-thinking block still fires when the user hasn't opted out."""
+    config.run_config_properties.thinking_level = "high"
+    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+
+    mock_provider = Mock()
+    mock_provider.name = ModelProviderName.anthropic
+    mock_provider.default_thinking_level = "high"
+    mock_provider.openrouter_reasoning_object = False
+    mock_provider.require_openrouter_reasoning = False
+    mock_provider.gemini_reasoning_enabled = False
+    mock_provider.anthropic_extended_thinking = True
+    mock_provider.r1_openrouter_options = False
+    mock_provider.logprobs_openrouter_options = False
+    mock_provider.openrouter_skip_required_parameters = False
+    mock_provider.siliconflow_enable_thinking = None
+
+    extra_body = adapter.build_extra_body(mock_provider)
+
+    assert extra_body.get("thinking") == {"type": "enabled", "budget_tokens": 4000}
+
+
 def test_build_extra_body_thinking_level_skipped_when_provider_has_no_levels(
     config, mock_task
 ):

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -609,6 +609,57 @@ def test_build_extra_body_thinking_level_explicit_none(config, mock_task):
     assert "reasoning_effort" not in extra_body
 
 
+def test_build_extra_body_thinking_level_anthropic_none_omits_reasoning_effort(
+    config, mock_task
+):
+    """Anthropic has no reasoning_effort='none' (sending it crashes litellm). Selecting
+    the 'none' thinking level must omit the param entirely so thinking is disabled and
+    custom temperature/top_p become allowed."""
+    config.run_config_properties.thinking_level = "none"
+    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+
+    mock_provider = Mock()
+    mock_provider.name = ModelProviderName.anthropic
+    mock_provider.default_thinking_level = "high"
+    mock_provider.openrouter_reasoning_object = False
+    mock_provider.require_openrouter_reasoning = False
+    mock_provider.gemini_reasoning_enabled = False
+    mock_provider.anthropic_extended_thinking = False
+    mock_provider.r1_openrouter_options = False
+    mock_provider.logprobs_openrouter_options = False
+    mock_provider.openrouter_skip_required_parameters = False
+    mock_provider.siliconflow_enable_thinking = None
+
+    extra_body = adapter.build_extra_body(mock_provider)
+
+    assert "reasoning_effort" not in extra_body
+    assert "reasoning" not in extra_body
+
+
+def test_build_extra_body_thinking_level_anthropic_non_none_sets_reasoning_effort(
+    config, mock_task
+):
+    """Non-'none' Anthropic thinking levels are still sent as reasoning_effort."""
+    config.run_config_properties.thinking_level = "high"
+    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+
+    mock_provider = Mock()
+    mock_provider.name = ModelProviderName.anthropic
+    mock_provider.default_thinking_level = "high"
+    mock_provider.openrouter_reasoning_object = False
+    mock_provider.require_openrouter_reasoning = False
+    mock_provider.gemini_reasoning_enabled = False
+    mock_provider.anthropic_extended_thinking = False
+    mock_provider.r1_openrouter_options = False
+    mock_provider.logprobs_openrouter_options = False
+    mock_provider.openrouter_skip_required_parameters = False
+    mock_provider.siliconflow_enable_thinking = None
+
+    extra_body = adapter.build_extra_body(mock_provider)
+
+    assert extra_body.get("reasoning_effort") == "high"
+
+
 def test_build_extra_body_thinking_level_skipped_when_provider_has_no_levels(
     config, mock_task
 ):
@@ -1603,6 +1654,76 @@ async def test_build_completion_kwargs_temp_top_p_not_exclusive(config, mock_tas
 
         assert kwargs["temperature"] == 0.7
         assert kwargs["top_p"] == 0.9
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_name", "extra_body", "temperature", "top_p", "expected_error"),
+    [
+        # Anthropic + thinking on (reasoning_effort) + custom temperature -> clear error
+        (
+            ModelProviderName.anthropic,
+            {"reasoning_effort": "high"},
+            0.5,
+            1.0,
+            "temperature to be 1 when a thinking level",
+        ),
+        # Anthropic + thinking on (legacy thinking block) + custom temperature -> clear error
+        (
+            ModelProviderName.anthropic,
+            {"thinking": {"type": "enabled"}},
+            0.5,
+            1.0,
+            "temperature to be 1 when a thinking level",
+        ),
+        # Anthropic + thinking on + custom top_p below 0.95 -> clear error
+        (
+            ModelProviderName.anthropic,
+            {"reasoning_effort": "high"},
+            1.0,
+            0.8,
+            "top_p to be 0.95 or higher",
+        ),
+        # Anthropic + thinking on + default sampling (1.0/1.0 dropped) -> ok
+        (ModelProviderName.anthropic, {"reasoning_effort": "high"}, 1.0, 1.0, None),
+        # Anthropic + thinking on + top_p exactly 0.95 -> ok (boundary allowed)
+        (ModelProviderName.anthropic, {"reasoning_effort": "high"}, 1.0, 0.95, None),
+        # Anthropic + thinking OFF (no reasoning_effort) + custom temperature -> ok
+        (ModelProviderName.anthropic, {}, 0.5, 1.0, None),
+        # Non-Anthropic + thinking on + custom temperature -> not guarded here -> ok
+        (ModelProviderName.openai, {"reasoning_effort": "high"}, 0.5, 1.0, None),
+    ],
+)
+async def test_build_completion_kwargs_anthropic_thinking_sampling(
+    config, mock_task, provider_name, extra_body, temperature, top_p, expected_error
+):
+    """Anthropic rejects custom temperature/top_p while a thinking level is enabled
+    (temperature must be 1, top_p must be >= 0.95 or unset). build_completion_kwargs
+    should fail fast with a clear ValueError instead of letting the provider 400."""
+    config.run_config_properties.temperature = temperature
+    config.run_config_properties.top_p = top_p
+
+    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+    mock_provider = Mock()
+    mock_provider.name = provider_name
+    # Mirror real config: native-Anthropic reasoning models are temp/top_p exclusive.
+    mock_provider.temp_top_p_exclusive = provider_name == ModelProviderName.anthropic
+    messages = [{"role": "user", "content": "Hello"}]
+
+    with (
+        patch.object(adapter, "model_provider", return_value=mock_provider),
+        patch.object(adapter, "litellm_model_id", return_value="anthropic/test-model"),
+        patch.object(adapter, "build_extra_body", return_value=extra_body),
+        patch.object(adapter, "response_format_options", return_value={}),
+    ):
+        if expected_error is not None:
+            with pytest.raises(ValueError, match=expected_error):
+                await adapter.build_completion_kwargs(mock_provider, messages, None)
+        else:
+            kwargs = await adapter.build_completion_kwargs(
+                mock_provider, messages, None
+            )
+            assert kwargs is not None
 
 
 @pytest.mark.asyncio

--- a/libs/core/kiln_ai/adapters/model_adapters/test_temp_top_p_thinking_paid.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_temp_top_p_thinking_paid.py
@@ -101,6 +101,15 @@ def native_anthropic_thinking_models() -> list[str]:
     return names
 
 
+# Resolve once at import so a config drift that empties the list fails loudly at
+# collection time instead of silently turning this regression suite into a no-op.
+NATIVE_ANTHROPIC_THINKING_MODELS = native_anthropic_thinking_models()
+assert NATIVE_ANTHROPIC_THINKING_MODELS, (
+    "Expected at least one native Anthropic model exposing thinking levels "
+    "{'none', 'high'}; model config may have drifted."
+)
+
+
 def build_test_task(tmp_path: Path) -> datamodel.Task:
     project = datamodel.Project(name="test", path=tmp_path / "test.kiln")
     project.save_to_file()
@@ -146,7 +155,7 @@ INTERACTION_CASES = [
 
 
 @pytest.mark.paid
-@pytest.mark.parametrize("model_name", native_anthropic_thinking_models())
+@pytest.mark.parametrize("model_name", NATIVE_ANTHROPIC_THINKING_MODELS)
 @pytest.mark.parametrize(
     ("thinking_level", "temperature", "top_p", "expected"),
     INTERACTION_CASES,

--- a/libs/core/kiln_ai/adapters/model_adapters/test_temp_top_p_thinking_paid.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_temp_top_p_thinking_paid.py
@@ -1,0 +1,208 @@
+"""Paid tests for the temperature / top_p / thinking-level interaction on
+Anthropic models.
+
+Anthropic has two sampling restrictions that collide with thinking levels:
+
+1. ``temp_top_p_exclusive``: you may only set a custom value for ONE of
+   ``temperature`` or ``top_p`` (not both). Kiln already guards this with a
+   clear ``ValueError`` in ``build_completion_kwargs``.
+
+2. When extended thinking is enabled (Kiln sends ``reasoning_effort``),
+   Anthropic requires ``temperature`` to be 1 (and disallows custom ``top_p``).
+   Kiln does NOT guard this today, so a user who sets a custom temperature on a
+   thinking-enabled Anthropic model gets an opaque provider 400 that
+   ``format_error_message`` collapses to "An unexpected error occurred." The
+   native-Anthropic thinking dropdown also has no "None" entry, so there is no
+   way to turn thinking off and use a custom temperature instead.
+
+These tests pin the *intended* behavior:
+
+- A custom temperature/top_p combined with thinking should fail fast with a
+  clear, actionable Kiln ``ValueError`` (NOT an opaque provider error, and NOT
+  by silently dropping the user's value).
+- Setting ``thinking_level="none"`` should disable thinking and let a custom
+  temperature / top_p through (this is the "try None" escape hatch we want to
+  verify actually works against the live provider).
+
+Run with: ``--runpaid``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import kiln_ai.datamodel as datamodel
+from kiln_ai.adapters.adapter_registry import adapter_for_task
+from kiln_ai.adapters.errors import KilnRunError
+from kiln_ai.adapters.ml_model_list import (
+    ModelName,
+    ModelProviderName,
+    built_in_models,
+)
+from kiln_ai.adapters.model_adapters.test_paid_utils import (
+    skip_if_missing_provider_keys,
+)
+from kiln_ai.adapters.model_adapters.test_thinking_level_paid import (
+    reasoning_content_from_run,
+)
+from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
+
+# A short prompt that reliably elicits internal reasoning on thinking models
+# while staying cheap.
+PROMPT = (
+    "A bat and a ball cost $1.10 in total. The bat costs $1.00 more than the "
+    "ball. How much does the ball cost? Answer with just the dollar amount."
+)
+
+# Expected outcomes for each interaction case.
+EXPECT_REASONING = "reasoning"  # call succeeds and returns reasoning content
+EXPECT_NO_REASONING = "no_reasoning"  # call succeeds with no reasoning content
+EXPECT_KILN_VALUE_ERROR = "kiln_value_error"  # fail fast with a clear ValueError
+
+
+# Native-Anthropic models that expose thinking levels but are currently broken
+# for reasons UNRELATED to the temperature/top_p vs thinking bug, so we exclude
+# them from this regression suite and track them separately:
+#   - Opus 4.6/4.7/4.8: extended thinking 400s because litellm emits the legacy
+#     thinking.type="enabled" block, but these models require Anthropic's newer
+#     "adaptive" thinking API (thinking.type="adaptive" + output_config.effort).
+#   - Opus 4.7/4.8 additionally reject `temperature`/`top_p` as deprecated, even
+#     with thinking disabled.
+# These look like a litellm-version / model-config gap, not this bug. Including
+# them would keep the suite permanently red on issues this test isn't about.
+KNOWN_BROKEN_THINKING_MODELS = {
+    ModelName.claude_opus_4_6,
+    ModelName.claude_opus_4_7,
+    ModelName.claude_opus_4_8,
+}
+
+
+def native_anthropic_thinking_models() -> list[str]:
+    """Native-Anthropic models that exhibit *only* the temperature/top_p vs
+    thinking bug this suite guards against.
+
+    Selects providers that expose thinking levels including both "none" (off)
+    and "high" (the on-level we exercise) -- these share Sonnet 4.6's
+    preconditions (``temp_top_p_exclusive`` + reasoning-effort thinking).
+    Derived dynamically so new Anthropic models are covered automatically, minus
+    the ``KNOWN_BROKEN_THINKING_MODELS`` that fail for unrelated reasons.
+    """
+    names: list[str] = []
+    for model in built_in_models:
+        if model.name in KNOWN_BROKEN_THINKING_MODELS:
+            continue
+        for provider in model.providers:
+            if provider.name != ModelProviderName.anthropic:
+                continue
+            levels = set((provider.available_thinking_levels or {}).values())
+            if {"none", "high"} <= levels:
+                names.append(model.name)
+                break
+    return names
+
+
+def build_test_task(tmp_path: Path) -> datamodel.Task:
+    project = datamodel.Project(name="test", path=tmp_path / "test.kiln")
+    project.save_to_file()
+    task = datamodel.Task(
+        parent=project,
+        name="test task",
+        instruction="You are a careful assistant.",
+    )
+    task.save_to_file()
+    return task
+
+
+# (case_id, thinking_level, temperature, top_p, expected_outcome)
+INTERACTION_CASES = [
+    # Baseline: thinking on with default sampling works (defaults of 1.0 are
+    # dropped before the call, so Anthropic is happy).
+    pytest.param(
+        "high", 1.0, 1.0, EXPECT_REASONING, id="thinking_high__default_sampling"
+    ),
+    # THE BUG: thinking on + a custom temperature. Anthropic requires temp==1
+    # when thinking is enabled. We want a clear Kiln error, not a 400.
+    pytest.param(
+        "high", 0.5, 1.0, EXPECT_KILN_VALUE_ERROR, id="thinking_high__custom_temp"
+    ),
+    # thinking on + a custom top_p. Anthropic also disallows custom top_p with
+    # thinking enabled.
+    pytest.param(
+        "high", 1.0, 0.8, EXPECT_KILN_VALUE_ERROR, id="thinking_high__custom_top_p"
+    ),
+    # The "try None" escape hatch: disabling thinking should let a custom
+    # temperature through and produce no reasoning content.
+    pytest.param(
+        "none", 0.5, 1.0, EXPECT_NO_REASONING, id="thinking_none__custom_temp"
+    ),
+    # Disabling thinking should also let a custom top_p through.
+    pytest.param(
+        "none", 1.0, 0.8, EXPECT_NO_REASONING, id="thinking_none__custom_top_p"
+    ),
+    # Existing guard: temp AND top_p both custom is rejected with a clear
+    # ValueError regardless of thinking. Locks in current behavior.
+    pytest.param("high", 0.5, 0.8, EXPECT_KILN_VALUE_ERROR, id="custom_temp_and_top_p"),
+]
+
+
+@pytest.mark.paid
+@pytest.mark.parametrize("model_name", native_anthropic_thinking_models())
+@pytest.mark.parametrize(
+    ("thinking_level", "temperature", "top_p", "expected"),
+    INTERACTION_CASES,
+)
+async def test_anthropic_temp_top_p_thinking_interaction(
+    tmp_path,
+    model_name: str,
+    thinking_level: str,
+    temperature: float,
+    top_p: float,
+    expected: str,
+):
+    provider_name = ModelProviderName.anthropic
+    skip_if_missing_provider_keys(provider_name)
+
+    task = build_test_task(tmp_path)
+    adapter = adapter_for_task(
+        task,
+        KilnAgentRunConfigProperties(
+            model_name=model_name,
+            model_provider_name=provider_name,
+            prompt_id="simple_prompt_builder",
+            structured_output_mode="default",
+            thinking_level=thinking_level,
+            temperature=temperature,
+            top_p=top_p,
+        ),
+    )
+
+    if expected == EXPECT_KILN_VALUE_ERROR:
+        with pytest.raises(KilnRunError) as exc_info:
+            await adapter.invoke(PROMPT)
+        err = exc_info.value
+        # The failure must be a clear, pre-call Kiln ValueError, not an opaque
+        # provider error (which format_error_message turns into the useless
+        # "An unexpected error occurred.").
+        assert isinstance(err.original, ValueError), (
+            f"Expected a clear Kiln ValueError for thinking_level={thinking_level!r}, "
+            f"temperature={temperature}, top_p={top_p}, but got "
+            f"{err.error_type}: {err.original}"
+        )
+        message = str(err.original).lower()
+        assert any(term in message for term in ("temperature", "top_p", "thinking")), (
+            f"Error message should mention the conflicting params, got: {err.original}"
+        )
+        return
+
+    run = await adapter.invoke(PROMPT)
+    reasoning_content = reasoning_content_from_run(run)
+
+    if expected == EXPECT_NO_REASONING:
+        assert reasoning_content is None, (
+            f"Expected no reasoning for thinking_level={thinking_level!r}, "
+            f"but got {len(reasoning_content or '')} chars"
+        )
+    else:  # EXPECT_REASONING
+        assert reasoning_content is not None, (
+            f"Expected reasoning for thinking_level={thinking_level!r}, but got None"
+        )


### PR DESCRIPTION
## Problem

Anthropic requires `temperature=1` (and `top_p >= 0.95` or unset) when extended thinking is enabled. On the **native Anthropic provider**, Kiln's thinking dropdown only exposed Low/Medium/High — there was no way to turn thinking off. So a user who set a custom temperature hit a provider 400 that the UI rendered as the useless **"An unexpected error occurred."**, with no escape hatch.

Reported for Sonnet 4.6, but it affects every native-Anthropic reasoning model.

## Fix

- **Add `Off/None`** to the native-Anthropic thinking-level options so thinking can be disabled and custom sampling used.
- **Omit `reasoning_effort` for Anthropic when the level is `none`** — sending `reasoning_effort="none"` crashes *inside litellm* (`'NoneType' object has no attribute 'get'`); Anthropic thinking is opt-in, so omitting the param disables it.
- **Fail fast with an actionable error** when thinking is on with a custom `temperature`/`top_p` ("Set temperature to 1, or set the thinking level to None…") instead of the opaque 400 — and **without silently dropping** the user's value.

## Workarounds for existing versions (no upgrade)

- Want thinking → leave temperature/top_p at the default `1.0` (Kiln drops the defaults, so it already works).
- Want a custom temperature → use the model's **OpenRouter** provider variant, which already exposes `Off/None`.
- `top_p >= 0.95` is allowed alongside thinking.

## Tests

New `--runpaid` regression test `test_temp_top_p_thinking_paid.py` exercising the temperature × top_p × thinking matrix. Verified green on **Sonnet 4.5/4.6, Haiku 4.5, Opus 4.5**. (Paid tests don't run in default CI.)

## Out of scope / follow-ups

- **Opus 4.6/4.7/4.8**: extended thinking 400s because litellm emits the legacy `thinking.type="enabled"` block, but these models need Anthropic's newer adaptive API (`thinking.type="adaptive"` + `output_config.effort`); 4.7/4.8 also reject `temperature`/`top_p` as deprecated. Excluded from the test via `KNOWN_BROKEN_THINKING_MODELS` — looks like a litellm-version gap.
- **Fable 5** (native Anthropic): its thinking dropdown also lacks a `None` option — unverified whether that's intentional (like the `_pro` models) or the same gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)