### PR TITLE
Git auth error recovery: fix error display + re-import recovery flow

### DIFF
--- a/app/desktop/desktop_server.py
+++ b/app/desktop/desktop_server.py
@@ -123,8 +123,12 @@ def make_app(tk_root: tk.Tk | None = None):
     if not should_skip_remote_model_list():
         refresh_model_list_background()
 
-    app = kiln_server.make_app(lifespan=lifespan)
-    app.add_middleware(GitSyncMiddleware)
+    # GitSyncMiddleware must be installed INNER to CORS (via extra_middleware)
+    # so that its short-circuit error responses still pass back out through
+    # CORSMiddleware and receive CORS headers. Adding it here with
+    # app.add_middleware() would make it outermost, bypassing CORS and causing
+    # the browser to block git-sync error responses ("origin not allowed").
+    app = kiln_server.make_app(lifespan=lifespan, extra_middleware=[GitSyncMiddleware])
     connect_provider_api(app)
     connect_prompt_api(app)
     connect_repair_api(app)

--- a/app/desktop/git_sync/errors.py
+++ b/app/desktop/git_sync/errors.py
@@ -22,6 +22,12 @@ class WriteLockTimeoutError(GitSyncError):
     pass
 
 
+class GitAuthError(GitSyncError):
+    """Git authentication failed or expired (bad/expired token, 401/403)."""
+
+    pass
+
+
 class CorruptRepoError(GitSyncError):
     """Git repo is in unexpected state after recovery attempt."""
 

--- a/app/desktop/git_sync/git_sync_api.py
+++ b/app/desktop/git_sync/git_sync_api.py
@@ -9,10 +9,11 @@ from typing import Literal
 from fastapi import FastAPI, HTTPException, Query
 from fastapi import Path as FastAPIPath
 from fastapi.responses import HTMLResponse
-from kiln_ai.utils.config import Config
 from kiln_ai.utils.project_utils import (
     DuplicateProjectError,
     check_duplicate_project_id,
+    project_from_id as project_from_id_core,
+    remove_project_from_config,
 )
 from kiln_server.project_api import (
     add_project_to_config,
@@ -305,6 +306,11 @@ class SaveConfigRequest(BaseModel):
     sync_mode: Literal["auto", "manual"] = Field(
         default="auto", description="Sync mode: 'auto' or 'manual'."
     )
+    remove_conflicting_id: bool = Field(
+        default=False,
+        description="When true and a duplicate project ID conflict is detected, "
+        "remove the existing project registration before saving.",
+    )
 
 
 class GitSyncConfigResponse(BaseModel):
@@ -409,6 +415,13 @@ def _validate_clone_path(clone_path: str) -> Path:
             detail="clone_path must be within the project directory",
         )
     return resolved
+
+
+async def _deregister_project(project_path: str) -> None:
+    """Remove a project from config and unregister its git-sync manager."""
+    clone_path = remove_project_from_config(project_path)
+    if clone_path is not None:
+        await GitSyncRegistry.unregister(Path(clone_path))
 
 
 def connect_git_sync_api(app: FastAPI):
@@ -602,7 +615,11 @@ def connect_git_sync_api(app: FastAPI):
         try:
             check_duplicate_project_id(request.project_id, full_project_path)
         except DuplicateProjectError as e:
-            raise HTTPException(status_code=409, detail=str(e))
+            if not request.remove_conflicting_id:
+                raise HTTPException(status_code=409, detail=str(e))
+            conflicting = project_from_id_core(request.project_id)
+            if conflicting is not None:
+                await _deregister_project(str(conflicting.path))
 
         project_config = GitSyncProjectConfig(
             sync_mode=request.sync_mode,
@@ -863,23 +880,7 @@ def connect_git_sync_api(app: FastAPI):
     ) -> dict:
         """Removes the project from Kiln but does not delete the files from disk."""
         project = project_from_id(project_id)
