### PR TITLE
fix: handle process pool crashes in PDF conversion and event loop lock binding

### DIFF
--- a/libs/core/kiln_ai/utils/pdf_utils.py
+++ b/libs/core/kiln_ai/utils/pdf_utils.py
@@ -4,8 +4,11 @@ Utilities for working with PDF files.
 
 import asyncio
 import atexit
+import logging
 import tempfile
+import weakref
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
@@ -13,7 +16,22 @@ from typing import AsyncGenerator
 import pypdfium2
 from pypdf import PdfReader, PdfWriter
 
+logger = logging.getLogger(__name__)
+
+
 _pdf_conversion_executor: ProcessPoolExecutor | None = None
+_pdf_conversion_locks = weakref.WeakKeyDictionary()
+
+
+def get_pdf_conversion_lock() -> asyncio.Lock:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.Lock()
+
+    if loop not in _pdf_conversion_locks:
+        _pdf_conversion_locks[loop] = asyncio.Lock()
+    return _pdf_conversion_locks[loop]
 
 
 # Lazy load for speed, singleton so dev-server reloading doesn't recreate the executor
@@ -71,14 +89,31 @@ def _convert_pdf_to_images_sync(pdf_path: Path, output_dir: Path) -> list[Path]:
 
 
 async def convert_pdf_to_images(pdf_path: Path, output_dir: Path) -> list[Path]:
-    loop = asyncio.get_running_loop()
-    result = await loop.run_in_executor(
-        get_pdf_conversion_executor(),
-        _convert_pdf_to_images_sync,
-        pdf_path,
-        output_dir,
-    )
-    return result
+    async with get_pdf_conversion_lock():
+        global _pdf_conversion_executor
+        try:
+            executor = get_pdf_conversion_executor()
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(
+                executor,
+                _convert_pdf_to_images_sync,
+                pdf_path,
+                output_dir,
+            )
+            return result
+        except (BrokenProcessPool, Exception) as e:
+            logger.warning(
+                f"PDF conversion via process pool failed, falling back to thread: {e}"
+            )
+            # Reset executor so it gets recreated next time
+            _shutdown_pdf_conversion_executor()
+
+            # Fallback: run in a thread (which is safe here since we are holding _pdf_conversion_lock)
+            return await asyncio.to_thread(
+                _convert_pdf_to_images_sync,
+                pdf_path,
+                output_dir,
+            )
 
 
 def _shutdown_pdf_conversion_executor():

--- a/libs/core/kiln_ai/utils/test_pdf_utils.py
+++ b/libs/core/kiln_ai/utils/test_pdf_utils.py
@@ -131,3 +131,37 @@ def test_convert_pdf_to_images_sync(mock_file_factory):
 async def test_convert_pdf_to_images_concurrent_access_100(mock_file_factory):
     """Test running convert_pdf_to_images concurrently from multiple tasks."""
     await run_convert_pdf_concurrently(mock_file_factory, concurrency=50)
+
+
+async def test_convert_pdf_to_images_process_pool_broken_fallback(mock_file_factory):
+    """Test that if the process pool executor fails with BrokenProcessPool, it falls back to thread execution and succeeds."""
+    from concurrent.futures.process import BrokenProcessPool
+    from unittest.mock import patch
+
+    test_file = mock_file_factory(MockFileFactoryMimeType.PDF)
+
+    # We patch run_in_executor on the event loop to raise BrokenProcessPool
+    original_run_in_executor = asyncio.get_running_loop().run_in_executor
+
+    call_count = 0
+
+    def mock_run_in_executor(executor, func, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        # Raise BrokenProcessPool only when calling _convert_pdf_to_images_sync in executor
+        actual_func = func.func if hasattr(func, "func") else func
+        if (
+            hasattr(actual_func, "__name__")
+            and actual_func.__name__ == "_convert_pdf_to_images_sync"
+        ):
+            raise BrokenProcessPool("Simulated process pool crash")
+        return original_run_in_executor(executor, func, *args, **kwargs)
+
+    with patch.object(
+        asyncio.get_running_loop(), "run_in_executor", side_effect=mock_run_in_executor
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            images = await convert_pdf_to_images(test_file, Path(temp_dir))
+            assert len(images) == 2
+            assert all(image.exists() for image in images)
+            assert call_count > 0


### PR DESCRIPTION
Addresses process pool crashes on Ollama/RAG due to process pool failures, fallback to serial threads, and solves the event loop lock binding mismatch issue.