### PR TITLE
Fix clone task dropping/drifting array-of-object sub-schemas

### DIFF
--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_form_element.svelte
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_form_element.svelte
@@ -25,7 +25,12 @@
       return raw_schema
     } else {
       validate_schema(schema_model, [name])
-      return JSON.stringify(schema_from_model(schema_model, true))
+      // creating=false preserves each property's stored key (id) instead of
+      // recomputing it from the human title. This keeps clone/edit a faithful
+      // copy -- otherwise array-of-object sub-schemas drift to the wrong parent
+      // (or collide) when a key != string_to_json_key(title). New properties
+      // have an empty id, so they still fall back to a title-derived key.
+      return JSON.stringify(schema_from_model(schema_model, false))
     }
   }
 
@@ -76,8 +81,9 @@
   function switch_to_raw_schema(): boolean {
     raw = true
 
-    // Convert the schema model to a pretty JSON Schema string
-    const json_schema_format = schema_from_model(schema_model, true)
+    // Convert the schema model to a pretty JSON Schema string.
+    // creating=false preserves stored property keys (see get_schema_string above).
+    const json_schema_format = schema_from_model(schema_model, false)
     raw_schema = JSON.stringify(json_schema_format, null, 2)
 
     // Close the dialog

--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
@@ -1174,3 +1174,121 @@ describe("round-trip conversion tests", () => {
     expect(reconstructedSchema).toEqual(objectWithRequiredArraySchema)
   })
 })
