### PR TITLE
Add "Write Access Required" error state for Git connect flow

### DIFF
--- a/app/desktop/git_sync/clone.py
+++ b/app/desktop/git_sync/clone.py
@@ -408,13 +408,15 @@ def test_write_access(
     pat_token: str | None = None,
     auth_mode: AuthMode = "system_keys",
     oauth_token: str | None = None,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, bool]:
     """Test write access by pushing an empty commit.
 
     The pygit2 Repository is freed before returning to release libgit2
     file handles (required on Windows).
 
-    Returns (success, message).
+    Returns (success, message, write_denied).  *write_denied* is True when
+    the user authenticated but the remote rejected the push due to
+    insufficient permissions (e.g. read-only access on the branch).
     """
     repo: pygit2.Repository | None = None
     try:
@@ -444,16 +446,22 @@ def test_write_access(
 
         if push_errors:
             repo.reset(pre_commit_head, pygit2.enums.ResetMode.HARD)
-            return False, "; ".join(push_errors)
+            return False, "; ".join(push_errors), True
 
-        return True, "Write access confirmed"
+        return True, "Write access confirmed", False
     except pygit2.GitError as e:
         error_str = str(e).lower()
-        if "401" in error_str or "403" in error_str or "auth" in error_str:
-            return False, "Authentication failed - check your token permissions"
-        return False, f"Write access check failed: {e}"
+        if "403" in error_str:
+            return (
+                False,
+                "Write permission denied - your access to this branch is read-only",
+                True,
+            )
+        if "401" in error_str or "auth" in error_str:
+            return False, "Authentication failed - check your token permissions", False
+        return False, f"Write access check failed: {e}", False
     except Exception as e:
-        return False, f"Write access check failed: {e}"
+        return False, f"Write access check failed: {e}", False
     finally:
         if repo is not None:
             repo.free()

--- a/app/desktop/git_sync/clone.py
+++ b/app/desktop/git_sync/clone.py
@@ -403,6 +403,22 @@ def _ensure_gitignore(
         logger.warning("Gitignore push failed: %s", "; ".join(push_errors))
 
 
+def _rollback_dummy_commit(
+    repo: pygit2.Repository | None,
+    pre_commit_head: pygit2.Oid | str | None,
+) -> None:
+    """Reset the repo HEAD to undo a dummy test commit, if one was created.
+
+    Silently swallows any error so the caller's original exception is
+    always propagated unchanged.
+    """
+    if repo is not None and pre_commit_head is not None:
+        try:
+            repo.reset(pre_commit_head, pygit2.enums.ResetMode.HARD)
+        except Exception:
+            pass
+
+
 def test_write_access(
     clone_path: Path,
     pat_token: str | None = None,
@@ -419,6 +435,7 @@ def test_write_access(
     insufficient permissions (e.g. read-only access on the branch).
     """
     repo: pygit2.Repository | None = None
+    pre_commit_head: pygit2.Oid | str | None = None
     try:
         repo = pygit2.Repository(str(clone_path))
         sig = pygit2.Signature(get_committer_name(), get_committer_email())
@@ -445,11 +462,13 @@ def test_write_access(
         remote.push([f"refs/heads/{branch_name}"], callbacks=push_cb)
 
         if push_errors:
+            assert pre_commit_head is not None
             repo.reset(pre_commit_head, pygit2.enums.ResetMode.HARD)
             return False, "; ".join(push_errors), True
 
         return True, "Write access confirmed", False
     except pygit2.GitError as e:
+        _rollback_dummy_commit(repo, pre_commit_head)
         error_str = str(e).lower()
         if "403" in error_str:
             return (
@@ -461,6 +480,7 @@ def test_write_access(
             return False, "Authentication failed - check your token permissions", False
         return False, f"Write access check failed: {e}", False
     except Exception as e:
+        _rollback_dummy_commit(repo, pre_commit_head)
         return False, f"Write access check failed: {e}", False
     finally:
         if repo is not None:

--- a/app/desktop/git_sync/git_sync_api.py
+++ b/app/desktop/git_sync/git_sync_api.py
@@ -165,6 +165,10 @@ class TestAccessResponse(BaseModel):
         default=False,
         description="True when the failure is due to missing authentication.",
     )
+    write_denied: bool = Field(
+        default=False,
+        description="True when the user authenticated but the remote rejected the push due to insufficient write permissions.",
+    )
     auth_method: str | None = Field(
         default=None,
         description="Auth method that succeeded: 'system_keys', 'pat_token', or 'github_oauth'. Null on failure.",
@@ -516,16 +520,19 @@ def connect_git_sync_api(app: FastAPI):
         request: TestWriteAccessRequest,
     ) -> TestAccessResponse:
         _validate_clone_path(request.clone_path)
-        success, message = await asyncio.to_thread(
+        success, message, write_denied = await asyncio.to_thread(
             test_write_access,
             Path(request.clone_path),
             request.pat_token,
             request.auth_mode,
             request.oauth_token,
         )
-        auth_required = not success and "auth" in message.lower()
+        auth_required = not success and not write_denied and "auth" in message.lower()
         return TestAccessResponse(
-            success=success, message=message, auth_required=auth_required
+            success=success,
+            message=message,
+            auth_required=auth_required,
+            write_denied=write_denied,
         )
 
     @app.post(

--- a/app/desktop/git_sync/test_clone.py
+++ b/app/desktop/git_sync/test_clone.py
@@ -483,9 +483,10 @@ class TestTestWriteAccessFreesRepository:
             patch("app.desktop.git_sync.clone.make_credentials"),
             patch("app.desktop.git_sync.clone.make_push_callbacks"),
         ):
-            success, msg = check_write_access(Path("/tmp/clone"))
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
 
         assert success is True
+        assert denied is False
         mock_repo.free.assert_called_once()
 
     def test_frees_repo_on_git_error(self):
@@ -498,9 +499,10 @@ class TestTestWriteAccessFreesRepository:
             ),
             patch("app.desktop.git_sync.clone.pygit2.Signature"),
         ):
-            success, msg = check_write_access(Path("/tmp/clone"))
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
 
         assert success is False
+        assert denied is False
         mock_repo.free.assert_called_once()
 
     def test_frees_repo_on_unexpected_error(self):
@@ -513,7 +515,111 @@ class TestTestWriteAccessFreesRepository:
             ),
             patch("app.desktop.git_sync.clone.pygit2.Signature"),
         ):
-            success, msg = check_write_access(Path("/tmp/clone"))
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
 
         assert success is False
+        assert denied is False
         mock_repo.free.assert_called_once()
+
+
+class TestWriteAccessDeniedClassification:
+    def _make_mock_repo(self) -> MagicMock:
+        mock_repo = MagicMock()
+        mock_repo.head.target = "abc123"
+        mock_repo.head.name = "refs/heads/main"
+        mock_repo.head.shorthand = "main"
+        mock_repo.index.write_tree.return_value = "tree_oid"
+        mock_repo.create_commit.return_value = "commit_oid"
+        return mock_repo
+
+    def test_push_rejection_sets_write_denied(self):
+        mock_repo = self._make_mock_repo()
+
+        def fake_make_push_callbacks(cred_callbacks, push_errors):
+            push_errors.append("Push rejected for refs/heads/main: permission denied")
+            return MagicMock()
+
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+            patch("app.desktop.git_sync.clone.make_credentials"),
+            patch(
+                "app.desktop.git_sync.clone.make_push_callbacks",
+                side_effect=fake_make_push_callbacks,
+            ),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is False
+        assert denied is True
+        assert "permission denied" in msg.lower()
+
+    def test_403_git_error_sets_write_denied(self):
+        mock_repo = self._make_mock_repo()
+        mock_repo.index.write_tree.side_effect = pygit2.GitError(
+            "403 Forbidden: write access denied"
+        )
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is False
+        assert denied is True
+        assert "read-only" in msg.lower()
+
+    def test_401_git_error_does_not_set_write_denied(self):
+        mock_repo = self._make_mock_repo()
+        mock_repo.index.write_tree.side_effect = pygit2.GitError("401 Unauthorized")
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is False
+        assert denied is False
+        assert "authentication failed" in msg.lower()
+
+    def test_auth_git_error_does_not_set_write_denied(self):
+        mock_repo = self._make_mock_repo()
+        mock_repo.index.write_tree.side_effect = pygit2.GitError(
+            "authentication required"
+        )
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is False
+        assert denied is False
+        assert "authentication failed" in msg.lower()
+
+    def test_generic_git_error_does_not_set_write_denied(self):
+        mock_repo = self._make_mock_repo()
+        mock_repo.index.write_tree.side_effect = pygit2.GitError("network timeout")
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is False
+        assert denied is False

--- a/app/desktop/git_sync/test_clone.py
+++ b/app/desktop/git_sync/test_clone.py
@@ -556,6 +556,7 @@ class TestWriteAccessDeniedClassification:
         assert success is False
         assert denied is True
         assert "permission denied" in msg.lower()
+        mock_repo.reset.assert_called_once_with("abc123", pygit2.enums.ResetMode.HARD)
 
     def test_403_git_error_sets_write_denied(self):
         mock_repo = self._make_mock_repo()
@@ -623,3 +624,112 @@ class TestWriteAccessDeniedClassification:
 
         assert success is False
         assert denied is False
+
+
+class TestWriteAccessRollbackDummyCommit:
+    """Verify the dummy test commit is rolled back on all failure paths."""
+
+    def _make_mock_repo(self) -> MagicMock:
+        mock_repo = MagicMock()
+        mock_repo.head.target = "abc123"
+        mock_repo.head.name = "refs/heads/main"
+        mock_repo.head.shorthand = "main"
+        mock_repo.index.write_tree.return_value = "tree_oid"
+        mock_repo.create_commit.return_value = "commit_oid"
+        return mock_repo
+
+    def test_rollback_on_git_error_during_push(self):
+        mock_repo = self._make_mock_repo()
+        mock_remote = MagicMock()
+        mock_remote.push.side_effect = pygit2.GitError("403 Forbidden")
+        mock_repo.remotes.__getitem__ = MagicMock(return_value=mock_remote)
+
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+            patch("app.desktop.git_sync.clone.make_credentials"),
+            patch("app.desktop.git_sync.clone.make_push_callbacks"),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is False
+        mock_repo.reset.assert_called_once_with("abc123", pygit2.enums.ResetMode.HARD)
+
+    def test_rollback_on_unexpected_error_during_push(self):
+        mock_repo = self._make_mock_repo()
+        mock_remote = MagicMock()
+        mock_remote.push.side_effect = RuntimeError("connection lost")
+        mock_repo.remotes.__getitem__ = MagicMock(return_value=mock_remote)
+
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+            patch("app.desktop.git_sync.clone.make_credentials"),
+            patch("app.desktop.git_sync.clone.make_push_callbacks"),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is False
+        mock_repo.reset.assert_called_once_with("abc123", pygit2.enums.ResetMode.HARD)
+
+    def test_rollback_on_git_error_before_commit(self):
+        mock_repo = self._make_mock_repo()
+        mock_repo.index.write_tree.side_effect = pygit2.GitError("disk full")
+
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is False
+        mock_repo.reset.assert_called_once_with("abc123", pygit2.enums.ResetMode.HARD)
+
+    def test_no_rollback_on_success(self):
+        mock_repo = self._make_mock_repo()
+
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+            patch("app.desktop.git_sync.clone.make_credentials"),
+            patch("app.desktop.git_sync.clone.make_push_callbacks"),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is True
+        mock_repo.reset.assert_not_called()
+
+    def test_rollback_failure_does_not_mask_original_error(self):
+        mock_repo = self._make_mock_repo()
+        mock_remote = MagicMock()
+        mock_remote.push.side_effect = pygit2.GitError("network timeout")
+        mock_repo.remotes.__getitem__ = MagicMock(return_value=mock_remote)
+        mock_repo.reset.side_effect = Exception("reset failed too")
+
+        with (
+            patch(
+                "app.desktop.git_sync.clone.pygit2.Repository",
+                return_value=mock_repo,
+            ),
+            patch("app.desktop.git_sync.clone.pygit2.Signature"),
+            patch("app.desktop.git_sync.clone.make_credentials"),
+            patch("app.desktop.git_sync.clone.make_push_callbacks"),
+        ):
+            success, msg, denied = check_write_access(Path("/tmp/clone"))
+
+        assert success is False
+        assert "network timeout" in msg
+        mock_repo.reset.assert_called_once()
+        mock_repo.free.assert_called_once()

--- a/app/desktop/git_sync/test_git_sync_api.py
+++ b/app/desktop/git_sync/test_git_sync_api.py
@@ -260,13 +260,62 @@ class TestTestWriteAccess:
             ),
             patch("app.desktop.git_sync.git_sync_api.test_write_access") as mock,
         ):
-            mock.return_value = (True, "Write access confirmed")
+            mock.return_value = (True, "Write access confirmed", False)
             resp = api_client.post(
                 "/api/git_sync/test_write_access",
                 json={"clone_path": str(clone_dir)},
             )
         data = resp.json()
         assert data["success"] is True
+        assert data["write_denied"] is False
+
+    def test_write_denied(self, api_client, tmp_path):
+        clone_dir = tmp_path / "kiln_clone_abc"
+        clone_dir.mkdir()
+        with (
+            patch(
+                "app.desktop.git_sync.git_sync_api.default_project_path",
+                return_value=str(tmp_path),
+            ),
+            patch("app.desktop.git_sync.git_sync_api.test_write_access") as mock,
+        ):
+            mock.return_value = (
+                False,
+                "Push rejected for refs/heads/main: denied",
+                True,
+            )
+            resp = api_client.post(
+                "/api/git_sync/test_write_access",
+                json={"clone_path": str(clone_dir)},
+            )
+        data = resp.json()
+        assert data["success"] is False
+        assert data["write_denied"] is True
+        assert data["auth_required"] is False
+
+    def test_auth_required(self, api_client, tmp_path):
+        clone_dir = tmp_path / "kiln_clone_abc"
+        clone_dir.mkdir()
+        with (
+            patch(
+                "app.desktop.git_sync.git_sync_api.default_project_path",
+                return_value=str(tmp_path),
+            ),
+            patch("app.desktop.git_sync.git_sync_api.test_write_access") as mock,
+        ):
+            mock.return_value = (
+                False,
+                "Authentication failed - check your token permissions",
+                False,
+            )
+            resp = api_client.post(
+                "/api/git_sync/test_write_access",
+                json={"clone_path": str(clone_dir)},
+            )
+        data = resp.json()
+        assert data["success"] is False
+        assert data["write_denied"] is False
+        assert data["auth_required"] is True
 
 
 class TestScanProjects:

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -10056,6 +10056,12 @@ export interface components {
              */
             auth_required: boolean;
             /**
+             * Write Denied
+             * @description True when the user authenticated but the remote rejected the push due to insufficient write permissions.
+             * @default false
+             */
+            write_denied: boolean;
+            /**
              * Auth Method
              * @description Auth method that succeeded: 'system_keys', 'pat_token', or 'github_oauth'. Null on failure.
              */

--- a/app/web_ui/src/lib/components/import/step_branch.svelte
+++ b/app/web_ui/src/lib/components/import/step_branch.svelte
@@ -25,6 +25,7 @@
   let submitting = false
   let saved = false
   let status_message = ""
+  let write_denied = false
 
   onMount(async () => {
     try {
@@ -63,10 +64,20 @@
     return [{ options }] as OptionGroup[]
   })()
 
-  async function clone_and_test() {
+  // Exported for test access only
+  export function choose_another_branch() {
+    write_denied = false
+    error = null
+    submitting = false
+    status_message = ""
+  }
+
+  // Exported for test access only
+  export async function clone_and_test() {
     let clone_path = ""
     try {
       error = null
+      write_denied = false
       submitting = true
       status_message = "Cloning repository..."
 
@@ -93,6 +104,10 @@
       )
 
       if (!write_result.success) {
+        if (write_result.write_denied) {
+          write_denied = true
+          return
+        }
         if (write_result.auth_required) {
           on_selected(selected_branch, clone_path, true)
           return
@@ -119,35 +134,71 @@
   }
 </script>
 
-<h2 class="text-xl font-medium mb-2">Select Branch</h2>
-<p class="text-sm text-gray-500 mb-6">
-  Choose the branch Kiln will auto-sync with. This will clone the repository to
-  a local directory managed by Kiln.
-</p>
+{#if write_denied}
+  <div class="flex flex-col items-center py-8 gap-4">
+    <div
+      class="w-12 h-12 rounded-full bg-error/10 flex items-center justify-center"
+    >
+      <svg
+        class="w-6 h-6 text-error"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        />
+      </svg>
+    </div>
 
-{#if loading}
-  <div class="flex justify-center py-8">
-    <span class="loading loading-spinner loading-md"></span>
+    <h2 class="text-xl font-medium">Write Access Required</h2>
+
+    <p class="text-sm text-gray-500 text-center max-w-md">
+      Kiln Git Sync needs read/write access, but your permissions on this branch
+      are read-only. Ask your Git administrator for write access, or switch to a
+      branch where you have write permissions.
+    </p>
+
+    <div class="mt-2">
+      <button class="btn btn-primary" on:click={choose_another_branch}>
+        Choose Another Branch
+      </button>
+    </div>
   </div>
-{:else if branches.length === 0 && error}
-  <Warning warning_message={error.getMessage()} warning_color="error" />
 {:else}
-  <FormContainer
-    submit_label="Clone & Continue"
-    on:submit={clone_and_test}
-    bind:submitting
-    bind:error
-    bind:saved
-    focus_on_mount={false}
-    submitting_status={status_message}
-  >
-    <FormElement
-      label="Branch"
-      id="branch"
-      inputType="fancy_select"
-      info_description="This is the Git branch Kiln will auto-sync with."
-      bind:value={selected_branch}
-      fancy_select_options={branch_option_groups}
-    />
-  </FormContainer>
+  <h2 class="text-xl font-medium mb-2">Select Branch</h2>
+  <p class="text-sm text-gray-500 mb-6">
+    Choose the branch Kiln will auto-sync with. This will clone the repository
+    to a local directory managed by Kiln.
+  </p>
+
+  {#if loading}
+    <div class="flex justify-center py-8">
+      <span class="loading loading-spinner loading-md"></span>
+    </div>
+  {:else if branches.length === 0 && error}
+    <Warning warning_message={error.getMessage()} warning_color="error" />
+  {:else}
+    <FormContainer
+      submit_label="Clone & Continue"
+      on:submit={clone_and_test}
+      bind:submitting
+      bind:error
+      bind:saved
+      focus_on_mount={false}
+      submitting_status={status_message}
+    >
+      <FormElement
+        label="Branch"
+        id="branch"
+        inputType="fancy_select"
+        info_description="This is the Git branch Kiln will auto-sync with."
+        bind:value={selected_branch}
+        fancy_select_options={branch_option_groups}
+      />
+    </FormContainer>
+  {/if}
 {/if}

--- a/app/web_ui/src/lib/components/import/step_branch.test.ts
+++ b/app/web_ui/src/lib/components/import/step_branch.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
+import { render, cleanup, fireEvent, waitFor } from "@testing-library/svelte"
+import { tick } from "svelte"
+
+vi.mock("$lib/git_sync/api", () => ({
+  listBranches: vi.fn(),
+  cloneRepo: vi.fn(),
+  testWriteAccess: vi.fn(),
+}))
+
+import StepBranch from "./step_branch.svelte"
+import { cloneRepo, testWriteAccess } from "$lib/git_sync/api"
+
+const baseProps = {
+  git_url: "https://github.com/org/repo.git",
+  pat_token: "token",
+  oauth_token: null,
+  auth_mode: "pat_token",
+  on_selected: vi.fn(),
+}
+
+beforeEach(() => {
+  vi.mocked(cloneRepo).mockResolvedValue({
+    clone_path: "/tmp/clone_abc",
+    success: true,
+    message: "OK",
+  })
+  vi.mocked(testWriteAccess).mockResolvedValue({
+    success: true,
+    message: "Write access confirmed",
+    auth_required: false,
+    write_denied: false,
+    auth_method: "pat_token",
+  })
+  vi.mocked(baseProps.on_selected).mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+// Svelte 4 async onMount callbacks do not execute in jsdom/vitest, so we
+// call the component's exported functions directly to exercise the
+// write-denied detection, auth-required redirect, and success paths.
+
+describe("StepBranch", () => {
+  it("renders loading spinner as initial state", () => {
+    const { container } = render(StepBranch, { props: baseProps })
+    expect(container.textContent).toContain("Select Branch")
+    expect(container.querySelector(".loading-spinner")).not.toBeNull()
+  })
+
+  it("shows write denied state when write access is rejected", async () => {
+    vi.mocked(testWriteAccess).mockResolvedValue({
+      success: false,
+      message: "Push rejected for refs/heads/main: permission denied",
+      auth_required: false,
+      write_denied: true,
+      auth_method: null,
+    })
+
+    const { container, component } = render(StepBranch, { props: baseProps })
+
+    await component.clone_and_test()
+    await tick()
+
+    expect(container.textContent).toContain("Write Access Required")
+    expect(container.textContent).toContain("read/write access")
+    expect(container.textContent).toContain("read-only")
+    expect(container.textContent).toContain("Choose Another Branch")
+    expect(container.textContent).not.toContain("Select Branch")
+    expect(container.querySelector(".rounded-full")).not.toBeNull()
+    expect(baseProps.on_selected).not.toHaveBeenCalled()
+  })
+
+  it("choose another branch clears write denied state", async () => {
+    vi.mocked(testWriteAccess).mockResolvedValue({
+      success: false,
+      message: "Push rejected for refs/heads/main: permission denied",
+      auth_required: false,
+      write_denied: true,
+      auth_method: null,
+    })
+
+    const { container, component, getByText } = render(StepBranch, {
+      props: baseProps,
+    })
+
+    await component.clone_and_test()
+    await tick()
+
+    expect(container.textContent).toContain("Write Access Required")
+
+    const chooseBtn = getByText("Choose Another Branch")
+    await fireEvent.click(chooseBtn)
+    await tick()
+
+    expect(container.textContent).not.toContain("Write Access Required")
+    expect(container.textContent).toContain("Select Branch")
+  })
+
+  it("choose_another_branch exported function clears state", async () => {
+    vi.mocked(testWriteAccess).mockResolvedValue({
+      success: false,
+      message: "denied",
+      auth_required: false,
+      write_denied: true,
+      auth_method: null,
+    })
+
+    const { container, component } = render(StepBranch, { props: baseProps })
+
+    await component.clone_and_test()
+    await tick()
+
+    expect(container.textContent).toContain("Write Access Required")
+
+    component.choose_another_branch()
+    await tick()
+
+    expect(container.textContent).not.toContain("Write Access Required")
+  })
+
+  it("redirects to credentials on auth_required", async () => {
+    vi.mocked(testWriteAccess).mockResolvedValue({
+      success: false,
+      message: "Authentication failed - check your token permissions",
+      auth_required: true,
+      write_denied: false,
+      auth_method: null,
+    })
+
+    const { component } = render(StepBranch, { props: baseProps })
+
+    await component.clone_and_test()
+    await tick()
+
+    expect(baseProps.on_selected).toHaveBeenCalledWith(
+      "",
+      "/tmp/clone_abc",
+      true,
+    )
+  })
+
+  it("proceeds on successful write access", async () => {
+    const { component } = render(StepBranch, { props: baseProps })
+
+    await component.clone_and_test()
+    await tick()
+
+    expect(baseProps.on_selected).toHaveBeenCalledWith(
+      "",
+      "/tmp/clone_abc",
+      false,
+    )
+  })
+
+  it("write_denied takes priority over auth_required", async () => {
+    vi.mocked(testWriteAccess).mockResolvedValue({
+      success: false,
+      message: "denied",
+      auth_required: true,
+      write_denied: true,
+      auth_method: null,
+    })
+
+    const { container, component } = render(StepBranch, { props: baseProps })
+
+    await component.clone_and_test()
+    await tick()
+
+    expect(container.textContent).toContain("Write Access Required")
+    expect(baseProps.on_selected).not.toHaveBeenCalled()
+  })
+
+  it("shows generic error for non-write-denied, non-auth failures", async () => {
+    vi.mocked(testWriteAccess).mockResolvedValue({
+      success: false,
+      message: "Write access check failed: network timeout",
+      auth_required: false,
+      write_denied: false,
+      auth_method: null,
+    })
+
+    const { container, component } = render(StepBranch, { props: baseProps })
+
+    await component.clone_and_test()
+    await tick()
+
+    expect(container.textContent).not.toContain("Write Access Required")
+    expect(baseProps.on_selected).not.toHaveBeenCalled()
+  })
+})

--- a/app/web_ui/src/lib/git_sync/api.ts
+++ b/app/web_ui/src/lib/git_sync/api.ts
@@ -54,6 +54,7 @@ export type TestAccessResponse = {
   success: boolean
   message: string
   auth_required: boolean
+  write_denied: boolean
   auth_method: string | null
 }
 

--- a/app/web_ui/src/lib/git_sync/oauth_with_install.test.ts
+++ b/app/web_ui/src/lib/git_sync/oauth_with_install.test.ts
@@ -106,6 +106,7 @@ describe("createOAuthWithInstall", () => {
       success: true,
       message: "",
       auth_required: false,
+      write_denied: false,
       auth_method: "github_oauth",
     })
 
@@ -128,6 +129,7 @@ describe("createOAuthWithInstall", () => {
       success: false,
       message: "No access",
       auth_required: true,
+      write_denied: false,
       auth_method: null,
     })
 
@@ -247,6 +249,7 @@ describe("createOAuthWithInstall", () => {
       success: true,
       message: "",
       auth_required: false,
+      write_denied: false,
       auth_method: "github_oauth",
     })
     staleCallbacks.onSuccess("ghu_stale_token")
@@ -272,6 +275,7 @@ describe("createOAuthWithInstall", () => {
       success: true,
       message: "",
       auth_required: false,
+      write_denied: false,
       auth_method: "github_oauth",
     })
     firstCallbacks.onSuccess("ghu_stale")
@@ -313,6 +317,7 @@ describe("createOAuthWithInstall", () => {
       success: false,
       message: "No access",
       auth_required: true,
+      write_denied: false,
       auth_method: null,
     })
     getCallbacks().onSuccess("ghu_token123")
@@ -324,6 +329,7 @@ describe("createOAuthWithInstall", () => {
       success: true,
       message: "",
       auth_required: false,
+      write_denied: false,
       auth_method: "github_oauth",
     })
     await flow.verify_access()

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/import_project/+page.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/import_project/+page.svelte
@@ -53,7 +53,7 @@
 <h1 class="text-2xl lg:text-4xl flex-none font-bold text-center">
   Import Project
 </h1>
-<h3 class="text-base font-medium text-center mt-3 max-w-[600px] mx-auto">
+<h3 class="text-base font-medium text-center mt-3 mb-4 max-w-[600px] mx-auto">
   Import an existing Kiln project
 </h3>
 


### PR DESCRIPTION
## Problem

When connecting a Git repo via `/settings/import_project#git-credentials`, Kiln runs a write-permission check. When that check failed, the UI rendered nothing for the failure — it silently bounced the user back to the GitHub **Authentication** screen ("Connect your GitHub account…") which they had already passed. No explanation of what went wrong.

## Fix

**Backend** (`clone.py`, `git_sync_api.py`)
- `test_write_access` now returns a `write_denied` flag, distinguishing **403 / push-rejection** (write denied) from **401** (auth failure).
- The `TestAccessResponse` carries `write_denied` and `auth_required` as mutually exclusive states.

**Frontend** (`step_branch.svelte`)
- A dedicated **"Write Access Required"** error state — standard red warning icon, explanatory copy, and a **"Choose Another Branch"** button — renders *in place of* the branch-selection header instead of redirecting to the auth screen.
- The write-denied state takes priority over auth-required, so the user no longer gets bounced.
- Minor: `mb-4` spacing tweak under the import subtitle.

## Copy

- **Title:** Write Access Required
- **Body:** Kiln Git Sync needs read/write access, but your permissions on this branch are read-only. Ask your Git administrator for write access, or switch to a branch where you have write permissions.
- **Button:** Choose Another Branch

## Tests

- Backend: write-denied classification (push rejection, 403, 401, auth keyword, generic) + API response-shape tests for `write_denied` / `auth_required` / success.
- Frontend: 8 tests covering the error display, "Choose Another Branch" reset, auth redirect, success/error paths, and write-denied-over-auth priority.

## Note

Any push rejection — including branch-protection rules — is classified as write-denied. The "switch to a branch where you have write permissions" guidance still applies in those cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)