### PR TITLE
Add release-digest skill

### DIFF
--- a/.agents/skills/release-digest/SKILL.md
+++ b/.agents/skills/release-digest/SKILL.md
@@ -36,14 +36,18 @@ The JSON contains:
 - `pr_count`, `commit_count`
 - `prs[]` — `{number, title, author_name, author_login, url, labels, additions, deletions, body}`
 - `direct_commits[]` — teammate commits pushed straight to main, no PR — `{sha, title, author_login, author_name}`
-- `excluded_prs[]` — PRs/commits from non-teammates, dropped from the recap (see below)
+- `excluded_prs[]` — PRs/commits from non-teammates, dropped from the recap. PR entries
+  have a `number`; direct-commit entries have `number: null` and rely on `title`.
+- `unresolved_prs[]` — PRs whose `gh pr view` failed (`{number, error}`). If non-empty,
+  the change set is partial — tell the user which PRs couldn't load before posting.
 
 Only the five teammates in the script's `TEAM` map (Sam, Leonard, Daniel, Mike,
 Steve) are included in the recap. PRs from anyone else are filtered into
 `excluded_prs` rather than itemized. To add a teammate, edit `TEAM` in the script.
 
-**If `pr_count` is 0:** tell the user `main` is even with `<last_tag>` — nothing to QA
-or release yet. Do not post to Slack. Stop here.
+**If `pr_count` is 0 AND `direct_commits` is empty:** tell the user `main` is even with
+`<last_tag>` — nothing to QA or release yet. Do not post to Slack. Stop here. (Direct
+commits alone, with no PRs, still count as unreleased changes worth a digest.)
 
 ---
 
@@ -147,8 +151,10 @@ Rules:
   1. A **bold** `:bar_chart:` tally line: `:bar_chart: *<X> features · <Y> fixes · <Z> tasks*`.
   2. A blank line.
   3. If `excluded_prs` is non-empty, an **italic** `:information_source:` line noting the
