### PR TITLE
Archived tools shouldn't be able to run on existing config

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/eval_utils/eval_utils.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_utils/eval_utils.py
@@ -39,7 +39,11 @@ class EvalUtils:
 
         for index, tool in enumerate(available_tools):
             try:
-                tool_object = tool_from_id(tool, task_run.parent_task())
+                # Past runs may reference now-archived tools; resolve them so we
+                # can describe what was available when the run happened.
+                tool_object = tool_from_id(
+                    tool, task_run.parent_task(), allow_archived=True
+                )
                 tool_definition = await tool_object.toolcall_definition()
 
                 tool_name = tool_definition["function"]["name"]

--- a/libs/core/kiln_ai/adapters/eval/test_eval_utils.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_utils.py
@@ -628,7 +628,7 @@ Add two numbers together and return the result</tool_description>
             return_value=tool_definition_side_effect("subtract_numbers")
         )
 
-        def tool_from_id_side_effect(tool_id, parent_task):
+        def tool_from_id_side_effect(tool_id, parent_task, allow_archived=False):
             if tool_id == "add_numbers":
                 return mock_tool1
             elif tool_id == "subtract_numbers":
@@ -687,7 +687,7 @@ Add two numbers together and return the result</tool_description>
             side_effect=ValueError("Tool broken")
         )
 
-        def tool_from_id_side_effect(tool_id, parent_task):
+        def tool_from_id_side_effect(tool_id, parent_task, allow_archived=False):
             if tool_id == "add_numbers":
                 return mock_tool1
             elif tool_id == "broken_tool":

--- a/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
+++ b/libs/core/kiln_ai/adapters/fine_tune/dataset_formatter.py
@@ -445,7 +445,9 @@ class DatasetFormatter:
                 continue
 
             try:
-                tool = tool_from_id(tool_id, task)
+                # Historical runs may reference tools archived after the fact; we
+                # still need their definitions to build the training data.
+                tool = tool_from_id(tool_id, task, allow_archived=True)
                 tool_def = await tool.toolcall_definition()
 
                 self._tool_cache[tool_id] = tool_def

--- a/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
@@ -640,7 +640,12 @@ class BaseAdapter(metaclass=ABCMeta):
             if sid in seen:
                 continue
             seen.add(sid)
-            skills.append(injected[sid])
+            skill = injected[sid]
+            if skill.is_archived:
+                raise ValueError(
+                    f"Skill '{skill.name}' is archived. Unarchive it or remove it from the run config to run it."
+                )
+            skills.append(skill)
 
         self._resolved_skills = skills
         return self._resolved_skills

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -1737,6 +1737,16 @@ class TestResolveSkills:
         assert len(result) == 1
         assert result[0].name == "my-skill"
 
+    def test_raises_when_skill_archived(self, base_task, _run_config_with_tools):
+        skill = Skill(name="my-skill", description="A skill", is_archived=True)
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=_run_config_with_tools([f"kiln_tool::skill::{skill.id}"]),
+            config=AdapterConfig(skills={skill.id: skill}),
+        )
+        with pytest.raises(ValueError, match="Skill 'my-skill' is archived"):
+            adapter._resolve_skills()
+
     def test_deduplicates_skill_ids(self, base_task, _run_config_with_tools):
         skill = Skill(name="my-skill", description="A skill", body="do things")
         adapter = MockAdapter(

--- a/libs/core/kiln_ai/tools/test_tool_registry.py
+++ b/libs/core/kiln_ai/tools/test_tool_registry.py
@@ -198,6 +198,49 @@ class TestToolRegistry:
             ):
                 tool_from_id(tool_id, task=mock_task)
 
