### PR TITLE
feat: assistant upgrade nudge / required banners in chat assistant

### DIFF
--- a/app/desktop/studio_server/chat/routes.py
+++ b/app/desktop/studio_server/chat/routes.py
@@ -32,7 +32,7 @@ from fastapi.responses import StreamingResponse
 from kiln_server.cancellable_streaming_response import CancellableStreamingResponse
 from kiln_server.git_sync_decorators import no_write_lock
 from kiln_server.utils.agent_checks.policy import DENY_AGENT
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 
 def _build_upstream_headers(api_key: str) -> dict[str, str]:
@@ -200,7 +200,9 @@ def connect_chat_api(app: FastAPI) -> None:
             return ClientVersionPolicy()
         try:
             return ClientVersionPolicy.model_validate(resp.json())
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValidationError):
+            # Pydantic v2 ValidationError is not a ValueError, so catch it
+            # explicitly — a malformed upstream body degrades to "no banner".
             return ClientVersionPolicy()
 
     @app.get(

--- a/app/desktop/studio_server/chat/routes.py
+++ b/app/desktop/studio_server/chat/routes.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from http import HTTPStatus
 from typing import Annotated, Any, NoReturn
 
+import httpx
+
 from app.desktop.studio_server.api_client.kiln_ai_server_client.api.chat import (
     delete_session_v1_chat_sessions_session_id_delete,
     get_session_v1_chat_sessions_session_id_get,
@@ -62,6 +64,13 @@ class ChatSessionListItem(BaseModel):
     id: str
     title: str | None = None
     updated_at: datetime | None = None
+
+
+class ClientVersionPolicy(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    required: bool = False
+    upgrade_nudge_version: str | None = None
 
 
 class TraceToolCallFunction(BaseModel):
@@ -164,6 +173,35 @@ def connect_chat_api(app: FastAPI) -> None:
             content=generate(),
             media_type="text/event-stream",
         )
+
+    @app.get(
+        "/api/chat/version_policy",
+        summary="Client version policy",
+        tags=["Copilot"],
+        openapi_extra=DENY_AGENT,
+    )
+    async def chat_version_policy() -> ClientVersionPolicy:
+        """Proxy to Kiln Copilot ``GET /v1/chat/version_policy``.
+
+        Lets the assistant page show the upgrade banners on load. Forwards the
+        desktop version header so the server can compute the verdict; on any
+        upstream/transport failure we degrade to "no banner" rather than error.
+        """
+        api_key = get_copilot_api_key()
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(
+                    f"{_get_base_url()}/v1/chat/version_policy",
+                    headers=_build_upstream_headers(api_key),
+                )
+        except httpx.HTTPError:
+            return ClientVersionPolicy()
+        if resp.status_code != HTTPStatus.OK:
+            return ClientVersionPolicy()
+        try:
+            return ClientVersionPolicy.model_validate(resp.json())
+        except (json.JSONDecodeError, ValueError):
+            return ClientVersionPolicy()
 
     @app.get(
         "/api/chat/sessions",

--- a/app/desktop/studio_server/chat/test_routes.py
+++ b/app/desktop/studio_server/chat/test_routes.py
@@ -1134,14 +1134,11 @@ def test_execute_tools_has_no_write_lock(app):
 PATCH_ROUTES_ASYNC_CLIENT = "app.desktop.studio_server.chat.routes.httpx.AsyncClient"
 
 
-def _mock_version_policy_client(*, json_body=None, status_code=200, raise_exc=None):
+def _mock_version_policy_client(*, json_body=None, status_code=200):
     """Build a mock httpx.AsyncClient whose async .get() returns a fake response."""
     resp = MagicMock()
     resp.status_code = status_code
-    if raise_exc is not None:
-        resp.json.side_effect = raise_exc
-    else:
-        resp.json.return_value = json_body
+    resp.json.return_value = json_body
     http_client = MagicMock()
     http_client.get = AsyncMock(return_value=resp)
     http_client.__aenter__ = AsyncMock(return_value=http_client)

--- a/app/desktop/studio_server/chat/test_routes.py
+++ b/app/desktop/studio_server/chat/test_routes.py
@@ -3,6 +3,8 @@ from http import HTTPStatus
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+
 from app.desktop.studio_server.api_client.kiln_ai_server_client.models import (
     ChatSnapshot,
 )
@@ -1125,3 +1127,62 @@ def test_chat_stream_has_no_write_lock(app):
 def test_execute_tools_has_no_write_lock(app):
     endpoint = _find_endpoint_by_path(app, "/api/chat/execute-tools")
     assert getattr(endpoint, "_git_sync_no_write_lock", False) is True
+
+
+# --- GET /api/chat/version_policy proxy ---
+
+PATCH_ROUTES_ASYNC_CLIENT = "app.desktop.studio_server.chat.routes.httpx.AsyncClient"
+
+
+def _mock_version_policy_client(*, json_body=None, status_code=200, raise_exc=None):
+    """Build a mock httpx.AsyncClient whose async .get() returns a fake response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    if raise_exc is not None:
+        resp.json.side_effect = raise_exc
+    else:
+        resp.json.return_value = json_body
+    http_client = MagicMock()
+    http_client.get = AsyncMock(return_value=resp)
+    http_client.__aenter__ = AsyncMock(return_value=http_client)
+    http_client.__aexit__ = AsyncMock(return_value=None)
+    return MagicMock(return_value=http_client)
+
+
+def test_version_policy_forwards_and_parses(client, mock_api_key):
+    mock_class = _mock_version_policy_client(
+        json_body={"required": False, "upgrade_nudge_version": "1.0.5"}
+    )
+    with patch(PATCH_ROUTES_ASYNC_CLIENT, mock_class):
+        r = client.get("/api/chat/version_policy")
+    assert r.status_code == 200
+    assert r.json() == {"required": False, "upgrade_nudge_version": "1.0.5"}
+
+
+def test_version_policy_degrades_on_non_200(client, mock_api_key):
+    mock_class = _mock_version_policy_client(json_body={}, status_code=503)
+    with patch(PATCH_ROUTES_ASYNC_CLIENT, mock_class):
+        r = client.get("/api/chat/version_policy")
+    assert r.status_code == 200
+    assert r.json() == {"required": False, "upgrade_nudge_version": None}
+
+
+def test_version_policy_degrades_on_invalid_upstream_body(client, mock_api_key):
+    # Pydantic v2 ValidationError is not a ValueError; ensure it's caught and we
+    # degrade to "no banner" rather than 500.
+    mock_class = _mock_version_policy_client(json_body={"required": "not-a-bool"})
+    with patch(PATCH_ROUTES_ASYNC_CLIENT, mock_class):
+        r = client.get("/api/chat/version_policy")
+    assert r.status_code == 200
+    assert r.json() == {"required": False, "upgrade_nudge_version": None}
+
+
+def test_version_policy_degrades_on_transport_error(client, mock_api_key):
+    http_client = MagicMock()
+    http_client.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
+    http_client.__aenter__ = AsyncMock(return_value=http_client)
+    http_client.__aexit__ = AsyncMock(return_value=None)
+    with patch(PATCH_ROUTES_ASYNC_CLIENT, MagicMock(return_value=http_client)):
+        r = client.get("/api/chat/version_policy")
+    assert r.status_code == 200
+    assert r.json() == {"required": False, "upgrade_nudge_version": None}

--- a/app/desktop/studio_server/chat/test_sse_parser.py
+++ b/app/desktop/studio_server/chat/test_sse_parser.py
@@ -26,6 +26,18 @@ class TestEventParser:
         assert result.chat_trace_id is None
         assert any(b"finish" in line for line in result.lines_to_forward)
 
+    def test_forwards_upgrade_nudge_event_unchanged(self):
+        # The non-blocking upgrade nudge is an opaque event to the proxy: it has
+        # no special handling here but must still pass through to the web UI.
+        raw = b'data: {"type":"kiln_client_upgrade_nudge","preferred_version":"1.2.3"}\n\n'
+        result = EventParser().parse(raw)
+        assert result.has_error_event is False
+        assert result.chat_trace_id is None
+        assert result.text_delta == ""
+        assert any(
+            b"kiln_client_upgrade_nudge" in line for line in result.lines_to_forward
+        )
+
     def test_handles_empty_input(self):
         result = EventParser().parse(b"")
         assert result.finish_tool_calls is False

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -3058,6 +3058,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/version_policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Client version policy
+         * @description Proxy to Kiln Copilot ``GET /v1/chat/version_policy``.
+         *
+         *     Lets the assistant page show the upgrade banners on load. Forwards the
+         *     desktop version header so the server can compute the verdict; on any
+         *     upstream/transport failure we degrade to "no banner" rather than error.
+         */
+        get: operations["chat_version_policy_api_chat_version_policy_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/chat/sessions": {
         parameters: {
             query?: never;
@@ -4082,6 +4106,16 @@ export interface components {
             examples_for_feedback: components["schemas"]["SubsampleBatchOutputItemApi"][];
             judge_result: components["schemas"]["SyntheticDataGenerationStepConfigApi"];
             sdg_session_config: components["schemas"]["SyntheticDataGenerationSessionConfigApi"];
+        };
+        /** ClientVersionPolicy */
+        ClientVersionPolicy: {
+            /**
+             * Required
+             * @default false
+             */
+            required: boolean;
+            /** Upgrade Nudge Version */
+            upgrade_nudge_version?: string | null;
         };
         /**
          * CloneRequest
@@ -17591,6 +17625,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    chat_version_policy_api_chat_version_policy_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ClientVersionPolicy"];
                 };
             };
         };

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { get, writable } from "svelte/store"
 import type { ChatMessage, StreamChatOptions } from "./streaming_chat"
+import { CHAT_CLIENT_VERSION_TOO_OLD } from "$lib/error_codes"
 
 vi.mock("./streaming_chat", () => ({
   streamChat: vi.fn(),
@@ -339,6 +340,134 @@ describe("createChatSessionStore", () => {
       const sent = await store.sendMessage("hello")
       expect(sent).toBe(true)
       expect(consentFn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("upgrade nudge", () => {
+    it("sets upgradeNudgeVersion via onVersionNudge", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      const capture: { options: StreamChatOptions | null } = { options: null }
+      streamChatMock.mockImplementation(capturingStreamChat(capture))
+      const store = createChatSessionStore()
+
+      expect(get(store).upgradeNudgeVersion).toBeNull()
+
+      await store.sendMessage("hi")
+      capture.options!.onVersionNudge!("1.2.3")
+
+      expect(get(store).upgradeNudgeVersion).toBe("1.2.3")
+    })
+
+    it("dismissUpgradeNudge clears the nudge", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      const capture: { options: StreamChatOptions | null } = { options: null }
+      streamChatMock.mockImplementation(capturingStreamChat(capture))
+      const store = createChatSessionStore()
+
+      await store.sendMessage("hi")
+      capture.options!.onVersionNudge!("1.2.3")
+      expect(get(store).upgradeNudgeVersion).toBe("1.2.3")
+
+      store.dismissUpgradeNudge()
+      expect(get(store).upgradeNudgeVersion).toBeNull()
+    })
+  })
+
+  describe("version required banner", () => {
+    it("sets versionRequired (not a chat message) on a too-old error", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      const capture: { options: StreamChatOptions | null } = { options: null }
+      streamChatMock.mockImplementation(capturingStreamChat(capture))
+      const store = createChatSessionStore()
+
+      await store.sendMessage("hi")
+      capture.options!.onInlineError!(
+        "Please update the Kiln desktop app to continue using chat.",
+        undefined,
+        CHAT_CLIENT_VERSION_TOO_OLD,
+      )
+
+      const state = get(store)
+      expect(state.versionRequired).toBe(true)
+      expect(state.status).toBe("ready")
+      // It must NOT show up as a conversation error bubble.
+      expect(state.messages.some((m) => m.role === "error")).toBe(false)
+    })
+
+    it("persists versionRequired across reset (aligned with the nudge)", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      const capture: { options: StreamChatOptions | null } = { options: null }
+      streamChatMock.mockImplementation(capturingStreamChat(capture))
+      const store = createChatSessionStore()
+
+      await store.sendMessage("hi")
+      capture.options!.onInlineError!(
+        "too old",
+        undefined,
+        CHAT_CLIENT_VERSION_TOO_OLD,
+      )
+      expect(get(store).versionRequired).toBe(true)
+
+      // New Chat / reset must not clear a blocking version banner.
+      store.reset()
+      expect(get(store).versionRequired).toBe(true)
+    })
+  })
+
+  describe("checkVersionPolicy", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it("sets versionRequired from the policy endpoint", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({ required: true, upgrade_nudge_version: null }),
+        }),
+      )
+      const { createChatSessionStore } = await importFreshWithMock()
+      const store = createChatSessionStore()
+
+      await store.checkVersionPolicy()
+      expect(get(store).versionRequired).toBe(true)
+      expect(get(store).upgradeNudgeVersion).toBeNull()
+    })
+
+    it("sets the nudge version from the policy endpoint", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              required: false,
+              upgrade_nudge_version: "1.0.5",
+            }),
+        }),
+      )
+      const { createChatSessionStore } = await importFreshWithMock()
+      const store = createChatSessionStore()
+
+      await store.checkVersionPolicy()
+      expect(get(store).versionRequired).toBe(false)
+      expect(get(store).upgradeNudgeVersion).toBe("1.0.5")
+    })
+
+    it("leaves banners untouched on a failed request", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }))
+      const { createChatSessionStore } = await importFreshWithMock()
+      const store = createChatSessionStore()
+
+      await store.checkVersionPolicy()
+      expect(get(store).versionRequired).toBe(false)
+      expect(get(store).upgradeNudgeVersion).toBeNull()
     })
   })
 

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -15,6 +15,7 @@ import {
   type AppState,
 } from "$lib/agent"
 import { chat_cost_disclaimer_acknowledged } from "$lib/stores"
+import { CHAT_CLIENT_VERSION_TOO_OLD } from "$lib/error_codes"
 
 const CHAT_API_URL = `${base_url}/api/chat`
 const SESSION_STORAGE_KEY = "kiln_chat_session"
@@ -36,6 +37,17 @@ export interface ChatSessionState extends PersistedChatSession {
   toolApprovalPicks: Record<string, boolean | undefined>
   toolExecuting: boolean
   showActivityIndicator: boolean
+  /**
+   * Preferred version from a server upgrade nudge (non-blocking), or null when
+   * no nudge is active or the user dismissed it. Runtime-only, not persisted.
+   */
+  upgradeNudgeVersion: string | null
+  /**
+   * True when the server rejected the request because the client is below the
+   * required minimum version (HTTP 426). Surfaced as a blocking banner above
+   * the composer rather than as a conversation message. Runtime-only.
+   */
+  versionRequired: boolean
 }
 
 export interface ChatSessionStore extends Readable<ChatSessionState> {
@@ -47,6 +59,9 @@ export interface ChatSessionStore extends Readable<ChatSessionState> {
   togglePartCollapsed(key: string, currentlyCollapsed: boolean): void
   applyToolApprovalRun(toolCallId: string): void
   applyToolApprovalSkip(toolCallId: string): void
+  dismissUpgradeNudge(): void
+  /** Fetch the server's version verdict and set the banner state up front. */
+  checkVersionPolicy(): Promise<void>
   onConsentNeeded: (() => Promise<boolean>) | null
 }
 
@@ -81,6 +96,8 @@ export function createChatSessionStore(
     toolApprovalPicks: {},
     toolExecuting: false,
     showActivityIndicator: false,
+    upgradeNudgeVersion: null,
+    versionRequired: false,
   })
 
   // Intentionally never unsubscribed — this store is a module-level singleton
@@ -239,8 +256,25 @@ export function createChatSessionStore(
           return p
         })
       },
+      onVersionNudge: (preferredVersion) => {
+        if (isStale()) return
+        // Set unconditionally: repeated nudges across tool rounds collapse to a
+        // single banner, and a new server preference re-surfaces it even if a
+        // prior nudge was dismissed.
+        combined.update((s) => ({
+          ...s,
+          upgradeNudgeVersion: preferredVersion,
+        }))
+      },
       onInlineError: (message, traceId, code) => {
         if (isStale()) return
+        // Blocking "client too old" rejection: show it as a banner above the
+        // composer (like the upgrade nudge) instead of a conversation message.
+        if (code === CHAT_CLIENT_VERSION_TOO_OLD) {
+          combined.update((s) => ({ ...s, versionRequired: true }))
+          setRuntimeState("ready", null)
+          return
+        }
         const errorMsg: ChatMessage = {
           id: chatGenerateId(),
           role: "error",
@@ -433,6 +467,33 @@ export function createChatSessionStore(
     maybeFinishToolApproval()
   }
 
+  function dismissUpgradeNudge(): void {
+    combined.update((s) => ({ ...s, upgradeNudgeVersion: null }))
+  }
+
+  async function checkVersionPolicy(): Promise<void> {
+    // Surface the upgrade banners on load, before the user sends anything.
+    // Best-effort: any failure just leaves the banners as-is.
+    try {
+      const res = await fetch(`${base_url}/api/chat/version_policy`)
+      if (!res.ok) return
+      const data = (await res.json()) as {
+        required?: boolean
+        upgrade_nudge_version?: string | null
+      }
+      combined.update((s) => ({
+        ...s,
+        versionRequired: !!data.required,
+        upgradeNudgeVersion:
+          typeof data.upgrade_nudge_version === "string"
+            ? data.upgrade_nudge_version
+            : null,
+      }))
+    } catch {
+      /* network/desktop error — leave banner state untouched */
+    }
+  }
+
   function togglePartCollapsed(key: string, currentlyCollapsed: boolean): void {
     persisted.update((p) => ({
       ...p,
@@ -450,6 +511,8 @@ export function createChatSessionStore(
     togglePartCollapsed,
     applyToolApprovalRun,
     applyToolApprovalSkip,
+    dismissUpgradeNudge,
+    checkVersionPolicy,
     get onConsentNeeded() {
       return onConsentNeeded
     },

--- a/app/web_ui/src/lib/chat/streaming_chat.test.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.test.ts
@@ -195,4 +195,46 @@ describe("streamChat", () => {
 
     vi.unstubAllGlobals()
   })
+
+  it("calls onVersionNudge for kiln_client_upgrade_nudge events", async () => {
+    const lines = [
+      'data: {"type":"kiln_client_upgrade_nudge","preferred_version":"1.2.3"}\n\n',
+      'data: {"type":"kiln_chat_trace","trace_id":"trace-1"}\n\n',
+    ]
+    let i = 0
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: () => {
+            if (i >= lines.length) {
+              return Promise.resolve({ done: true, value: undefined })
+            }
+            const value = new TextEncoder().encode(lines[i])
+            i += 1
+            return Promise.resolve({ done: false, value })
+          },
+        }),
+      },
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const versionNudgeSpy = vi.fn()
+    const errorSpy = vi.fn()
+
+    await streamChat({
+      apiUrl: "https://example.test/api/chat",
+      messages: [{ id: "u1", role: "user", content: "hi" }],
+      onAssistantMessage: () => {},
+      onVersionNudge: versionNudgeSpy,
+      onFinish: () => {},
+      onError: errorSpy,
+    })
+
+    expect(versionNudgeSpy).toHaveBeenCalledOnce()
+    expect(versionNudgeSpy).toHaveBeenCalledWith("1.2.3")
+    expect(errorSpy).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
 })

--- a/app/web_ui/src/lib/chat/streaming_chat.test.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { CHAT_CLIENT_VERSION_TOO_OLD } from "$lib/error_codes"
 import {
   streamChat,
@@ -28,6 +28,12 @@ describe("traceIdForNextChatRequest", () => {
 })
 
 describe("streamChat", () => {
+  // Always restore globals, even if an assertion throws mid-test, so a stubbed
+  // fetch can't leak into later tests.
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it("includes trace_id in POST body when traceId option is set", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -55,8 +61,6 @@ describe("streamChat", () => {
       messages: [{ role: "user", content: "hi" }],
       trace_id: "tid-1",
     })
-
-    vi.unstubAllGlobals()
   })
 
   it("posts execute-tools when tool-calls-pending is received", async () => {
@@ -131,8 +135,6 @@ describe("streamChat", () => {
     expect(chatExecuteToolsUrl("https://example.test/api/chat")).toBe(
       "https://example.test/api/chat/execute-tools",
     )
-
-    vi.unstubAllGlobals()
   })
 
   it("calls onInlineError with code when response has chat_client_version_too_old", async () => {
@@ -165,8 +167,6 @@ describe("streamChat", () => {
 
     expect(inlineErrorSpy).toHaveBeenCalledOnce()
     expect(inlineErrorSpy.mock.calls[0][2]).toBe(CHAT_CLIENT_VERSION_TOO_OLD)
-
-    vi.unstubAllGlobals()
   })
 
   it("calls onError for non-version error responses", async () => {
@@ -192,8 +192,6 @@ describe("streamChat", () => {
 
     expect(errorSpy).toHaveBeenCalledOnce()
     expect(inlineErrorSpy).not.toHaveBeenCalled()
-
-    vi.unstubAllGlobals()
   })
 
   it("calls onVersionNudge for kiln_client_upgrade_nudge events", async () => {
@@ -234,7 +232,5 @@ describe("streamChat", () => {
     expect(versionNudgeSpy).toHaveBeenCalledOnce()
     expect(versionNudgeSpy).toHaveBeenCalledWith("1.2.3")
     expect(errorSpy).not.toHaveBeenCalled()
-
-    vi.unstubAllGlobals()
   })
 })

--- a/app/web_ui/src/lib/chat/streaming_chat.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.ts
@@ -82,6 +82,8 @@ interface StreamEvent {
   messageMetadata?: { finishReason?: string; usage?: unknown }
   items?: ToolCallsPendingItem[]
   tool_count?: number
+  /** Preferred client version from a ``kiln_client_upgrade_nudge`` event */
+  preferred_version?: string
 }
 
 export interface ToolCallsPendingItem {
@@ -107,6 +109,12 @@ export interface StreamChatOptions {
   onChatTrace?: (traceId: string) => void
   /** Fired when backend sends an inline error event */
   onInlineError?: (message: string, traceId?: string, code?: string) => void
+  /**
+   * Fired when the server nudges the client to upgrade (non-blocking): the
+   * client is older than the server's preferred version but still above the
+   * enforced minimum. ``preferredVersion`` is the version to suggest.
+   */
+  onVersionNudge?: (preferredVersion: string) => void
   /**
    * After ``tool-calls-pending`` the stream ends; return whether to run each
    * tool that requires approval (toolCallId → allowed).
@@ -176,6 +184,7 @@ class StreamEventProcessor {
     traceId?: string,
     code?: string,
   ) => void
+  private onVersionNudge?: (preferredVersion: string) => void
   private onToolExecutionStart?: (toolCount: number) => void
   private onToolExecutionEnd?: (toolCount: number) => void
   private onShowActivityIndicator?: (show: boolean) => void
@@ -186,6 +195,7 @@ class StreamEventProcessor {
     onAssistantMessage: (update: (draft: ChatMessage) => void) => void
     onChatTrace?: (traceId: string) => void
     onInlineError?: (message: string, traceId?: string, code?: string) => void
+    onVersionNudge?: (preferredVersion: string) => void
     onToolExecutionStart?: (toolCount: number) => void
     onToolExecutionEnd?: (toolCount: number) => void
     onShowActivityIndicator?: (show: boolean) => void
@@ -193,6 +203,7 @@ class StreamEventProcessor {
     this.onAssistantMessage = opts.onAssistantMessage
     this.onChatTrace = opts.onChatTrace
     this.onInlineError = opts.onInlineError
+    this.onVersionNudge = opts.onVersionNudge
     this.onToolExecutionStart = opts.onToolExecutionStart
     this.onToolExecutionEnd = opts.onToolExecutionEnd
     this.onShowActivityIndicator = opts.onShowActivityIndicator
@@ -225,6 +236,7 @@ class StreamEventProcessor {
       "tool-output-available": (e) => this.handleToolOutputAvailable(e),
       "tool-output-error": (e) => this.handleToolOutputError(e),
       kiln_chat_trace: (e) => this.handleChatTrace(e),
+      kiln_client_upgrade_nudge: (e) => this.handleVersionNudge(e),
       "kiln-tool-execution-start": (e) => {
         this.onShowActivityIndicator?.(true)
         this.onToolExecutionStart?.(e.tool_count ?? 0)
@@ -411,6 +423,13 @@ class StreamEventProcessor {
     }
   }
 
+  private handleVersionNudge(event: StreamEvent): void {
+    const preferred = event.preferred_version
+    if (typeof preferred === "string" && preferred) {
+      this.onVersionNudge?.(preferred)
+    }
+  }
+
   private handleError(event: StreamEvent): void {
     this.onInlineError?.(
       event.message ?? "An error occurred.",
@@ -452,6 +471,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
     onAssistantMessage,
     onChatTrace,
     onInlineError,
+    onVersionNudge,
     onToolCallsPending,
     onToolExecutionStart,
     onToolExecutionEnd,
@@ -529,6 +549,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
       onChatTrace?.(tid)
     },
     onInlineError,
+    onVersionNudge,
     onToolExecutionStart,
     onToolExecutionEnd,
     onShowActivityIndicator,

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -5,7 +5,6 @@
   import posthog from "posthog-js"
   import ChatCostDisclaimer from "./chat_cost_disclaimer.svelte"
   import type { ChatMessage, ChatMessagePart } from "$lib/chat/streaming_chat"
-  import { CHAT_CLIENT_VERSION_TOO_OLD } from "$lib/error_codes"
   import ChatMarkdown from "$lib/ui/chat/chat_markdown.svelte"
   import ArrowUpIcon from "$lib/ui/icons/arrow_up_icon.svelte"
   import StopIcon from "$lib/ui/icons/stop_icon.svelte"
@@ -37,6 +36,8 @@
   $: toolApprovalWaiter = $store.toolApprovalWaiter
   $: toolApprovalPicks = $store.toolApprovalPicks
   $: showActivityIndicator = $store.showActivityIndicator
+  $: upgradeNudgeVersion = $store.upgradeNudgeVersion
+  $: versionRequired = $store.versionRequired
 
   export let hasMessages = false
   $: messages = $store.messages
@@ -59,7 +60,9 @@
   }
 
   $: isLoading = status === "submitted" || status === "streaming"
-  $: inputDisabled = isLoading
+  // Block input entirely when the client is too old: sending would just 426
+  // again and the message would go nowhere.
+  $: inputDisabled = isLoading || versionRequired
 
   let prevIsLoading = false
   $: {
@@ -338,6 +341,9 @@
   let lastTouchY = 0
 
   onMount(() => {
+    // Surface the upgrade banners up front, before any message is sent.
+    void store.checkVersionPolicy()
+
     const container = messagesContainer
     const end = messagesEndRef
     if (container && end) {
@@ -411,6 +417,10 @@
 
   function retryLastRequest() {
     store.retryLastRequest()
+  }
+
+  function dismissUpgradeNudge() {
+    store.dismissUpgradeNudge()
   }
 
   function stop() {
@@ -488,30 +498,17 @@
                   : "flex flex-col gap-3"}
             >
               {#if message.role === "error"}
-                {#if message.errorCode === CHAT_CLIENT_VERSION_TOO_OLD}
-                  <div class="flex items-center gap-3">
-                    <span
-                      >A newer version of Kiln is required.
-                      <a
-                        href="/settings/check_for_update"
-                        class="underline font-medium hover:text-error/80"
-                        >Check for updates</a
-                      ></span
-                    >
-                  </div>
-                {:else}
-                  <div class="flex items-center justify-between gap-3">
-                    <span>{message.content}</span>
-                    <button
-                      type="button"
-                      class="shrink-0 rounded-md bg-error/20 px-2 py-1 text-xs font-medium hover:bg-error/30 transition-colors"
-                      on:click={retryLastRequest}
-                      disabled={isLoading}
-                    >
-                      Retry
-                    </button>
-                  </div>
-                {/if}
+                <div class="flex items-center justify-between gap-3">
+                  <span>{message.content}</span>
+                  <button
+                    type="button"
+                    class="shrink-0 rounded-md bg-error/20 px-2 py-1 text-xs font-medium hover:bg-error/30 transition-colors"
+                    on:click={retryLastRequest}
+                    disabled={isLoading}
+                  >
+                    Retry
+                  </button>
+                </div>
               {:else}
                 <div class="flex flex-col leading-tight">
                   {#if message.parts && message.parts.length > 0}
@@ -1040,6 +1037,46 @@
         />
       </div>
     </div>
+
+    {#if versionRequired}
+      <div class="flex-none w-full md:max-w-3xl md:mx-auto px-1 pt-2">
+        <div
+          class="flex items-center gap-3 rounded-lg bg-error/10 border border-error/30 px-3 py-2 text-sm text-error"
+        >
+          <span class="flex-1">
+            A newer version of Kiln is required to continue using chat.
+            <a
+              href="/settings/check_for_update"
+              class="underline font-medium hover:text-error/80"
+              >Check for updates</a
+            >
+          </span>
+        </div>
+      </div>
+    {:else if upgradeNudgeVersion}
+      <div class="flex-none w-full md:max-w-3xl md:mx-auto px-1 pt-2">
+        <div
+          class="flex items-center gap-3 rounded-lg bg-warning/10 border border-warning/40 px-3 py-2 text-sm"
+        >
+          <span class="flex-1 text-warning">
+            A newer version of Kiln ({upgradeNudgeVersion}) is available.
+            <a
+              href="/settings/check_for_update"
+              class="underline font-medium hover:text-warning/80"
+              >Check for updates</a
+            >
+          </span>
+          <button
+            type="button"
+            class="shrink-0 rounded-md px-2 py-1 text-xs font-medium text-warning/80 hover:bg-warning/20 hover:text-warning transition-colors"
+            on:click={dismissUpgradeNudge}
+            aria-label="Dismiss upgrade notice"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    {/if}
 
     <form
       class="flex-none relative w-full md:max-w-3xl md:mx-auto px-1 pt-2"

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -8,6 +8,8 @@
   import ChatMarkdown from "$lib/ui/chat/chat_markdown.svelte"
   import ArrowUpIcon from "$lib/ui/icons/arrow_up_icon.svelte"
   import StopIcon from "$lib/ui/icons/stop_icon.svelte"
+  import CloseIcon from "$lib/ui/icons/close_icon.svelte"
+  import Warning from "$lib/ui/warning.svelte"
   import {
     chatSessionStore,
     type ChatSessionStore,
@@ -1040,39 +1042,37 @@
 
     {#if versionRequired}
       <div class="flex-none w-full md:max-w-3xl md:mx-auto px-1 pt-2">
-        <div
-          class="flex items-center gap-3 rounded-lg bg-error/10 border border-error/30 px-3 py-2 text-sm text-error"
-        >
-          <span class="flex-1">
-            A newer version of Kiln is required to continue using chat.
-            <a
-              href="/settings/check_for_update"
-              class="underline font-medium hover:text-error/80"
-              >Check for updates</a
-            >
-          </span>
+        <div class="rounded-lg border border-error/40 bg-error/5 px-3 py-2">
+          <Warning
+            warning_color="error"
+            tight
+            markdown
+            trusted
+            warning_message={"A newer version of Kiln is required to continue using chat. [Check for updates](/settings/check_for_update)"}
+          />
         </div>
       </div>
     {:else if upgradeNudgeVersion}
       <div class="flex-none w-full md:max-w-3xl md:mx-auto px-1 pt-2">
         <div
-          class="flex items-center gap-3 rounded-lg bg-warning/10 border border-warning/40 px-3 py-2 text-sm"
+          class="flex items-center gap-2 rounded-lg border border-warning/40 bg-warning/5 px-3 py-2"
         >
-          <span class="flex-1 text-warning">
-            A newer version of Kiln ({upgradeNudgeVersion}) is available.
-            <a
-              href="/settings/check_for_update"
-              class="underline font-medium hover:text-warning/80"
-              >Check for updates</a
-            >
-          </span>
+          <div class="flex-1 min-w-0">
+            <Warning
+              warning_color="warning"
+              tight
+              markdown
+              trusted
+              warning_message={`A newer version of Kiln (${upgradeNudgeVersion}) is available. [Check for updates](/settings/check_for_update)`}
+            />
+          </div>
           <button
             type="button"
-            class="shrink-0 rounded-md px-2 py-1 text-xs font-medium text-warning/80 hover:bg-warning/20 hover:text-warning transition-colors"
+            class="shrink-0 text-base-content/40 hover:text-base-content/70 transition-colors"
             on:click={dismissUpgradeNudge}
             aria-label="Dismiss upgrade notice"
           >
-            Dismiss
+            <span class="size-4 block"><CloseIcon /></span>
           </button>
         </div>
       </div>

--- a/libs/server/kiln_server/utils/agent_checks/annotations/get_api_chat_version_policy.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/get_api_chat_version_policy.json
@@ -1,0 +1,8 @@
+{
+  "method": "get",
+  "path": "/api/chat/version_policy",
+  "agent_policy": {
+    "permission": "deny",
+    "requires_approval": false
+  }
+}


### PR DESCRIPTION
## What

Surfaces client-version status in the Assistant chat UI, in a banner above the composer.

- **Yellow, dismissible nudge** — "A newer version of Kiln (X) is available" (non-blocking).
- **Red, non-dismissible required banner** — "A newer version of Kiln is required to continue using chat", which also **disables the composer**. Moved out of the conversation flow into the same banner slot.
- Both render **proactively on load** via the new `GET /api/chat/version_policy` (desktop proxy forwards the version header to kiln_server), and also react to the `kiln_client_upgrade_nudge` SSE event and `426` responses while chatting.
- Banner styling matches the existing daisyUI `warning` / `error` conventions.

## Changes

- `streaming_chat.ts`: handle the `kiln_client_upgrade_nudge` event (`onVersionNudge`).
- `chat_session_store.ts`: `upgradeNudgeVersion` + `versionRequired` state, `dismissUpgradeNudge()`, and `checkVersionPolicy()` (called on mount). Both states persist across New Chat.
- `chat.svelte`: the two banners above the composer; `inputDisabled` includes `versionRequired`.
- Desktop proxy `routes.py`: `GET /api/chat/version_policy` forwarding to kiln_server (degrades to "no banner" on upstream/transport error).

## Testing

`vitest` chat suite (116 passed) incl. nudge event, `versionRequired` routing/persistence, and `checkVersionPolicy`. Desktop `pytest` chat routes + sse_parser pass. `svelte-check` 0 errors, `eslint` clean. Verified end-to-end in a headed browser for both the nudge and required cases (proactive on load + composer disabled when required).

<img width="1846" height="1588" alt="image" src="https://github.com/user-attachments/assets/b45f1212-15bf-4935-aa67-20976add9d35" />

<img width="1832" height="1604" alt="image" src="https://github.com/user-attachments/assets/b74ad856-30c5-460b-ab0e-a76cfa04674b" />

<img width="1838" height="1616" alt="image" src="https://github.com/user-attachments/assets/427b5b88-1c36-4997-850f-3f7978dcdf80" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)