-     excluded non-teammate PRs (so the omission is visible, not silent):
-     `:information_source: _<N> PR(s) from a non-teammate: #<num> (<login>)._`
+     excluded non-teammate changes (so the omission is visible, not silent). Reference a
+     PR entry by `#<num>` and a direct-commit entry (where `number` is null) by its
+     `title` — never print `#None`. E.g.
+     `:information_source: _<N> change(s) from non-teammates excluded: #1456 (ianjamesburke)._`
 - Link the PR numbers if easy (`<url|#1501>`), but plain `#1501` is fine — keep it readable.
 
 **Show the composed message to the user and get confirmation before posting** (it's an

--- a/.agents/skills/release-digest/SKILL.md
+++ b/.agents/skills/release-digest/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: release-digest
+description: Post a "what's changed since the last release" recap to the release Slack channel for final QA. Groups merged PRs by author and classifies each as feature / bug fix / task. Use when the user wants a release recap, a changelog since the last tag, or to prep QA before cutting a release from main.
+---
+
+# Release Digest
+
+Build a human-readable recap of everything merged to `main` that is **not yet in the
+latest release tag**, and post it to the team's release Slack channel for final QA.
+
+The recap is grouped **by author** and each change is classified as **feature**,
+**bug fix**, or **task**. This is on-demand: run it when someone asks for a release
+recap or wants to QA before cutting a release.
+
+> Linear ticket tracking ("which tickets are targeted for this release") is **out of
+> scope for now** — punted to a later iteration. This skill only covers what's changed.
+
+---
+
+## Phase 1 — Gather the change set
+
+Run the gather script from the repo root. It fetches tags + `origin/main`, finds the
+latest tag, and lists every merged PR in the range `<last_tag>..origin/main`:
+
+```bash
+python3 .agents/skills/release-digest/scripts/gather_changes.py > /tmp/release_digest.json
+```
+
+Key design point: it uses the **git commit range** as the source of truth, not merge
+dates. A PR merged the same day a tag was cut can already be in that release, so a
+date filter would over-report. Trust the range.
+
+The JSON contains:
+- `last_tag` — the most recent release (e.g. `v1.0.3`)
+- `head_ref` — `origin/main` (or `main` if no remote ref)
+- `pr_count`, `commit_count`
+- `prs[]` — `{number, title, author_name, author_login, url, labels, additions, deletions, body}`
+- `direct_commits[]` — teammate commits pushed straight to main, no PR — `{sha, title, author_login, author_name}`
+- `excluded_prs[]` — PRs/commits from non-teammates, dropped from the recap (see below)
+
+Only the five teammates in the script's `TEAM` map (Sam, Leonard, Daniel, Mike,
+Steve) are included in the recap. PRs from anyone else are filtered into
+`excluded_prs` rather than itemized. To add a teammate, edit `TEAM` in the script.
+
+**If `pr_count` is 0:** tell the user `main` is even with `<last_tag>` — nothing to QA
+or release yet. Do not post to Slack. Stop here.
+
+---
+
+## Phase 2 — Classify and group
+
+Read `/tmp/release_digest.json`. Treat every item in `prs[]` **and** `direct_commits[]`
+as a change to recap (direct commits are real work that shipped — just with no PR
+number). Classify each into one of three buckets:
+
+- **Feature** — a substantive *new product capability*: new UI, a new endpoint, a new
+  tool, new eval/RAG/fine-tune functionality, or a meaningful enhancement to how the
+  product works. Reserve this for things a user would notice as "Kiln can now do X."
+- **Bug fix** — corrects broken or incorrect behavior: regressions, crashes, hangs,
+  wrong output, security fixes.
+- **Task** — everything that is *neither* a substantive new capability *nor* a fix to
+  broken behavior: refactors, docs/README, tests, CI/build, dependency bumps, version
+  bumps, chores, internal flags, code removal/cleanup — **and routine model-catalog
+  work** (see below). Matches Linear's "Task" issue type: maintenance/internal work.
+
+**Adding models is a Task, not a Feature.** Kiln ships new model and provider entries
+constantly — "Add <model> to model list", "Add <provider> for <model>", backfilling a
+model on a provider, re-enabling/un-recommending a model, version bumps to a model
+entry. These are catalog/config maintenance, so they go in **Task** even though the
+title starts with `Add`/`Enable`. Only promote to **Feature** if the PR adds a genuinely
+new *capability* around models (e.g. a new thinking-level control, a new extraction
+modality, a new provider *integration type*) rather than just registering a model_id.
+
+**Decision order** (use the first signal that's decisive):
+1. **PR labels** — `bug`/`fix` → Bug fix; `feature`/`enhancement` → Feature;
+   `chore`/`docs`/`refactor`/`ci` → Task. (Kiln PRs are usually unlabeled, so this
+   rarely fires — fall through to the title.)
+2. **Model-catalog check** — if the change just registers/edits model or provider
+   entries (not new behavior), it's a **Task**, regardless of the `Add`/`Enable` verb.
+3. **Conventional-commit / verb prefix in the title** — `fix:`/`Fix ` → Bug fix;
+   `feat:`/`Add `/`Enable ` (a new *capability*) → Feature; `chore:`/`refactor:`/`ci:`/
+   `docs:`/`Bump `/`Remove `/`Deprecate `/`Version bump` → Task.
+4. **What the change does** (read the title, and `body` if still unclear) — ask "does
+   this give the user a genuinely new capability (Feature), fix something that was
+   broken (Bug fix), or is it routine/maintenance (Task)?"
+
+**"Task" is the residual bucket**, not a guess: a change lands there only because it
+is positively *not* a new capability and *not* a fix — e.g. `Deprecate Models`,
+`min age for dependencies`, `Version bump`, `new draft readme`, `fix typos`. When a
+change is genuinely ambiguous between Feature and Bug fix, prefer the one the title
+leans toward; only fall to Task when it's truly neither. This is a judgment call made
+per item — surface it to the user before posting so they can re-bucket anything.
+
+Then **group by author** (`author_name`). Within each author, list changes by PR
+number, newest first; put any direct commits (no PR number) last. The feature / fix /
+task split is **not** shown per line — it only feeds the tally at the bottom.
+
+---
+
+## Phase 3 — Compose the Slack message
+
+**First, ask the user for the new release name** — the version being cut (e.g.
+`v1.0.4`). This is the release these changes are going into; it isn't tagged yet, so
+it can't be derived from git. Use their answer as `<new_release>` in the title.
+
+Use this shape (Slack mrkdwn — `*bold*`, not `**bold**`):
+
+```
+:rocket: *v1.0.4 Release Status* :rocket:
+
+*12 changes since v1.0.3*
+_<one-to-two sentence plain-English recap of the headline changes>_
+
+*Daniel Chiang*
+• Add deprecated flag to embedding models (#1466)
+• Add deprecated flag to reranker models (#1465)
+
+*Sam Fierro*
+• Dedup frozen prompts and bake type into their name (#1501)
+
+*Steve Cosman*
+• Add Jinja2 input transform on RunConfigs (#1433)
+• Version bump in lock and desktop app version check
+
+:bar_chart: *7 features · 3 fixes · 2 tasks*
+
+:information_source: _1 PR from a non-teammate: #1456 (ianjamesburke)._
+```
+
+Rules:
+- **Header:** `:rocket: *<new_release> Release Status* :rocket:`, then a blank line.
+- **Change count** on its own line, **bold**: `*<N> changes since <last_tag>*`.
+- **Recap paragraph** immediately under it, wrapped in **italics** (`_..._` around the
+  whole paragraph) — the "what did we do" summary in plain English, not just a list.
+  Compose it so the italics survive: write it as **a single line with no hard line
+  breaks** (wrap is fine, but don't insert `\n` mid-paragraph — newlines break the
+  italic span in Slack), and use **no literal `_` anywhere inside** (an underscore
+  would close the italics mid-paragraph — rewrite e.g. `snake_case`/`model_id` or any
+  underscored identifier without it).
+- One **bullet** per change, no per-line emoji: `• <title> (#<number>)`. Keep the
+  title; trim trailing noise.
+- **Direct commits have no PR number** — render them as `• <title>` with nothing in
+  parentheses (e.g. `• Version bump`). List them under their author, after the PRs.
+- Within each author, list newest PR first; direct commits last. Don't print the
+  feature/fix/task bucket per line.
+- **Summary block** at the end, in this order:
+  1. A **bold** `:bar_chart:` tally line: `:bar_chart: *<X> features · <Y> fixes · <Z> tasks*`.
+  2. A blank line.
+  3. If `excluded_prs` is non-empty, an **italic** `:information_source:` line noting the
+     excluded non-teammate PRs (so the omission is visible, not silent):
+     `:information_source: _<N> PR(s) from a non-teammate: #<num> (<login>)._`
+- Link the PR numbers if easy (`<url|#1501>`), but plain `#1501` is fine — keep it readable.
+
+**Show the composed message to the user and get confirmation before posting** (it's an
+outward-facing post to a shared channel).
+
+---
+
+## Phase 4 — Post to Slack
+
+Post to **`#release`** (channel ID `C0BDGTGBL4Q`) — the team's release channel. This is
+the default target; only post elsewhere if the user explicitly names a different
+channel. (If the ID ever fails to resolve, fall back to `slack_search_channels` with
+query `release` to re-find it.)
+
+Only post after the user has confirmed the composed message in Phase 3. Post with
+`mcp__claude_ai_Slack__slack_send_message`. After posting, give the user the channel
+name and a link/confirmation.
+
+---
+
+## Checklist
+
+- [ ] Gather script run; `/tmp/release_digest.json` written
+- [ ] If `pr_count` is 0, reported "nothing unreleased" and stopped
+- [ ] Asked the user for the new release name (used in the title)
+- [ ] Each PR classified (feature / bug fix / task)
+- [ ] Grouped by author, recap paragraph written
+- [ ] Message shown to user and confirmed
+- [ ] Posted to #release (C0BDGTGBL4Q); confirmation returned to user

--- a/.agents/skills/release-digest/scripts/gather_changes.py
+++ b/.agents/skills/release-digest/scripts/gather_changes.py
@@ -7,6 +7,7 @@ as the source of truth, not merge dates -- a PR merged the same day a tag was cu
 may already be in that release.
 """
 
+import concurrent.futures
 import json
 import re
 import subprocess
@@ -24,8 +25,20 @@ TEAM = {
     "scosman": "Steve Cosman",
 }
 
+# PR-number markers in a mainline commit subject. Anchored so we only match a real
+# merged-PR reference -- a squash subject `Title (#456)` or a merge subject
+# `Merge pull request #456 from ...` -- rather than any `#123` issue ref that might
+# also appear mid-subject (which would pick the wrong number or misclassify a
+# direct-to-main commit as a PR).
+MERGE_RE = re.compile(r"^Merge pull request #(\d+)\b")
+SQUASH_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+# Fields requested from `gh pr view` for each PR.
+PR_FIELDS = "number,title,author,url,labels,mergedAt,additions,deletions,body"
+
 
 def display_name(author: dict) -> str:
+    """Return the preferred display name for a PR/commit author dict."""
     login = author.get("login", "unknown")
     return TEAM.get(login) or author.get("name") or login
 
@@ -40,21 +53,73 @@ def login_from_email(email: str) -> str | None:
     return m.group(1) if m else None
 
 
+def pr_number_from_subject(subject: str) -> int | None:
+    """Return the merged-PR number from a mainline commit subject, or None.
+
+    Matches squash subjects (`... (#N)`) and merge-commit subjects
+    (`Merge pull request #N ...`) only; a bare `#N` elsewhere is ignored.
+    """
+    m = SQUASH_RE.search(subject) or MERGE_RE.match(subject)
+    return int(m.group(1)) if m else None
+
+
 def run(cmd: list[str]) -> str:
+    """Run a command and return its stdout, exiting with its stderr on failure."""
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
-        print(f"ERROR running {' '.join(cmd)}:\n{result.stderr}", file=sys.stderr)
+        sys.stderr.write(f"ERROR running {' '.join(cmd)}:\n{result.stderr}\n")
         sys.exit(1)
     return result.stdout.strip()
 
 
+def require_gh() -> None:
+    """Exit early with a clear message if `gh` is missing or unauthenticated."""
+    try:
+        status = subprocess.run(
+            ["gh", "auth", "status"], capture_output=True, text=True
+        )
+    except FileNotFoundError:
+        sys.stderr.write(
+            "ERROR: GitHub CLI (gh) is not installed. Install it from https://cli.github.com.\n"
+        )
+        sys.exit(1)
+    if status.returncode != 0:
+        sys.stderr.write(
+            "ERROR: GitHub CLI (gh) is not authenticated. Run 'gh auth login'.\n"
+        )
+        sys.exit(1)
+
+
+def fetch_pr(num: int) -> tuple[int, dict | None, str]:
+    """Fetch one PR's metadata via `gh pr view`. Returns (num, data|None, error)."""
+    view = subprocess.run(
+        ["gh", "pr", "view", str(num), "--json", PR_FIELDS],
+        capture_output=True,
+        text=True,
+    )
+    if view.returncode != 0:
+        return num, None, view.stderr.strip()
+    try:
+        return num, json.loads(view.stdout), ""
+    except json.JSONDecodeError as e:
+        return num, None, str(e)
+
+
 def main() -> None:
-    # Make sure tags and remote main are current.
-    subprocess.run(
+    """Compute the unreleased change set and print it as JSON to stdout."""
+    require_gh()
+
+    # Refresh tags + origin/main. A fetch failure isn't fatal (offline runs with
+    # recent refs are still useful), but warn loudly since the digest could be stale.
+    fetch = subprocess.run(
         ["git", "fetch", "--tags", "--quiet", "origin"],
         capture_output=True,
         text=True,
     )
+    if fetch.returncode != 0:
+        sys.stderr.write(
+            "WARNING: 'git fetch' failed -- digest may be based on stale refs/tags.\n"
+        )
 
     last_tag = run(["git", "describe", "--tags", "--abbrev=0"])
 
@@ -72,9 +137,8 @@ def main() -> None:
 
     # Subjects on the mainline only. --first-parent gives one node per merged PR
     # (the merge/squash commit) plus genuine direct-to-main commits, instead of every
-    # constituent commit inside each PR -- otherwise "unmatched" balloons with commits
-    # that are already itemized via their PR. PR numbers live in these subjects for both
-    # merge-commit ("Merge pull request #N from ...") and squash ("Title (#N)") workflows.
+    # constituent commit inside each PR -- otherwise direct commits would balloon with
+    # commits that are already itemized via their PR.
     subjects = run(
         ["git", "log", rng, "--first-parent", "--format=%H%x1f%an%x1f%ae%x1f%s"]
     )
@@ -86,9 +150,8 @@ def main() -> None:
     seen: set[int] = set()
     for line in commit_lines:
         sha, an, ae, subject = (*line.split("\x1f", 3), "", "", "")[:4]
-        m = re.search(r"#(\d+)", subject)
-        if m:
-            num = int(m.group(1))
+        num = pr_number_from_subject(subject)
+        if num is not None:
             if num not in seen:
                 seen.add(num)
                 pr_numbers.append(num)
@@ -110,24 +173,22 @@ def main() -> None:
                 {"number": None, "title": subject, "author_login": login or an}
             )
 
+    # Fetch PR metadata in parallel (network-bound), then process in PR-number order
+    # so output is deterministic regardless of completion order.
+    fetched: dict[int, tuple[dict | None, str]] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        for num, data, err in executor.map(fetch_pr, pr_numbers):
+            fetched[num] = (data, err)
+
     prs = []
+    unresolved = []
     for num in pr_numbers:
-        view = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "view",
-                str(num),
-                "--json",
-                "number,title,author,url,labels,mergedAt,additions,deletions,body",
-            ],
-            capture_output=True,
-            text=True,
-        )
-        if view.returncode != 0:
-            # PR number referenced but not viewable (e.g. from a fork / different repo).
+        data, err = fetched[num]
+        if data is None:
+            # Don't silently drop a PR -- surface it so the digest is visibly partial.
+            unresolved.append({"number": num, "error": err})
+            sys.stderr.write(f"WARNING: could not load PR #{num}: {err}\n")
             continue