+    def test_tool_from_id_mcp_archived_server_raises(self):
+        """Archived MCP servers can't be run via tool_from_id."""
+        mock_server = ExternalToolServer(
+            name="archived_server",
+            type=ToolServerType.remote_mcp,
+            properties={
+                "server_url": "https://example.com",
+                "is_archived": True,
+            },
+        )
+        mock_project = Mock(spec=Project)
+        mock_project.id = "test_project_id"
+        mock_project.external_tool_servers.return_value = [mock_server]
+        mock_task = Mock(spec=Task)
+        mock_task.parent_project.return_value = mock_project
+
+        tool_id = f"{MCP_REMOTE_TOOL_ID_PREFIX}{mock_server.id}::echo"
+
+        with pytest.raises(ValueError, match="archived tool server 'archived_server'"):
+            tool_from_id(tool_id, task=mock_task)
+
+    def test_tool_from_id_mcp_archived_server_allowed(self):
+        """allow_archived lets historical callers resolve an archived MCP server."""
+        mock_server = ExternalToolServer(
+            name="archived_server",
+            type=ToolServerType.remote_mcp,
+            properties={
+                "server_url": "https://example.com",
+                "is_archived": True,
+            },
+        )
+        mock_project = Mock(spec=Project)
+        mock_project.id = "test_project_id"
+        mock_project.external_tool_servers.return_value = [mock_server]
+        mock_task = Mock(spec=Task)
+        mock_task.parent_project.return_value = mock_project
+
+        tool_id = f"{MCP_REMOTE_TOOL_ID_PREFIX}{mock_server.id}::echo"
+        tool = tool_from_id(tool_id, task=mock_task, allow_archived=True)
+
+        assert isinstance(tool, MCPServerTool)
+        assert tool._tool_server_model == mock_server
+
     def test_tool_from_id_rag_tool_success(self):
         """Test that tool_from_id works with RAG tool IDs."""
         # Create mock RAG config
@@ -210,6 +253,7 @@ class TestToolRegistry:
             # Setup mock RAG config
             mock_rag_config = Mock()
             mock_rag_config.id = "test_rag_config"
+            mock_rag_config.is_archived = False
             mock_rag_config_class.from_id_and_parent_path.return_value = mock_rag_config
 
             # Setup mock RAG tool
@@ -284,6 +328,55 @@ class TestToolRegistry:
                 match="RAG config not found: missing_rag_config in project test_project_id for tool",
             ):
                 tool_from_id(tool_id, task=mock_task)
+
+    def test_tool_from_id_rag_archived_raises(self):
+        """Archived RAG configs can't be run via tool_from_id."""
+        from unittest.mock import patch
+
+        with patch("kiln_ai.tools.tool_registry.RagConfig") as mock_rag_config_class:
+            mock_rag_config = Mock()
+            mock_rag_config.id = "test_rag_config"
+            mock_rag_config.name = "archived_rag"
+            mock_rag_config.is_archived = True
+            mock_rag_config_class.from_id_and_parent_path.return_value = mock_rag_config
+
+            mock_project = Mock(spec=Project)
+            mock_project.id = "test_project_id"
+            mock_project.path = Path("/test/path")
+            mock_task = Mock(spec=Task)
+            mock_task.parent_project.return_value = mock_project
+
+            tool_id = f"{RAG_TOOL_ID_PREFIX}test_rag_config"
+
+            with pytest.raises(ValueError, match="'archived_rag' is archived"):
+                tool_from_id(tool_id, task=mock_task)
+
+    def test_tool_from_id_rag_archived_allowed(self):
+        """allow_archived lets historical callers resolve an archived RAG config."""
+        from unittest.mock import patch
+
+        with (
+            patch("kiln_ai.tools.tool_registry.RagConfig") as mock_rag_config_class,
+            patch("kiln_ai.tools.rag_tools.RagTool") as mock_rag_tool_class,
+        ):
+            mock_rag_config = Mock()
+            mock_rag_config.id = "test_rag_config"
+            mock_rag_config.name = "archived_rag"
+            mock_rag_config.is_archived = True
+            mock_rag_config_class.from_id_and_parent_path.return_value = mock_rag_config
+            mock_rag_tool = Mock()
+            mock_rag_tool_class.return_value = mock_rag_tool
+
+            mock_project = Mock(spec=Project)
+            mock_project.id = "test_project_id"
+            mock_project.path = Path("/test/path")
+            mock_task = Mock(spec=Task)
+            mock_task.parent_project.return_value = mock_project
+
+            tool_id = f"{RAG_TOOL_ID_PREFIX}test_rag_config"
+            tool = tool_from_id(tool_id, task=mock_task, allow_archived=True)
+
+            assert tool == mock_rag_tool
 
     def test_all_built_in_tools_are_registered(self):
         """Test that all KilnBuiltInToolId enum members are handled by the registry."""
