### PR TITLE
Add Cerebras provider for GPT OSS 120B and re-enable GLM 4.7

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -1716,6 +1716,12 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
             ),
             KilnModelProvider(
+                name=ModelProviderName.cerebras,
+                model_id="gpt-oss-120b",
+                structured_output_mode=StructuredOutputMode.json_instructions,
+                reasoning_capable=True,
+            ),
+            KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/gpt-oss-120b",
                 structured_output_mode=StructuredOutputMode.json_instructions,
@@ -7246,7 +7252,6 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.cerebras,
                 model_id="zai-glm-4.7",
-                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 reasoning_capable=True,
             ),


### PR DESCRIPTION
## What does this PR do?

Cerebras now serves both `gpt-oss-120b` (production) and `zai-glm-4.7` (preview) on its standard inference API (confirmed against the live Cerebras API and [Cerebras model docs](https://inference-docs.cerebras.ai/models/overview)). This PR:

- Adds a **Cerebras** provider entry to **GPT OSS 120B** (`gpt-oss-120b`, `json_instructions`, `reasoning_capable`).
- **Un-deprecates** the existing **Cerebras** entry on **GLM 4.7** (`zai-glm-4.7`, `json_schema`, `reasoning_capable`) — it was added speculatively as `deprecated` before Cerebras served it, and is now live.

### Scope note

The Slack request also asked to add **Qwen 3.6 27B to Groq** (`qwen/qwen3.6-27b`, verified from GroqDocs). That change is intentionally **left for a follow-up**: this environment has no `GROQ_API_KEY`, so the Groq provider couldn't be exercised against a real endpoint. Rather than ship an untested provider, we're landing only the fully-tested Cerebras changes here.

### Test Results

All paid tests were run against the live Cerebras API. Every failure below is a transient Cerebras `429 / queue_exceeded` ("We're experiencing high traffic right now") rate-limit flake — not a config error. Across multiple runs the *specific* failing test varied run-to-run (e.g. `test_data_gen_sample_all_models_providers_with_structured_output` failed for one combo in one run and passed in another), which confirms capacity throttling rather than a deterministic problem. The structured-output tests pass for both models, validating the slugs and the chosen `structured_output_mode` (`json_schema` for GLM 4.7, `json_instructions` for GPT OSS 120B). Every individual test passed in at least one run.

GLM 4.7 (cerebras):
- 8 passed, 1 failed (Cerebras 429 capacity flake)

GPT OSS 120B (cerebras):
- 7 passed, 2 failed (Cerebras 429 capacity flakes)

---
GLM 4.7 (cerebras):
✅ test_data_gen_all_models_providers[glm_4_7-cerebras]
✅ test_data_gen_sample_all_models_providers[glm_4_7-cerebras]
✅ test_data_gen_sample_all_models_providers_with_structured_output[glm_4_7-cerebras]
✅ test_all_models_providers_plaintext[glm_4_7-cerebras]
✅ test_cot_prompt_builder[glm_4_7-cerebras]
✅ test_all_built_in_models_structured_output[glm_4_7-cerebras]
✅ test_all_built_in_models_structured_input[glm_4_7-cerebras]
✅ test_structured_output_cot_prompt_builder[glm_4_7-cerebras]
⚠️ test_structured_input_cot_prompt_builder[glm_4_7-cerebras] — Cerebras 429 queue_exceeded (transient capacity; passed in a prior run)

GPT OSS 120B (cerebras):
✅ test_data_gen_all_models_providers[gpt_oss_120b-cerebras]
✅ test_data_gen_sample_all_models_providers[gpt_oss_120b-cerebras]
✅ test_all_models_providers_plaintext[gpt_oss_120b-cerebras]
✅ test_cot_prompt_builder[gpt_oss_120b-cerebras]
✅ test_all_built_in_models_structured_output[gpt_oss_120b-cerebras]
✅ test_all_built_in_models_structured_input[gpt_oss_120b-cerebras]
✅ test_structured_output_cot_prompt_builder[gpt_oss_120b-cerebras]
⚠️ test_data_gen_sample_all_models_providers_with_structured_output[gpt_oss_120b-cerebras] — Cerebras 429 queue_exceeded (transient capacity; passed in a prior run)
⚠️ test_structured_input_cot_prompt_builder[gpt_oss_120b-cerebras] — Cerebras 429 queue_exceeded (transient capacity; passed in a prior run)

## Checklists

- [X] Tests have been run locally and passed (failures are transient Cerebras 429 rate limits, not config errors)
- [X] New tests have been added to any work in /lib (covered by the existing parametrized model+provider test suite)

---

Slack thread: https://getkiln.slack.com/archives/C0AG8U78MNG/p1782137219461189?thread_ts=1782137176.125409&cid=C0AG8U78MNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lc1me6Eo6yWTRK4SjsfQvk)_