### PR TITLE
feat: support configurable concurrency limits for evals and generation

### DIFF
--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/generate_samples_modal.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/generate_samples_modal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte"
   import type { SampleDataNode } from "./gen_model"
   import IncrementUi from "$lib/ui/increment_ui.svelte"
   import { KilnError } from "$lib/utils/error_handlers"
@@ -12,6 +13,19 @@
   import type { RunConfigProperties } from "$lib/types"
   import { isKilnAgentRunConfig } from "$lib/types"
   import { get } from "svelte/store"
+
+  let max_concurrency = 5
+
+  onMount(async () => {
+    try {
+      const { data: settings } = await client.GET("/api/settings")
+      if (settings && typeof settings.max_concurrent_generation === "number") {
+        max_concurrency = settings.max_concurrent_generation
+      }
+    } catch (e) {
+      console.error("Failed to load max concurrent generation setting", e)
+    }
+  })
 
   export let guidance_data: SynthDataGuidanceDataModel
   // Local instance for dynamic reactive updates
@@ -217,9 +231,9 @@
       ? collect_leaf_topic_nodes()
       : [{ path, node: data }]
 
-    // Create and start 5 workers
-    // 5 because browsers can only handle 6 concurrent requests. The 6th is for the rest of the UI to keep working.
-    const workers = Array(5)
+    // Create and start workers
+    // Default is 5 because browsers can only handle 6 concurrent requests. The 6th is for the rest of the UI to keep working.
+    const workers = Array(max_concurrency)
       .fill(null)
       .map(() => worker(queue, run_config_properties))
 

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth/+page.svelte
@@ -53,6 +53,7 @@
   let data_guide: DataGuide | null = null
   let guide_loading = true
   let skip_data_guide = false
+  let max_concurrency = 5
 
   async function fetch_data_guide() {
     if (!project_id || !task_id) return
@@ -216,6 +217,15 @@
   }
 
   onMount(async () => {
+    try {
+      const { data: settings } = await client.GET("/api/settings")
+      if (settings && typeof settings.max_concurrent_generation === "number") {
+        max_concurrency = settings.max_concurrent_generation
+      }
+    } catch (e) {
+      console.error("Failed to load max concurrent generation setting", e)
+    }
+
     if ($page.url.searchParams.get("data_guide_saved") === "true") {
       data_guide_just_saved = true
       const cleaned = new URL($page.url.toString())
@@ -632,9 +642,9 @@
 
       const queue = [...samples_to_generate]
 
-      // Create and start 5 workers
-      // 5 because browsers can only handle 6 concurrent requests. The 6th is for the rest of the UI to keep working.
-      const workers = Array(5)
+      // Create and start workers
+      // Default is 5 because browsers can only handle 6 concurrent requests. The 6th is for the rest of the UI to keep working.
+      const workers = Array(max_concurrency)
         .fill(null)
         .map(() => generate_worker(queue, run_config_properties))
 

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -15,6 +15,7 @@ from kiln_ai.datamodel.eval import EvalConfig, EvalDataType, EvalRun, EvalScores
 from kiln_ai.datamodel.task import TaskRunConfig
 from kiln_ai.datamodel.task_run import TaskRun, Usage
 from kiln_ai.utils.async_job_runner import AsyncJobRunner, Progress, RetryableError
+from kiln_ai.utils.config import Config
 from kiln_ai.utils.git_sync_protocols import SaveContext, default_save_context
 
 logger = logging.getLogger(__name__)
@@ -183,10 +184,13 @@ class EvalRunner:
             merged.update(skills)
         return merged
 
-    async def run(self, concurrency: int = 25) -> AsyncGenerator[Progress, None]:
+    async def run(self, concurrency: int | None = None) -> AsyncGenerator[Progress, None]:
         """
         Runs the configured eval run with parallel workers and yields progress updates.
         """
+        if concurrency is None:
+            concurrency = Config.shared().max_concurrent_evals or 25
+
         jobs = self.collect_tasks()
 
         runner = AsyncJobRunner(

--- a/libs/core/kiln_ai/adapters/extractors/extractor_runner.py
+++ b/libs/core/kiln_ai/adapters/extractors/extractor_runner.py
@@ -14,6 +14,7 @@ from kiln_ai.datamodel.extraction import (
     ExtractorConfig,
 )
 from kiln_ai.utils.async_job_runner import AsyncJobRunner, Progress
+from kiln_ai.utils.config import Config
 from kiln_ai.utils.git_sync_protocols import SaveContext, default_save_context
 
 logger = logging.getLogger(__name__)
@@ -60,7 +61,10 @@ class ExtractorRunner:
 
         return jobs
 
-    async def run(self, concurrency: int = 25) -> AsyncGenerator[Progress, None]:
+    async def run(self, concurrency: int | None = None) -> AsyncGenerator[Progress, None]:
+        if concurrency is None:
+            concurrency = Config.shared().max_concurrent_evals or 25
+
         jobs = self.collect_jobs()
 
         runner = AsyncJobRunner(

--- a/libs/core/kiln_ai/utils/config.py
+++ b/libs/core/kiln_ai/utils/config.py
@@ -216,6 +216,16 @@ class Config:
             "personal_use_contact": ConfigProperty(
                 str,
             ),
+            "max_concurrent_generation": ConfigProperty(
+                int,
+                env_var="KILN_MAX_CONCURRENT_GENERATION",
+                default=5,
+            ),
+            "max_concurrent_evals": ConfigProperty(
+                int,
+                env_var="KILN_MAX_CONCURRENT_EVALS",
+                default=25,
+            ),
         }
         self._lock = threading.Lock()
         self._in_memory_settings: Dict[str, Any] = {}


### PR DESCRIPTION
Closes #779. Adds configuration settings and environment variables (KILN_MAX_CONCURRENT_GENERATION and KILN_MAX_CONCURRENT_EVALS) to restrict/configure concurrency in evaluations, extractor runs, and UI synthetic data generation workers, preventing GPU OOM / timeouts on self-hosted model setups.