### PR TITLE
feat: show total run counts and add collapsible topics in web UI

### DIFF
--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/+page.svelte
@@ -538,63 +538,74 @@
   {:else if runs}
     <div class="mb-4">
       <div
-        class="flex flex-row items-center justify-end py-2 gap-3 {select_mode
+        class="flex flex-row items-center justify-between py-2 gap-3 {select_mode
           ? 'sticky top-0 z-10 backdrop-blur'
           : ''}"
       >
-        {#if select_mode}
-          <div class="font-light text-sm">
-            {selected_runs.size} selected
-          </div>
-          {#if selected_runs.size > 0}
-            <div class="dropdown dropdown-end">
-              <div tabindex="0" role="button" class="btn btn-mid !px-3">
-                <img alt="tags" src="/images/tag.svg" class="w-5 h-5" />
-              </div>
-              <ul
-                class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow"
-              >
-                <li>
-                  <button tabindex="0" on:click={() => show_add_tags_modal()}>
-                    Add Tags
-                  </button>
-                </li>
-                <li>
-                  <button
-                    tabindex="0"
-                    on:click={() => show_remove_tags_modal()}
-                  >
-                    Remove Tags
-                  </button>
-                </li>
-              </ul>
+        <div class="text-sm text-gray-500 font-medium">
+          {#if filtered_runs && runs}
+            {#if filtered_runs.length === runs.length}
+              {runs.length} {runs.length === 1 ? "run" : "runs"}
+            {:else}
+              {filtered_runs.length} of {runs.length} runs
+            {/if}
+          {/if}
+        </div>
+        <div class="flex flex-row items-center gap-3">
+          {#if select_mode}
+            <div class="font-light text-sm">
+              {selected_runs.size} selected
             </div>
+            {#if selected_runs.size > 0}
+              <div class="dropdown dropdown-end">
+                <div tabindex="0" role="button" class="btn btn-mid !px-3">
+                  <img alt="tags" src="/images/tag.svg" class="w-5 h-5" />
+                </div>
+                <ul
+                  class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow"
+                >
+                  <li>
+                    <button tabindex="0" on:click={() => show_add_tags_modal()}>
+                      Add Tags
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      tabindex="0"
+                      on:click={() => show_remove_tags_modal()}
+                    >
+                      Remove Tags
+                    </button>
+                  </li>
+                </ul>
+              </div>
+              <button
+                class="btn btn-mid !px-3"
+                on:click={() => show_delete_modal()}
+              >
+                <img alt="delete" src="/images/delete.svg" class="w-5 h-5" />
+              </button>
+            {/if}
+            <button class="btn btn-mid" on:click={() => (select_mode = false)}>
+              Cancel Selection
+            </button>
+          {:else}
+            <button class="btn btn-mid" on:click={() => (select_mode = true)}>
+              Select
+            </button>
             <button
               class="btn btn-mid !px-3"
-              on:click={() => show_delete_modal()}
+              on:click={() => filter_tags_dialog?.show()}
             >
-              <img alt="delete" src="/images/delete.svg" class="w-5 h-5" />
+              <img alt="filter" src="/images/filter.svg" class="w-5 h-5" />
+              {#if filter_tags.length > 0}
+                <span class="badge badge-primary badge-sm"
+                  >{filter_tags.length}</span
+                >
+              {/if}
             </button>
           {/if}
-          <button class="btn btn-mid" on:click={() => (select_mode = false)}>
-            Cancel Selection
-          </button>
-        {:else}
-          <button class="btn btn-mid" on:click={() => (select_mode = true)}>
-            Select
-          </button>
-          <button
-            class="btn btn-mid !px-3"
-            on:click={() => filter_tags_dialog?.show()}
-          >
-            <img alt="filter" src="/images/filter.svg" class="w-5 h-5" />
-            {#if filter_tags.length > 0}
-              <span class="badge badge-primary badge-sm"
-                >{filter_tags.length}</span
-              >
-            {/if}
-          </button>
-        {/if}
+        </div>
       </div>
       <div class="overflow-x-auto rounded-lg border">
         <table class="table">

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/generated_data_node.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/generated_data_node.svelte
@@ -19,6 +19,10 @@
   import Dialog from "$lib/ui/dialog.svelte"
 
   let custom_topic_mode: boolean = false
+  let collapsed = false
+  $: has_children =
+    (data.sub_topics && data.sub_topics.length > 0) ||
+    (data.samples && data.samples.length > 0)
 
   export let guidance_data: SynthDataGuidanceDataModel
   // Local instance for dynamic reactive updates
@@ -496,13 +500,42 @@
       class="py-2"
       style="padding-left: {(depth - 1) * 25 + 20}px"
     >
-      <div class="font-medium flex flex-row pr-4 w-full">
-        <div class="flex-1">
+      <div
+        class="font-medium flex flex-row items-center pr-4 w-full cursor-pointer select-none"
+        on:click={() => {
+          if (has_children) {
+            collapsed = !collapsed
+          }
+        }}
+        role="button"
+        tabindex="0"
+        on:keydown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault()
+            if (has_children) {
+              collapsed = !collapsed
+            }
+          }
+        }}
+      >
+        <div class="flex-1 flex flex-row items-center gap-1">
           {#if depth > 1}
-            <span class="text-xs relative" style="top: -3px">⮑</span>
+            <span class="text-xs relative" style="top: -1px">⮑</span>
           {/if}
-          {data.topic}
-          <span class="relative inline-block w-3 h-3">
+          {#if has_children}
+            <span class="text-xs font-mono text-gray-500 w-4 inline-block"
+              >{collapsed ? "▶" : "▼"}</span
+            >
+          {/if}
+          <span>{data.topic}</span>
+          <span
+            class="relative inline-block w-3 h-3"
+            on:click|stopPropagation={() => {}}
+            on:keydown|stopPropagation={() => {}}
+            role="button"
+            tabindex="-1"
+            aria-label="Info Tooltip"
+          >
             <div class="absolute top-[-3px] left-0">
               <InfoTooltip
                 tooltip_text={"This is a topic. Content inside of it should relate to this theme." +
@@ -545,81 +578,83 @@
     </td>
   </tr>
 {/if}
-{#each data.samples as sample, index}
-  {@const { status: output_status, output: formatted_output } =
-    formatSampleOutput(sample, expandedSamples[index])}
-  <tr on:click={() => toggleExpand(index)} class="cursor-pointer">
-    <td style="padding-left: {depth * 25 + 20}px" class="py-2">
-      {#if expandedSamples[index]}
-        <pre class="whitespace-pre-wrap break-words">{formatExpandedSample(
-            sample.input,
-          )}</pre>
-      {:else}
-        <div class="truncate w-0 min-w-full">{sample.input}</div>
-      {/if}
-    </td>
-    <td class="py-2">
-      {#if !formatted_output}
-        {output_status}
-      {:else if expandedSamples[index]}
-        <pre class="whitespace-pre-wrap break-words">{formatted_output}</pre>
-      {:else}
-        <div class="truncate w-0 min-w-full">
-          {formatted_output}
-        </div>
-      {/if}
-    </td>
-    <td class="py-2">
-      {#if sample.saved_id}
-        <a
-          href={`/dataset/${guidance_data.project_id}/${guidance_data.task_id}/${sample.saved_id}/run`}
-          class="hover:underline">Saved</a
-        >
-      {:else if sample.output}
-        Unsaved
-      {:else}
-        No Output
-      {/if}
-    </td>
-    <td class="p-0">
-      <TableActionMenu
-        items={[
-          {
-            label: "Remove Sample",
-            onclick: () => delete_sample(sample),
-            hidden: !!sample.saved_id,
-          },
-          {
-            label: "Remove Output",
-            onclick: () => remove_sample_output(sample),
-            hidden: !!sample.saved_id || !sample.output,
-          },
-          {
-            label: "View in Dataset",
-            onclick: () => open_sample(sample),
-            hidden: !sample.saved_id,
-          },
-        ]}
-      />
-    </td>
-  </tr>
-{/each}
-<!-- Hidden element purely for scroll targeting, not 'hidden' as that breaks scrolling -->
-<tr class="h-0" id={`${id}-samples-end`}></tr>
-{#if data.sub_topics}
-  {#each data.sub_topics as sub_node}
-    <svelte:self
-      data={sub_node}
-      path={[...path, sub_node.topic]}
-      {guidance_data}
-      {triggerSave}
-      bind:num_subtopics_to_generate
-      bind:num_samples_to_generate
-      on:delete_topic={handleChildDeleteTopic}
-    />
+{#if !collapsed}
+  {#each data.samples as sample, index}
+    {@const { status: output_status, output: formatted_output } =
+      formatSampleOutput(sample, expandedSamples[index])}
+    <tr on:click={() => toggleExpand(index)} class="cursor-pointer">
+      <td style="padding-left: {depth * 25 + 20}px" class="py-2">
+        {#if expandedSamples[index]}
+          <pre class="whitespace-pre-wrap break-words">{formatExpandedSample(
+              sample.input,
+            )}</pre>
+        {:else}
+          <div class="truncate w-0 min-w-full">{sample.input}</div>
+        {/if}
+      </td>
+      <td class="py-2">
+        {#if !formatted_output}
+          {output_status}
+        {:else if expandedSamples[index]}
+          <pre class="whitespace-pre-wrap break-words">{formatted_output}</pre>
+        {:else}
+          <div class="truncate w-0 min-w-full">
+            {formatted_output}
+          </div>
+        {/if}
+      </td>
+      <td class="py-2">
+        {#if sample.saved_id}
+          <a
+            href={`/dataset/${guidance_data.project_id}/${guidance_data.task_id}/${sample.saved_id}/run`}
+            class="hover:underline">Saved</a
+          >
+        {:else if sample.output}
+          Unsaved
+        {:else}
+          No Output
+        {/if}
+      </td>
+      <td class="p-0">
+        <TableActionMenu
+          items={[
+            {
+              label: "Remove Sample",
+              onclick: () => delete_sample(sample),
+              hidden: !!sample.saved_id,
+            },
+            {
+              label: "Remove Output",
+              onclick: () => remove_sample_output(sample),
+              hidden: !!sample.saved_id || !sample.output,
+            },
+            {
+              label: "View in Dataset",
+              onclick: () => open_sample(sample),
+              hidden: !sample.saved_id,
+            },
+          ]}
+        />
+      </td>
+    </tr>
   {/each}
   <!-- Hidden element purely for scroll targeting, not 'hidden' as that breaks scrolling -->
-  <tr class="h-0" id={`${id}-subtopics`}></tr>
+  <tr class="h-0" id={`${id}-samples-end`}></tr>
+  {#if data.sub_topics}
+    {#each data.sub_topics as sub_node}
+      <svelte:self
+        data={sub_node}
+        path={[...path, sub_node.topic]}
+        {guidance_data}
+        {triggerSave}
+        bind:num_subtopics_to_generate
+        bind:num_samples_to_generate
+        on:delete_topic={handleChildDeleteTopic}
+      />
+    {/each}
+    <!-- Hidden element purely for scroll targeting, not 'hidden' as that breaks scrolling -->
+    <tr class="h-0" id={`${id}-subtopics`}></tr>
+  {/if}
 {/if}
 
 {#if generate_subtopics}


### PR DESCRIPTION
This PR addresses tasks #123 and #143 in the Kiln Svelte web UI.

### Summary of Changes:
1. **Dataset UI (#123)**:
   - Added runs count to the header bar showing '{runs.length} runs' (unfiltered) or '{filtered_runs.length} of {runs.length} runs' (filtered).
2. **Collapsible Topics (#143)**:
   - Introduced collapsed status to data nodes in the generated data tree.
   - Made headers clickable/interactive to toggle collapse state with toggle arrows (▶/▼).
   - Implemented proper accessibility tags (role='button', tabindex, on:keydown for Space/Enter, and tooltip click/keydown propagation fixes) to prevent Svelte a11y compiler warnings.

All Svelte check and Vitest unit tests (1043 passed) run successfully.