@@ -787,3 +880,56 @@ class TestToolRegistry:
             match="Kiln Task External tool server not found: nonexistent_server in project ID test_project_id",
         ):
             tool_from_id(tool_id, task=mock_task)
+
+    def test_tool_from_id_kiln_task_archived_raises(self):
+        """Archived Kiln task tools can't be run via tool_from_id."""
+        mock_server = ExternalToolServer(
+            name="archived_kiln_task",
+            type=ToolServerType.kiln_task,
+            description="Archived Kiln task server",
+            properties={
+                "name": "archived_tool",
+                "description": "An archived task tool",
+                "task_id": "test_task_123",
+                "run_config_id": "test_config_456",
+                "is_archived": True,
+            },
+        )
+        mock_project = Mock(spec=Project)
+        mock_project.id = "test_project_id"
+        mock_project.external_tool_servers.return_value = [mock_server]
+        mock_task = Mock(spec=Task)
+        mock_task.parent_project.return_value = mock_project
+
+        tool_id = f"{KILN_TASK_TOOL_ID_PREFIX}{mock_server.id}"
+
+        with pytest.raises(
+            ValueError, match="Kiln Task tool 'archived_kiln_task' is archived"
+        ):
+            tool_from_id(tool_id, task=mock_task)
+
+    def test_tool_from_id_kiln_task_archived_allowed(self):
+        """allow_archived lets historical callers resolve an archived Kiln task tool."""
+        mock_server = ExternalToolServer(
+            name="archived_kiln_task",
+            type=ToolServerType.kiln_task,
+            description="Archived Kiln task server",
+            properties={
+                "name": "archived_tool",
+                "description": "An archived task tool",
+                "task_id": "test_task_123",
+                "run_config_id": "test_config_456",
+                "is_archived": True,
+            },
+        )
+        mock_project = Mock(spec=Project)
+        mock_project.id = "test_project_id"
+        mock_project.external_tool_servers.return_value = [mock_server]
+        mock_task = Mock(spec=Task)
+        mock_task.parent_project.return_value = mock_project
+
+        tool_id = f"{KILN_TASK_TOOL_ID_PREFIX}{mock_server.id}"
+        tool = tool_from_id(tool_id, task=mock_task, allow_archived=True)
+
+        assert isinstance(tool, KilnTaskTool)
+        assert tool._tool_server_model == mock_server

--- a/libs/core/kiln_ai/tools/tool_registry.py
+++ b/libs/core/kiln_ai/tools/tool_registry.py
@@ -25,9 +25,15 @@ from kiln_ai.utils.config import Config
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 
 
-def tool_from_id(tool_id: str, task: Task | None = None) -> KilnToolInterface:
+def tool_from_id(
+    tool_id: str, task: Task | None = None, allow_archived: bool = False
+) -> KilnToolInterface:
     """
     Get a tool from its ID.
+
+    allow_archived lets callers that describe historical runs (fine-tune dataset
+    export, evals) resolve a tool that was archived after the run. Execution paths
+    leave it False so archived tools can't be run.
     """
     # Check built-in tools
     if tool_id in [member.value for member in KilnBuiltInToolId]:
