### PR TITLE
refactor: align colors for buttons for send (disabled) and stop in assistant ui

### DIFF
--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -1051,7 +1051,7 @@
       {#if isLoading}
         <button
           type="button"
-          class="absolute right-3 bottom-6 flex size-8 items-center justify-center rounded-full bg-base-300 text-base-content hover:opacity-90 transition-opacity"
+          class="absolute right-3 bottom-6 btn btn-sm btn-circle btn-neutral"
           on:click={stop}
           aria-label="Stop"
         >
@@ -1060,7 +1060,7 @@
       {:else}
         <button
           type="submit"
-          class="absolute right-3 bottom-6 flex size-8 items-center justify-center rounded-full bg-primary text-primary-content hover:opacity-90 disabled:bg-base-300 disabled:text-base-content/40 disabled:pointer-events-none transition-colors"
+          class="absolute right-3 bottom-6 btn btn-sm btn-circle btn-primary"
           disabled={!input.trim() || inputDisabled}
           aria-label="Send"
         >


### PR DESCRIPTION
## What

Cleans up the Kiln Assistant chat input's send/stop buttons, which were using one-off hand-rolled styling instead of standard DaisyUI buttons.

- **Send** button: now `btn btn-sm btn-circle btn-primary`. It inherits DaisyUI's standard `:disabled` styling (matching every other button in the app, e.g. the "Add" button in the Add Documents dialog) instead of custom `disabled:bg-*/disabled:text-*` classes.
- **Stop** button (shown while streaming): now `btn btn-sm btn-circle btn-neutral`. The previous `bg-base-300` grey blended into the disabled grey textarea; `btn-neutral` is a dark filled circle that stays clearly visible and reads as an active control.

Same shape/size as before (`btn-sm btn-circle` ≈ the old `size-8 rounded-full`).

Now:
<img width="506" height="238" alt="image" src="https://github.com/user-attachments/assets/95fa716a-242e-4dad-9c9a-a1bab1ca2ad0" />

<img width="855" height="206" alt="image" src="https://github.com/user-attachments/assets/8bba2611-a637-4cc4-ae3a-356dadc208bc" />

## Why

The original "black arrow on dark-grey circle" looked off and used non-standard disabled styling. Using DaisyUI buttons makes the disabled/active states consistent with the rest of the app.

## Testing

- `npm run lint` — clean
- `npm run check` — 0 errors (pre-existing unrelated warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)