-        data = json.loads(view.stdout)
         author = data.get("author") or {}
         login = author.get("login", "unknown")
         if login not in TEAM:
@@ -145,7 +206,7 @@ def main() -> None:
             {
                 "number": data["number"],
                 "title": data["title"],
-                "author_login": author.get("login", "unknown"),
+                "author_login": login,
                 "author_name": display_name(author),
                 "url": data["url"],
                 "labels": [label["name"] for label in data.get("labels", [])],
@@ -165,26 +226,35 @@ def main() -> None:
         "prs": prs,
         "direct_commits": direct_commits,
         "excluded_prs": excluded,
+        "unresolved_prs": unresolved,
     }
-    print(json.dumps(output, indent=2))
+    sys.stdout.write(json.dumps(output, indent=2) + "\n")
 
     # Human summary to stderr.
-    print(
+    sys.stderr.write(
         f"\nChanges since {last_tag} on {head_ref}: "
         f"{len(prs)} PRs + {len(direct_commits)} direct commits "
-        f"across {len(commit_lines)} mainline commits.",
-        file=sys.stderr,
+        f"across {len(commit_lines)} mainline commits.\n"
     )
     if excluded:
-        print(
-            f"Excluded {len(excluded)} PR(s) from non-teammates: "
-            + ", ".join(f"#{e['number']} ({e['author_login']})" for e in excluded),
-            file=sys.stderr,
+        sys.stderr.write(
+            f"Excluded {len(excluded)} change(s) from non-teammates: "
+            + ", ".join(
+                f"#{e['number']} ({e['author_login']})"
+                if e["number"] is not None
+                else f"{e['title']!r} ({e['author_login']})"
+                for e in excluded
+            )
+            + "\n"
+        )
+    if unresolved:
+        sys.stderr.write(
+            f"WARNING: {len(unresolved)} PR(s) could not be loaded: "
+            + ", ".join(f"#{u['number']}" for u in unresolved)
+            + "\n"
         )
     if not prs and not direct_commits:
-        print(
-            "Nothing unreleased -- main is even with the latest tag.", file=sys.stderr
-        )
+        sys.stderr.write("Nothing unreleased -- main is even with the latest tag.\n")
 
 
 if __name__ == "__main__":

--- a/.agents/skills/release-digest/scripts/gather_changes.py
+++ b/.agents/skills/release-digest/scripts/gather_changes.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Gather merged PRs that are on main but not yet in the latest release tag.
+
+Outputs JSON to stdout (the authoritative change set for the next release) and a
+human-readable summary to stderr. Uses the git commit RANGE (last_tag..origin/main)
+as the source of truth, not merge dates -- a PR merged the same day a tag was cut
+may already be in that release.
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+# The five teammates whose work goes in the recap, keyed by GitHub login. The value
+# is the preferred display name (takes priority over the GitHub profile name, which
+# some leave unset or lowercased). PRs from any login NOT in this map are excluded
+# from the recap (reported separately as excluded_prs). Add new teammates here.
+TEAM = {
+    "sfierro": "Sam Fierro",
+    "leonardmq": "Leonard Q. Marcq",
+    "chiang-daniel": "Daniel Chiang",
+    "tawnymanticore": "Mike Chatzidakis",
+    "scosman": "Steve Cosman",
+}
+
+
+def display_name(author: dict) -> str:
+    login = author.get("login", "unknown")
+    return TEAM.get(login) or author.get("name") or login
+
+
+def login_from_email(email: str) -> str | None:
+    """Extract the GitHub login from a github.com noreply commit email.
+
+    Handles both `1234567+login@users.noreply.github.com` and the older
+    `login@users.noreply.github.com` form. Returns None for other emails.
+    """
+    m = re.match(r"^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$", email or "")
+    return m.group(1) if m else None
+
+
+def run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ERROR running {' '.join(cmd)}:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+def main() -> None:
+    # Make sure tags and remote main are current.
+    subprocess.run(
+        ["git", "fetch", "--tags", "--quiet", "origin"],
+        capture_output=True,
+        text=True,
+    )
+
+    last_tag = run(["git", "describe", "--tags", "--abbrev=0"])
+
+    # Prefer origin/main; fall back to local main if there's no remote-tracking ref.
+    head_ref = "origin/main"
+    check = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", head_ref],
+        capture_output=True,
+        text=True,
+    )
+    if check.returncode != 0:
+        head_ref = "main"
+
+    rng = f"{last_tag}..{head_ref}"
+
+    # Subjects on the mainline only. --first-parent gives one node per merged PR
+    # (the merge/squash commit) plus genuine direct-to-main commits, instead of every
+    # constituent commit inside each PR -- otherwise "unmatched" balloons with commits
+    # that are already itemized via their PR. PR numbers live in these subjects for both
+    # merge-commit ("Merge pull request #N from ...") and squash ("Title (#N)") workflows.
+    subjects = run(
+        ["git", "log", rng, "--first-parent", "--format=%H%x1f%an%x1f%ae%x1f%s"]
+    )
+    commit_lines = [line for line in subjects.splitlines() if line.strip()]
+
+    pr_numbers: list[int] = []
+    direct_commits = []
+    excluded = []
+    seen: set[int] = set()
+    for line in commit_lines:
+        sha, an, ae, subject = (*line.split("\x1f", 3), "", "", "")[:4]
+        m = re.search(r"#(\d+)", subject)
+        if m:
+            num = int(m.group(1))
+            if num not in seen:
+                seen.add(num)
+                pr_numbers.append(num)
+            continue
+        # A direct-to-main commit (no PR). Attribute it to its author and list it
+        # under that person, same as a PR but with no PR number. Apply the team filter.
+        login = login_from_email(ae)
+        if login in TEAM:
+            direct_commits.append(
+                {
+                    "sha": sha[:9],
+                    "title": subject,
+                    "author_login": login,
+                    "author_name": TEAM[login],
+                }
+            )
+        else:
+            excluded.append(
+                {"number": None, "title": subject, "author_login": login or an}
+            )
+
+    prs = []
+    for num in pr_numbers:
+        view = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(num),
+                "--json",
+                "number,title,author,url,labels,mergedAt,additions,deletions,body",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if view.returncode != 0:
+            # PR number referenced but not viewable (e.g. from a fork / different repo).
+            continue
+        data = json.loads(view.stdout)
+        author = data.get("author") or {}
+        login = author.get("login", "unknown")
+        if login not in TEAM:
+            # Not one of the five teammates -- excluded from the recap, but reported
+            # so the omission is visible rather than silent.
+            excluded.append(
+                {
+                    "number": data["number"],
+                    "title": data["title"],
+                    "author_login": login,
+                }
+            )
+            continue
+        prs.append(
+            {
+                "number": data["number"],
+                "title": data["title"],
+                "author_login": author.get("login", "unknown"),
+                "author_name": display_name(author),
+                "url": data["url"],
+                "labels": [label["name"] for label in data.get("labels", [])],
+                "merged_at": data.get("mergedAt"),
+                "additions": data.get("additions", 0),
+                "deletions": data.get("deletions", 0),
+                "body": (data.get("body") or "")[:600],
+            }
+        )
+
+    output = {
+        "last_tag": last_tag,
+        "head_ref": head_ref,
+        "range": rng,
+        "commit_count": len(commit_lines),
+        "pr_count": len(prs),
+        "prs": prs,
+        "direct_commits": direct_commits,
+        "excluded_prs": excluded,
+    }
+    print(json.dumps(output, indent=2))
+
+    # Human summary to stderr.
+    print(
+        f"\nChanges since {last_tag} on {head_ref}: "
+        f"{len(prs)} PRs + {len(direct_commits)} direct commits "
+        f"across {len(commit_lines)} mainline commits.",
+        file=sys.stderr,
+    )
+    if excluded:
+        print(
+            f"Excluded {len(excluded)} PR(s) from non-teammates: "
+            + ", ".join(f"#{e['number']} ({e['author_login']})" for e in excluded),
+            file=sys.stderr,
+        )
+    if not prs and not direct_commits:
+        print(
+            "Nothing unreleased -- main is even with the latest tag.", file=sys.stderr
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds an on-demand **`release-digest`** skill (`/release-digest`) that recaps everything merged to `main` since the latest release tag and posts it to **#release** for final QA.

It groups changes **by author**, classifies each as **feature / bug fix / task**, and renders a Slack-formatted digest:

```
:rocket: *v1.0.4 Release Status* :rocket:

*N changes since v1.0.3*
_<one-line recap>_

*Author*
• Change title (#1234)
…

:bar_chart: *X features · Y fixes · Z tasks*

:information_source: _M PR(s) from a non-teammate: #… (login)._
```

## How it works

- **`scripts/gather_changes.py`** — the data layer. Uses the git **first-parent** commit range `last_tag..origin/main` as the source of truth (not merge dates — a PR merged the same day a tag was cut may already be in that release). Enriches each PR via `gh`, attributes **direct-to-main commits** to their author (resolved from the noreply commit email), and filters to the five teammates via a `TEAM` map. Non-teammate work is **reported in `excluded_prs`, not silently dropped**.
- **`SKILL.md`** — the orchestration + formatting/classification rules. Notably: adding a model to the catalog classifies as a **task**, not a feature.

Stops cleanly with no Slack post when `main` is even with the latest tag.

## Notes

- Committed under `.agents/skills/` (the tracked location); `.claude/` and `.cursor/` are gitignored local mirrors, consistent with the existing skills.
- Linear ticket tracking is intentionally out of scope for this first version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)