-
-        project_path_str = str(project.path)
-
-        projects_before = Config.shared().projects
-        projects_after = [p for p in projects_before if p != project_path_str]
-        Config.shared().save_setting("projects", projects_after)
-
-        git_sync = Config.shared().git_sync_projects or {}
-        clone_path = None
-        if project_path_str in git_sync:
-            clone_path = git_sync[project_path_str].get("clone_path")
-            git_sync.pop(project_path_str)
-            Config.shared().save_setting("git_sync_projects", git_sync)
-
-        if clone_path is not None:
-            await GitSyncRegistry.unregister(Path(clone_path))
-
+        await _deregister_project(str(project.path))
         return {"message": f"Project removed. ID: {project_id}"}
 
     @app.delete(

--- a/app/desktop/git_sync/git_sync_manager.py
+++ b/app/desktop/git_sync/git_sync_manager.py
@@ -15,6 +15,8 @@ from app.desktop.git_sync.commit_message import generate_commit_message
 from app.desktop.git_sync.config import AuthMode
 from app.desktop.git_sync.errors import (
     CorruptRepoError,
+    GitAuthError,
+    GitSyncError,
     RemoteUnreachableError,
     SyncConflictError,
     WriteLockTimeoutError,
@@ -31,6 +33,23 @@ _settings.server_timeout = 30_000
 T = TypeVar("T")
 
 FRESHNESS_THRESHOLD = 15.0
+
+_AUTH_ERROR_MARKERS = (
+    "authentication",
+    "authoriz",
+    "credential",
+    "401",
+    "403",
+    "too many redirects",
+    "invalid username or password",
+    "password authentication",
+)
+
+
+def _is_auth_error(e: Exception) -> bool:
+    msg = str(e).lower()
+    return any(marker in msg for marker in _AUTH_ERROR_MARKERS)
+
 
 _cached_committer_name: str | None = None
 _cached_committer_email: str | None = None
@@ -215,7 +234,7 @@ class GitSyncManager:
 
         try:
             await self.fetch()
-        except RemoteUnreachableError:
+        except GitSyncError:
             raise
         except Exception as e:
             raise RemoteUnreachableError(f"Cannot sync with remote: {e}") from e
@@ -238,7 +257,7 @@ class GitSyncManager:
 
         try:
             await self.fetch()
-        except RemoteUnreachableError:
+        except GitSyncError:
             raise
         except Exception as e:
             raise RemoteUnreachableError(f"Cannot sync with remote: {e}") from e
@@ -269,6 +288,7 @@ class GitSyncManager:
                 first_push_error,
             )
             try:
+                # Auth classification on the push-retry path is out of scope (see spec Part B).
                 await self.fetch()
             except Exception as fetch_err:
                 raise RemoteUnreachableError(
@@ -312,6 +332,8 @@ class GitSyncManager:
         try:
             await self._run_git(self._fetch_sync)
         except pygit2.GitError as e:
+            if _is_auth_error(e):
+                raise GitAuthError(f"Git authentication failed: {e}") from e
             raise RemoteUnreachableError(f"Cannot sync with remote: {e}") from e
 
     async def has_new_remote_commits(self) -> bool:

--- a/app/desktop/git_sync/integration_tests/conftest.py
+++ b/app/desktop/git_sync/integration_tests/conftest.py
@@ -195,7 +195,7 @@ class APIWriteContext:
         error = None
         if resp.status_code >= 400:
             try:
-                error = resp.json().get("detail")
+                error = resp.json().get("message")
             except Exception:
                 error = resp.text
 
@@ -212,7 +212,7 @@ class APIWriteContext:
         body = None
         if resp.status_code >= 400:
             try:
-                error = resp.json().get("detail")
+                error = resp.json().get("message")
             except Exception:
                 error = resp.text
         else:

--- a/app/desktop/git_sync/integration_tests/test_decorators.py
+++ b/app/desktop/git_sync/integration_tests/test_decorators.py
@@ -153,7 +153,7 @@ class TestStreamingResponseUnderLock:
                 resp = client.post(f"/api/projects/{PROJECT_ID}/test_stream")
 
                 assert resp.status_code == 500
-                assert "no_write_lock" in resp.json().get("detail", "").lower()
+                assert "no_write_lock" in resp.json().get("message", "").lower()
 
 
 class TestLongLockHoldWarning:

--- a/app/desktop/git_sync/integration_tests/test_fixtures.py
+++ b/app/desktop/git_sync/integration_tests/test_fixtures.py
@@ -238,9 +238,11 @@ class TestNetworkFailure:
     async def test_break_network_causes_fetch_failure(
         self, git_repos, manager, break_network
     ):
-        from app.desktop.git_sync.errors import RemoteUnreachableError
+        from app.desktop.git_sync.errors import GitAuthError, RemoteUnreachableError
 
-        with pytest.raises((RemoteUnreachableError, pygit2.GitError, TimeoutError)):
+        with pytest.raises(
+            (RemoteUnreachableError, GitAuthError, pygit2.GitError, TimeoutError)
+        ):
             await manager.fetch()
 
     @pytest.mark.asyncio

--- a/app/desktop/git_sync/integration_tests/test_network_failure.py
+++ b/app/desktop/git_sync/integration_tests/test_network_failure.py
@@ -47,7 +47,10 @@ class TestNetworkFailureOnStaleRead:
 
         result = await api_ctx.do_read()
 
-        assert result.status_code == 503
+        if network_failure.name == "auth_failure":
+            assert result.status_code == 401
+        else:
+            assert result.status_code == 503
         assert result.error is not None
 
     @pytest.mark.parametrize(
@@ -220,7 +223,7 @@ class TestNetworkFailureAPIStatusCodes:
     async def test_write_fetch_failure_api_status(
         self, api_ctx, git_repos, network_failure, monkeypatch
     ):
-        """Fetch failure on write returns 503."""
+        """Fetch failure on write returns error status (401 for auth, 503 otherwise)."""
         local_path, _ = git_repos
 
         monkeypatch.setattr(
@@ -234,7 +237,10 @@ class TestNetworkFailureAPIStatusCodes:
             expect_error=True,
         )
 
-        assert result.status_code == 503
+        if network_failure.name == "auth_failure":
+            assert result.status_code == 401
+        else:
+            assert result.status_code == 503
 
     @pytest.mark.parametrize(
         "network_failure",
@@ -245,7 +251,7 @@ class TestNetworkFailureAPIStatusCodes:
     async def test_read_failure_api_status(
         self, api_ctx, git_repos, network_failure, monkeypatch
     ):
-        """Read failure when stale returns appropriate error status."""
+        """Read failure when stale returns error status (401 for auth, 503 otherwise)."""
         local_path, _ = git_repos
 
         monkeypatch.setattr(
@@ -256,4 +262,7 @@ class TestNetworkFailureAPIStatusCodes:
 
         result = await api_ctx.do_read()
 
-        assert result.status_code == 503
+        if network_failure.name == "auth_failure":
+            assert result.status_code == 401
+        else:
+            assert result.status_code == 503

--- a/app/desktop/git_sync/middleware.py
+++ b/app/desktop/git_sync/middleware.py
@@ -15,6 +15,7 @@ from starlette.types import Receive, Scope, Send
 from app.desktop.git_sync.config import get_git_sync_config, project_path_from_id
 from app.desktop.git_sync.errors import (
     CorruptRepoError,
+    GitAuthError,
     GitSyncError,
     RemoteUnreachableError,
     SyncConflictError,
@@ -46,6 +47,11 @@ class _StreamingUnderWriteLock(Exception):
 
 
 ERROR_MAP: dict[type[GitSyncError], tuple[int, str]] = {
+    GitAuthError: (
+        401,
+        "Git authentication failed or expired. Re-import the project to "
+        "reconnect with fresh credentials.",
+    ),
     RemoteUnreachableError: (
         503,
         "Cannot sync with remote. Check your connection.",
@@ -110,7 +116,7 @@ class GitSyncMiddleware(BaseHTTPMiddleware):
         except GitSyncError as e:
             status, message = self._map_error(e)
             error_response = Response(
-                content=json.dumps({"detail": message}, ensure_ascii=False),
+                content=json.dumps({"message": message}, ensure_ascii=False),
                 status_code=status,
                 media_type="application/json",
             )
@@ -156,7 +162,7 @@ class GitSyncMiddleware(BaseHTTPMiddleware):
             except GitSyncError as e:
                 status, message = self._map_error(e)
                 return Response(
-                    content=json.dumps({"detail": message}, ensure_ascii=False),
+                    content=json.dumps({"message": message}, ensure_ascii=False),
                     status_code=status,
                     media_type="application/json",
                 )
@@ -217,7 +223,7 @@ class GitSyncMiddleware(BaseHTTPMiddleware):
             return Response(
                 content=json.dumps(
                     {
-                        "detail": "Internal error: streaming endpoint missing @no_write_lock decorator."
+                        "message": "Internal error: streaming endpoint missing @no_write_lock decorator."
                     },
                     ensure_ascii=False,
                 ),
@@ -227,7 +233,7 @@ class GitSyncMiddleware(BaseHTTPMiddleware):
         except GitSyncError as e:
             status, message = self._map_error(e)
             return Response(
-                content=json.dumps({"detail": message}, ensure_ascii=False),
+                content=json.dumps({"message": message}, ensure_ascii=False),
                 status_code=status,
                 media_type="application/json",
             )
@@ -268,7 +274,7 @@ class GitSyncMiddleware(BaseHTTPMiddleware):
             return Response(
                 content=json.dumps(
                     {
-                        "detail": "Dev mode: this endpoint wrote files without "
+                        "message": "Dev mode: this endpoint wrote files without "
                         "holding a write lock, or a parallel request is "
                         "mid-write. See server logs for details."
                     },
@@ -318,7 +324,7 @@ class GitSyncMiddleware(BaseHTTPMiddleware):
                 return Response(
                     content=json.dumps(
                         {
-                            "detail": "Dev mode: a non-project-scoped endpoint wrote "
+                            "message": "Dev mode: a non-project-scoped endpoint wrote "
                             "to a synced repo without going through "
                             "GitSyncMiddleware. See server logs for details."
                         },

--- a/app/desktop/git_sync/test_git_sync_api.py
+++ b/app/desktop/git_sync/test_git_sync_api.py
@@ -1120,6 +1120,141 @@ class TestOAuthTokenInConfig:
         assert saved_config["oauth_token"] is None
 
 
+class TestSaveConfigRemoveConflicting:
+    def test_remove_conflicting_deregisters_and_saves(self, api_client, tmp_path):
+        clone_dir = tmp_path / "kiln_clone_new"
+        clone_dir.mkdir()
+        conflicting_project = MagicMock(path="/old/clone/project.kiln")
+        with (
+            patch(
+                "app.desktop.git_sync.git_sync_api.default_project_path",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "app.desktop.git_sync.git_sync_api.check_duplicate_project_id",
+                side_effect=DuplicateProjectError(
+                    "You already have a project with this ID.", same_path=False
+                ),
+            ),
+            patch(
+                "app.desktop.git_sync.git_sync_api.project_from_id_core",
+                return_value=conflicting_project,
+            ),
+            patch(
+                "app.desktop.git_sync.git_sync_api.remove_project_from_config",
+                return_value="/old/clone",
+            ) as mock_remove,
+            patch(
+                "app.desktop.git_sync.git_sync_api.GitSyncRegistry.unregister",
+                new_callable=AsyncMock,
+            ) as mock_unregister,
+            patch("app.desktop.git_sync.git_sync_api.save_git_sync_config"),
+            patch("app.desktop.git_sync.git_sync_api.add_project_to_config"),
+        ):
+            resp = api_client.post(
+                "/api/git_sync/save_config",
+                json={
+                    "project_id": "proj1",
+                    "project_path": "project.kiln",
+                    "git_url": "https://github.com/test/repo.git",
+                    "clone_path": str(clone_dir),
+                    "branch": "main",
+                    "remove_conflicting_id": True,
+                },
+            )
+        assert resp.status_code == 200
+        mock_remove.assert_called_once_with("/old/clone/project.kiln")
+        mock_unregister.assert_awaited_once_with(Path("/old/clone"))
+
+    def test_remove_conflicting_false_still_409(self, api_client, tmp_path):
+        clone_dir = tmp_path / "kiln_clone_new"
+        clone_dir.mkdir()
+        with (
+            patch(
+                "app.desktop.git_sync.git_sync_api.default_project_path",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "app.desktop.git_sync.git_sync_api.check_duplicate_project_id",
+                side_effect=DuplicateProjectError(
+                    "You already have a project with this ID.", same_path=False
+                ),
+            ),
+        ):
+            resp = api_client.post(
+                "/api/git_sync/save_config",
+                json={
+                    "project_id": "proj1",
+                    "project_path": "project.kiln",
+                    "git_url": "https://github.com/test/repo.git",
+                    "clone_path": str(clone_dir),
+                    "branch": "main",
+                    "remove_conflicting_id": False,
+                },
+            )
+        assert resp.status_code == 409
+
+    def test_remove_conflicting_no_conflict_is_noop(self, api_client, tmp_path):
+        clone_dir = tmp_path / "kiln_clone_new"
+        clone_dir.mkdir()
+        with (
+            patch(
+                "app.desktop.git_sync.git_sync_api.default_project_path",
+                return_value=str(tmp_path),
+            ),
+            patch("app.desktop.git_sync.git_sync_api.save_git_sync_config"),
+            patch("app.desktop.git_sync.git_sync_api.add_project_to_config"),
+        ):
+            resp = api_client.post(
+                "/api/git_sync/save_config",
+                json={
+                    "project_id": "proj1",
+                    "project_path": "project.kiln",
+                    "git_url": "https://github.com/test/repo.git",
+                    "clone_path": str(clone_dir),
+                    "branch": "main",
+                    "remove_conflicting_id": True,
+                },
+            )
+        assert resp.status_code == 200
+
+    def test_remove_conflicting_project_not_found_still_saves(
+        self, api_client, tmp_path
+    ):
+        clone_dir = tmp_path / "kiln_clone_new"
+        clone_dir.mkdir()
+        with (
+            patch(
+                "app.desktop.git_sync.git_sync_api.default_project_path",
+                return_value=str(tmp_path),
+            ),
+            patch(
+                "app.desktop.git_sync.git_sync_api.check_duplicate_project_id",
+                side_effect=DuplicateProjectError(
+                    "You already have a project with this ID.", same_path=False
+                ),
+            ),
+            patch(
+                "app.desktop.git_sync.git_sync_api.project_from_id_core",
+                return_value=None,
+            ),
+            patch("app.desktop.git_sync.git_sync_api.save_git_sync_config"),
+            patch("app.desktop.git_sync.git_sync_api.add_project_to_config"),
+        ):
+            resp = api_client.post(
+                "/api/git_sync/save_config",
+                json={
+                    "project_id": "proj1",
+                    "project_path": "project.kiln",
+                    "git_url": "https://github.com/test/repo.git",
+                    "clone_path": str(clone_dir),
+                    "branch": "main",
+                    "remove_conflicting_id": True,
+                },
+            )
+        assert resp.status_code == 200
+
+
 class TestSaveConfigClonePathValidation:
     def test_rejects_clone_path_outside_project_directory(self, api_client, tmp_path):
         with patch(

--- a/app/desktop/git_sync/test_git_sync_manager.py
+++ b/app/desktop/git_sync/test_git_sync_manager.py
@@ -8,11 +8,14 @@ import pytest
 
 from app.desktop.git_sync.conftest import _test_sig, commit_in_repo, push_from
 from app.desktop.git_sync.errors import (
+    GitAuthError,
+    RemoteUnreachableError,
     SyncConflictError,
     WriteLockTimeoutError,
 )
 from app.desktop.git_sync.git_sync_manager import (
     GitSyncManager,
+    _is_auth_error,
     get_committer_email,
     get_committer_name,
     reset_committer_cache,
@@ -594,3 +597,81 @@ def test_committer_caching(monkeypatch):
     get_committer_email()
     assert call_count == 2
     reset_committer_cache()
+
+
+# --- _is_auth_error classification ---
+
+
+@pytest.mark.parametrize(
+    "message,expected",
+    [
+        ("HTTP 401 Unauthorized", True),
+        ("HTTP 403 Forbidden", True),
+        ("authentication required", True),
+        ("authorization failed", True),
+        ("bad credentials", True),
+        ("invalid username or password", True),
+        ("password authentication was removed", True),
+        ("too many redirects", True),
+        ("could not resolve host", False),
+        ("connection timed out", False),
+        ("network is unreachable", False),
+        ("unexpected http status code: 500", False),
+    ],
+)
+def test_is_auth_error_markers(message, expected):
+    assert _is_auth_error(pygit2.GitError(message)) is expected
+
+
+# --- fetch auth classification ---
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_git_auth_error_for_auth_failure(manager):
+    def broken_fetch():
+        raise pygit2.GitError("HTTP 401 Unauthorized")
+
+    manager._fetch_sync = broken_fetch  # type: ignore[assignment]
+
+    with pytest.raises(GitAuthError, match="Git authentication failed"):
+        await manager.fetch()
+
+
+@pytest.mark.asyncio
+async def test_fetch_raises_remote_unreachable_for_non_auth_failure(manager):
+    def broken_fetch():
+        raise pygit2.GitError("could not resolve host")
+
+    manager._fetch_sync = broken_fetch  # type: ignore[assignment]
+
+    with pytest.raises(RemoteUnreachableError, match="Cannot sync with remote"):
+        await manager.fetch()
+
+
+# --- ensure_fresh / ensure_fresh_for_read propagation ---
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_for_read_propagates_git_auth_error(manager):
+    manager._last_sync = 0.0
+
+    def broken_fetch():
+        raise pygit2.GitError("authentication required")
+
+    manager._fetch_sync = broken_fetch  # type: ignore[assignment]
+
+    with pytest.raises(GitAuthError):
+        await manager.ensure_fresh_for_read()
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_propagates_git_auth_error(manager):
+    manager._last_sync = 0.0
+
+    def broken_fetch():
+        raise pygit2.GitError("HTTP 403 Forbidden")
+
+    manager._fetch_sync = broken_fetch  # type: ignore[assignment]
+
+    with pytest.raises(GitAuthError):
+        await manager.ensure_fresh()

--- a/app/desktop/git_sync/test_middleware.py
+++ b/app/desktop/git_sync/test_middleware.py
@@ -23,6 +23,7 @@ from app.desktop.git_sync.errors import (
 from app.desktop.git_sync.middleware import GitSyncMiddleware
 from app.desktop.git_sync.registry import GitSyncRegistry
 from kiln_server.git_sync_decorators import no_write_lock, write_lock
+from kiln_server.server import make_app
 
 PROJECT_ID = "test_proj_123"
 PROJECT_PATH = "/tmp/test/project.kiln"
@@ -383,6 +384,50 @@ def test_error_mapping(git_repos, error_class, expected_status, expected_detail)
     assert resp.status_code == expected_status
     body = resp.json()
     assert body["message"] == expected_detail
+
+
+def test_git_sync_error_response_has_cors_headers():
+    """GitSyncMiddleware error short-circuits must still carry CORS headers.
+
+    GitSyncMiddleware must be installed INNER to CORSMiddleware (via
+    make_app's extra_middleware), so error responses it short-circuits pass
+    back out through CORS and get Access-Control-Allow-Origin. If the ordering
+    regresses (GitSyncMiddleware outermost), the browser blocks the response
+    as "origin not allowed" and the user sees "Load failed" with no error
+    message instead of the descriptive git-sync error.
+    """
+    config = _auto_config("/tmp/test/clone.kiln")
+    origin = "http://localhost:5173"
+
+    mock_manager = MagicMock(repo_path=PROJECT_PATH)
+    mock_manager.ensure_fresh_for_read = AsyncMock(
+        side_effect=GitAuthError("auth failed")
+    )
+
+    # Mirror the real desktop assembly: GitSyncMiddleware inner, CORS outermost.
+    app = make_app(extra_middleware=[GitSyncMiddleware])
+
+    with (
+        mock_git_sync_config(config),
+        patch.object(GitSyncRegistry, "get_or_create", return_value=mock_manager),
+        patch(
+            "app.desktop.git_sync.middleware.GitSyncRegistry.get_background_sync",
+            return_value=None,
+        ),
+    ):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            f"/api/projects/{PROJECT_ID}/tasks",
+            headers={"Origin": origin},
+        )
+
+    assert resp.status_code == 401
+    assert resp.json()["message"] == (
+        "Git authentication failed or expired. Re-import the project to "
+        "reconnect with fresh credentials."
+    )
+    # The fix: CORS header is present on the short-circuited error response.
+    assert resp.headers.get("access-control-allow-origin") == origin
 
 
 def test_write_lock_timeout_from_lock_acquisition(git_repos):

--- a/app/desktop/git_sync/test_middleware.py
+++ b/app/desktop/git_sync/test_middleware.py
@@ -15,6 +15,7 @@ from app.desktop.git_sync.config import GitSyncProjectConfig
 from kiln_server.cancellable_streaming_response import CancellableStreamingResponse
 from app.desktop.git_sync.errors import (
     CorruptRepoError,
+    GitAuthError,
     RemoteUnreachableError,
     SyncConflictError,
     WriteLockTimeoutError,
@@ -344,6 +345,12 @@ def test_no_write_lock_decorator_on_post(git_repos):
     "error_class,expected_status,expected_detail",
     [
         (
+            GitAuthError,
+            401,
+            "Git authentication failed or expired. Re-import the project to "
+            "reconnect with fresh credentials.",
+        ),
+        (
             RemoteUnreachableError,
             503,
             "Cannot sync with remote. Check your connection.",
@@ -375,7 +382,7 @@ def test_error_mapping(git_repos, error_class, expected_status, expected_detail)
 
     assert resp.status_code == expected_status
     body = resp.json()
-    assert body["detail"] == expected_detail
+    assert body["message"] == expected_detail
 
 
 def test_write_lock_timeout_from_lock_acquisition(git_repos):
@@ -424,7 +431,7 @@ def test_write_lock_timeout_from_lock_acquisition(git_repos):
     assert resp.status_code == 503
     body = resp.json()
     assert (
-        body["detail"]
+        body["message"]
         == "Another save is in progress. Please wait a moment and try again."
     )
 
@@ -574,8 +581,8 @@ def test_dev_mode_dirty_read_returns_500(git_repos, monkeypatch, caplog):
 
     assert resp.status_code == 500
     body = resp.json()
-    assert "Dev mode" in body["detail"]
-    assert "without holding a write lock" in body["detail"]
+    assert "Dev mode" in body["message"]
+    assert "without holding a write lock" in body["message"]
     rendered = [r.getMessage() for r in caplog.records]
     assert any("DEV MODE: Request left repo dirty" in m for m in rendered)
     assert any("leaked_write.txt" in m for m in rendered)
@@ -741,7 +748,7 @@ def test_dev_mode_catchall_dirty_non_project_url_returns_500(
 
     assert resp.status_code == 500
     body = resp.json()
-    assert "non-project-scoped endpoint" in body["detail"]
+    assert "non-project-scoped endpoint" in body["message"]
     rendered = [r.getMessage() for r in caplog.records]
     assert any("DEV MODE: Non-project-scoped endpoint" in m for m in rendered)
     assert any("leaked_admin_write.txt" in m for m in rendered)
@@ -783,7 +790,7 @@ def test_dev_mode_catchall_dirty_non_project_url_get_returns_500(
 
     assert resp.status_code == 500
     body = resp.json()
-    assert "non-project-scoped endpoint" in body["detail"]
+    assert "non-project-scoped endpoint" in body["message"]
     rendered = [r.getMessage() for r in caplog.records]
     assert any("DEV MODE: Non-project-scoped endpoint" in m for m in rendered)
     assert any("leaked_admin_get.txt" in m for m in rendered)
@@ -1082,7 +1089,7 @@ def test_no_write_lock_ensure_fresh_error_returns_json():
 
     assert resp.status_code == 409
     body = resp.json()
-    assert body["detail"] == "There was a problem saving. Please try again."
+    assert body["message"] == "There was a problem saving. Please try again."
 
 
 def test_no_write_lock_no_manager_passes_through():

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -8742,6 +8742,12 @@ export interface components {
              * @enum {string}
              */
             sync_mode: "auto" | "manual";
+            /**
+             * Remove Conflicting Id
+             * @description When true and a duplicate project ID conflict is detected, remove the existing project registration before saving.
+             * @default false
+             */
+            remove_conflicting_id: boolean;
         };
         /** SaveQnaPairInput */
         SaveQnaPairInput: {

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -10686,6 +10686,8 @@ export interface operations {
             query: {
                 /** @description File path to the project.kiln file to import. */
                 project_path: string;
+                /** @description When true and a duplicate project ID conflict is detected, remove the existing project registration before importing. */
+                remove_conflicting_id?: boolean;
             };
             header?: never;
             path?: never;

--- a/app/web_ui/src/lib/components/import/import_project.svelte
+++ b/app/web_ui/src/lib/components/import/import_project.svelte
@@ -404,6 +404,7 @@
         {/if}
         {#if import_conflict}
           <button
+            type="button"
             class="btn btn-error btn-outline"
             on:click={() => import_project(true)}
           >

--- a/app/web_ui/src/lib/components/import/import_project.svelte
+++ b/app/web_ui/src/lib/components/import/import_project.svelte
@@ -111,6 +111,7 @@
       import_project_path = ""
       import_error = null
       import_conflict = false
+      conflict_path = null
       select_file_unavailable = false
       import_done = false
     }
@@ -241,12 +242,16 @@
   let import_saved = false
   let import_done = false
   let import_conflict = false
+  let conflict_path: string | null = null
 
-  function on_path_input() {
-    if (import_conflict) {
-      import_conflict = false
-      import_error = null
-    }
+  // conflict_path is set equal to import_project_path when a 409 fires, so the
+  // guard `import_project_path !== conflict_path` is false at that moment and the
+  // reactive block does NOT wipe the conflict on the initial 409. It only clears
+  // once the user actually changes the path (via typing or the file picker).
+  $: if (conflict_path !== null && import_project_path !== conflict_path) {
+    import_conflict = false
+    import_error = null
+    conflict_path = null
   }
 
   async function select_project_file() {
@@ -294,6 +299,7 @@
       if (post_error) {
         if (response?.status === 409) {
           import_conflict = true
+          conflict_path = import_project_path
         }
         throw post_error
       }
@@ -387,17 +393,14 @@
             Select Project File
           </button>
         {:else}
-          <!-- svelte-ignore a11y-no-static-element-interactions -->
-          <div on:input={on_path_input}>
-            <FormElement
-              label="Existing Project Path"
-              description="The path to a project.kiln file. For example, /Users/username/my_project/project.kiln"
-              info_description="You must enter the full path to the file, not just a filename. The path should be to a project.kiln file."
-              id="import_project_path"
-              inputType="input"
-              bind:value={import_project_path}
-            />
-          </div>
+          <FormElement
+            label="Existing Project Path"
+            description="The path to a project.kiln file. For example, /Users/username/my_project/project.kiln"
+            info_description="You must enter the full path to the file, not just a filename. The path should be to a project.kiln file."
+            id="import_project_path"
+            inputType="input"
+            bind:value={import_project_path}
+          />
         {/if}
         {#if import_conflict}
           <button

--- a/app/web_ui/src/lib/components/import/import_project.svelte
+++ b/app/web_ui/src/lib/components/import/import_project.svelte
@@ -110,6 +110,7 @@
     if (step === "local_file") {
       import_project_path = ""
       import_error = null
+      import_conflict = false
       select_file_unavailable = false
       import_done = false
     }
@@ -233,12 +234,20 @@
   // Local file import logic
   let select_file_unavailable = false
   $: show_select_file = !select_file_unavailable && !import_project_path
-  $: import_submit_visible = !show_select_file
+  $: import_submit_visible = !show_select_file && !import_conflict
   let import_project_path = ""
   let import_error: KilnError | null = null
   let import_submitting = false
   let import_saved = false
   let import_done = false
+  let import_conflict = false
+
+  function on_path_input() {
+    if (import_conflict) {
+      import_conflict = false
+      import_error = null
+    }
+  }
 
   async function select_project_file() {
     try {
@@ -264,21 +273,28 @@
     }
   }
 
-  const import_project = async () => {
+  const import_project = async (remove_conflicting_id = false) => {
     try {
       import_submitting = true
       import_saved = false
-      const { data, error: post_error } = await client.POST(
-        "/api/import_project",
-        {
-          params: {
-            query: {
-              project_path: import_project_path,
-            },
+      import_error = null
+      import_conflict = false
+      const {
+        data,
+        error: post_error,
+        response,
+      } = await client.POST("/api/import_project", {
+        params: {
+          query: {
+            project_path: import_project_path,
+            ...(remove_conflicting_id && { remove_conflicting_id: true }),
           },
         },
-      )
+      })
       if (post_error) {
+        if (response?.status === 409) {
+          import_conflict = true
+        }
         throw post_error
       }
 
@@ -360,7 +376,7 @@
     {#if !import_done}
       <FormContainer
         submit_label="Import Project"
-        on:submit={import_project}
+        on:submit={() => import_project()}
         bind:submitting={import_submitting}
         bind:error={import_error}
         bind:saved={import_saved}
@@ -371,14 +387,25 @@
             Select Project File
           </button>
         {:else}
-          <FormElement
-            label="Existing Project Path"
-            description="The path to a project.kiln file. For example, /Users/username/my_project/project.kiln"
-            info_description="You must enter the full path to the file, not just a filename. The path should be to a project.kiln file."
-            id="import_project_path"
-            inputType="input"
-            bind:value={import_project_path}
-          />
+          <!-- svelte-ignore a11y-no-static-element-interactions -->
+          <div on:input={on_path_input}>
+            <FormElement
+              label="Existing Project Path"
+              description="The path to a project.kiln file. For example, /Users/username/my_project/project.kiln"
+              info_description="You must enter the full path to the file, not just a filename. The path should be to a project.kiln file."
+              id="import_project_path"
+              inputType="input"
+              bind:value={import_project_path}
+            />
+          </div>
+        {/if}
+        {#if import_conflict}
+          <button
+            class="btn btn-error btn-outline"
+            on:click={() => import_project(true)}
+          >
+            Remove existing and re-import
+          </button>
         {/if}
       </FormContainer>
     {/if}

--- a/app/web_ui/src/lib/components/import/import_project.test.ts
+++ b/app/web_ui/src/lib/components/import/import_project.test.ts
@@ -131,6 +131,45 @@ describe("ImportProject local_file conflict handling", () => {
     expect(hiddenSubmit?.classList.contains("hidden")).toBe(true)
   })
 
+  it("conflict button is type=button so it cannot submit the form", async () => {
+    vi.mocked(client.POST).mockResolvedValue({
+      data: undefined,
+      error: { message: "Duplicate project ID" },
+      response: new Response(null, { status: 409 }),
+    } as never)
+
+    const { container, getByText } = await renderAtLocalStep()
+
+    const input = container.querySelector(
+      "#import_project_path",
+    ) as HTMLInputElement
+    await fireEvent.input(input, {
+      target: { value: "/path/to/project.kiln" },
+    })
+    await tick()
+
+    const submitBtn = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    await fireEvent.click(submitBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Remove existing and re-import")
+    })
+
+    // type="button" keeps the conflict button out of implicit form submission.
+    // Without it the button defaults to type="submit" and, as the first submit
+    // button in tree order, would become the form's default button -- so Enter
+    // in the path field could fire the destructive remove-and-re-import action.
+    const conflictBtn = getByText(
+      "Remove existing and re-import",
+    ) as HTMLButtonElement
+    expect(conflictBtn.getAttribute("type")).toBe("button")
+  })
+
   it("does not show conflict button on non-409 error", async () => {
     vi.mocked(client.POST).mockResolvedValue({
       data: undefined,

--- a/app/web_ui/src/lib/components/import/import_project.test.ts
+++ b/app/web_ui/src/lib/components/import/import_project.test.ts
@@ -247,7 +247,7 @@ describe("ImportProject local_file conflict handling", () => {
     })
     expect(submitBtn?.classList.contains("hidden")).toBe(true)
 
-    // Now edit the path - should clear conflict and restore normal submit
+    // Now edit the path via typing - should clear conflict and restore normal submit
     await fireEvent.input(input, {
       target: { value: "/different/path/project.kiln" },
     })
@@ -264,5 +264,124 @@ describe("ImportProject local_file conflict handling", () => {
       'button[type="submit"]',
     ) as HTMLButtonElement
     expect(restoredSubmit?.classList.contains("hidden")).toBe(false)
+  })
+
+  it("file picker programmatic path change clears conflict via reactive block", async () => {
+    // Validates the reactive clearing mechanism via the real file-picker path.
+    // select_project_file() sets import_project_path programmatically (no DOM
+    // input event), which the old on:input wrapper div would have missed.
+    const result = render(ImportProject, { props: baseProps })
+    await tick()
+
+    const localBtn = result.getByText("Import from Local Folder")
+    await fireEvent.click(localBtn)
+    await tick()
+
+    const { container } = result
+
+    // Use the file picker (not manual input) to set the initial path
+    vi.mocked(client.GET).mockResolvedValueOnce({
+      data: { file_path: "/path/to/project.kiln" },
+      error: undefined,
+      response: new Response(null, { status: 200 }),
+    } as never)
+
+    const selectBtn = container.querySelector(
+      "button.btn-primary",
+    ) as HTMLButtonElement
+    expect(selectBtn?.textContent).toContain("Select Project File")
+    await fireEvent.click(selectBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    // Path was set programmatically by the file picker; input field should show
+    const input = container.querySelector(
+      "#import_project_path",
+    ) as HTMLInputElement
+    expect(input).toBeTruthy()
+    expect(input.value).toBe("/path/to/project.kiln")
+
+    // Submit -> 409 conflict
+    vi.mocked(client.POST).mockResolvedValueOnce({
+      data: undefined,
+      error: { message: "Duplicate project ID" },
+      response: new Response(null, { status: 409 }),
+    } as never)
+
+    const submitBtn = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    await fireEvent.click(submitBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    // Conflict button appears (reactive did NOT self-wipe on the 409)
+    await waitFor(() => {
+      expect(container.textContent).toContain("Remove existing and re-import")
+    })
+    expect(submitBtn?.classList.contains("hidden")).toBe(true)
+
+    // Clear the path to make the file picker button reappear.
+    // This also clears the conflict (expected: path changed from the conflict path).
+    await fireEvent.input(input, { target: { value: "" } })
+    await tick()
+
+    await waitFor(() => {
+      expect(container.textContent).not.toContain(
+        "Remove existing and re-import",
+      )
+    })
+
+    // File picker button is visible again (select_file_unavailable is still false)
+    const selectBtn2 = container.querySelector(
+      "button.btn-primary",
+    ) as HTMLButtonElement
+    expect(selectBtn2?.textContent).toContain("Select Project File")
+
+    // Use the file picker to set a DIFFERENT path programmatically
+    vi.mocked(client.GET).mockResolvedValueOnce({
+      data: { file_path: "/different/programmatic/path.kiln" },
+      error: undefined,
+      response: new Response(null, { status: 200 }),
+    } as never)
+
+    await fireEvent.click(selectBtn2)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    // Verify the file picker set the new path programmatically
+    const updatedInput = container.querySelector(
+      "#import_project_path",
+    ) as HTMLInputElement
+    expect(updatedInput?.value).toBe("/different/programmatic/path.kiln")
+
+    // Submit again -> 409
+    vi.mocked(client.POST).mockResolvedValueOnce({
+      data: undefined,
+      error: { message: "Duplicate project ID" },
+      response: new Response(null, { status: 409 }),
+    } as never)
+
+    const submitBtn2 = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    await fireEvent.click(submitBtn2)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    // Conflict button appears again -- the reactive block correctly handled the
+    // programmatic path set from the file picker without self-wiping on the 409
+    await waitFor(() => {
+      expect(container.textContent).toContain("Remove existing and re-import")
+    })
+
+    const hiddenSubmit = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    expect(hiddenSubmit?.classList.contains("hidden")).toBe(true)
   })
 })

--- a/app/web_ui/src/lib/components/import/import_project.test.ts
+++ b/app/web_ui/src/lib/components/import/import_project.test.ts
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/svelte"
+import { tick } from "svelte"
+
+vi.mock("$lib/api_client", () => ({
+  client: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+  },
+}))
+
+vi.mock("$lib/stores", () => ({
+  load_projects: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("$app/navigation", () => ({
+  replaceState: vi.fn(),
+  beforeNavigate: vi.fn(),
+}))
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}))
+
+vi.mock("$lib/git_sync/url_utils", () => ({
+  sync_url_query_param: vi.fn(),
+  read_url_query_param: vi.fn().mockReturnValue(null),
+}))
+
+vi.mock("$lib/stores/git_import_wizard_store", () => {
+  const { writable } = require("svelte/store")
+  return {
+    git_import_wizard_store: writable({
+      git_url: "",
+      pat_token: null,
+      oauth_token: null,
+      auth_mode: "system_keys",
+      clone_path: "",
+      selected_branch: "",
+      selected_project_path: "",
+      selected_project_id: "",
+      selected_project_name: "",
+    }),
+    clear_wizard_store: vi.fn(),
+    validate_step_requirements: vi.fn().mockReturnValue(true),
+  }
+})
+
+import ImportProject from "./import_project.svelte"
+import { client } from "$lib/api_client"
+
+const baseProps = {
+  create_link: "/create",
+  on_complete: vi.fn(),
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  window.location.hash = ""
+})
+
+beforeEach(() => {
+  vi.mocked(client.POST).mockReset()
+  vi.mocked(client.GET).mockReset()
+  vi.mocked(baseProps.on_complete).mockReset()
+  window.location.hash = ""
+})
+
+describe("ImportProject local_file conflict handling", () => {
+  async function renderAtLocalStep() {
+    const result = render(ImportProject, { props: baseProps })
+    await tick()
+
+    // Click "Import from Local Folder" button to navigate to local_file step
+    const localBtn = result.getByText("Import from Local Folder")
+    await fireEvent.click(localBtn)
+    await tick()
+
+    // Now trigger the file selector error to reveal the manual path input
+    vi.mocked(client.GET).mockRejectedValue(new Error("No file selector"))
+    const selectBtn = result.container.querySelector(
+      "button.btn-primary",
+    ) as HTMLButtonElement
+    if (selectBtn?.textContent?.includes("Select Project File")) {
+      await fireEvent.click(selectBtn)
+      await tick()
+      await new Promise((r) => setTimeout(r, 0))
+      await tick()
+    }
+
+    return result
+  }
+
+  it("shows conflict button on 409 response", async () => {
+    vi.mocked(client.POST).mockResolvedValue({
+      data: undefined,
+      error: { message: "Duplicate project ID" },
+      response: new Response(null, { status: 409 }),
+    } as never)
+
+    const { container } = await renderAtLocalStep()
+
+    const input = container.querySelector(
+      "#import_project_path",
+    ) as HTMLInputElement
+    expect(input).toBeTruthy()
+    await fireEvent.input(input, {
+      target: { value: "/path/to/project.kiln" },
+    })
+    await tick()
+
+    const submitBtn = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    expect(submitBtn).toBeTruthy()
+    await fireEvent.click(submitBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Remove existing and re-import")
+    })
+
+    // Normal submit button should be hidden in conflict state
+    const hiddenSubmit = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    expect(hiddenSubmit?.classList.contains("hidden")).toBe(true)
+  })
+
+  it("does not show conflict button on non-409 error", async () => {
+    vi.mocked(client.POST).mockResolvedValue({
+      data: undefined,
+      error: { message: "Server error" },
+      response: new Response(null, { status: 500 }),
+    } as never)
+
+    const { container } = await renderAtLocalStep()
+
+    const input = container.querySelector(
+      "#import_project_path",
+    ) as HTMLInputElement
+    expect(input).toBeTruthy()
+    await fireEvent.input(input, {
+      target: { value: "/path/to/project.kiln" },
+    })
+    await tick()
+
+    const submitBtn = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    await fireEvent.click(submitBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Server error")
+    })
+    expect(container.textContent).not.toContain("Remove existing and re-import")
+  })
+
+  it("clicking conflict button retries with remove_conflicting_id=true", async () => {
+    // First call: 409 conflict
+    vi.mocked(client.POST).mockResolvedValueOnce({
+      data: undefined,
+      error: { message: "Duplicate project ID" },
+      response: new Response(null, { status: 409 }),
+    } as never)
+
+    const { container, getByText } = await renderAtLocalStep()
+
+    const input = container.querySelector(
+      "#import_project_path",
+    ) as HTMLInputElement
+    expect(input).toBeTruthy()
+    await fireEvent.input(input, {
+      target: { value: "/path/to/project.kiln" },
+    })
+    await tick()
+
+    const submitBtn = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    await fireEvent.click(submitBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Remove existing and re-import")
+    })
+
+    // Second call: success
+    vi.mocked(client.POST).mockResolvedValueOnce({
+      data: { id: "proj_1", name: "Imported" },
+      error: undefined,
+      response: new Response(null, { status: 200 }),
+    } as never)
+
+    const conflictBtn = getByText("Remove existing and re-import")
+    await fireEvent.click(conflictBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    // Verify the second call included remove_conflicting_id
+    const calls = vi.mocked(client.POST).mock.calls
+    expect(calls.length).toBe(2)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const secondCallOpts = calls[1][1] as any
+    expect(secondCallOpts?.params?.query?.remove_conflicting_id).toBe(true)
+  })
+
+  it("editing path after 409 clears conflict state and restores submit button", async () => {
+    vi.mocked(client.POST).mockResolvedValue({
+      data: undefined,
+      error: { message: "Duplicate project ID" },
+      response: new Response(null, { status: 409 }),
+    } as never)
+
+    const { container } = await renderAtLocalStep()
+
+    const input = container.querySelector(
+      "#import_project_path",
+    ) as HTMLInputElement
+    expect(input).toBeTruthy()
+    await fireEvent.input(input, {
+      target: { value: "/path/to/project.kiln" },
+    })
+    await tick()
+
+    const submitBtn = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    await fireEvent.click(submitBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    // Confirm conflict state is active
+    await waitFor(() => {
+      expect(container.textContent).toContain("Remove existing and re-import")
+    })
+    expect(submitBtn?.classList.contains("hidden")).toBe(true)
+
+    // Now edit the path - should clear conflict and restore normal submit
+    await fireEvent.input(input, {
+      target: { value: "/different/path/project.kiln" },
+    })
+    await tick()
+
+    await waitFor(() => {
+      expect(container.textContent).not.toContain(
+        "Remove existing and re-import",
+      )
+    })
+
+    // Normal submit button should be visible again
+    const restoredSubmit = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    expect(restoredSubmit?.classList.contains("hidden")).toBe(false)
+  })
+})

--- a/app/web_ui/src/lib/components/import/step_complete.svelte
+++ b/app/web_ui/src/lib/components/import/step_complete.svelte
@@ -128,7 +128,7 @@
     <button class="btn btn-primary" on:click={on_back}> Back </button>
     {#if is_conflict}
       <button class="btn btn-error btn-outline" on:click={() => run_save(true)}>
-        Remove existing and re-sync
+        Remove existing and sync
       </button>
     {/if}
   </div>

--- a/app/web_ui/src/lib/components/import/step_complete.svelte
+++ b/app/web_ui/src/lib/components/import/step_complete.svelte
@@ -5,6 +5,7 @@
     renameClone,
     saveConfig,
     is_stale_clone_error,
+    is_duplicate_project_error,
     isGitHubUrl,
     isGitLabUrl,
   } from "$lib/git_sync/api"
@@ -34,6 +35,7 @@
   let saving = true
   let error: KilnError | null = null
   let done = false
+  let is_conflict = false
 
   function git_host_label(url: string): string {
     if (isGitHubUrl(url)) return "github"
@@ -41,34 +43,24 @@
     return "other"
   }
 
-  onMount(async () => {
+  // Exported for test access only; callers must not invoke directly
+  // (bypasses onMount's rename-then-save sequence).
+  export async function run_save(remove_conflicting_id = false) {
+    saving = true
+    error = null
+    is_conflict = false
     try {
-      let final_clone_path = clone_path
-
-      const rename_result = await renameClone(
-        clone_path,
-        project_name,
-        project_id,
-      )
-      if (rename_result.success) {
-        final_clone_path = rename_result.new_clone_path
-        clone_path = final_clone_path
-      } else {
-        throw new Error(
-          rename_result.message || "Failed to rename clone directory",
-        )
-      }
-
       await saveConfig({
         project_id: project_id,
         project_path: project_path,
         git_url: git_url,
-        clone_path: final_clone_path,
+        clone_path: clone_path,
         branch: branch,
         pat_token: pat_token,
         oauth_token: oauth_token,
         auth_mode: auth_mode,
         sync_mode: "auto",
+        remove_conflicting_id,
       })
 
       posthog.capture("import_project", {
@@ -90,8 +82,35 @@
         on_stale_clone()
         return
       }
+      is_conflict = is_duplicate_project_error(e)
       error = createKilnError(e)
     } finally {
+      saving = false
+    }
+  }
+
+  onMount(async () => {
+    try {
+      const rename_result = await renameClone(
+        clone_path,
+        project_name,
+        project_id,
+      )
+      if (rename_result.success) {
+        clone_path = rename_result.new_clone_path
+      } else {
+        throw new Error(
+          rename_result.message || "Failed to rename clone directory",
+        )
+      }
+
+      await run_save(false)
+    } catch (e) {
+      if (is_stale_clone_error(e) && on_stale_clone) {
+        on_stale_clone()
+        return
+      }
+      error = createKilnError(e)
       saving = false
     }
   })
@@ -105,8 +124,13 @@
 {:else if error}
   <h2 class="text-xl font-medium mb-2">Setup Error</h2>
   <Warning warning_message={error.getMessage()} warning_color="error" />
-  <div class="mt-6">
+  <div class="mt-6 flex flex-row gap-3">
     <button class="btn btn-primary" on:click={on_back}> Back </button>
+    {#if is_conflict}
+      <button class="btn btn-error btn-outline" on:click={() => run_save(true)}>
+        Remove existing and re-sync
+      </button>
+    {/if}
   </div>
 {:else if done}
   <div class="flex flex-col items-center py-8 gap-4">

--- a/app/web_ui/src/lib/components/import/step_complete.test.ts
+++ b/app/web_ui/src/lib/components/import/step_complete.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
+import { render, cleanup, fireEvent } from "@testing-library/svelte"
+import { tick } from "svelte"
+
+vi.mock("$lib/git_sync/api", () => ({
+  renameClone: vi.fn().mockResolvedValue({
+    success: true,
+    new_clone_path: "/tmp/proj_1 - My Project",
+    message: "OK",
+  }),
+  saveConfig: vi.fn().mockResolvedValue({}),
+  is_stale_clone_error: vi.fn().mockReturnValue(false),
+  is_duplicate_project_error: vi.fn().mockReturnValue(false),
+  isGitHubUrl: () => true,
+  isGitLabUrl: () => false,
+  GitSyncRequestError: class extends Error {
+    status: number
+    constructor(message: string, status: number) {
+      super(message)
+      this.name = "GitSyncRequestError"
+      this.status = status
+    }
+  },
+}))
+
+vi.mock("$lib/stores/git_import_wizard_store", () => ({
+  clear_wizard_store: vi.fn(),
+}))
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}))
+
+vi.mock("$lib/stores", () => ({
+  load_projects: vi.fn().mockResolvedValue(undefined),
+}))
+
+import StepComplete from "./step_complete.svelte"
+import {
+  saveConfig,
+  is_duplicate_project_error,
+  GitSyncRequestError,
+} from "$lib/git_sync/api"
+
+const baseProps = {
+  git_url: "https://github.com/org/repo.git",
+  pat_token: "token",
+  oauth_token: null,
+  auth_mode: "pat_token",
+  clone_path: "/tmp/clone_abc",
+  branch: "main",
+  project_path: "project.kiln",
+  project_id: "proj_1",
+  project_name: "My Project",
+  on_complete: vi.fn(),
+  on_back: vi.fn(),
+}
+
+const saveConfigResponse = {
+  sync_mode: "auto",
+  auth_mode: "pat_token",
+  remote_name: "origin",
+  branch: "main",
+  clone_path: "/tmp/clone",
+  git_url: "https://github.com/org/repo.git",
+  has_pat_token: true,
+  has_oauth_token: false,
+}
+
+beforeEach(() => {
+  vi.mocked(saveConfig).mockResolvedValue(saveConfigResponse)
+  vi.mocked(is_duplicate_project_error).mockReturnValue(false)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("StepComplete", () => {
+  it("renders saving spinner as initial state", () => {
+    const { container } = render(StepComplete, { props: baseProps })
+    expect(container.textContent).toContain("Saving configuration...")
+    expect(container.querySelector(".loading-spinner")).not.toBeNull()
+  })
+
+  it("renders component without errors", () => {
+    const { container } = render(StepComplete, { props: baseProps })
+    expect(container).toBeTruthy()
+  })
+
+  // Svelte 4 async onMount callbacks do not execute in jsdom/vitest, so we
+  // cannot test the automatic rename->save flow triggered on mount. Instead
+  // we call the component's exported `run_save` directly to exercise the
+  // conflict-detection, retry, and success/error rendering paths. The
+  // underlying helpers (GitSyncRequestError, is_duplicate_project_error,
+  // saveConfig with remove_conflicting_id) are thoroughly unit-tested in
+  // api.test.ts (13+ tests).
+
+  it("run_save success transitions to done state", async () => {
+    const { container, component } = render(StepComplete, {
+      props: baseProps,
+    })
+
+    await component.run_save(false)
+    await tick()
+
+    expect(container.textContent).toContain("Git Auto Sync Enabled")
+    expect(vi.mocked(saveConfig)).toHaveBeenCalledWith(
+      expect.objectContaining({ remove_conflicting_id: false }),
+    )
+  })
+
+  it("run_save error shows Setup Error", async () => {
+    vi.mocked(saveConfig).mockRejectedValueOnce(new Error("Server error"))
+
+    const { container, component } = render(StepComplete, {
+      props: baseProps,
+    })
+
+    await component.run_save(false)
+    await tick()
+
+    expect(container.textContent).toContain("Setup Error")
+  })
+
+  it("run_save 409 conflict shows conflict button, click retries with remove_conflicting_id: true", async () => {
+    const conflictError = new GitSyncRequestError("Duplicate project ID", 409)
+    vi.mocked(saveConfig).mockRejectedValueOnce(conflictError)
+    vi.mocked(is_duplicate_project_error).mockReturnValueOnce(true)
+
+    const { container, component, getByText } = render(StepComplete, {
+      props: baseProps,
+    })
+
+    // First call: triggers 409 conflict
+    await component.run_save(false)
+    await tick()
+
+    // Verify conflict UI appears
+    expect(container.textContent).toContain("Setup Error")
+    expect(container.textContent).toContain("Remove existing and re-sync")
+
+    // Set up the retry to succeed
+    vi.mocked(saveConfig).mockResolvedValueOnce(saveConfigResponse)
+    vi.mocked(is_duplicate_project_error).mockReturnValue(false)
+
+    // Click the conflict-recovery button
+    const retryButton = getByText("Remove existing and re-sync")
+    await fireEvent.click(retryButton)
+    // Allow the async run_save promise to settle
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    // Verify saveConfig was called with remove_conflicting_id: true
+    const calls = vi.mocked(saveConfig).mock.calls
+    expect(calls.length).toBe(2)
+    expect(calls[1][0].remove_conflicting_id).toBe(true)
+
+    // After successful retry, should show success state
+    expect(container.textContent).toContain("Git Auto Sync Enabled")
+  })
+
+  it("non-409 error does not show conflict button", async () => {
+    vi.mocked(saveConfig).mockRejectedValueOnce(new Error("Internal error"))
+    vi.mocked(is_duplicate_project_error).mockReturnValue(false)
+
+    const { container, component } = render(StepComplete, {
+      props: baseProps,
+    })
+
+    await component.run_save(false)
+    await tick()
+
+    expect(container.textContent).toContain("Setup Error")
+    expect(container.textContent).not.toContain("Remove existing and re-sync")
+  })
+})

--- a/app/web_ui/src/lib/components/import/step_complete.test.ts
+++ b/app/web_ui/src/lib/components/import/step_complete.test.ts
@@ -140,14 +140,14 @@ describe("StepComplete", () => {
 
     // Verify conflict UI appears
     expect(container.textContent).toContain("Setup Error")
-    expect(container.textContent).toContain("Remove existing and re-sync")
+    expect(container.textContent).toContain("Remove existing and sync")
 
     // Set up the retry to succeed
     vi.mocked(saveConfig).mockResolvedValueOnce(saveConfigResponse)
     vi.mocked(is_duplicate_project_error).mockReturnValue(false)
 
     // Click the conflict-recovery button
-    const retryButton = getByText("Remove existing and re-sync")
+    const retryButton = getByText("Remove existing and sync")
     await fireEvent.click(retryButton)
     // Allow the async run_save promise to settle
     await new Promise((r) => setTimeout(r, 0))
@@ -174,6 +174,6 @@ describe("StepComplete", () => {
     await tick()
 
     expect(container.textContent).toContain("Setup Error")
-    expect(container.textContent).not.toContain("Remove existing and re-sync")
+    expect(container.textContent).not.toContain("Remove existing and sync")
   })
 })

--- a/app/web_ui/src/lib/git_sync/api.test.ts
+++ b/app/web_ui/src/lib/git_sync/api.test.ts
@@ -20,6 +20,8 @@ import {
   deleteConfig,
   oauthStart,
   oauthStatus,
+  GitSyncRequestError,
+  is_duplicate_project_error,
 } from "./api"
 
 const mockFetch = vi.fn()
@@ -420,6 +422,27 @@ describe("getConfig", () => {
       expect.stringContaining("/api/git_sync/config/proj_1"),
     )
   })
+
+  it("returns null for 404", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(null, 404))
+
+    const result = await getConfig("missing")
+    expect(result).toBeNull()
+  })
+
+  it("throws on non-404 error", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ detail: "Server error" }, 500))
+
+    await expect(getConfig("proj_1")).rejects.toThrow("Server error")
+  })
+
+  it("prefers message over detail in error response", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: "Bad request", detail: "fallback" }, 400),
+    )
+
+    await expect(getConfig("proj_1")).rejects.toThrow("Bad request")
+  })
 })
 
 describe("updateConfig", () => {
@@ -455,6 +478,16 @@ describe("deleteConfig", () => {
     mockFetch.mockResolvedValue(jsonResponse({ detail: "Not found" }, 404))
 
     await expect(deleteConfig("nonexistent")).rejects.toThrow("Not found")
+  })
+
+  it("prefers message over detail in error response", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: "Config not found", detail: "fallback" }, 404),
+    )
+
+    await expect(deleteConfig("nonexistent")).rejects.toThrow(
+      "Config not found",
+    )
   })
 })
 
@@ -525,5 +558,120 @@ describe("oauthStatus", () => {
     await expect(oauthStatus("bad_state")).rejects.toThrow(
       "Failed to check OAuth status",
     )
+  })
+})
+
+describe("GitSyncRequestError", () => {
+  it("is an Error subclass with status", () => {
+    const err = new GitSyncRequestError("conflict", 409)
+    expect(err).toBeInstanceOf(Error)
+    expect(err).toBeInstanceOf(GitSyncRequestError)
+    expect(err.message).toBe("conflict")
+    expect(err.status).toBe(409)
+    expect(err.name).toBe("GitSyncRequestError")
+  })
+
+  it("is thrown by request() on non-ok response", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ message: "Duplicate project" }, 409),
+    )
+
+    const thrown = await testAccess("https://github.com/org/repo.git").catch(
+      (e) => e,
+    )
+    expect(thrown).toBeInstanceOf(GitSyncRequestError)
+    expect(thrown.status).toBe(409)
+    expect(thrown.message).toBe("Duplicate project")
+  })
+
+  it("preserves status for different error codes", async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ message: "Auth failed" }, 401))
+
+    const thrown = await testAccess("https://github.com/org/repo.git").catch(
+      (e) => e,
+    )
+    expect(thrown).toBeInstanceOf(GitSyncRequestError)
+    expect(thrown.status).toBe(401)
+  })
+})
+
+describe("is_duplicate_project_error", () => {
+  it("returns true for 409 GitSyncRequestError", () => {
+    expect(
+      is_duplicate_project_error(new GitSyncRequestError("conflict", 409)),
+    ).toBe(true)
+  })
+
+  it("returns false for non-409 GitSyncRequestError", () => {
+    expect(
+      is_duplicate_project_error(new GitSyncRequestError("error", 500)),
+    ).toBe(false)
+    expect(
+      is_duplicate_project_error(new GitSyncRequestError("error", 401)),
+    ).toBe(false)
+  })
+
+  it("returns false for plain Error", () => {
+    expect(is_duplicate_project_error(new Error("conflict"))).toBe(false)
+  })
+
+  it("returns false for non-Error values", () => {
+    expect(is_duplicate_project_error("conflict")).toBe(false)
+    expect(is_duplicate_project_error(null)).toBe(false)
+    expect(is_duplicate_project_error(undefined)).toBe(false)
+  })
+})
+
+describe("saveConfig with remove_conflicting_id", () => {
+  it("sends remove_conflicting_id in body when provided", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        sync_mode: "auto",
+        remote_name: "origin",
+        branch: "main",
+        clone_path: "/tmp/clone",
+        git_url: "https://github.com/org/repo.git",
+        has_pat_token: true,
+        has_oauth_token: false,
+      }),
+    )
+
+    await saveConfig({
+      project_id: "proj_1",
+      project_path: "project.kiln",
+      git_url: "https://github.com/org/repo.git",
+      clone_path: "/tmp/clone",
+      branch: "main",
+      pat_token: "token",
+      remove_conflicting_id: true,
+    })
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(body.remove_conflicting_id).toBe(true)
+  })
+
+  it("omits remove_conflicting_id when not provided", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        sync_mode: "auto",
+        remote_name: "origin",
+        branch: "main",
+        clone_path: "/tmp/clone",
+        git_url: "https://github.com/org/repo.git",
+        has_pat_token: true,
+        has_oauth_token: false,
+      }),
+    )
+
+    await saveConfig({
+      project_id: "proj_1",
+      project_path: "project.kiln",
+      git_url: "https://github.com/org/repo.git",
+      clone_path: "/tmp/clone",
+      branch: "main",
+    })
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+    expect(body.remove_conflicting_id).toBeUndefined()
   })
 })

