### PR TITLE
KIL-701 Add tag search to Filter by Tags modal

### DIFF
--- a/app/web_ui/src/lib/ui/filter_tags_dialog.svelte
+++ b/app/web_ui/src/lib/ui/filter_tags_dialog.svelte
@@ -8,6 +8,8 @@
   export let onAddFilterTag: (tag: string) => void = () => {}
 
   let dialog: Dialog | null = null
+  let search_text = ""
+  let search_input: HTMLInputElement | null = null
 
   export function show() {
     dialog?.show()
@@ -16,12 +18,34 @@
   export function close() {
     dialog?.close()
   }
+
+  function on_dialog_show() {
+    // Reset the search each time the dialog opens, then focus the input so
+    // users can just start typing to search for a tag.
+    search_text = ""
+    setTimeout(() => search_input?.focus(), 0)
+  }
+
+  $: sorted_available_tags = Object.entries(available_filter_tags).sort(
+    (a, b) => b[1] - a[1],
+  )
+
+  $: filtered_available_tags = (() => {
+    const query = search_text.trim().toLowerCase()
+    if (!query) {
+      return sorted_available_tags
+    }
+    return sorted_available_tags.filter(([tag]) =>
+      tag.toLowerCase().includes(query),
+    )
+  })()
 </script>
 
 <Dialog
   bind:this={dialog}
   {title}
   action_buttons={[{ label: "Close", isCancel: true }]}
+  on:show={on_dialog_show}
 >
   {#if filter_tags.length > 0}
     <div class="text-sm mb-2 font-medium">Current Filters:</div>
@@ -43,13 +67,27 @@
     <p class="text-sm text-gray-500">
       Any further filters would show zero results.
     </p>
+  {:else}
+    <input
+      bind:this={search_input}
+      bind:value={search_text}
+      type="text"
+      autocomplete="off"
+      autocapitalize="none"
+      spellcheck="false"
+      placeholder="Search tags…"
+      class="input input-bordered input-sm w-full mb-3"
+    />
+    <div class="flex flex-row gap-2 flex-wrap">
+      {#each filtered_available_tags as [tag, count]}
+        <button
+          class="badge bg-gray-200 text-gray-500 py-3 px-3 max-w-full"
+          on:click={() => onAddFilterTag(tag)}>{tag} ({count})</button
+        >
+      {/each}
+    </div>
+    {#if filtered_available_tags.length === 0}
+      <p class="text-sm text-gray-500">No tags match "{search_text}".</p>
+    {/if}
   {/if}
-  <div class="flex flex-row gap-2 flex-wrap">
-    {#each Object.entries(available_filter_tags).sort((a, b) => b[1] - a[1]) as [tag, count]}
-      <button
-        class="badge bg-gray-200 text-gray-500 py-3 px-3 max-w-full"
-        on:click={() => onAddFilterTag(tag)}>{tag} ({count})</button
-      >
-    {/each}
-  </div>
 </Dialog>

--- a/app/web_ui/src/lib/ui/filter_tags_dialog.svelte
+++ b/app/web_ui/src/lib/ui/filter_tags_dialog.svelte
@@ -26,19 +26,14 @@
     setTimeout(() => search_input?.focus(), 0)
   }
 
-  $: sorted_available_tags = Object.entries(available_filter_tags).sort(
+  $: sorted_available_tags = Object.entries(available_filter_tags || {}).sort(
     (a, b) => b[1] - a[1],
   )
 
-  $: filtered_available_tags = (() => {
-    const query = search_text.trim().toLowerCase()
-    if (!query) {
-      return sorted_available_tags
-    }
-    return sorted_available_tags.filter(([tag]) =>
-      tag.toLowerCase().includes(query),
-    )
-  })()
+  $: query = search_text.trim().toLowerCase()
+  $: filtered_available_tags = query
+    ? sorted_available_tags.filter(([tag]) => tag.toLowerCase().includes(query))
+    : sorted_available_tags
 </script>
 
 <Dialog
@@ -76,6 +71,7 @@
       autocapitalize="none"
       spellcheck="false"
       placeholder="Search tags…"
+      aria-label="Search tags"
       class="input input-bordered input-sm w-full mb-3"
     />
     <div class="flex flex-row gap-2 flex-wrap">

--- a/app/web_ui/src/lib/ui/filter_tags_dialog.test.ts
+++ b/app/web_ui/src/lib/ui/filter_tags_dialog.test.ts
@@ -1,9 +1,20 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeAll, afterEach, vi } from "vitest"
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  vi,
+} from "vitest"
 import { render, fireEvent, cleanup } from "@testing-library/svelte"
 import FilterTagsDialog from "./filter_tags_dialog.svelte"
 
 // jsdom does not implement HTMLDialogElement.showModal/close.
+const originalShowModal = HTMLDialogElement.prototype.showModal
+const originalClose = HTMLDialogElement.prototype.close
+
 beforeAll(() => {
   if (!HTMLDialogElement.prototype.showModal) {
     HTMLDialogElement.prototype.showModal = function () {
@@ -15,6 +26,11 @@ beforeAll(() => {
       this.open = false
     }
   }
+})
+
+afterAll(() => {
+  HTMLDialogElement.prototype.showModal = originalShowModal
+  HTMLDialogElement.prototype.close = originalClose
 })
 
 afterEach(() => {

--- a/app/web_ui/src/lib/ui/filter_tags_dialog.test.ts
+++ b/app/web_ui/src/lib/ui/filter_tags_dialog.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest"
+import { render, fireEvent, cleanup } from "@testing-library/svelte"
+import FilterTagsDialog from "./filter_tags_dialog.svelte"
+
+// jsdom does not implement HTMLDialogElement.showModal/close.
+beforeAll(() => {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function () {
+      this.open = true
+    }
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function () {
+      this.open = false
+    }
+  }
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+const available = {
+  golden: 12,
+  needs_rating: 3,
+  eval_set: 7,
+}
+
+describe("FilterTagsDialog tag search", () => {
+  it("renders all available tags by default, sorted by count", () => {
+    const { container } = render(FilterTagsDialog, {
+      props: { title: "Filter by Tags", available_filter_tags: available },
+    })
+    const tags = [...container.querySelectorAll("button.badge")].map((b) =>
+      b.textContent?.trim(),
+    )
+    expect(tags).toEqual(["golden (12)", "eval_set (7)", "needs_rating (3)"])
+  })
+
+  it("filters the available tags by case-insensitive substring as the user types", async () => {
+    const { container, getByPlaceholderText } = render(FilterTagsDialog, {
+      props: { title: "Filter by Tags", available_filter_tags: available },
+    })
+    const input = getByPlaceholderText("Search tags…")
+    await fireEvent.input(input, { target: { value: "EVAL" } })
+
+    const tags = [...container.querySelectorAll("button.badge")].map((b) =>
+      b.textContent?.trim(),
+    )
+    expect(tags).toEqual(["eval_set (7)"])
+  })
+
+  it("shows a no-results message when nothing matches", async () => {
+    const { container, getByPlaceholderText } = render(FilterTagsDialog, {
+      props: { title: "Filter by Tags", available_filter_tags: available },
+    })
+    await fireEvent.input(getByPlaceholderText("Search tags…"), {
+      target: { value: "zzz" },
+    })
+    expect(container.querySelectorAll("button.badge").length).toBe(0)
+    expect(container.textContent).toContain('No tags match "zzz".')
+  })
+
+  it("calls onAddFilterTag when a tag is clicked", async () => {
+    const onAddFilterTag = vi.fn()
+    const { getByText } = render(FilterTagsDialog, {
+      props: {
+        title: "Filter by Tags",
+        available_filter_tags: available,
+        onAddFilterTag,
+      },
+    })
+    await fireEvent.click(getByText("golden (12)"))
+    expect(onAddFilterTag).toHaveBeenCalledWith("golden")
+  })
+
+  it("does not show the search input when there are no available tags", () => {
+    const { queryByPlaceholderText, container } = render(FilterTagsDialog, {
+      props: { title: "Filter by Tags", available_filter_tags: {} },
+    })
+    expect(queryByPlaceholderText("Search tags…")).toBeNull()
+    expect(container.textContent).toContain(
+      "Any further filters would show zero results.",
+    )
+  })
+
+  it("resets the search text when the dialog is re-opened", async () => {
+    const { getByPlaceholderText, component } = render(FilterTagsDialog, {
+      props: { title: "Filter by Tags", available_filter_tags: available },
+    })
+    const input = getByPlaceholderText("Search tags…") as HTMLInputElement
+    await fireEvent.input(input, { target: { value: "golden" } })
+    expect(input.value).toBe("golden")
+
+    component.show()
+    await Promise.resolve()
+    expect(input.value).toBe("")
+  })
+})


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-701

## Description

In the **Filter Dataset by Tags** modal, you should be able to just start typing and a search bar pops up like we have in the Run Options fields like model selector.

## Changes

Adds tag search to the shared `filter_tags_dialog.svelte` (used by both the **Dataset** page and the **Evals** page):

- A search input at the top of the "Add a filter" section filters the available tags by case-insensitive substring match as you type (still sorted by count desc).
- The input auto-focuses when the modal opens, so you can just start typing to search — matching the model-selector UX referenced in the ticket.
- Shows a "No tags match …" message when the search yields no results.
- Search resets each time the modal is reopened, and is hidden when there are no available tags (preserving the existing "zero results" message).

Adds a Vitest suite (`filter_tags_dialog.test.ts`) covering default render/sort, filtering, no-results, click-to-add, hidden-when-empty, and reset-on-reopen.

No backend/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)