### PR TITLE
fix: repair output textarea focus ring clipped on run page

### DIFF
--- a/app/web_ui/src/lib/ui/run_config_component/input_transform_create_modal.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/input_transform_create_modal.svelte
@@ -65,7 +65,7 @@
     <textarea
       aria-label="Jinja2 template"
       placeholder="Enter your Jinja2 template..."
-      class="textarea textarea-bordered w-full font-mono h-40 text-base wrap-pre text-left align-top"
+      class="textarea textarea-bordered w-full font-mono h-40 text-base whitespace-pre-wrap break-words text-left align-top"
       bind:value={template_draft}
       on:input={() => {
         validation_error = null

--- a/app/web_ui/src/lib/utils/form_element.svelte
+++ b/app/web_ui/src/lib/utils/form_element.svelte
@@ -220,7 +220,7 @@
         {id}
         class="textarea text-base textarea-bordered w-full {height_class[
           height
-        ]} wrap-pre text-left align-top
+        ]} whitespace-pre-wrap break-words text-left align-top
        {error_message || inline_error ? 'textarea-error' : ''}"
         bind:value
         autocomplete="off"

--- a/app/web_ui/src/routes/(app)/run/run.svelte
+++ b/app/web_ui/src/routes/(app)/run/run.svelte
@@ -905,7 +905,11 @@
 
 <div>
   <div class="flex flex-col xl:flex-row gap-8 xl:gap-16">
-    <div class="grow min-w-0 overflow-hidden">
+    <!-- px/-mx pair: overflow-hidden contains wide trace content, but would
+         otherwise clip the 4px focus ring (outline-offset: 2px) of inputs like
+         the repair textarea. The padding gives the ring room; the matching
+         negative margin keeps content aligned with the rest of the page. -->
+    <div class="grow min-w-0 overflow-hidden px-1.5 -mx-1.5">
       <div class="text-xl font-bold mb-1">Output</div>
       {#if task.output_json_schema}
         <div class="text-xs font-medium text-gray-500 flex flex-row mb-2">


### PR DESCRIPTION
## Summary

On the dataset run page, the **Repair Instructions** textarea's focus ring was visibly clipped on its left and right edges when focused ([KIL-725](https://linear.app/kiln-ai/issue/KIL-725)).

**Root cause:** the output/repair column in `run.svelte` is wrapped in `overflow-hidden` (added alongside the trace UI to contain wide message-trace content). DaisyUI draws the textarea focus ring with `outline-width: 2px; outline-offset: 2px`, so the ring extends ~4px beyond the element — and `overflow-hidden` clipped it horizontally.

> Note: the original Linear hypothesis (the `wrap-pre` typo breaking text wrapping) was not the cause — textareas wrap by default and the issue was the clipped focus *ring*, not text overflow.

Before:
<img width="1283" height="861" alt="image" src="https://github.com/user-attachments/assets/cf814167-2d50-4ea7-9363-84aaa9899af2" />

After:
<img width="1010" height="810" alt="image" src="https://github.com/user-attachments/assets/d1d9e5df-c63c-4bd2-93f8-b273aab470ae" />


## Changes

- **`run.svelte`** — add `px-1.5 -mx-1.5` to the `overflow-hidden` column: the padding gives the focus ring room, the matching negative margin cancels the shift so content stays aligned with the rest of the page.
- **`form_element.svelte` / `input_transform_create_modal.svelte`** — replace the dead `wrap-pre` class (a typo for `whitespace-pre-wrap`) with `whitespace-pre-wrap break-words`. Minor hygiene cleanup of a no-op class.

## Testing

- `prettier --check` passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)