### PR TITLE
Make schema property Description field optional in the visual editor

### DIFF
--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_item.svelte
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_item.svelte
@@ -265,6 +265,7 @@
   inputType="input"
   bind:value={model.description}
   light_label={true}
+  optional={true}
 />
 
 <!-- Per type fields -->


### PR DESCRIPTION
## Problem

The visual schema editor requires a **description** on every property before you can Save, but Kiln's data model and backend treat a property `description` as **optional** (a valid JSON Schema doesn't need one). This is inconsistent, and especially painful when cloning/migrating a task that was created via the Kiln API (which has no field descriptions): you're forced to type a description into every field just to save the clone.

Root cause: each property's Description field uses the shared `FormElement`, whose `optional` flag **defaults to `false`** (`form_element.svelte`). Its default validator treats any non-optional empty field as required:

```js
if (!optional && is_empty(value)) return '"' + label + '" is required'
```

The Description `FormElement` in `json_schema_item.svelte` never set `optional={true}`, so an empty description blocked Save.

## Fix

Pass `optional={true}` to the Description `FormElement` in `json_schema_item.svelte`. Descriptions are now optional in the editor (matching the data model and backend), and the field shows an "Optional" badge. The Name and Type fields remain required.

## Notes

Surfaced while reproducing a separate clone schema-drift bug (#1495): a task created via the Kiln API has no field descriptions, so cloning it through the visual editor forced a description onto every field before it could be saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