--- a/app/web_ui/src/lib/git_sync/api.ts
+++ b/app/web_ui/src/lib/git_sync/api.ts
@@ -1,5 +1,18 @@
 import { base_url } from "$lib/api_client"
 
+export class GitSyncRequestError extends Error {
+  status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = "GitSyncRequestError"
+    this.status = status
+  }
+}
+
+export function is_duplicate_project_error(e: unknown): boolean {
+  return e instanceof GitSyncRequestError && e.status === 409
+}
+
 async function request<T>(
   method: string,
   path: string,
@@ -12,8 +25,9 @@ async function request<T>(
   })
   if (!resp.ok) {
     const detail = await resp.json().catch(() => null)
-    throw new Error(
-      detail?.detail || detail?.message || `Request failed: ${resp.statusText}`,
+    throw new GitSyncRequestError(
+      detail?.message || detail?.detail || `Request failed: ${resp.statusText}`,
+      resp.status,
     )
   }
   return resp.json()
@@ -185,6 +199,7 @@ export async function saveConfig(config: {
   oauth_token?: string | null
   auth_mode?: string
   sync_mode?: string
+  remove_conflicting_id?: boolean
 }): Promise<GitSyncConfigResponse> {
   return post("/api/git_sync/save_config", config)
 }
@@ -198,7 +213,9 @@ export async function getConfig(
   }
   if (!resp.ok) {
     const detail = await resp.json().catch(() => null)
-    throw new Error(detail?.detail || `Request failed: ${resp.statusText}`)
+    throw new Error(
+      detail?.message || detail?.detail || `Request failed: ${resp.statusText}`,
+    )
   }
   return resp.json()
 }