@@ -82,6 +88,11 @@ def tool_from_id(tool_id: str, task: Task | None = None) -> KilnToolInterface:
                     f"External tool server not found: {tool_server_id} in project ID {project.id}"
                 )
 
+            if not allow_archived and server.properties.get("is_archived", False):
+                raise ValueError(
+                    f"Tool '{tool_name}' belongs to archived tool server '{server.name}'. Unarchive the server or remove the tool from the run config to run it."
+                )
+
             return MCPServerTool(server, tool_name)
 
         # Check Kiln Task Tools
@@ -101,6 +112,11 @@ def tool_from_id(tool_id: str, task: Task | None = None) -> KilnToolInterface:
                     f"Kiln Task External tool server not found: {server_id} in project ID {project.id}"
                 )
 
+            if not allow_archived and server.properties.get("is_archived", False):
+                raise ValueError(
+                    f"Kiln Task tool '{server.name}' is archived. Unarchive it or remove it from the run config to run it."
+                )
+
             return KilnTaskTool(project.id, tool_id, server)
 
     elif tool_id.startswith(RAG_TOOL_ID_PREFIX):
@@ -117,6 +133,11 @@ def tool_from_id(tool_id: str, task: Task | None = None) -> KilnToolInterface:
                 f"RAG config not found: {rag_config_id} in project {project.id} for tool {tool_id}"
             )
 
+        if not allow_archived and rag_config.is_archived:
+            raise ValueError(
+                f"Search tool (RAG) '{rag_config.name}' is archived. Unarchive it or remove it from the run config to run it."
+            )
+
         # Lazy import to avoid circular dependency
         from kiln_ai.tools.rag_tools import RagTool
 
@@ -131,7 +152,7 @@ def tool_from_id(tool_id: str, task: Task | None = None) -> KilnToolInterface:
 
 
 async def tool_definitions_from_ids(
-    tool_ids: list[str], task: Task | None = None
+    tool_ids: list[str], task: Task | None = None, allow_archived: bool = False
 ) -> list[ToolCallDefinition]:
     """
     Get OpenAI-compatible tool definitions from a list of tool IDs.
@@ -139,7 +160,7 @@ async def tool_definitions_from_ids(
     tool_definitions = []
     for tool_id in tool_ids:
         try:
-            tool = tool_from_id(tool_id, task)
+            tool = tool_from_id(tool_id, task, allow_archived=allow_archived)
             tool_def = await tool.toolcall_definition()
             tool_definitions.append(tool_def)
         except Exception as e:


### PR DESCRIPTION
## What does this PR do?

Archiving a tool (MCP server, Kiln Task, RAG config, or Skill) previously only hid it from the tool picker. Run configs that already referenced the tool kept executing it, because run-time resolution ignored is_archived entirely.

This makes archived tools fail closed at run time. The guard lives in tool_from_id, which the agent run path (base_adapter.available_tools) and the single-tool MCP adapter both funnel through, and in _resolve_skills for skills (which resolve separately). RAG configs and Kiln Task tools are checked the same way inside tool_from_id.

Describing a historical run is different from executing it: the fine-tune dataset formatter and eval utils need to resolve tools that were archived after a past run. So tool_from_id and tool_definitions_from_ids take an allow_archived flag (default False), and those two callers pass True. Dataset export and evals over past data keep working.

Tests: MCP, Kiln Task, and RAG each get a pair (rejected by default, resolves with allow_archived); skills get a rejected-by-default test (skills have no allow_archived path). Existing tests whose mocks needed the new signature were updated. Diff coverage is 100%.

Follow-up KIL-724 adds the proactive UI notice, since this fix only surfaces the problem at execution time (a saved run config that references an archived tool errors on run, and saved configs aren't editable, so the resolution today is to unarchive the tool or create a new run config).

## Contributor License Agreement

I, @aiyakitori, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib