### PR TITLE
fix: fall back to raw JSON editor for schemas the visual editor can't represent

### DIFF
--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_form_element.svelte
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_form_element.svelte
@@ -25,7 +25,12 @@
       return raw_schema
     } else {
       validate_schema(schema_model, [name])
-      return JSON.stringify(schema_from_model(schema_model, true))
+      // creating=false preserves each property's stored key (id) instead of
+      // recomputing it from the human title. This keeps clone/edit a faithful
+      // copy -- otherwise array-of-object sub-schemas drift to the wrong parent
+      // (or collide) when a key != string_to_json_key(title). New properties
+      // have an empty id, so they still fall back to a title-derived key.
+      return JSON.stringify(schema_from_model(schema_model, false))
     }
   }
 
@@ -76,8 +81,9 @@
   function switch_to_raw_schema(): boolean {
     raw = true
 
-    // Convert the schema model to a pretty JSON Schema string
-    const json_schema_format = schema_from_model(schema_model, true)
+    // Convert the schema model to a pretty JSON Schema string.
+    // creating=false preserves stored property keys (see get_schema_string above).
+    const json_schema_format = schema_from_model(schema_model, false)
     raw_schema = JSON.stringify(json_schema_format, null, 2)
 
     // Close the dialog

--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
@@ -1174,3 +1174,121 @@ describe("round-trip conversion tests", () => {
     expect(reconstructedSchema).toEqual(objectWithRequiredArraySchema)
   })
 })
+
+// Regression tests for the "Clone Task" schema-drift bug. Clone loads a task's
+// schema into the visual editor (model_from_schema) and on Save re-serializes it
+// via schema_from_model(schema_model, creating). The Save path passes creating=false
+// so each property keeps its stored key (id). The previously hardcoded creating=true
+// recomputed keys from human titles, drifting array-of-object sub-schemas to the
+// wrong parent (or colliding) whenever a stored key != string_to_json_key(title) --
+// e.g. schemas authored via the Raw JSON editor or imported during a migration.
+describe("clone task schema fidelity", () => {
+  it("keeps array-of-object sub-schemas under their stored key when key != slug(title)", () => {
+    // Stored keys and human titles are crossed.
+    const schema: JsonSchemaProperty = {
+      type: "object",
+      properties: {
+        entities: {
+          title: "Audiences", // slug("Audiences") = "audiences" != key "entities"
+          type: "array",
+          items: {
+            title: "",
+            type: "object",
+            properties: {
+              type: { title: "type", type: "string" },
+              value: { title: "value", type: "string" },
+            },
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        audiences: {
+          title: "Entities", // slug("Entities") = "entities" != key "audiences"
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    }
+    const model = model_from_schema(schema)
+
+    // Fixed Save path (creating=false): sub-schemas stay under their real keys.
+    const fixed = schema_from_model(model, false)
+    expect(fixed.properties?.entities?.items?.type).toBe("object")
+    expect(fixed.properties?.audiences?.items?.type).toBe("string")
+
+    // Documents the old bug: creating=true re-keys by title and drifts the
+    // {type, value} sub-schema onto "audiences" (and vice versa).
+    const drifted = schema_from_model(model, true)
+    expect(drifted.properties?.entities?.items?.type).toBe("string")
+    expect(drifted.properties?.audiences?.items?.type).toBe("object")
+  })
+
+  it("does not drop a sub-schema when two property titles slug to the same key", () => {
+    const schema: JsonSchemaProperty = {
+      type: "object",
+      properties: {
+        entity_type: {
+          title: "Entity Type", // slug -> "entity_type"
+          type: "array",
+          items: {
+            title: "",
+            type: "object",
+            properties: { code: { title: "code", type: "string" } },
+            required: [],
+            additionalProperties: false,
+          },
+        },
+        entity_type_legacy: {
+          title: "Entity_Type", // slug -> "entity_type" (would collide)
+          type: "string",
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    }
+    const model = model_from_schema(schema)
+
+    // Fixed Save path: distinct stored keys are preserved, sub-schema survives.
+    const fixed = schema_from_model(model, false)
+    expect(Object.keys(fixed.properties!)).toHaveLength(2)
+    expect(fixed.properties?.entity_type?.items?.type).toBe("object")
+
+    // Documents the old bug: both titles slug to "entity_type" under creating=true;
+    // the second property clobbers the first and the array sub-schema is lost.
+    const collided = schema_from_model(model, true)
+    expect(Object.keys(collided.properties!)).toHaveLength(1)
+  })
+
+  it("does not mutate an empty array-item title on round-trip", () => {
+    // Mirrors the real brand-post-analyzer output schema: array-of-object items
+    // are stored with an empty title by the editor at creation time.
+    const schema: JsonSchemaProperty = {
+      type: "object",
+      properties: {
+        entities: {
+          title: "entities",
+          description: "Entities mentioned in the post; each is {type, value}",
+          type: "array",
+          items: {
+            title: "",
+            type: "object",
+            properties: {
+              type: { title: "type", type: "string" },
+              value: { title: "value", type: "string" },
+            },
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    }
+    const model = model_from_schema(schema)
+
+    // Empty item title is preserved (previously fabricated as "items").
+    expect(schema_from_model(model, false)).toEqual(schema)
+  })
+})

--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.test.ts
@@ -1291,4 +1291,58 @@ describe("clone task schema fidelity", () => {
     // Empty item title is preserved (previously fabricated as "items").
     expect(schema_from_model(model, false)).toEqual(schema)
   })
+
+  it("preserves camelCase keys (top-level and nested) on a migration-style schema", () => {
+    // Mirrors a schema imported/ported during a migration: camelCase keys with
+    // Title Case titles, so every key != string_to_json_key(title). Reproduced
+    // end-to-end: cloning this on the old creating=true path rewrote every key
+    // (and nested key) to snake_case.
+    const schema: JsonSchemaProperty = {
+      type: "object",
+      properties: {
+        detectedEntities: {
+          title: "Detected Entities",
+          type: "array",
+          items: {
+            title: "",
+            type: "object",
+            properties: {
+              entityType: { title: "Entity Type", type: "string" },
+              entityValue: { title: "Entity Value", type: "string" },
+            },
+            required: ["entityType", "entityValue"],
+            additionalProperties: false,
+          },
+        },
+        targetAudiences: {
+          title: "Target Audiences",
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: ["detectedEntities", "targetAudiences"],
+      additionalProperties: false,
+    }
+    const model = model_from_schema(schema)
+
+    // Fixed Save path keeps every stored key, top-level and nested.
+    const fixed = schema_from_model(model, false)
+    expect(Object.keys(fixed.properties!)).toEqual([
+      "detectedEntities",
+      "targetAudiences",
+    ])
+    expect(
+      Object.keys(fixed.properties!.detectedEntities.items!.properties!),
+    ).toEqual(["entityType", "entityValue"])
+
+    // Documents the old bug: creating=true rewrites every key to snake_case.
+    const drifted = schema_from_model(model, true)
+    expect(Object.keys(drifted.properties!)).toEqual([
+      "detected_entities",
+      "target_audiences",
+    ])
+    expect(
+      Object.keys(drifted.properties!.detected_entities.items!.properties!),
+    ).toEqual(["entity_type", "entity_value"])
+  })
 })

--- a/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.ts
+++ b/app/web_ui/src/lib/utils/json_schema_editor/json_schema_templates.ts
@@ -64,7 +64,10 @@ function build_schema_model_property(
 ): SchemaModelProperty {
   const result: SchemaModelProperty = {
     id,
-    title: options.title || id,
+    // Use ?? (not ||) so an explicit empty title round-trips unchanged. Array
+    // items are stored with an empty title; || would fabricate the synthetic
+    // id ("items") and mutate the schema on every clone.
+    title: options.title ?? id,
     description: options.description,
     type: options.type,
     required: !!required.includes(id),

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/schema_section.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/schema_section.svelte
@@ -3,6 +3,8 @@
   import {
     example_schema_model,
     model_from_schema,
+    type SchemaModelProperty,
+    type SchemaModelType,
     type SchemaModelTypedObject,
   } from "$lib/utils/json_schema_editor/json_schema_templates"
 
@@ -61,7 +63,8 @@
       if (
         model.type === "object" &&
         model.properties &&
-        model.additionalProperties === false
+        model.additionalProperties === false &&
+        representable_in_visual_editor(model)
       ) {
         return model as SchemaModelTypedObject
       }
@@ -69,6 +72,32 @@
       // Invalid JSON or unsupported shape -- fall back to the raw editor.
     }
     return null
+  }
+
+  const REPRESENTABLE_TYPES: SchemaModelType[] = [
+    "number",
+    "string",
+    "integer",
+    "boolean",
+    "array",
+    "object",
+  ]
+
+  // The visual editor models each property's type as a single primitive. A node
+  // with a union type (e.g. ["string", "null"]) or any other non-primitive type
+  // can't be represented and would be silently mangled on save -- so recurse and
+  // bail to the raw editor if any node (root or nested) has an unsupported type.
+  function representable_in_visual_editor(model: SchemaModelProperty): boolean {
+    if (!(REPRESENTABLE_TYPES as string[]).includes(model.type)) {
+      return false
+    }
+    if (model.items && !representable_in_visual_editor(model.items)) {
+      return false
+    }
+    if (model.properties) {
+      return model.properties.every(representable_in_visual_editor)
+    }
+    return true
   }
 
   let schema_form_element: JsonSchemaFormElement | null = null

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/schema_section.svelte
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/schema_section.svelte
@@ -13,21 +13,49 @@
   // We're reactive for setting the schema_string, which allows the caller to set a well known schema (like the demo/example)
   // It's not reactive when the user starts editing (the string stays static), as we need a more complex in memory view-model. Access the new string via the accessor below.
   export let schema_string: string | null = null
-  let schema_model: SchemaModelTypedObject =
-    schema_model_from_string(schema_string)
-  $: schema_model = schema_model_from_string(schema_string)
-  let plaintext: boolean = !schema_string
-  $: plaintext = !schema_string
 
-  // Keep the copy the raw state here, so it persists even if they toggle the radio back to plaintext, and the component is removed.
+  // The visual editor can only represent a subset of JSON Schema: a typed object
+  // with additionalProperties:false, single-type properties, etc. Schemas authored
+  // via the API or the raw JSON editor often fall outside that subset (union types,
+  // open objects, camelCase keys, missing root additionalProperties). For those we
+  // fall back to the raw JSON editor instead of crashing, so the schema is preserved
+  // verbatim and stays editable (e.g. when cloning such a task).
+  let schema_model: SchemaModelTypedObject = example_schema_model()
+  let plaintext: boolean = !schema_string
+
+  // Keep the raw state here, so it persists even if they toggle the radio back to plaintext, and the component is removed.
   let raw = false
   let raw_schema_string: string = ""
 
-  // Update our live VM from the schema string
-  function schema_model_from_string(
-    new_schema_string: string | null,
-  ): SchemaModelTypedObject {
-    if (new_schema_string) {
+  $: load_schema(schema_string)
+
+  // Load the schema string into the editor. Supported schemas open in the visual
+  // editor; anything the visual editor can't represent opens in the raw editor.
+  function load_schema(new_schema_string: string | null) {
+    plaintext = !new_schema_string
+    if (!new_schema_string) {
+      schema_model = example_schema_model()
+      raw = false
+      raw_schema_string = ""
+      return
+    }
+    const model = typed_object_from_string(new_schema_string)
+    if (model) {
+      schema_model = model
+      raw = false
+      raw_schema_string = ""
+    } else {
+      raw = true
+      raw_schema_string = new_schema_string
+    }
+  }
+
+  // Parse a schema string into the visual editor's view-model, or return null if
+  // it isn't a typed object the visual editor supports.
+  function typed_object_from_string(
+    new_schema_string: string,
+  ): SchemaModelTypedObject | null {
+    try {
       const model = model_from_schema(JSON.parse(new_schema_string))
       // Check it's a valid object with properties (aka SchemaModelTypedObject) -- we only support typed objects for now
       if (
@@ -36,14 +64,11 @@
         model.additionalProperties === false
       ) {
         return model as SchemaModelTypedObject
-      } else {
-        throw new Error(
-          "Invalid schema string: not a valid JSON schema object with properties",
-        )
       }
-    } else {
-      return example_schema_model()
+    } catch {
+      // Invalid JSON or unsupported shape -- fall back to the raw editor.
     }
+    return null
   }
 
   let schema_form_element: JsonSchemaFormElement | null = null

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/schema_section.test.ts
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/schema_section.test.ts
@@ -44,6 +44,23 @@ const supported_schema = JSON.stringify({
   required: ["name"],
 })
 
+// Supported root (typed object, additionalProperties:false) but a nested union
+// type the visual editor can't represent -- must still fall back to raw so the
+// nested type isn't silently mangled on save.
+const supported_root_unsupported_nested_schema = JSON.stringify(
+  {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      name: { title: "Name", type: "string" },
+      nickname: { title: "Nickname", type: ["string", "null"] },
+    },
+    required: ["name"],
+  },
+  null,
+  2,
+)
+
 describe("SchemaSection raw-editor fallback", () => {
   it("falls back to the raw editor for schemas the visual editor can't represent", async () => {
     const { container, getByLabelText } = render(SchemaSection, {
@@ -72,6 +89,30 @@ describe("SchemaSection raw-editor fallback", () => {
     expect(component.get_schema_string("output_schema")).toBe(
       unsupported_schema,
     )
+  })
+
+  it("falls back to raw for a supported root with an unsupported nested type", async () => {
+    const { component, getByLabelText } = render(SchemaSection, {
+      props: { schema_string: supported_root_unsupported_nested_schema },
+    })
+    await tick()
+    const textarea = getByLabelText("Raw JSON Schema") as HTMLTextAreaElement
+    expect(textarea.value).toBe(supported_root_unsupported_nested_schema)
+    expect(component.get_schema_string("output_schema")).toBe(
+      supported_root_unsupported_nested_schema,
+    )
+  })
+
+  it("falls back to the raw editor for invalid JSON and preserves it verbatim", async () => {
+    const invalid_schema =
+      '{"type":"object","properties":{"name":{"type":"string"}}'
+    const { component, getByLabelText } = render(SchemaSection, {
+      props: { schema_string: invalid_schema },
+    })
+    await tick()
+    const textarea = getByLabelText("Raw JSON Schema") as HTMLTextAreaElement
+    expect(textarea.value).toBe(invalid_schema)
+    expect(component.get_schema_string("output_schema")).toBe(invalid_schema)
   })
 
   it("opens supported schemas in the visual editor, not the raw editor", async () => {

--- a/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/schema_section.test.ts
+++ b/app/web_ui/src/routes/(fullscreen)/setup/(setup)/create_task/schema_section.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/svelte"
+import { tick } from "svelte"
+import SchemaSection from "./schema_section.svelte"
+
+afterEach(() => cleanup())
+
+// A schema authored via the API / raw JSON editor that the visual editor cannot
+// represent: the root has no `additionalProperties: false`, properties use union
+// types ("string" | "null"), and an open object (`additionalProperties: true`).
+// This is the shape that previously crashed Clone Task with
+// "Invalid schema string: not a valid JSON schema object with properties".
+const unsupported_schema = JSON.stringify(
+  {
+    type: "object",
+    properties: {
+      priorMessages: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            replyToId: { type: ["string", "null"] },
+          },
+          required: ["id"],
+        },
+      },
+      channelContext: { type: ["string", "null"] },
+      _eval_metadata: { type: "object", additionalProperties: true },
+    },
+    required: ["priorMessages"],
+  },
+  null,
+  2,
+)
+
+const supported_schema = JSON.stringify({
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    name: { title: "Name", type: "string" },
+  },
+  required: ["name"],
+})
+
+describe("SchemaSection raw-editor fallback", () => {
+  it("falls back to the raw editor for schemas the visual editor can't represent", async () => {
+    const { container, getByLabelText } = render(SchemaSection, {
+      props: { schema_string: unsupported_schema },
+    })
+    await tick()
+
+    // The raw JSON textarea is shown, with the schema preserved verbatim.
+    const textarea = getByLabelText("Raw JSON Schema") as HTMLTextAreaElement
+    expect(textarea).not.toBeNull()
+    expect(textarea.value).toBe(unsupported_schema)
+
+    // "Structured JSON" radio is selected (not plain text).
+    const radios = container.querySelectorAll<HTMLInputElement>(
+      'input[type="radio"]',
+    )
+    const structured = Array.from(radios).find((r) => r.value === "false")
+    expect(structured?.checked).toBe(true)
+  })
+
+  it("returns the unsupported schema verbatim from get_schema_string", async () => {
+    const { component } = render(SchemaSection, {
+      props: { schema_string: unsupported_schema },
+    })
+    await tick()
+    expect(component.get_schema_string("output_schema")).toBe(
+      unsupported_schema,
+    )
+  })
+
+  it("opens supported schemas in the visual editor, not the raw editor", async () => {
+    const { queryByLabelText } = render(SchemaSection, {
+      props: { schema_string: supported_schema },
+    })
+    await tick()
+    expect(queryByLabelText("Raw JSON Schema")).toBeNull()
+  })
+
+  it("treats a missing schema as plain text", async () => {
+    const { component, queryByLabelText } = render(SchemaSection, {
+      props: { schema_string: null },
+    })
+    await tick()
+    expect(queryByLabelText("Raw JSON Schema")).toBeNull()
+    expect(component.get_schema_string("output_schema")).toBe(null)
+  })
+})


### PR DESCRIPTION
## Problem

Stacks on top of #1495 (`fix/clone-schema-subschema-drift`).

Clone Task loads a task's schema into the **visual** schema editor (`schema_section.svelte` → `model_from_schema`). The visual editor only supports a subset of JSON Schema: a typed object with `additionalProperties: false`, single-type properties, no open objects. Schemas authored via the **API or the raw JSON editor** routinely fall outside that subset.

When such a schema was loaded, `schema_section.svelte` **threw** — crashing the clone/edit page:

```
Uncaught (in promise) Error: Invalid schema string: not a valid JSON schema object with properties
    at schema_model_from_string (schema_section.svelte)
```

Real example that triggered it (an API-authored task schema): no root `additionalProperties: false`, union types (`"type": ["string", "null"]`), and an open `additionalProperties: true` object. #1495 fixes key **drift** for schemas the editor *can* load, but these tasks can't even reach the editor.

## Fix

`schema_section.svelte`: instead of throwing when a schema isn't a representable typed object, **fall back to the raw JSON editor** with the schema preserved verbatim. Parsing is now a `try/catch` that returns `null` on unsupported/invalid input rather than throwing.

- Supported schema → visual editor (unchanged).
- Unrepresentable schema → raw JSON editor, schema kept byte-for-byte and still editable / cloneable.
- Missing schema → plain text (unchanged).

## Tests

Adds `schema_section.test.ts` (component test, jsdom): unrepresentable schema falls back to the raw editor and round-trips verbatim through `get_schema_string`, supported schema stays in the visual editor, and a missing schema is treated as plain text.

Full `web_ui` suite passes (971 tests); eslint clean; `svelte-check` 0 errors; build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)