@@ -223,7 +240,9 @@ export async function deleteConfig(
   })
   if (!resp.ok) {
     const detail = await resp.json().catch(() => null)
-    throw new Error(detail?.detail || `Request failed: ${resp.statusText}`)
+    throw new Error(
+      detail?.message || detail?.detail || `Request failed: ${resp.statusText}`,
+    )
   }
   return resp.json()
 }
@@ -237,8 +256,8 @@ export async function oauthStatus(state: string): Promise<OAuthStatusResponse> {
   if (!resp.ok) {
     const detail = await resp.json().catch(() => null)
     throw new Error(
-      detail?.detail ||
-        detail?.message ||
+      detail?.message ||
+        detail?.detail ||
         `Failed to check OAuth status (${resp.status})`,
     )
   }

--- a/app/web_ui/src/routes/(app)/select_tasks_menu.svelte
+++ b/app/web_ui/src/routes/(app)/select_tasks_menu.svelte
@@ -11,6 +11,7 @@
 
   export let new_project_url = "/settings/create_project"
   export let new_task_url = "/settings/create_task"
+  export let import_project_url = "/settings/import_project"
 
   $: project_list = $projects?.projects || []
   let manually_selected_project: Project | null | undefined = undefined
@@ -239,6 +240,13 @@
                 <div class="text-sm text-base-content/60">
                   {tasks_loading_error}
                 </div>
+                <a
+                  href={import_project_url}
+                  class="text-xs text-base-content/40 hover:underline mt-1 inline-block"
+                  on:click={() => dispatch("dismiss")}
+                >
+                  Re-import project?
+                </a>
               </div>
             </div>
           {:else}

--- a/app/web_ui/src/routes/(app)/select_tasks_menu.svelte
+++ b/app/web_ui/src/routes/(app)/select_tasks_menu.svelte
@@ -242,7 +242,7 @@
                 </div>
                 <a
                   href={import_project_url}
-                  class="text-xs text-base-content/40 hover:underline mt-1 inline-block"
+                  class="text-xs text-gray-500 hover:underline mt-4 inline-block"
                   on:click={() => dispatch("dismiss")}
                 >
                   Re-import project?

--- a/app/web_ui/src/routes/(app)/select_tasks_menu.test.ts
+++ b/app/web_ui/src/routes/(app)/select_tasks_menu.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, cleanup, waitFor } from "@testing-library/svelte"
+
+vi.mock("$lib/stores", () => {
+  const { writable } = require("svelte/store")
+  return {
+    projects: writable({
+      projects: [{ id: "proj_1", name: "My Project" }],
+    }),
+    current_project: writable({ id: "proj_1", name: "My Project" }),
+    current_task: writable(null),
+    ui_state: writable({
+      current_project_id: "proj_1",
+      current_task_id: null,
+    }),
+  }
+})
+
+vi.mock("$lib/api_client", () => ({
+  client: {
+    GET: vi.fn(),
+  },
+}))
+
+vi.mock("$app/navigation", () => ({
+  goto: vi.fn(),
+}))
+
+import SelectTasksMenu from "./select_tasks_menu.svelte"
+import { client } from "$lib/api_client"
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  vi.mocked(client.GET).mockReset()
+})
+
+describe("SelectTasksMenu error state", () => {
+  it("shows the error message and re-import link on task load failure", async () => {
+    vi.mocked(client.GET).mockRejectedValue(
+      new Error("Git authentication failed"),
+    )
+
+    const { container } = render(SelectTasksMenu)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Git authentication failed")
+    })
+
+    const link = container.querySelector(
+      'a[href="/settings/import_project"]',
+    ) as HTMLAnchorElement
+    expect(link).not.toBeNull()
+    expect(link.textContent?.trim()).toBe("Re-import project?")
+  })
+
+  it("uses the default import_project_url for the in-app context", async () => {
+    vi.mocked(client.GET).mockRejectedValue(new Error("some error"))
+
+    const { container } = render(SelectTasksMenu)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("some error")
+    })
+
+    const link = container.querySelector(
+      'a[href="/settings/import_project"]',
+    ) as HTMLAnchorElement
+    expect(link).not.toBeNull()
+  })
+
+  it("uses the custom import_project_url prop for the setup context", async () => {
+    vi.mocked(client.GET).mockRejectedValue(new Error("some error"))
+
+    const { container } = render(SelectTasksMenu, {
+      props: { import_project_url: "/setup/import_project" },
+    })
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("some error")
+    })
+
+    const link = container.querySelector(
+      'a[href="/setup/import_project"]',
+    ) as HTMLAnchorElement
+    expect(link).not.toBeNull()
+    expect(link.textContent?.trim()).toBe("Re-import project?")
+  })
+
+  it("does not show re-import link when tasks load successfully", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(client.GET).mockResolvedValue({
+      data: [{ id: "task_1", name: "My Task" }],
+      error: undefined,
+      response: new Response(),
+    } as any)
+
+    const { container } = render(SelectTasksMenu)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("My Task")
+    })
+
+    const link = container.querySelector('a[href="/settings/import_project"]')
+    expect(link).toBeNull()
+  })
+})

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/select_task/+page.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/select_task/+page.svelte
@@ -25,6 +25,7 @@
   <SelectTasksMenu
     new_project_url="/setup/create_project"
     new_task_url="/setup/create_task"
+    import_project_url="/setup/import_project"
   />
 </div>
 

--- a/libs/core/kiln_ai/utils/project_utils.py
+++ b/libs/core/kiln_ai/utils/project_utils.py
@@ -19,6 +19,23 @@ def project_from_id(project_id: str) -> Project | None:
     return None
 
 
+def remove_project_from_config(project_path: str) -> str | None:
+    """Remove a project from Kiln config. Does NOT delete files from disk.
+
+    Returns the git-sync clone_path if the project was git-synced, else None.
+    """
+    projects = Config.shared().projects or []
+    Config.shared().save_setting("projects", [p for p in projects if p != project_path])
+
+    git_sync = Config.shared().git_sync_projects or {}
+    clone_path = None
+    if project_path in git_sync:
+        clone_path = git_sync[project_path].get("clone_path")
+        git_sync.pop(project_path)
+        Config.shared().save_setting("git_sync_projects", git_sync)
+    return clone_path
+
+
 class DuplicateProjectError(Exception):
     """Raised when trying to import a project whose ID is already registered."""
 

--- a/libs/core/kiln_ai/utils/test_project_utils.py
+++ b/libs/core/kiln_ai/utils/test_project_utils.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -7,6 +7,7 @@ from kiln_ai.utils.project_utils import (
     DuplicateProjectError,
     check_duplicate_project_id,
     project_from_id,
+    remove_project_from_config,
 )
 
 
@@ -122,3 +123,69 @@ class TestCheckDuplicateProjectId:
         with patch("kiln_ai.utils.project_utils.Config.shared") as mock_config:
             mock_config.return_value.projects = []
             check_duplicate_project_id("proj-1", "/path/project.kiln")
+
+
+class TestRemoveProjectFromConfig:
+    def test_removes_project_and_git_sync(self):
+        with patch("kiln_ai.utils.project_utils.Config.shared") as mock_config:
+            mock_config.return_value.projects = [
+                "/path/to/project.kiln",
+                "/path/to/other.kiln",
+            ]
+            mock_config.return_value.git_sync_projects = {
+                "/path/to/project.kiln": {
+                    "clone_path": "/clones/repo",
+                    "branch": "main",
+                },
+                "/path/to/other.kiln": {
+                    "clone_path": "/clones/other",
+                    "branch": "dev",
+                },
+            }
+            mock_config.return_value.save_setting = MagicMock()
+
+            result = remove_project_from_config("/path/to/project.kiln")
+
+        assert result == "/clones/repo"
+        mock_config.return_value.save_setting.assert_any_call(
+            "projects", ["/path/to/other.kiln"]
+        )
+        mock_config.return_value.save_setting.assert_any_call(
+            "git_sync_projects",
+            {"/path/to/other.kiln": {"clone_path": "/clones/other", "branch": "dev"}},
+        )
+
+    def test_non_git_synced_project(self):
+        with patch("kiln_ai.utils.project_utils.Config.shared") as mock_config:
+            mock_config.return_value.projects = ["/path/to/project.kiln"]
+            mock_config.return_value.git_sync_projects = {}
+            mock_config.return_value.save_setting = MagicMock()
+
+            result = remove_project_from_config("/path/to/project.kiln")
+
+        assert result is None
+        mock_config.return_value.save_setting.assert_called_once_with("projects", [])
+
+    def test_missing_project_is_idempotent(self):
+        with patch("kiln_ai.utils.project_utils.Config.shared") as mock_config:
+            mock_config.return_value.projects = ["/path/to/other.kiln"]
+            mock_config.return_value.git_sync_projects = {}
+            mock_config.return_value.save_setting = MagicMock()
+
+            result = remove_project_from_config("/nonexistent/project.kiln")
+
+        assert result is None
+        mock_config.return_value.save_setting.assert_called_once_with(
+            "projects", ["/path/to/other.kiln"]
+        )
+
+    def test_none_projects_list(self):
+        with patch("kiln_ai.utils.project_utils.Config.shared") as mock_config:
+            mock_config.return_value.projects = None
+            mock_config.return_value.git_sync_projects = None
+            mock_config.return_value.save_setting = MagicMock()
+
+            result = remove_project_from_config("/path/to/project.kiln")
+
+        assert result is None
+        mock_config.return_value.save_setting.assert_called_once_with("projects", [])