+
+// Regression tests for the "Clone Task" schema-drift bug. Clone loads a task's
+// schema into the visual editor (model_from_schema) and on Save re-serializes it
+// via schema_from_model(schema_model, creating). The Save path passes creating=false
+// so each property keeps its stored key (id). The previously hardcoded creating=true
+// recomputed keys from human titles, drifting array-of-object sub-schemas to the
+// wrong parent (or colliding) whenever a stored key != string_to_json_key(title) --
+// e.g. schemas authored via the Raw JSON editor or imported during a migration.
+describe("clone task schema fidelity", () => {
+  it("keeps array-of-object sub-schemas under their stored key when key != slug(title)", () => {
+    // Stored keys and human titles are crossed.
+    const schema: JsonSchemaProperty = {
+      type: "object",
+      properties: {
+        entities: {
+          title: "Audiences", // slug("Audiences") = "audiences" != key "entities"
+          type: "array",
+          items: {
+            title: "",
+            type: "object",
+            properties: {
+              type: { title: "type", type: "string" },
+              value: { title: "value", type: "string" },
+            },
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        audiences: {
+          title: "Entities", // slug("Entities") = "entities" != key "audiences"
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    }
+    const model = model_from_schema(schema)
+
+    // Fixed Save path (creating=false): sub-schemas stay under their real keys.
+    const fixed = schema_from_model(model, false)
+    expect(fixed.properties?.entities?.items?.type).toBe("object")
+    expect(fixed.properties?.audiences?.items?.type).toBe("string")
+
+    // Documents the old bug: creating=true re-keys by title and drifts the
+    // {type, value} sub-schema onto "audiences" (and vice versa).
+    const drifted = schema_from_model(model, true)
+    expect(drifted.properties?.entities?.items?.type).toBe("string")
+    expect(drifted.properties?.audiences?.items?.type).toBe("object")
+  })
+
+  it("does not drop a sub-schema when two property titles slug to the same key", () => {
+    const schema: JsonSchemaProperty = {
+      type: "object",
+      properties: {
+        entity_type: {
+          title: "Entity Type", // slug -> "entity_type"
+          type: "array",
+          items: {
+            title: "",
+            type: "object",
+            properties: { code: { title: "code", type: "string" } },
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        entity_type_legacy: {
+          title: "Entity_Type", // slug -> "entity_type" (would collide)
+          type: "string",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    }
+    const model = model_from_schema(schema)
+
+    // Fixed Save path: distinct stored keys are preserved, sub-schema survives.
+    const fixed = schema_from_model(model, false)
+    expect(Object.keys(fixed.properties!)).toHaveLength(2)
+    expect(fixed.properties?.entity_type?.items?.type).toBe("object")
+
+    // Documents the old bug: both titles slug to "entity_type" under creating=true;
+    // the second property clobbers the first and the array sub-schema is lost.
+    const collided = schema_from_model(model, true)
+    expect(Object.keys(collided.properties!)).toHaveLength(1)
+  })
+
+  it("does not mutate an empty array-item title on round-trip", () => {
+    // Mirrors the real brand-post-analyzer output schema: array-of-object items
+    // are stored with an empty title by the editor at creation time.
+    const schema: JsonSchemaProperty = {
+      type: "object",
+      properties: {
+        entities: {
+          title: "entities",
+          description: "Entities mentioned in the post; each is {type, value}",
+          type: "array",
+          items: {
+            title: "",
+            type: "object",
+            properties: {
+              type: { title: "type", type: "string" },
+              value: { title: "value", type: "string" },
+            },
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    }
+    const model = model_from_schema(schema)
+
+    // Empty item title is preserved (previously fabricated as "items").
+    expect(schema_from_model(model, false)).toEqual(schema)
+  })
+})

--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
@@ -1291,4 +1291,58 @@ describe("clone task schema fidelity", () => {
     // Empty item title is preserved (previously fabricated as "items").
     expect(schema_from_model(model, false)).toEqual(schema)
   })
+
+  it("preserves camelCase keys (top-level and nested) on a migration-style schema", () => {
+    // Mirrors a schema imported/ported during a migration: camelCase keys with
+    // Title Case titles, so every key != string_to_json_key(title). Reproduced
+    // end-to-end: cloning this on the old creating=true path rewrote every key
+    // (and nested key) to snake_case.
+    const schema: JsonSchemaProperty = {
+      type: "object",
+      properties: {
+        detectedEntities: {
+          title: "Detected Entities",
+          type: "array",
+          items: {
+            title: "",
+            type: "object",
+            properties: {
+              entityType: { title: "Entity Type", type: "string" },
+              entityValue: { title: "Entity Value", type: "string" },
+            },
+            required: ["entityType", "entityValue"],
+            additionalProperties: false,
+          },
+        },
+        targetAudiences: {
+          title: "Target Audiences",
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: ["detectedEntities", "targetAudiences"],
+      additionalProperties: false,
+    }
+    const model = model_from_schema(schema)
+
+    // Fixed Save path keeps every stored key, top-level and nested.
+    const fixed = schema_from_model(model, false)
+    expect(Object.keys(fixed.properties!)).toEqual([
+      "detectedEntities",
+      "targetAudiences",
+    ])
+    expect(
+      Object.keys(fixed.properties!.detectedEntities.items!.properties!),
+    ).toEqual(["entityType", "entityValue"])
+
+    // Documents the old bug: creating=true rewrites every key to snake_case.
+    const drifted = schema_from_model(model, true)
+    expect(Object.keys(drifted.properties!)).toEqual([
+      "detected_entities",
+      "target_audiences",
+    ])
+    expect(
+      Object.keys(drifted.properties!.detected_entities.items!.properties!),
+    ).toEqual(["entity_type", "entity_value"])
+  })
 })

--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.ts
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.ts
@@ -64,7 +64,10 @@ function build_schema_model_property(
 ): SchemaModelProperty {
   const result: SchemaModelProperty = {
     id,
-    title: options.title || id,
+    // Use ?? (not ||) so an explicit empty title round-trips unchanged. Array
+    // items are stored with an empty title; || would fabricate the synthetic
+    // id ("items") and mutate the schema on every clone.
+    title: options.title ?? id,
     description: options.description,
     type: options.type,
     required: !!required.includes(id),


### PR DESCRIPTION
## Problem

Task schemas are immutable after creation, so **Clone Task** is the supported path for schema migration — but clone is not a faithful copy. The clone flow loads the task into the visual schema editor (`model_from_schema`) and on **Save** re-serializes it via `schema_from_model(schema_model, true)`. `creating=true` was hardcoded in `json_schema_form_element.svelte`.

With `creating=true`, `validate_and_get_key` **discards each property's stored key (`id`) and recomputes it from the human title** (`string_to_json_key(title)`). Consequences for any schema where a stored key differs from `slug(title)` — e.g. schemas authored via the Raw JSON editor or imported/ported during a migration (camelCase/mixed-case keys, etc.):

- An Array-of-Object property's sub-schema is emitted under `slug(title)` instead of its real key, so it **drifts to the wrong parent** (e.g. `entities` loses its `{type, value}`; `audiences` inherits it).
- If two properties' titles slug to the **same** key, the second **overwrites** the first and a sub-schema is silently dropped.

A secondary fidelity bug: `build_schema_model_property` did `title: options.title || id`, fabricating the synthetic title `"items"` for empty array-item titles on every round-trip (the benign `items.title: "" → "items"` change visible even on UI-built schemas).

## Fix

- `json_schema_form_element.svelte` (`get_schema_string` Save path + `switch_to_raw_schema`): pass `creating=false`, preserving each property's stored key. New properties carry an empty `id`, so they still fall back to a title-derived key — this matches the documented intent of `validate_and_get_key` and the existing `creating=false` round-trip tests.
- `json_schema_templates.ts`: `title: options.title || id` → `?? id`, so an explicit empty item title round-trips unchanged.

## Tests

Adds a `clone task schema fidelity` suite covering: sub-schema preservation when `key != slug(title)`, no sub-schema loss on title collisions, empty item titles round-tripping unchanged, and a migration-style camelCase schema preserving keys at every level. The tests assert the fixed `creating=false` behavior and keep `creating=true` contrast assertions documenting the original drift. Full `web_ui` suite passes; eslint clean; `svelte-check` 0 errors.

## End-to-end verification (manual, through the running app)

Confirmed the bug and the fix through the real Clone Task UI flow, not just unit tests:

1. Created a task with a migration-style output schema via the Kiln API (bypassing the visual editor): camelCase keys (`detectedEntities`, `targetAudiences`, `extractedQuotes`) with Title Case titles and nested array-of-object fields (`entityType`/`entityValue`, `quoteText`/`speakerName`). Every key differs from `slug(title)`, which is the drift trigger.
2. **On `main` (before fix):** cloned it in the UI and saved. The clone's schema rewrote **every** key — top-level *and* nested — to snake_case. The clone did not match the source.
3. **On this branch (after fix):** cloned the same task in the UI and saved. The clone's schema preserved all keys exactly.

| key level | source | clone on `main` | clone on this branch |
|---|---|---|---|
| top-level | `detectedEntities`, `targetAudiences`, `extractedQuotes` | `detected_entities`, `target_audiences`, `extracted_quotes` ❌ | `detectedEntities`, `targetAudiences`, `extractedQuotes` ✅ |
| nested | `entityType`, `entityValue` / `quoteText`, `speakerName` | `entity_type`, `entity_value` / `quote_text`, `speaker_name` ❌ | `entityType`, `entityValue` / `quoteText`, `speakerName` ✅ |

Same task, same clone action, opposite outcome — isolating this change as the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