--- a/libs/server/kiln_server/project_api.py
+++ b/libs/server/kiln_server/project_api.py
@@ -8,6 +8,7 @@ from kiln_ai.utils.config import Config
 from kiln_ai.utils.project_utils import (
     DuplicateProjectError,
     check_duplicate_project_id,
+    remove_project_from_config,
 )
 from kiln_ai.utils.project_utils import (
     project_from_id as project_from_id_core,
@@ -135,6 +136,13 @@ def connect_project_api(app: FastAPI):
         project_path: Annotated[
             str, Query(description="File path to the project.kiln file to import.")
         ],
+        remove_conflicting_id: Annotated[
+            bool,
+            Query(
+                description="When true and a duplicate project ID conflict is detected, "
+                "remove the existing project registration before importing."
+            ),
+        ] = False,
     ) -> Project:
         if project_path is None or not os.path.exists(project_path):
             raise HTTPException(
@@ -154,7 +162,18 @@ def connect_project_api(app: FastAPI):
             try:
                 check_duplicate_project_id(project.id, project_path)
             except DuplicateProjectError as e:
-                raise HTTPException(status_code=409, detail=str(e))
+                if not remove_conflicting_id:
+                    raise HTTPException(status_code=409, detail=str(e))
+                # Resolve and de-register the conflicting project before proceeding.
+                # Layering caveat: libs/server cannot call GitSyncRegistry.unregister
+                # (app layer), so if the removed project was git-synced and had a live
+                # manager this session, its in-memory manager lingers until restart.
+                conflicting = project_from_id_core(project.id)
+                if conflicting is not None:
+                    remove_project_from_config(str(conflicting.path))
+                # If conflicting is None the project is already gone from
+                # config (e.g. manually removed); safe to fall through to
+                # add_project_to_config which will (re-)register the path.
 
         # add to projects list
         add_project_to_config(project_path)

--- a/libs/server/kiln_server/server.py
+++ b/libs/server/kiln_server/server.py
@@ -112,7 +112,7 @@ tags_metadata = [
 ]
 
 
-def make_app(lifespan=None):
+def make_app(lifespan=None, extra_middleware: list[type] | None = None):
     app = FastAPI(
         title="Kiln AI API",
         summary="A REST API for Kiln AI.",
@@ -149,6 +149,16 @@ def make_app(lifespan=None):
         f"https://localhost:{frontend_port}",
         f"https://127.0.0.1:{frontend_port}",
     ]
+
+    # Install any caller-provided middleware BEFORE CORS so it ends up inner to
+    # CORS. CORS must remain the outermost middleware: Starlette makes the
+    # last-added middleware outermost, and CORS only adds its headers to
+    # responses that pass back out through it. Inner middleware that
+    # short-circuits a response (e.g. GitSyncMiddleware returning a git-sync
+    # error) would otherwise bypass CORS entirely, and the browser would block
+    # the response with "origin not allowed".
+    for middleware_class in extra_middleware or []:
+        app.add_middleware(middleware_class)
 
     app.add_middleware(
         # Type issue https://github.com/astral-sh/ty/issues/1635

--- a/libs/server/kiln_server/test_project_api.py
+++ b/libs/server/kiln_server/test_project_api.py
@@ -265,6 +265,125 @@ def test_import_project_duplicate_different_path(client):
     assert "remove project" in response.json()["message"]
 
 
+def test_import_project_duplicate_remove_conflicting_id_success(client):
+    mock_project = Project(
+        name="Imported Project", description="An imported project", id="dup-id"
+    )
+    conflicting_project = Project(
+        name="Existing Project",
+        description="Already imported",
+        id="dup-id",
+        path="/old/path/project.kiln",
+    )
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("kiln_ai.datamodel.Project.load_from_file", return_value=mock_project),
+        patch(
+            "kiln_server.project_api.check_duplicate_project_id",
+            side_effect=DuplicateProjectError(
+                'You already have a project with this ID. You must remove project "Existing" before adding this.',
+                same_path=False,
+            ),
+        ),
+        patch(
+            "kiln_server.project_api.project_from_id_core",
+            return_value=conflicting_project,
+        ),
+        patch("kiln_server.project_api.remove_project_from_config") as mock_remove,
+        patch("kiln_server.project_api.add_project_to_config") as mock_add,
+    ):
+        response = client.post(
+            "/api/import_project?project_path=/new/path/project.kiln&remove_conflicting_id=true"
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["name"] == "Imported Project"
+    mock_remove.assert_called_once_with("/old/path/project.kiln")
+    mock_add.assert_called_once_with("/new/path/project.kiln")
+
+
+def test_import_project_duplicate_remove_conflicting_id_false_still_409(client):
+    mock_project = Project(
+        name="Imported Project", description="An imported project", id="dup-id"
+    )
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("kiln_ai.datamodel.Project.load_from_file", return_value=mock_project),
+        patch(
+            "kiln_server.project_api.check_duplicate_project_id",
+            side_effect=DuplicateProjectError(
+                "You already have a project with this ID.",
+                same_path=False,
+            ),
+        ),
+    ):
+        response = client.post(
+            "/api/import_project?project_path=/path/to/project.kiln&remove_conflicting_id=false"
+        )
+
+    assert response.status_code == 409
+
+
+def test_import_project_duplicate_same_path_remove_conflicting_id(client):
+    """Re-importing the exact same path with remove_conflicting_id=true is a
+    benign de-register + re-add of the same path."""
+    mock_project = Project(
+        name="Imported Project", description="An imported project", id="dup-id"
+    )
+    conflicting_project = Project(
+        name="Imported Project",
+        description="An imported project",
+        id="dup-id",
+        path="/path/to/project.kiln",
+    )
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("kiln_ai.datamodel.Project.load_from_file", return_value=mock_project),
+        patch(
+            "kiln_server.project_api.check_duplicate_project_id",
+            side_effect=DuplicateProjectError(
+                "This project is already imported.", same_path=True
+            ),
+        ),
+        patch(
+            "kiln_server.project_api.project_from_id_core",
+            return_value=conflicting_project,
+        ),
+        patch("kiln_server.project_api.remove_project_from_config") as mock_remove,
+        patch("kiln_server.project_api.add_project_to_config") as mock_add,
+    ):
+        response = client.post(
+            "/api/import_project?project_path=/path/to/project.kiln&remove_conflicting_id=true"
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["name"] == "Imported Project"
+    mock_remove.assert_called_once_with("/path/to/project.kiln")
+    mock_add.assert_called_once_with("/path/to/project.kiln")
+
+
+def test_import_project_remove_conflicting_id_no_conflict(client):
+    mock_project = Project(
+        name="Imported Project", description="An imported project", id="dup-id"
+    )
+    with (
+        patch("os.path.exists", return_value=True),
+        patch("kiln_ai.datamodel.Project.load_from_file", return_value=mock_project),
+        patch("kiln_server.project_api.check_duplicate_project_id"),
+        patch("kiln_server.project_api.add_project_to_config") as mock_add,
+    ):
+        response = client.post(
+            "/api/import_project?project_path=/path/to/project.kiln&remove_conflicting_id=true"
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["name"] == "Imported Project"
+    mock_add.assert_called_once_with("/path/to/project.kiln")
+
+
 def test_import_project_missing_path(client):
     response = client.post("/api/import_project")
 

--- a/specs/projects/git_auth_recovery/architecture.md
+++ b/specs/projects/git_auth_recovery/architecture.md
@@ -1,0 +1,370 @@
+---
+status: complete
+---
+
+# Architecture: Git Creds Error Recovery
+
+Single architecture doc (no separate component designs). The change is localized to
+a handful of files across the git-sync middleware/manager, two API endpoints, and
+two small frontend affordances.
+
+## Layering note (important)
+
+Three layers are involved, and dependencies only flow downward:
+
+- `libs/core` (`kiln_ai`) — persistent config (`Config`: `projects` list,
+  `git_sync_projects` dict) and project utils. Knows nothing about runtime managers.
+- `libs/server` (`kiln_server`) — core REST API, including
+  `POST /api/import_project` and the `custom_errors` handlers.
+- `app/desktop` (`git_sync`) — the git-sync middleware, `GitSyncManager`,
+  `GitSyncRegistry` (in-memory managers + background sync), and the git-sync API
+  (`save_config`, `delete_project`).
+
+Consequence: the **persistent-config** part of "remove a project" lives in
+`libs/core` so both `libs/server` (local import) and `app/desktop` (git save_config,
+delete_project) can call it. The **runtime-registry teardown** part is an
+`app/desktop` wrapper layered on top. See "Shared removal helper" below.
+
+---
+
+## Part A — Middleware error envelope
+
+**File:** `app/desktop/git_sync/middleware.py`
+
+Every JSON error `Response` the middleware constructs currently uses
+`{"detail": message}`. Change all of them to `{"message": message}` to match the
+app-wide convention enforced by `libs/server/kiln_server/custom_errors.py`
+(`http_exception_handler` emits `{"message": exc.detail}`). The middleware bypasses
+that handler (it returns `Response` objects directly), which is why it must self-apply
+the convention.
+
+Sites to change (all `json.dumps({"detail": ...})` → `{"message": ...}`):
+
+1. `_no_write_lock_asgi` read-sync error (~L112-116)
+2. `dispatch` read-path sync error (~L158-162)
+3. `_StreamingUnderWriteLock` branch (~L217-226)
+4. write-path `GitSyncError` branch (~L228-233)
+5. dev-mode dirty-check 500 (~L268-279)
+6. `_unmatched_dispatch` dev-mode 500 (~L318-329)
+
+No status codes change here. No frontend change: `createKilnError`
+(`error_handlers.ts`) already reads `message`.
+
+---
+
+## Part B — Distinct auth error (`GitAuthError`)
+
+### B.1 New error type
+
+**File:** `app/desktop/git_sync/errors.py`
+
+```python
+class GitAuthError(GitSyncError):
+    """Git authentication failed or expired (bad/expired token, 401/403)."""
+```
+
+### B.2 Classify in `fetch()`
+
+**File:** `app/desktop/git_sync/git_sync_manager.py`
+
+Add a module-level best-effort classifier and use it in `fetch()`:
+
+```python
+_AUTH_ERROR_MARKERS = (
+    "authentication",
+    "authoriz",          # authorization / unauthorized
+    "credential",
+    "401",
+    "403",
+    "too many redirects",
+    "invalid username or password",
+    "password authentication",
+)
+
+def _is_auth_error(e: Exception) -> bool:
+    msg = str(e).lower()
+    return any(marker in msg for marker in _AUTH_ERROR_MARKERS)
+```
+
+```python
+async def fetch(self) -> None:
+    try:
+        await self._run_git(self._fetch_sync)
+    except pygit2.GitError as e:
+        if _is_auth_error(e):
+            raise GitAuthError(f"Git authentication failed: {e}") from e
+        raise RemoteUnreachableError(f"Cannot sync with remote: {e}") from e
+```
+
+pygit2's error text is not a stable API; when markers don't match we fall back to
+`RemoteUnreachableError` (today's behavior) — classification never makes messaging
+worse. The `asyncio.TimeoutError` path in `_run_git` continues to raise
+`RemoteUnreachableError` (a genuine timeout, not auth).
+
+### B.3 Let `GitAuthError` propagate (critical)
+
+`ensure_fresh()` and `ensure_fresh_for_read()` currently wrap any non-
+`RemoteUnreachableError` exception from `fetch()` back into `RemoteUnreachableError`:
+
+```python
+try:
+    await self.fetch()
+except RemoteUnreachableError:
+    raise
+except Exception as e:
+    raise RemoteUnreachableError(f"Cannot sync with remote: {e}") from e
+```
+
+Since `GitAuthError` is a `GitSyncError` (not a `RemoteUnreachableError`), it would be
+silently re-wrapped and the classification lost. Change both methods' first `except`
+to the base class so any `GitSyncError` propagates unchanged:
+
+```python
+except GitSyncError:
+    raise
+```
+
+Update the imports in `git_sync_manager.py` to include `GitAuthError` and
+`GitSyncError`.
+
+### B.4 Map in middleware
+
+**File:** `app/desktop/git_sync/middleware.py` — add to `ERROR_MAP`:
+
+```python
+GitAuthError: (
+    401,
+    "Git authentication failed or expired. Re-import the project to "
+    "reconnect with fresh credentials.",
+),
+```
+
+`GitAuthError` is a sibling of the other mapped types (no subclass ordering issue in
+`_map_error`'s `isinstance` scan). Import `GitAuthError` in the middleware.
+
+Effect: a git-synced read (`GET /api/projects/{id}/tasks`) with expired creds now
+returns `401 {"message": "Git authentication failed or expired. …"}`, which the task
+picker renders verbatim. Mutating requests through `atomic_write` also surface it via
+the existing write-path `except GitSyncError` branch — a free, consistent bonus.
+(Push-failure auth classification inside `commit_and_push` remains out of scope.)
+
+---
+
+## Part C — Re-import recovery
+
+### C.1 Shared removal helper (config layer + registry layer)
+
+**Core (config) — `libs/core/kiln_ai/utils/project_utils.py`:**
+
+```python
+def remove_project_from_config(project_path: str) -> str | None:
+    """Remove a project from Kiln config. Does NOT delete files from disk.
+
+    Returns the git-sync clone_path if the project was git-synced, else None.
+    """
+    projects = Config.shared().projects or []
+    Config.shared().save_setting(
+        "projects", [p for p in projects if p != project_path]
+    )
+
+    git_sync = Config.shared().git_sync_projects or {}
+    clone_path = None
+    if project_path in git_sync:
+        clone_path = git_sync[project_path].get("clone_path")
+        git_sync.pop(project_path)
+        Config.shared().save_setting("git_sync_projects", git_sync)
+    return clone_path
+```
+
+This is exactly the persistent-config portion of today's `delete_project`.
+
+**App (registry) — `app/desktop/git_sync/git_sync_api.py`:**
+
+```python
+async def _deregister_project(project_path: str) -> None:
+    clone_path = remove_project_from_config(project_path)
+    if clone_path is not None:
+        await GitSyncRegistry.unregister(Path(clone_path))
+```
+
+Refactor `delete_project` to use it:
+
+```python
+project = project_from_id(project_id)
+# (existing not-found handling preserved)
+await _deregister_project(str(project.path))
+return {"message": f"Project removed. ID: {project_id}"}
+```
+
+### C.2 `remove_conflicting_id` on git `save_config`
+
+**File:** `app/desktop/git_sync/git_sync_api.py`
+
+- Add `remove_conflicting_id: bool = False` to `SaveConfigRequest`.
+- In `api_save_config`, change the duplicate handling:
+
+```python
+try:
+    check_duplicate_project_id(request.project_id, full_project_path)
+except DuplicateProjectError as e:
+    if not request.remove_conflicting_id:
+        raise HTTPException(status_code=409, detail=str(e))
+    conflicting = project_from_id(request.project_id)
+    if conflicting is not None:
+        await _deregister_project(str(conflicting.path))
+    # fall through to save the new clone
+```
+
+The conflicting project shares `request.project_id` (that's why it conflicts), so
+`project_from_id(request.project_id)` resolves it. After de-registration the
+subsequent `save_git_sync_config` + `add_project_to_config` register the new clone.
+Files for the old clone remain on disk (intentional). Behavior with the flag `False`
+is unchanged (409).
+
+Import `project_from_id` and `remove_project_from_config` as needed.
+
+### C.3 Local `import_project` parity (Phase 4)
+
+**File:** `libs/server/kiln_server/project_api.py`
+
+- Add `remove_conflicting_id: bool = False` query parameter to the
+  `POST /api/import_project` endpoint.
+- On `DuplicateProjectError` with the flag set, call the **core** helper
+  `remove_project_from_config(str(conflicting.path))` (resolved via
+  `project_from_id(project.id)`), then proceed with `add_project_to_config`.
+
+Layering caveat: `libs/server` cannot call `GitSyncRegistry.unregister` (app layer).
+If the removed conflicting project happened to be git-synced *and* had a live manager
+this session, its in-memory manager/background-sync lingers until restart. This is a
+rare edge for local-folder import and is acceptable; document it in a code comment.
+(The git path in C.2 does full registry teardown.)
+
+### C.4 Frontend — task-picker recovery link
+
+**File:** `app/web_ui/src/routes/(app)/select_tasks_menu.svelte`
+
+- Add an export prop `import_project_url: string` (default e.g.
+  `/settings/import_project`), alongside the existing `new_project_url` /
+  `new_task_url`.
+- In the task-load **error state** block (currently the "Error" panel), render the
+  accurate `tasks_loading_error` message and, directly beneath it, a subtle link:
+
+```svelte
+<a href={import_project_url} class="text-xs text-base-content/40 hover:underline mt-1">
+  Re-import project?
+</a>
+```
+
+  Small, grey, low-emphasis. Shown for any task-load error.
+
+**File:** `app/web_ui/src/routes/(fullscreen)/setup/(setup)/select_task/+page.svelte`
+
+- Pass `import_project_url="/setup/import_project"` to `SelectTasksMenu` (the
+  fullscreen setup context). The in-app sidebar usage keeps the default
+  `/settings/import_project`.
+
+The recovery link lands the user on the generic import method picker, where they pick
+"Git Auto Sync" (fresh creds) or "Local Folder". `handle_complete` in
+`/setup/import_project/+page.svelte` already routes back to `select_task` afterward;
+with fresh creds the task load now succeeds.
+
+### C.5 Frontend — git wizard "Remove existing and re-sync"
+
+**File:** `app/web_ui/src/lib/git_sync/api.ts`
+
+The hand-rolled `request()` helper throws a bare `Error` with no status. Give it a
+typed error so callers can detect the 409 conflict (mirroring `is_stale_clone_error`):
+
+```ts
+export class GitSyncRequestError extends Error {
+  status: number
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = "GitSyncRequestError"
+    this.status = status
+  }
+}
+
+export function is_duplicate_project_error(e: unknown): boolean {
+  return e instanceof GitSyncRequestError && e.status === 409
+}
+```
+
+In `request()`, throw `new GitSyncRequestError(msg, resp.status)` instead of
+`new Error(msg)`. Existing callers (which read `.message`) are unaffected — it's an
+`Error` subclass. Add `remove_conflicting_id?: boolean` to `saveConfig`'s config
+type so it passes through in the POST body.
+
+**File:** `app/web_ui/src/lib/components/import/step_complete.svelte`
+
+- Extract the save call into `async function run_save(remove_conflicting_id = false)`
+  that calls `saveConfig({ ...payload, remove_conflicting_id })` using the
+  already-renamed `clone_path`. `onMount` runs `renameClone` once, then
+  `run_save(false)`. (Rename must not re-run on retry.)
+- Track `let is_conflict = false`. In the catch: keep the existing
+  `is_stale_clone_error` branch; then set
+  `is_conflict = is_duplicate_project_error(e)` and `error = createKilnError(e)`.
+- In the error view, when `is_conflict`, additionally show a destructive (red) button
+  "Remove existing and re-sync" that calls `run_save(true)` (resetting `saving`,
+  `error`, `is_conflict`). The red, explicitly-labeled button is the confirmation; no
+  dialog. "Back" remains.
+
+### C.6 Frontend — local import "Remove existing and re-import" (Phase 4)
+
+**File:** `app/web_ui/src/lib/components/import/import_project.svelte`
+
+The local-file path uses the openapi-fetch `client.POST`, which exposes `response`:
+
+```ts
+const { data, error: post_error, response } = await client.POST(
+  "/api/import_project",
+  { params: { query: { project_path: import_project_path, ...(retry && { remove_conflicting_id: true }) } } },
+)
+```
+
+- Track `let import_conflict = false`; set it from `response?.status === 409` on error.
+- When `import_conflict`, show a red "Remove existing and re-import" button that
+  re-issues the POST with `remove_conflicting_id: true`.
+
+---
+
+## Error handling strategy
+
+- Auth misclassification: false negative → falls back to today's
+  `RemoteUnreachableError` (no regression); false positive → user is routed to
+  re-import, which still recovers most states.
+- `remove_conflicting_id` is a no-op when no duplicate exists; idempotent (removing an
+  already-absent path is harmless).
+- `same_path` duplicates don't arise in re-import (fresh clone path); if they did,
+  de-register + re-add the same path is benign.
+- Recovery preserves the project ID (stored in `project.kiln`), so
+  `ui_state.current_project_id` still resolves post-recovery.
+
+## Testing strategy
+
+Frameworks: pytest (Python), vitest/`@testing-library/svelte` (web).
+
+**Python**
+- `middleware`: each error branch returns `{"message": ...}` (update existing
+  assertions that check `detail`); `GitAuthError` → 401 + message via `ERROR_MAP`.
+- `git_sync_manager`: `fetch()` raises `GitAuthError` for auth-marker `pygit2.GitError`
+  and `RemoteUnreachableError` otherwise; `ensure_fresh_for_read` propagates
+  `GitAuthError` unchanged (regression guard for the re-wrap bug).
+- `project_utils`: `remove_project_from_config` removes the path and git_sync entry,
+  returns `clone_path`, idempotent on a missing path.
+- `git_sync_api`: `save_config` with `remove_conflicting_id=true` de-registers the
+  conflict (files remain on disk) and succeeds; `false` still 409; `delete_project`
+  unchanged via the shared helper.
+- `project_api`: `import_project` with `remove_conflicting_id=true` (Phase 4).
+
+**Web**
+- `select_tasks_menu`: error state renders the message + the "Re-import project?" link
+  with the correct `import_project_url` per context.
+- `api.ts`: `is_duplicate_project_error` true only for status-409 `GitSyncRequestError`.
+- `step_complete`: 409 shows "Remove existing and re-sync"; retry calls `saveConfig`
+  with the flag and reaches `done`.
+- `import_project` local step: 409 shows "Remove existing and re-import" and retries
+  with the flag (Phase 4).
+
+**Checks:** regenerate OpenAPI bindings (`generate_schema.sh`) after the request-model
+changes; run full Python + web lint/format/typecheck/test/build.

--- a/specs/projects/git_auth_recovery/functional_spec.md
+++ b/specs/projects/git_auth_recovery/functional_spec.md
@@ -1,0 +1,275 @@
+---
+status: complete
+---
+
+# Functional Spec: Git Creds Error Recovery
+
+## Problem
+
+A user with a single Git-synced project hit an unrecoverable state when their Git
+credentials expired:
+
+1. **Misleading error**: The expired-token failure was reported as
+   "Cannot sync with remote. Check your connection." — a connectivity message for
+   an auth problem.
+2. **Broken error display**: The task picker rendered `Tasks failed to load:
+   [Object object]` (or "Unknown error") instead of the API's message string.
+3. **No recovery path**: With one project the app redirects to `/setup/select_task`,
+   which has no way to remove/re-import/re-auth a project, so the user was stuck.
+
+This project delivers three coordinated fixes: correct the error shape, classify
+auth failures distinctly, and add a re-import recovery path that works even from
+the locked-out single-project state.
+
+---
+
+## Part A — Fix the task-picker error display
+
+### Root cause
+
+Kiln's app-wide error convention is `{"message": ...}`. The server's
+`connect_custom_errors` handler (`libs/server/kiln_server/custom_errors.py`)
+reshapes every `HTTPException` into `{"message": exc.detail}`, and the frontend
+helper `createKilnError` (`app/web_ui/src/lib/utils/error_handlers.ts`) only reads
+`message`.
+
+`GitSyncMiddleware` runs **outside** the exception-handler chain (it returns a
+`Response` directly), so its error bodies use FastAPI's raw `{"detail": ...}`
+shape (`app/desktop/git_sync/middleware.py`). `createKilnError` can't read
+`detail`, so it falls through to "Unknown error" (rendered as `[Object object]`
+where the raw object is interpolated). The API string is correct; only the
+**envelope shape** is wrong for this one code path.
+
+### Behavior
+
+- **All** JSON error responses emitted by `GitSyncMiddleware` use the
+  `{"message": ...}` envelope (matching the app convention), not `{"detail": ...}`.
+  This covers every error-return site in the middleware: the read-path sync error
+  (both the `dispatch` read branch and the `_no_write_lock_asgi` branch), the
+  write-path `GitSyncError` branch, the `_StreamingUnderWriteLock` branch, and the
+  dev-mode dirty-check branches.
+- After this change, `createKilnError` extracts the real message and the task
+  picker shows e.g. "Tasks failed to load: Git authentication failed or expired…".
+- **No frontend change** is required for the display fix. `createKilnError` is
+  left as-is (we are not adding `detail` parsing); the fix is server-side only.
+
+### Out of scope for Part A
+
+- Hardening `createKilnError` to also parse FastAPI's native `{detail}` shape was
+  considered and explicitly deferred. The middleware is the only path that emitted
+  `{detail}`; fixing it at the source is sufficient.
+
+---
+
+## Part B — Distinguish auth failures from connectivity failures
+
+### Root cause
+
+`GitSyncManager.fetch()` wraps every `pygit2.GitError` — including HTTP 401/403
+auth failures — as `RemoteUnreachableError`
+(`app/desktop/git_sync/git_sync_manager.py`), which the middleware's `ERROR_MAP`
+maps to "Cannot sync with remote. Check your connection." There is no auth-specific
+error type today.
+
+### Behavior
+
+- Add a new error type `GitAuthError(GitSyncError)` in
+  `app/desktop/git_sync/errors.py`.
+- In `GitSyncManager.fetch()` (the read-sync path that produced the reported bug),
+  when a `pygit2.GitError` is caught, **classify** it:
+  - If the error indicates an authentication/authorization failure, raise
+    `GitAuthError`.
+  - Otherwise raise `RemoteUnreachableError` (unchanged behavior).
+- Classification is **best-effort** by inspecting the pygit2 error (e.g. message
+  containing any of: `401`, `403`, `authentication`, `authorization`,
+  `unauthorized`, `credentials`, `too many redirects`/auth-replay). pygit2's error
+  text is not a stable API, so when in doubt we fall back to
+  `RemoteUnreachableError` (today's behavior) — we never make messaging *worse*.
+- Add `GitAuthError` to the middleware `ERROR_MAP`:
+  - Status: `401`.
+  - Message: "Git authentication failed or expired. Re-import the project to
+    reconnect with fresh credentials." (final wording may be tuned during
+    implementation/UX review).
+- Scope: only `fetch()` is required for this project (it is the read path behind
+  the reported `/tasks` failure). The push path already has its own
+  rebase/conflict handling; auth classification there is **out of scope** for now.
+
+---
+
+## Part C — Recovery via re-import (`remove_conflicting_id`)
+
+The chosen recovery mechanism is **re-import only**: the user re-runs the import
+flow (which collects fresh credentials), and when the duplicate-project-ID conflict
+appears, a "Remove existing and re-sync" action removes the old project
+registration and completes the import.
+
+### C.1 Entry point — make the locked-out state recoverable
+
+- `/setup/select_task` renders `SelectTasksMenu`
+  (`app/web_ui/src/routes/(app)/select_tasks_menu.svelte`), which today offers only
+  "+ New Project" and "+ New Task" — no import, remove, or settings access.
+- When task loading fails, the picker's **error state** shows:
+  - The corrected, accurate error message (from Parts A/B).
+  - Directly **under** the error, a subtle recovery link — small, grey, low
+    emphasis — reading "Re-import project?". It navigates to the **import flow**,
+    landing on the **generic import method picker** (where the user chooses "Local
+    Folder" vs "Git Auto Sync").
+- The link is shown for **any** task-load error (it is the escape hatch from the
+  lock-out point); we do not try to detect git-vs-local errors in the picker.
+- `SelectTasksMenu` is used in two contexts with different chrome, so the import
+  destination is passed in as a prop (mirroring the existing `new_project_url` /
+  `new_task_url` props):
+  - Setup (fullscreen) context → `/setup/import_project`.
+  - In-app (sidebar dialog) context → `/settings/import_project`.
+- The link appears only in the task-load **error state**. It is not added to the
+  normal/healthy picker.
+
+### C.2 Re-import flow (existing wizard, fresh creds)
+
+- The recovery navigation lands on the import method picker. For a Git-synced
+  broken project the user chooses **Git Auto Sync** and proceeds through the
+  existing wizard: URL → credentials (**fresh PAT or OAuth here**) → branch →
+  clone → project → complete.
+- The wizard clones to a **new** directory; the old clone is untouched.
+- Because the project ID is stored in `project.kiln` inside the repo, the
+  re-imported project has the **same ID** as the broken one. Two consequences:
+  1. The final `save_config` step hits the duplicate-ID conflict (see C.3).
+  2. After successful recovery, the user's persisted selection
+     (`ui_state.current_project_id`) still resolves — no dangling selection.
+
+### C.3 Backend — `remove_conflicting_id` on save_config
+
+Endpoint: `POST /api/git_sync/save_config`
+(`app/desktop/git_sync/git_sync_api.py`).
+
+- Add an optional field `remove_conflicting_id: bool = False` to
+  `SaveConfigRequest`.
+- Current behavior: `check_duplicate_project_id(...)` raises `DuplicateProjectError`
+  → `HTTPException(409, detail=str(e))`.
+- New behavior when `remove_conflicting_id` is `True` and a duplicate is detected:
+  1. Remove the **existing** project that owns the conflicting ID
+     (`request.project_id`), using the **same removal logic** as the Settings
+     "Remove project" flow — i.e. the body of `delete_project` factored into a
+     shared helper. Removal:
+     - removes the project path from `Config.shared().projects`,
+     - removes its `git_sync_projects` entry,
+     - unregisters its `GitSyncManager` from `GitSyncRegistry`,
+     - **does not delete any files from disk** (the old clone is left on disk).
+  2. Proceed with the normal `save_config` (register the new clone, save config).
+- Net effect: equivalent to two existing API calls (delete project + save config)
+  performed atomically in one request. No new removal semantics are invented; the
+  recovery path reuses the de-register-only behavior of `delete_project`.
+- When `remove_conflicting_id` is `False` (default), behavior is unchanged
+  (raises 409).
+- The shared helper is also called by the existing `delete_project` endpoint so
+  both paths share one implementation.
+
+### C.4 Frontend — "Remove existing and re-sync" button
+
+- The duplicate conflict surfaces in the wizard's final step
+  (`app/web_ui/src/lib/components/import/step_complete.svelte`), currently shown as
+  a "Setup Error" with only a "Back" button.
+- When `saveConfig` fails with the duplicate-ID conflict (HTTP 409), the error view
+  additionally shows a destructive-styled (red) **"Remove existing and re-sync"**
+  button.
+  - The red, explicitly-labeled button is itself the confirmation; no separate
+    confirm dialog is required.
+  - Clicking it re-invokes `saveConfig` with the same payload plus
+    `remove_conflicting_id: true`.
+  - On success, the flow proceeds to the normal "done" state and `on_complete`.
+- "Back" remains available as a non-destructive alternative.
+- The `saveConfig` API wrapper (`app/web_ui/src/lib/git_sync/api.ts`) and generated
+  OpenAPI bindings are updated to carry the new optional field.
+
+### C.5 Local-folder import parity (separate phase)
+
+The recovery navigation lands on the generic method picker, so a user may choose
+"Local Folder" instead of "Git Auto Sync". Local import must therefore support the
+same recovery, built as a **separate implementation phase** after the Git path.
+
+- Endpoint: `POST /api/import_project`
+  (`libs/server/kiln_server/project_api.py`). Add an optional
+  `remove_conflicting_id: bool = False` query parameter. When true and
+  `check_duplicate_project_id` finds a same-ID duplicate, remove the conflicting
+  project via the **same shared helper** used by the Git path (de-register only,
+  files left on disk), then add the project. Default false → unchanged 409.
+- Frontend: the local-file step in
+  `app/web_ui/src/lib/components/import/import_project.svelte` (the
+  `current_step === "local_file"` branch / `import_project` function) shows the same
+  red **"Remove existing and re-sync"** action on a 409 duplicate, retrying the
+  POST with `remove_conflicting_id=true`.
+- Same edge-case handling as C.3 (`same_path` benign re-register; flag is a no-op
+  when there's no conflict).
+
+---
+
+## API contract changes
+
+| Endpoint | Change |
+|---|---|
+| `POST /api/git_sync/save_config` | `SaveConfigRequest` gains optional `remove_conflicting_id: bool = False`. When true and a same-ID-different-path duplicate exists, the conflicting project is de-registered (files left on disk) before saving. |
+| `POST /api/import_project` | Gains optional `remove_conflicting_id: bool = False` query param with the same semantics (local-folder parity; separate phase). |
+| `GitSyncMiddleware` error responses | Envelope changes from `{"detail": ...}` to `{"message": ...}` for all error bodies. Status codes unchanged except the new auth case. |
+| Git sync read errors (via middleware) | New `GitAuthError` → HTTP **401** with an auth-specific message. Existing `RemoteUnreachableError` (503), `SyncConflictError` (409), `WriteLockTimeoutError` (503), `CorruptRepoError` (500) unchanged. |
+
+No change to `DELETE /api/delete_project/{project_id}`'s external contract; its
+implementation is refactored to share a helper with the recovery path.
+
+---
+
+## Edge cases & error handling
+
+- **Auth classification false negative**: if a real auth failure isn't recognized,
+  it falls back to `RemoteUnreachableError` (today's behavior). No regression.
+- **Auth classification false positive**: a connectivity error mis-tagged as auth
+  would point the user at re-import; re-import re-runs credential entry and a fresh
+  clone, which still recovers most states, so the downside is limited.
+- **`remove_conflicting_id` with no actual conflict**: the duplicate check simply
+  doesn't fire; the flag is a no-op and save proceeds normally.
+- **`same_path` duplicate** ("This project is already imported"): does not occur in
+  the recovery flow because re-import always clones to a fresh path. If it somehow
+  occurs, removing the existing same-path registration and re-adding the same path
+  is a benign re-register.
+- **Stale selection after recovery**: preserved, because the re-imported project
+  keeps its original ID (see C.2).
+- **Orphaned old clone on disk**: intentional — consistent with `delete_project`'s
+  "does not delete files" guarantee; avoids any risk of discarding unpushed local
+  commits.
+
+---
+
+## Out of scope
+
+- **Re-authenticate in place** from the task picker (reusing the existing "Update
+  Auth" UI in `git_sync_status.svelte`). Considered; the chosen recovery is
+  re-import only.
+- **Auth-error classification on the push path.** Only the read/`fetch` path is in
+  scope.
+- **General settings/manage-projects navigation** from the fullscreen setup flow.
+  Recovery is handled by the inline error-state affordance instead.
+- **Hardening `createKilnError`** to parse FastAPI `{detail}`.
+
+---
+
+## Testing considerations
+
+- **Backend**
+  - Middleware error bodies use `{"message": ...}` for each error branch.
+  - `fetch()` classifies representative auth-failure pygit2 errors as
+    `GitAuthError` and non-auth errors as `RemoteUnreachableError`; `ERROR_MAP`
+    maps `GitAuthError` → 401 + message.
+  - `save_config` with `remove_conflicting_id=true` removes the conflicting
+    project (via the shared helper) and succeeds; with the flag false it still
+    returns 409. Verify the old project is de-registered and files remain on disk.
+  - `import_project` (local) with `remove_conflicting_id=true` behaves the same via
+    the shared helper (separate phase).
+  - `delete_project` still works through the shared helper (no behavior change).
+- **Frontend**
+  - Task-picker error state shows the real message and the subtle "Re-import
+    project?" link, with the correct destination per context (setup vs app).
+  - `step_complete.svelte` shows "Remove existing and re-sync" on a 409 and retries
+    with `remove_conflicting_id: true`, reaching the done state on success.
+  - Local-file import step shows the same "Remove existing and re-sync" action on a
+    409 and retries with `remove_conflicting_id=true` (separate phase).
+- **Checks**: OpenAPI bindings regenerated; lint/format/typecheck/tests pass for
+  both Python and web.

--- a/specs/projects/git_auth_recovery/implementation_plan.md
+++ b/specs/projects/git_auth_recovery/implementation_plan.md
@@ -32,7 +32,7 @@ See `functional_spec.md` and `architecture.md` for details.
   "Remove existing and re-sync" button + `run_save` refactor in `step_complete.svelte`.
   Regenerate OpenAPI bindings. (Spec: Part C.1 entry, C.3–C.4 frontend.)
 
-- [ ] **Phase 4 — Local-folder import parity.**
+- [x] **Phase 4 — Local-folder import parity.**
   `remove_conflicting_id` query param on `POST /api/import_project` (libs/server, via
   the core helper); red "Remove existing and re-import" button on the local-file step
   in `import_project.svelte` using `response.status === 409`. Regenerate bindings.

--- a/specs/projects/git_auth_recovery/implementation_plan.md
+++ b/specs/projects/git_auth_recovery/implementation_plan.md
@@ -12,7 +12,7 @@ See `functional_spec.md` and `architecture.md` for details.
 
 ## Phases
 
-- [ ] **Phase 1 — Error envelope + auth classification (backend).**
+- [x] **Phase 1 — Error envelope + auth classification (backend).**
   Middleware error bodies `{"detail": …}` → `{"message": …}` (all sites). Add
   `GitAuthError`; classify auth failures in `GitSyncManager.fetch()`; widen
   `ensure_fresh`/`ensure_fresh_for_read` `except` to `GitSyncError` so it propagates;

--- a/specs/projects/git_auth_recovery/implementation_plan.md
+++ b/specs/projects/git_auth_recovery/implementation_plan.md
@@ -25,7 +25,7 @@ See `functional_spec.md` and `architecture.md` for details.
   `remove_conflicting_id` to `SaveConfigRequest` and the de-register-then-save path in
   `api_save_config`. (Spec: Part C.1–C.3 backend.)
 
-- [ ] **Phase 3 — Recovery UI (frontend).**
+- [x] **Phase 3 — Recovery UI (frontend).**
   Subtle "Re-import project?" link in `select_tasks_menu.svelte` error state + the
   `import_project_url` prop wiring (setup vs app); typed `GitSyncRequestError` +
   `is_duplicate_project_error` + `remove_conflicting_id` in `git_sync/api.ts`; red

--- a/specs/projects/git_auth_recovery/implementation_plan.md
+++ b/specs/projects/git_auth_recovery/implementation_plan.md
@@ -1,0 +1,39 @@
+---
+status: complete
+---
+
+# Implementation Plan: Git Creds Error Recovery
+
+Phases are ordered so each is independently reviewable and committable. Phase 1 is
+shippable on its own (fixes the broken error display + misleading message). Phases
+2–3 deliver the git re-import recovery. Phase 4 adds local-folder import parity.
+
+See `functional_spec.md` and `architecture.md` for details.
+
+## Phases
+
+- [ ] **Phase 1 — Error envelope + auth classification (backend).**
+  Middleware error bodies `{"detail": …}` → `{"message": …}` (all sites). Add
+  `GitAuthError`; classify auth failures in `GitSyncManager.fetch()`; widen
+  `ensure_fresh`/`ensure_fresh_for_read` `except` to `GitSyncError` so it propagates;
+  map `GitAuthError` → 401 in the middleware `ERROR_MAP`. Update affected backend
+  tests. (Spec: Part A, Part B.)
+
+- [ ] **Phase 2 — Git re-import recovery (backend).**
+  Add `remove_project_from_config` (libs/core); add the `_deregister_project`
+  app-layer wrapper and refactor `delete_project` to use it; add
+  `remove_conflicting_id` to `SaveConfigRequest` and the de-register-then-save path in
+  `api_save_config`. (Spec: Part C.1–C.3 backend.)
+
+- [ ] **Phase 3 — Recovery UI (frontend).**
+  Subtle "Re-import project?" link in `select_tasks_menu.svelte` error state + the
+  `import_project_url` prop wiring (setup vs app); typed `GitSyncRequestError` +
+  `is_duplicate_project_error` + `remove_conflicting_id` in `git_sync/api.ts`; red
+  "Remove existing and re-sync" button + `run_save` refactor in `step_complete.svelte`.
+  Regenerate OpenAPI bindings. (Spec: Part C.1 entry, C.3–C.4 frontend.)
+
+- [ ] **Phase 4 — Local-folder import parity.**
+  `remove_conflicting_id` query param on `POST /api/import_project` (libs/server, via
+  the core helper); red "Remove existing and re-import" button on the local-file step
+  in `import_project.svelte` using `response.status === 409`. Regenerate bindings.
+  (Spec: Part C.5.)

--- a/specs/projects/git_auth_recovery/implementation_plan.md
+++ b/specs/projects/git_auth_recovery/implementation_plan.md
@@ -19,7 +19,7 @@ See `functional_spec.md` and `architecture.md` for details.
   map `GitAuthError` → 401 in the middleware `ERROR_MAP`. Update affected backend
   tests. (Spec: Part A, Part B.)
 
-- [ ] **Phase 2 — Git re-import recovery (backend).**
+- [x] **Phase 2 — Git re-import recovery (backend).**
   Add `remove_project_from_config` (libs/core); add the `_deregister_project`
   app-layer wrapper and refactor `delete_project` to use it; add
   `remove_conflicting_id` to `SaveConfigRequest` and the de-register-then-save path in

--- a/specs/projects/git_auth_recovery/phase_plans/phase_1.md
+++ b/specs/projects/git_auth_recovery/phase_plans/phase_1.md
@@ -1,0 +1,62 @@
+---
+status: complete
+---
+
+# Phase 1: Error envelope + auth classification (backend)
+
+## Overview
+
+Fix the middleware error envelope shape and add auth-specific error classification.
+Today, `GitSyncMiddleware` emits `{"detail": ...}` while the rest of the app uses
+`{"message": ...}`, causing the frontend to show "Unknown error". Additionally, all
+git fetch failures are reported as connectivity errors even when the real cause is
+expired credentials. This phase fixes both issues server-side.
+
+## Steps
+
+1. **Add `GitAuthError` to `app/desktop/git_sync/errors.py`**
+   ```python
+   class GitAuthError(GitSyncError):
+       """Git authentication failed or expired (bad/expired token, 401/403)."""
+   ```
+
+2. **Classify auth errors in `GitSyncManager.fetch()` (`git_sync_manager.py`)**
+   - Add `_AUTH_ERROR_MARKERS` tuple and `_is_auth_error(e)` helper at module level.
+   - In `fetch()`, catch `pygit2.GitError` and branch on `_is_auth_error`:
+     raise `GitAuthError` for auth failures, `RemoteUnreachableError` otherwise.
+
+3. **Widen `except` in `ensure_fresh` / `ensure_fresh_for_read`**
+   - Change `except RemoteUnreachableError: raise` to `except GitSyncError: raise`
+     so `GitAuthError` propagates instead of being re-wrapped as
+     `RemoteUnreachableError`.
+
+4. **Add `GitAuthError` to `ERROR_MAP` in `middleware.py`**
+   ```python
+   GitAuthError: (
+       401,
+       "Git authentication failed or expired. Re-import the project to "
+       "reconnect with fresh credentials.",
+   ),
+   ```
+
+5. **Change all `{"detail": ...}` to `{"message": ...}` in `middleware.py`**
+   Six sites: `_no_write_lock_asgi` read error, `dispatch` read error,
+   `_StreamingUnderWriteLock` catch, write-path `GitSyncError` catch,
+   `_dev_mode_dirty_check` 500, `_unmatched_dispatch` dev-mode 500.
+
+6. **Update existing tests in `test_middleware.py`**
+   - Change all `body["detail"]` assertions to `body["message"]`.
+
+## Tests
+
+- `test_error_mapping` parametrized: add `GitAuthError` -> 401 case; update all
+  expected keys from `detail` to `message`.
+- `test_fetch_raises_git_auth_error_for_auth_failure`: `fetch()` raises `GitAuthError`
+  when pygit2 error contains auth markers.
+- `test_fetch_raises_remote_unreachable_for_non_auth_failure`: `fetch()` raises
+  `RemoteUnreachableError` for generic network errors.
+- `test_ensure_fresh_for_read_propagates_git_auth_error`: verifies `GitAuthError`
+  from `fetch()` propagates through `ensure_fresh_for_read` unchanged.
+- `test_ensure_fresh_propagates_git_auth_error`: same for `ensure_fresh`.
+- `test_is_auth_error_markers`: parametrized test for `_is_auth_error` with
+  representative auth and non-auth messages.

--- a/specs/projects/git_auth_recovery/phase_plans/phase_2.md
+++ b/specs/projects/git_auth_recovery/phase_plans/phase_2.md
@@ -1,0 +1,41 @@
+---
+status: complete
+---
+
+# Phase 2: Git Re-Import Recovery (Backend)
+
+## Overview
+
+Adds the backend plumbing for the "remove conflicting project and re-import" recovery flow. This phase factors the existing `delete_project` logic into a shared helper so that both `delete_project` and the new `remove_conflicting_id` path on `save_config` use the same de-registration code.
+
+## Steps
+
+1. **Add `remove_project_from_config` to `libs/core/kiln_ai/utils/project_utils.py`**
+   - New function that removes a project path from `Config.shared().projects` and from `Config.shared().git_sync_projects`.
+   - Returns the `clone_path` if the project was git-synced, else `None`.
+   - This is the persistent-config-only portion of project removal (no runtime registry teardown).
+
+2. **Add `_deregister_project` helper to `app/desktop/git_sync/git_sync_api.py`**
+   - Async wrapper that calls `remove_project_from_config` and then `GitSyncRegistry.unregister` if a `clone_path` was returned.
+   - This is the full app-layer removal (config + runtime registry).
+
+3. **Refactor `delete_project` endpoint to use `_deregister_project`**
+   - Replace the inline config-removal logic with a call to `_deregister_project(str(project.path))`.
+   - No change to external behavior or response shape.
+
+4. **Add `remove_conflicting_id: bool = False` to `SaveConfigRequest`**
+   - New optional field on the Pydantic model.
+
+5. **Update `api_save_config` to handle `remove_conflicting_id=True`**
+   - On `DuplicateProjectError` with the flag set: resolve the conflicting project via `project_from_id_core`, de-register it, then fall through to the normal save path.
+   - With the flag `False` (default): behavior unchanged (raises 409).
+
+## Tests
+
+- `test_remove_project_from_config_removes_project_and_git_sync`: verifies both `projects` and `git_sync_projects` are updated, returns `clone_path`.
+- `test_remove_project_from_config_non_git_synced`: verifies it works for non-git-synced projects, returns `None`.
+- `test_remove_project_from_config_missing_project`: verifies idempotent behavior when the path isn't in config.
+- `test_delete_project_uses_shared_helper`: verifies `delete_project` endpoint calls `_deregister_project` and still returns the expected response.
+- `test_save_config_remove_conflicting_deregisters_and_saves`: verifies the full flow with `remove_conflicting_id=True`.
+- `test_save_config_remove_conflicting_false_still_409`: verifies default behavior is unchanged.
+- `test_save_config_remove_conflicting_no_conflict_is_noop`: verifies the flag is a no-op when there's no conflict.

--- a/specs/projects/git_auth_recovery/phase_plans/phase_3.md
+++ b/specs/projects/git_auth_recovery/phase_plans/phase_3.md
@@ -1,0 +1,82 @@
+---
+status: complete
+---
+
+# Phase 3: Recovery UI (Frontend)
+
+## Overview
+
+Adds the frontend recovery affordances for git auth errors and duplicate-project
+conflicts. Three coordinated changes: (1) a subtle "Re-import project?" link in
+the task picker's error state, (2) typed error handling in the git sync API
+client, and (3) a "Remove existing and re-sync" destructive button in the import
+wizard's final step when a duplicate-project conflict (409) is detected.
+
+## Steps
+
+### 1. Regenerate OpenAPI bindings
+
+Phase 2 added `remove_conflicting_id` to `SaveConfigRequest`, so the TS bindings
+are stale. Run `generate_schema` and verify `check_schema` passes.
+
+### 2. Add `GitSyncRequestError` class and helpers to `api.ts`
+
+File: `app/web_ui/src/lib/git_sync/api.ts`
+
+- Add `GitSyncRequestError extends Error` with a `status: number` field.
+- Add `is_duplicate_project_error(e: unknown): boolean` (checks `e instanceof
+  GitSyncRequestError && e.status === 409`).
+- In the `request()` helper, throw `GitSyncRequestError(msg, resp.status)` instead
+  of `Error(msg)`. Existing callers read `.message`, so they are unaffected.
+- Add `remove_conflicting_id?: boolean` to the `saveConfig` config parameter type.
+
+### 3. Add `import_project_url` prop and recovery link to `select_tasks_menu.svelte`
+
+File: `app/web_ui/src/routes/(app)/select_tasks_menu.svelte`
+
+- Add `export let import_project_url = "/settings/import_project"`.
+- In the error state block (the `{:else if tasks_loading_error}` branch), beneath
+  the error message text, add:
+  ```svelte
+  <a href={import_project_url} class="text-xs text-base-content/40 hover:underline mt-1">
+    Re-import project?
+  </a>
+  ```
+  Small, grey, low-emphasis. Dispatches `dismiss` on click (for the dialog context).
+
+### 4. Wire `import_project_url` in the setup context
+
+File: `app/web_ui/src/routes/(fullscreen)/setup/(setup)/select_task/+page.svelte`
+
+- Pass `import_project_url="/setup/import_project"` to `SelectTasksMenu`.
+
+### 5. Refactor `step_complete.svelte` for conflict recovery
+
+File: `app/web_ui/src/lib/components/import/step_complete.svelte`
+
+- Import `is_duplicate_project_error` from the api module.
+- Add `let is_conflict = false` state.
+- Extract the save call into `async function run_save(remove_conflicting_id = false)`.
+  `onMount` calls `renameClone` once, then `run_save(false)`. The rename must not
+  re-run on retry.
+- In the catch block: check `is_stale_clone_error` first, then set
+  `is_conflict = is_duplicate_project_error(e)` and `error = createKilnError(e)`.
+- In the error view, when `is_conflict`, show a red "Remove existing and re-sync"
+  button that calls `run_save(true)` (resetting `saving`, `error`, `is_conflict`).
+  "Back" remains available.
+
+## Tests
+
+- **api.test.ts — GitSyncRequestError**: verify `request()` throws
+  `GitSyncRequestError` with correct status on non-ok response.
+- **api.test.ts — is_duplicate_project_error**: true for 409
+  `GitSyncRequestError`, false for other statuses, false for plain `Error`.
+- **api.test.ts — saveConfig with remove_conflicting_id**: verify the field is
+  sent in the POST body when provided.
+- **select_tasks_menu.svelte — error state link**: render with a mock error, verify
+  the "Re-import project?" link is present with the correct href, and that the
+  custom `import_project_url` prop overrides the default.
+- **step_complete.svelte — conflict button**: mock `saveConfig` to reject with a
+  409 `GitSyncRequestError`, verify the "Remove existing and re-sync" button
+  appears, click it, verify `saveConfig` is retried with
+  `remove_conflicting_id: true`.

--- a/specs/projects/git_auth_recovery/phase_plans/phase_4.md
+++ b/specs/projects/git_auth_recovery/phase_plans/phase_4.md
@@ -1,0 +1,41 @@
+---
+status: complete
+---
+
+
+# Phase 4: Local-Folder Import Parity
+
+## Overview
+
+Adds `remove_conflicting_id` support to the local-folder import path (`POST /api/import_project`) and a corresponding red recovery button in the `import_project.svelte` UI, so that local-folder re-import works the same as the Git re-import path added in Phases 2-3.
+
+## Steps
+
+1. **Backend: Add `remove_conflicting_id` query param to `POST /api/import_project`** (`libs/server/kiln_server/project_api.py`)
+   - Add optional `remove_conflicting_id: bool = False` query parameter to the `import_project` endpoint.
+   - Import `remove_project_from_config` from `kiln_ai.utils.project_utils` and `project_from_id` (core version).
+   - When `DuplicateProjectError` is caught and `remove_conflicting_id` is true, resolve the conflicting project via `project_from_id_core(project.id)`, call `remove_project_from_config(str(conflicting.path))`, then proceed with `add_project_to_config`. Add a code comment noting the layering caveat (libs/server cannot unregister the in-memory GitSyncRegistry manager).
+   - When `remove_conflicting_id` is false (default), raise 409 as before.
+
+2. **Regenerate OpenAPI bindings** using `generate_schema` after the backend change.
+
+3. **Frontend: Add conflict recovery button to `import_project.svelte`** (`app/web_ui/src/lib/components/import/import_project.svelte`)
+   - Add `let import_conflict = false` state variable.
+   - In the `import_project` function, after catching an error, detect 409 from `response` and set `import_conflict = true`.
+   - Refactor `import_project` to accept a `remove_conflicting_id` boolean parameter, passing it as a query param when true.
+   - In the `local_file` template section, when `import_conflict` is true, show a red `btn btn-error btn-outline` button labeled "Remove existing and re-import" that retries with `remove_conflicting_id: true`.
+
+4. **Backend tests** (`libs/server/kiln_server/test_project_api.py`)
+   - `test_import_project_duplicate_remove_conflicting_id_success`: with `remove_conflicting_id=true`, resolves and removes the conflicting project, then succeeds.
+   - `test_import_project_duplicate_remove_conflicting_id_no_conflict`: flag is true but no duplicate exists; import succeeds normally.
+
+5. **Frontend tests** (new file: `app/web_ui/src/lib/components/import/import_project.test.ts`)
+   - Test that 409 response shows the conflict button.
+   - Test that clicking the conflict button retries with `remove_conflicting_id=true`.
+   - Test that non-409 errors do not show the conflict button.
+
+## Tests
+
+- `test_import_project_duplicate_remove_conflicting_id_success`: verifies that with flag=true a duplicate is resolved and import succeeds
+- `test_import_project_duplicate_remove_conflicting_id_no_conflict`: verifies flag is no-op when no conflict
+- Frontend: 409 renders "Remove existing and re-import" button; click retries with flag; non-409 does not show button

--- a/specs/projects/git_auth_recovery/project_overview.md
+++ b/specs/projects/git_auth_recovery/project_overview.md
@@ -1,0 +1,23 @@
+---
+status: complete
+---
+
+# Git Creds Error is Unrecoverable
+
+A user had 1 project synced via Git, then hit an unrecoverable error state.
+
+## Symptoms
+
+- The `/tasks` API used by the task picker (the [list select](http://localhost:8757/setup/select_task) page, and the same control in the app) errored. The underlying cause was expired Git auth, but the API returned `{detail: "Cannot sync with remote. Check your connection."}`. The UX was bad: the picker showed `Tasks failed to load: [Object object]`.
+
+## Fixes wanted
+
+### 1. Fix the task-picker error display
+
+Show the right error, not `[Object object]`. The API returns a reasonable string, but maybe not in the format the UI expects to render. Might change how the API returns the error, or how the UI renders it. Investigate and recommend.
+
+### 2. Allow recovery when Git creds expire (or any other issue)
+
+- **Option 1 (simple): allow importing again**, which goes through setup for fresh Git creds. This doesn't work today because re-import errors with "You already have a project with this ID. You must remove project X before adding this." If I have many projects that's reasonable (go to Settings > Manage projects > Remove). However, if I only have 1 project, we redirect to `/setup/select_task`, where it's not possible to remove — so I can't remove the old one to re-sync. Proposed solution: the import UI/API can show this error, then the button updates to "Remove existing and re-sync" (red), which calls back to the API with an extra flag like `remove_conflicting_id`.
+
+- **Option 2: allow re-authenticating from the task picker** (seems big).

--- a/specs/projects/git_oauth_token_refresh/architecture.md
+++ b/specs/projects/git_oauth_token_refresh/architecture.md
@@ -1,0 +1,279 @@
+---
+status: complete
+---
+
+# Architecture: GitHub OAuth Token Refresh
+
+Single-doc architecture (no separate component designs). All paths are relative to the
+repo root. This project spans `app/desktop/` (backend) and `app/web_ui/` (frontend), so
+it lives at the repo-root `specs/projects/`.
+
+## Overview
+
+Add a renewal layer to the existing OAuth user-access-token flow:
+
+```
+connect/reconnect → capture {access, refresh, expiries}  (Phase 1)
+                          │ persisted in GitSyncProjectConfig
+                          ▼
+GitSyncManager.fetch()/commit_and_push()
+   → _ensure_valid_oauth_token()  ── proactive refresh (Phase 2)
+   → run git op
+        └─ on auth rejection → reactive refresh + retry (Phase 3)
+        └─ on unrenewable auth → AuthExpiredError → 401 (Phase 3)
+frontend threads the new fields through the wizard/settings (Phase 4)
+```
+
+## Data model
+
+### `OAuthTokenResult` (new dataclass, `app/desktop/git_sync/oauth.py`)
+
+```python
+@dataclass
+class OAuthTokenResult:
+    access_token: str
+    refresh_token: str | None = None
+    access_token_expires_at: float | None = None      # epoch seconds (wall-clock)
+    refresh_token_expires_at: float | None = None
+```
+
+Computed at exchange/refresh time: `expires_at = time.time() + expires_in` when GitHub
+returns `expires_in`; else `None`.
+
+### `GitSyncProjectConfig` (`app/desktop/git_sync/config.py`) — add three fields
+
+```python
+oauth_refresh_token: str | None
+oauth_token_expires_at: float | None
+oauth_refresh_token_expires_at: float | None
+```
+
+`get_git_sync_config()` must default each to `None` via `.get(...)` (legacy configs lack
+them). `save_git_sync_config()` already writes the whole dict — no change beyond the
+TypedDict. Add a focused helper:
+
+```python
+def update_oauth_tokens(project_path: str, result: OAuthTokenResult) -> None:
+    """Synchronous read-modify-write of only the OAuth token fields for one project."""
+    config = Config.shared()
+    raw = config.git_sync_projects or {}
+    entry = raw.get(project_path)
+    if entry is None:
+        return
+    entry["oauth_token"] = result.access_token
+    entry["oauth_refresh_token"] = result.refresh_token
+    entry["oauth_token_expires_at"] = result.access_token_expires_at
+    entry["oauth_refresh_token_expires_at"] = result.refresh_token_expires_at
+    raw[project_path] = entry
+    config.git_sync_projects = raw   # synchronous persist; no await around this block
+```
+
+### `libs/core/kiln_ai/utils/config.py`
+
+In the `git_sync_projects` `ConfigProperty` (~line 202), extend `sensitive_keys`:
+`["pat_token", "oauth_token", "oauth_refresh_token"]`.
+
+## Components & changes
+
+### 1. `app/desktop/git_sync/oauth.py`
+
+- **`exchange_code_for_token(code, code_verifier) -> OAuthTokenResult`** (was `-> str`).
+  Parse `access_token`, `refresh_token`, `expires_in`, `refresh_token_expires_in`;
+  compute absolute expiries; return `OAuthTokenResult`. Keep raising `OAuthError` on the
+  `error`/`error_description` path.
+- **`refresh_access_token(refresh_token: str) -> OAuthTokenResult`** (new). POST to
+  `https://github.com/login/oauth/access_token` with
+  `{client_id, client_secret, grant_type: "refresh_token", refresh_token}`,
+  `Accept: application/json`, timeout 30s. Parse same fields (response includes a rotated
+  `refresh_token`). Raise `OAuthError` if no `access_token` in the response.
+- **`OAuthFlowState`**: add `refresh_token`, `oauth_token_expires_at`,
+  `oauth_refresh_token_expires_at` fields. `complete_flow()` takes an `OAuthTokenResult`
+  (or the extra fields) and stores them on the flow.
+
+> The single caller of `exchange_code_for_token` is the OAuth callback in
+> `git_sync_api.py`; update it together (Phase 1). The `time` import already exists.
+
+### 2. `app/desktop/git_sync/git_sync_api.py`
+
+- **`api_oauth_callback`**: `result = await exchange_code_for_token(...)`;
+  `oauth_manager.complete_flow(state, result)`.
+- **`OAuthStatusResponse`**: add `oauth_refresh_token`, `oauth_token_expires_at`,
+  `oauth_refresh_token_expires_at`. `api_oauth_status` returns them from the consumed flow.
+- **`SaveConfigRequest`** + **`api_save_config`**: accept and persist the three new fields
+  into `GitSyncProjectConfig`.
+- **`UpdateConfigRequest`** + **`api_update_config`**: accept the three new fields; when
+  set, write them. The existing auth-mode-switch logic that clears `oauth_token` must also
+  clear `oauth_refresh_token` / expiries when switching away from `github_oauth`, and the
+  `github_oauth` branch should accept the new refresh fields.
+- (Optional) **`GitSyncConfigResponse`**: add `has_oauth_refresh_token: bool`.
+
+### 3. `app/desktop/git_sync/errors.py`
+
+Add:
+```python
+class AuthExpiredError(GitSyncError):
+    """GitHub authorization expired / revoked and could not be refreshed."""
+```
+
+### 4. `app/desktop/git_sync/git_sync_manager.py` — the refresh engine
+
+**New constructor arg**: `project_path: str | None = None` (the project.kiln path used to
+key config; needed to read/persist refreshed tokens). Store as `self._project_path`. Add
+`self._refresh_lock = asyncio.Lock()`.
+
+**`_is_auth_error(exc: Exception) -> bool`** (module or method): return True when the
+pygit2 error indicates credential rejection. The credential callback in `clone.py` raises
+`pygit2.GitError("Authentication failed. Credentials were rejected by the server.")`;
+detect by checking the message for `"authentication failed"` / `"credentials were
+rejected"` / `"401"` / `"403"` (case-insensitive). Anything else is treated as network.
+
+**`_ensure_valid_oauth_token(self, *, force: bool = False) -> None`** (proactive/reactive):
+```
+if self._auth_mode != "github_oauth": return
+cfg = get_git_sync_config(self._project_path)         # None-safe
+expires_at = cfg.oauth_token_expires_at
+refresh_token = cfg.oauth_refresh_token
+if not force:
+    if expires_at is None: return                     # non-expiring / legacy → no-op
+    if time.time() < expires_at - REFRESH_SKEW_SECONDS: return   # still valid
+async with self._refresh_lock:
+    cfg = get_git_sync_config(self._project_path)      # re-read under lock (double-check)
+    if not force and cfg.expires_at valid: return
+    if cfg.oauth_refresh_token is None:
+        raise AuthExpiredError(...)                    # nothing to refresh
+    try:
+        result = await refresh_access_token(cfg.oauth_refresh_token)
+    except OAuthError as e:
+        raise AuthExpiredError(...) from e
+    update_oauth_tokens(self._project_path, result)    # persist rotated tokens
+    self._oauth_token = result.access_token            # in-memory for this manager
+```
+
+**Wire into remote ops:**
+- `fetch()`: call `await self._ensure_valid_oauth_token()` first; then current logic. The
+  `except pygit2.GitError` branch becomes:
+  ```
+  except pygit2.GitError as e:
+      if _is_auth_error(e) and <oauth + has refresh + not already refreshed>:
+          await self._ensure_valid_oauth_token(force=True)   # reactive
+          await self._run_git(self._fetch_sync)              # retry once
+      elif _is_auth_error(e):
+          raise AuthExpiredError(...) from e
+      else:
+          raise RemoteUnreachableError(...) from e
+  ```
+  If the retried fetch still raises an auth error → `AuthExpiredError`.
+- `commit_and_push()`: call `await self._ensure_valid_oauth_token()` before the first
+  `_push_sync`. Apply the same auth-vs-network classification to push failures (the
+  current code logs the first push error and tries fetch+rebase+retry; ensure an auth
+  rejection becomes `AuthExpiredError`, not a generic conflict/unreachable).
+
+**Re-raise pass-through**: in `ensure_fresh()` and `ensure_fresh_for_read()`, add
+`except AuthExpiredError: raise` alongside the existing `except RemoteUnreachableError:
+raise` so the catch-all `except Exception` does not re-wrap it into
+`RemoteUnreachableError`.
+
+### 5. `app/desktop/git_sync/registry.py` + call sites
+
+Thread `project_path` through `get_or_create(...)` and into `GitSyncManager(...)`, and
+set `existing._project_path = project_path` in the overwrite branch (mirroring the token
+overwrite). Call sites to update:
+- `app/desktop/git_sync/middleware.py` `_get_manager_for_request` (it already resolves the
+  project_path/config — pass it in).
+- `app/desktop/desktop_server.py` `_start_background_syncs` (iterates `git_sync_projects`
+  keyed by project_path — pass the key).
+
+### 6. `app/desktop/git_sync/middleware.py`
+
+Add to `ERROR_MAP`:
+```python
+AuthExpiredError: (401, "GitHub authorization expired. Reconnect your GitHub account in the project's Git Sync settings."),
+```
+Import `AuthExpiredError`. (Background sync already swallows/logs exceptions — confirm an
+`AuthExpiredError` there just logs a clear warning and does not crash the poll loop.)
+
+### 7. Frontend (`app/web_ui/`) — thread the new fields through
+
+Backend response/request models gain the fields, so regenerate the OpenAPI bindings
+first: `app/web_ui/src/lib/generate_schema.sh` (validated by
+`app/web_ui/src/lib/check_schema.sh`). Then update the **hand-written** types/functions
+(they duplicate the generated types — both must change):
+
+- `app/web_ui/src/lib/git_sync/api.ts`: `OAuthStatusResponse` type; `saveConfig` and
+  `updateConfig` inline request types/bodies — add `oauth_refresh_token`,
+  `oauth_token_expires_at`, `oauth_refresh_token_expires_at`.
+- `app/web_ui/src/lib/git_sync/oauth_flow.ts`: `OAuthFlowCallbacks.onSuccess` changes
+  from `(token: string)` to a payload object `{ oauth_token, oauth_refresh_token,
+  oauth_token_expires_at, oauth_refresh_token_expires_at }`; the poll code reads the new
+  fields off the status response.
+- `app/web_ui/src/lib/git_sync/oauth_with_install.ts`: `on_success` signature + the
+  `stored_token` holder become the payload object; `check_access` forwards it.
+- `app/web_ui/src/lib/stores/git_import_wizard_store.ts`: add the three fields to
+  `GitImportWizardState`, initial state, and keep the `github_oauth` validation.
+- `app/web_ui/src/lib/components/import/step_credentials.svelte`,
+  `import_project.svelte` (`on_credentials_success`), `step_complete.svelte`
+  (`saveConfig` body): carry the payload into the store and into `saveConfig`.
+  `step_branch.svelte` only needs the access token for clone/list/test (unchanged
+  semantics — it can keep using `oauth_token`).
+- `app/web_ui/src/lib/git_sync/git_sync_status.svelte`: reconnect `on_success` passes the
+  payload to `updateConfig`.
+
+> Frontend timestamps are **opaque pass-through** values (computed server-side). The
+> frontend never interprets or refreshes; it only carries them from OAuth status into
+> save/update config.
+
+## Concurrency & correctness
+
+- One `GitSyncManager` per repo (registry singleton); background sync uses the same
+  instance. A per-manager `asyncio.Lock` (`_refresh_lock`) serializes refreshes →
+  GitHub's single-use refresh token is consumed exactly once. Double-check expiry after
+  acquiring the lock so a coroutine that waited doesn't refresh again.
+- Persist (`update_oauth_tokens`) is a synchronous read-modify-write of the config dict
+  with no `await` in the middle → no event-loop interleaving across projects.
+
+## Error handling strategy
+
+- Renewable problems are renewed silently (B2/B3).
+- Unrenewable auth → `AuthExpiredError` → 401 with an actionable message (consumed later
+  by `git_auth_recovery`).
+- Network/remote → `RemoteUnreachableError` → 503 (unchanged).
+- Persist tokens only after a successful refresh; never persist partial state.
+
+## Testing strategy
+
+Python (`pytest`), colocated `app/desktop/git_sync/test_*.py` + integration tests:
+
+- **oauth**: `exchange_code_for_token` parses all fields and computes `expires_at`
+  (mock httpx); missing `expires_in` → `None`; `refresh_access_token` success + rotation
+  + `OAuthError` on failure. Patch `time.time` for deterministic expiry.
+- **config**: new fields round-trip; legacy config (missing keys) defaults to `None`;
+  `update_oauth_tokens` updates only token fields and is a no-op for unknown project_path.
+- **manager**: `_ensure_valid_oauth_token` — valid (no network call), within skew (no
+  call), expired+refresh (calls refresh, persists, updates `_oauth_token`),
+  expired+no-refresh (`AuthExpiredError`), non-oauth mode (no-op), `force=True`; refresh
+  serialized under concurrency (two awaiters → one network refresh). `_is_auth_error`
+  classification. `fetch()`/`commit_and_push()` reactive refresh + single retry; auth vs
+  network branching. `ensure_fresh*` re-raise `AuthExpiredError`.
+- **middleware**: `AuthExpiredError` → 401 + message; `RemoteUnreachableError` still 503.
+- **api**: callback stores refresh fields in flow; status returns them; save/update
+  persist them; auth-mode switch clears refresh fields.
+- **background_sync**: `AuthExpiredError` is logged and the poll loop survives.
+
+Frontend (`vitest`):
+- `oauth_flow.test.ts`: `onSuccess` receives the payload object; status mocks include the
+  new fields.
+- `api.test.ts` / wizard store tests: new fields threaded into save/update bodies.
+
+## Verification (end-to-end)
+
+1. `uv run ./checks.sh --agent-mode` (lint, format, ty, pytest, web lint/format/check/
+   test/build, schema check).
+2. Schema regen: `app/web_ui/src/lib/generate_schema.sh`, confirm
+   `app/web_ui/src/lib/check_schema.sh` passes.
+3. Manual (optional): connect a repo via OAuth; set `oauth_token_expires_at` in config to
+   a near-past value to force B2; confirm a fetch triggers a refresh (new token persisted)
+   and sync continues. Clear `oauth_refresh_token`; confirm the next op returns 401 with
+   the reconnect message (not 503).
+4. **Prerequisite check**: confirm the GitHub App has "Expire user authorization tokens"
+   enabled (GitHub App settings → Optional features) — required for GitHub to issue
+   refresh tokens at all (B6).

--- a/specs/projects/git_oauth_token_refresh/functional_spec.md
+++ b/specs/projects/git_oauth_token_refresh/functional_spec.md
@@ -1,0 +1,157 @@
+---
+status: complete
+---
+
+# Functional Spec: GitHub OAuth Token Refresh
+
+## Background
+
+Git sync runs entirely client-side in the desktop app (`app/desktop/git_sync/`) using
+pygit2. For GitHub-App-connected projects, the OAuth **user access token** is used as the
+git HTTPS password (`pygit2.UserPass(username="x-token", password=token)`). These tokens
+expire; Kiln currently never refreshes them. See `project_overview.md` for the root cause.
+
+## Goals
+
+1. Persist GitHub's `refresh_token` + token expiry timestamps when a user connects or
+   reconnects via OAuth.
+2. Keep the OAuth access token valid automatically for the life of the refresh token
+   (~6 months), with no user action.
+3. When the token genuinely cannot be renewed, surface a clear, correctly-classified
+   "reconnect GitHub" error.
+
+## Non-goals
+
+- No change to PAT or SSH auth flows.
+- No recovery UI / no fix to the `[Object object]` task-picker rendering (that is
+  `git_auth_recovery`).
+- No server-to-server (installation-token) auth. This stays a user-access-token (OAuth)
+  flow; only the renewal piece is added.
+
+## Behaviors
+
+### B1. Token capture (connect & reconnect)
+
+When `exchange_code_for_token()` succeeds, capture from GitHub's response:
+- `access_token`
+- `refresh_token` (may be absent — see B6)
+- `expires_in` → converted to an absolute `oauth_token_expires_at` (epoch seconds,
+  wall-clock, computed server-side at exchange time)
+- `refresh_token_expires_in` → absolute `oauth_refresh_token_expires_at`
+
+These flow through the existing OAuth status → wizard → `save_config` path (new connect)
+and the `PATCH /config` path (reconnect from project settings), and are persisted in
+`GitSyncProjectConfig`.
+
+### B2. Proactive refresh (before each remote op)
+
+Before any fetch or push for a `github_oauth` project, if
+`now >= oauth_token_expires_at - REFRESH_SKEW` (skew = 300s), refresh the access token
+using the refresh token, persist the new tokens, and use the new access token for the op.
+If the token is still valid (or expiry is unknown — B6), do nothing.
+
+### B3. Reactive refresh (on auth rejection)
+
+If a fetch/push fails with an authentication rejection (not a network error) for a
+`github_oauth` project that has a refresh token, and a refresh has not already been
+attempted in this operation, force a refresh (ignoring skew) and retry the op once. This
+covers clock skew and server-side token invalidation that proactive checks miss.
+
+### B4. Refresh token rotation
+
+GitHub rotates the refresh token on every refresh: the response contains a **new**
+`refresh_token` and invalidates the old one. The new refresh token (and new expiries)
+**must** be persisted immediately on every successful refresh. Persist only after a
+successful response; on failure, leave stored credentials untouched.
+
+### B5. Correct error classification
+
+- **Auth cannot be renewed** (refresh token missing/expired, refresh request returns an
+  OAuth error, or pygit2 reports credentials rejected and reactive refresh fails) →
+  raise a new `AuthExpiredError` → HTTP **401** with detail:
+  `"GitHub authorization expired. Reconnect your GitHub account in the project's Git Sync settings."`
+- **Genuine network/remote failure** (timeout, DNS, connection refused, non-auth
+  `pygit2.GitError`) → keep existing `RemoteUnreachableError` → HTTP 503
+  `"Cannot sync with remote. Check your connection."`
+
+### B6. Tokens with no expiry (app setting OFF / legacy)
+
+If GitHub returns no `expires_in`/`refresh_token` (the app's "Expire user authorization
+tokens" option is OFF), the access token is long-lived: store
+`oauth_token_expires_at = None`, `oauth_refresh_token = None`. Proactive refresh is a
+no-op; the token is used as-is. Sync works indefinitely without refresh. (Operational
+note: for the refresh path to engage at all, the GitHub App must have "Expire user
+authorization tokens" enabled. The production app almost certainly already does, since
+that is what produces the bug. This should be verified, not assumed — see verification.)
+
+### B7. Migration of existing OAuth users
+
+Existing configs have `oauth_token` but no refresh token / expiry (`expires_at = None`).
+Behavior: the stored token is used until it fails; on failure → `AuthExpiredError` (401
+reconnect message), since there is no refresh token to use. After the user reconnects,
+the new tokens include a refresh token and auto-refresh works from then on. No migration
+script is required.
+
+## Edge cases & error handling
+
+- **No refresh token but token expired** (legacy/setting-off user whose token died):
+  `AuthExpiredError`. Do not loop.
+- **Refresh request fails (network)**: surface as `AuthExpiredError` (user can reconnect)
+  rather than silently retrying forever; the refresh token itself is unverified, so we
+  cannot distinguish "GitHub down" from "refresh token dead" cleanly — prefer the
+  actionable reconnect message. (Acceptable trade-off; documented.)
+- **Concurrent refresh**: background sync (every 10s) and an inbound request can both hit
+  expiry at once. Refresh must be serialized per repo with double-checked expiry so the
+  single-use refresh token is consumed exactly once.
+- **Background sync** auth failures: log clearly and keep the existing
+  retry-on-next-poll behavior. Background sync must not crash on `AuthExpiredError`.
+- **Multiple Kiln projects sharing one clone** (rare: two imports of the same repo):
+  refresh persists to the manager's own project config; other projects sharing the clone
+  may retain a stale token in config until their next refresh/restart. Documented known
+  limitation; the common one-project-per-clone case is fully correct.
+
+## Contracts
+
+### Config (`GitSyncProjectConfig`) — new fields
+
+```python
+oauth_refresh_token: str | None
+oauth_token_expires_at: float | None            # epoch seconds, wall-clock
+oauth_refresh_token_expires_at: float | None
+```
+`oauth_refresh_token` is added to `sensitive_keys` for `git_sync_projects` in
+`libs/core/kiln_ai/utils/config.py` (redaction in logs/exports).
+
+### API fields (additive, optional, backward-compatible)
+
+- `OAuthStatusResponse`: add `oauth_refresh_token`, `oauth_token_expires_at`,
+  `oauth_refresh_token_expires_at`.
+- `SaveConfigRequest` and `UpdateConfigRequest`: accept the same three fields.
+- `GitSyncConfigResponse`: no raw tokens exposed (unchanged); optionally add a boolean
+  `has_oauth_refresh_token` for diagnostics (optional).
+
+### Error → HTTP mapping (middleware `ERROR_MAP`)
+
+| Exception | Status | Detail |
+|---|---|---|
+| `AuthExpiredError` (new) | 401 | "GitHub authorization expired. Reconnect your GitHub account in the project's Git Sync settings." |
+| `RemoteUnreachableError` | 503 | "Cannot sync with remote. Check your connection." (unchanged) |
+
+## Configuration & defaults
+
+- `REFRESH_SKEW_SECONDS = 300` (refresh when within 5 min of expiry).
+- GitHub token endpoint: `https://github.com/login/oauth/access_token` with
+  `grant_type=refresh_token` (same endpoint used for code exchange).
+- httpx timeout for refresh: 30s (matches existing exchange call).
+
+## Constraints
+
+- **Single process / single event loop**: the desktop app is one FastAPI process;
+  per-repo `asyncio.Lock` is sufficient for refresh serialization. Config
+  read-modify-write for the token fields must be synchronous (no `await` between read and
+  write) so coroutines cannot interleave a partial update.
+- **Security**: the refresh token transits the localhost frontend (sessionStorage) and
+  is stored in the config YAML exactly as `oauth_token` already is. Acceptable for a
+  local desktop app; covered by `sensitive_keys` redaction.
+- **Clocks**: expiry uses wall-clock `time.time()` (token validity is wall-clock), not
+  `time.monotonic()` (which is used only for the in-memory OAuth flow TTL).

--- a/specs/projects/git_oauth_token_refresh/implementation_plan.md
+++ b/specs/projects/git_oauth_token_refresh/implementation_plan.md
@@ -1,0 +1,47 @@
+---
+status: complete
+---
+
+# Implementation Plan: GitHub OAuth Token Refresh
+
+See `architecture.md` for per-file detail. Each phase is independently reviewable and
+ends with the project's automated checks passing.
+
+## Phases
+
+- [ ] **Phase 1 — Token capture & storage (backend)**
+  `oauth.py` (`OAuthTokenResult`, `exchange_code_for_token` returns it, `refresh_access_token`,
+  `OAuthFlowState` fields), `git_sync_api.py` (callback stores refresh/expiry,
+  `OAuthStatusResponse` + `SaveConfigRequest` + `UpdateConfigRequest` carry/persist the new
+  fields, auth-mode-switch clears refresh fields), `config.py` (TypedDict fields, `get_*`
+  defaults, `update_oauth_tokens` helper), `libs/core/.../config.py` (`sensitive_keys`).
+  Tests for oauth + config + api persistence.
+
+- [ ] **Phase 2 — Auto-refresh engine in the manager**
+  `errors.py` (`AuthExpiredError`), `git_sync_manager.py` (`project_path` + `_refresh_lock`,
+  `_ensure_valid_oauth_token` proactive refresh + persist, call before `fetch`/`push`),
+  `registry.py` + call sites (`middleware.py`, `desktop_server.py`) thread `project_path`.
+  Tests for proactive refresh, persistence, rotation, concurrency, no-op cases.
+
+- [ ] **Phase 3 — Error classification, reactive refresh, middleware mapping**
+  `git_sync_manager.py` (`_is_auth_error`, auth-vs-network branching in `fetch`/
+  `commit_and_push`, reactive refresh + single retry, `ensure_fresh*` re-raise
+  `AuthExpiredError`), `middleware.py` (`ERROR_MAP` → 401 reconnect message), confirm
+  `background_sync` survives `AuthExpiredError`. Tests for classification, reactive path,
+  401 mapping, background-sync resilience.
+
+- [ ] **Phase 4 — Frontend plumbing**
+  Regenerate OpenAPI bindings (`generate_schema.sh`), then update hand-written types and
+  the OAuth-token path: `api.ts`, `oauth_flow.ts`, `oauth_with_install.ts`,
+  `git_import_wizard_store.ts`, `step_credentials.svelte`, `import_project.svelte`,
+  `step_complete.svelte`, `git_sync_status.svelte`. Update `oauth_flow.test.ts` and
+  related tests for the new `onSuccess` payload shape.
+
+## Notes
+
+- Phases 1→2→3 are sequential (3 depends on the manager work in 2; 2 depends on the
+  config/capture in 1). Phase 4 depends on Phase 1's backend model changes (for schema
+  regen) but is otherwise independent of 2/3.
+- Boundary: this project does **not** build recovery UX or fix the `[Object object]`
+  task-picker error — that is the separate `git_auth_recovery` project, which consumes the
+  401 `AuthExpiredError` introduced here.

--- a/specs/projects/git_oauth_token_refresh/project_overview.md
+++ b/specs/projects/git_oauth_token_refresh/project_overview.md
@@ -1,0 +1,66 @@
+---
+status: complete
+---
+
+# GitHub OAuth Token Refresh
+
+## Problem
+
+Users who connect a project to GitHub via the **Kiln AI GitHub Sync** GitHub App
+("Connect with GitHub" / `auth_mode="github_oauth"`) sync fine at first, then after
+roughly 8–24 hours (usually overnight) every sync starts failing with HTTP 503
+`"Cannot sync with remote. Check your connection."`.
+
+## Root cause
+
+GitHub App **user access tokens are short-lived** (8h default when "Expire user
+authorization tokens" is enabled on the app). GitHub returns a `refresh_token` (valid
+~6 months) and `expires_in` alongside the access token so clients can renew silently.
+
+Kiln throws all of that away:
+
+- `app/desktop/git_sync/oauth.py` `exchange_code_for_token()` returns only
+  `data["access_token"]` — `refresh_token`, `expires_in`, and
+  `refresh_token_expires_in` are discarded.
+- `GitSyncProjectConfig` (`app/desktop/git_sync/config.py`) has no field to store a
+  refresh token or expiry.
+- There is **no refresh logic anywhere** — no `grant_type=refresh_token` call, no
+  expiry check.
+
+When the access token expires, pygit2's credential callback is rejected, raising
+`pygit2.GitError("Authentication failed...")`, which `GitSyncManager.fetch()` wraps as
+`RemoteUnreachableError` → middleware maps to 503 "Check your connection." So an **auth
+expiry is mislabeled as a network problem**, and there is no path back to a working
+state without manual reconnection.
+
+This only affects `github_oauth` users. PAT (`pat_token`) and SSH (`system_keys`) users
+have long-lived credentials and are unaffected.
+
+## Scope of this project
+
+1. **Capture** the refresh token and expiry returned by GitHub at connect/reconnect time
+   and persist them.
+2. **Auto-refresh** the access token before it expires (proactive), and recover by
+   refreshing on an auth-rejection (reactive), so OAuth sync keeps working indefinitely.
+3. **Classify the error correctly**: when refresh is impossible (no/expired refresh
+   token, revoked access), surface a distinct, accurate "reconnect your GitHub account"
+   error instead of the misleading "check your connection."
+
+## Out of scope (belongs to the separate `git_auth_recovery` project)
+
+- The task-picker `[Object object]` rendering bug.
+- The user-facing recovery UX (re-auth button, "remove existing and re-sync" flow).
+
+This project's job is *prevention* (keep the token alive) plus emitting a *correct*
+auth error when prevention is impossible. `git_auth_recovery` builds the UX that acts on
+that error.
+
+## Success criteria
+
+- An OAuth-connected project keeps syncing past 8h / overnight with no user action.
+- After ~6 months (refresh-token expiry) or if access is revoked/uninstalled, the user
+  sees a clear "reconnect GitHub" error (HTTP 401), not "check your connection."
+- Existing OAuth users (who have a token but no stored refresh token) get the clear
+  reconnect error once their token expires, and reconnecting enables auto-refresh going
+  forward.
+- PAT and SSH sync behavior is unchanged.


### PR DESCRIPTION
## Summary

Fixes the unrecoverable state when Git credentials expire (or any git-sync error occurs): the task picker showed `Tasks failed to load: [Object object]` (or, cross-origin, "Load failed"), and a single-project user had no way to recover. Now git-sync errors surface a real message and a re-import recovery path.

Implemented as the `git_auth_recovery` spec project (4 phases) plus a CORS fix uncovered during testing.

## What changed

**Phase 1 — Error envelope + auth classification (backend)**
- Middleware error bodies `{"detail": …}` → `{"message": …}` at all sites, so the UI renders the real error instead of `[Object object]`.
- Added `GitAuthError`; classify auth failures in `GitSyncManager.fetch()`; map to HTTP 401 with a "re-import to reconnect" message; widened `ensure_fresh`/`ensure_fresh_for_read` to propagate it.

**Phase 2 — Git re-import recovery (backend)**
- `remove_project_from_config` (core) + `_deregister_project` (app); refactored `delete_project` onto them.
- `remove_conflicting_id` on `save_config`: de-register the conflicting project (files left on disk) then save, enabling re-import recovery.

**Phase 3 — Recovery UI (frontend)**
- Subtle "Re-import project?" link in the task-picker error state (wired for app + setup).
- Typed `GitSyncRequestError` + `is_duplicate_project_error`; unified error-message precedence to message-first; red "Remove existing and sync" button on a 409 conflict that retries with `remove_conflicting_id`.

**Phase 4 — Local-folder import parity**
- `remove_conflicting_id` on `POST /api/import_project`; matching red recovery button on the local-file import step (editing the path clears the conflict state).

**CORS fix (uncovered while testing)**
- `GitSyncMiddleware` was registered outside `CORSMiddleware`, so its short-circuit error responses (401/503/…) carried no `Access-Control-Allow-Origin` header — the browser blocked them ("origin not allowed" → "Load failed") and the message never reached the client. Added an opt-in `extra_middleware` param to `make_app` so desktop installs `GitSyncMiddleware` **inner** to CORS, keeping CORS outermost. Regression test included.

## Known trade-off (intentional)

"Remove existing and sync" de-registers the conflicting project but leaves its clone on disk (we never delete user data), so a stale clone can be orphaned under `.git-projects/`. Disk-only, no data loss or correctness impact — accepted, not fixed here.

## Testing

- Python + web suites green via the project's check tooling; new tests cover auth classification, the de-register/save flow, the frontend conflict/retry flows, and the CORS-header regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
