### PR TITLE
KIL-727: assistant context-usage gauge + compaction indicator (app side)

### DIFF
--- a/app/desktop/studio_server/chat/auto/runner.py
+++ b/app/desktop/studio_server/chat/auto/runner.py
@@ -18,6 +18,9 @@ from app.desktop.studio_server.chat.tool_metadata import tool_input_executor_is_
 from kiln_ai.tools.built_in_tools.disable_auto_mode_tool import (
     DISABLE_AUTO_MODE_TOOL_NAME,
 )
+from kiln_ai.tools.built_in_tools.enable_auto_mode_tool import (
+    ENABLE_AUTO_MODE_TOOL_NAME,
+)
 
 from .models import AutoChatSeed, AutoRunStatus, InboundMessage
 from .sse import (
@@ -35,6 +38,18 @@ MAX_TOOL_ROUNDS_MESSAGE = "Maximum tool rounds exceeded. Please start a new mess
 # The tool result the app server resolves an intercepted disable_auto_mode call
 # to, fed back to the backend so it continues interactively.
 DISABLE_AUTO_MODE_RESULT = json.dumps({"status": "disabled"}, ensure_ascii=False)
+
+# The tool result for an enable_auto_mode call made WHILE auto mode is already on
+# (i.e. during an auto run). enable_auto_mode is a signal, never executed — but
+# the toolset is intentionally stable (both auto-mode tools are always exposed so
+# the prompt cache survives the whole conversation), so the model can still call
+# it redundantly. Resolve it as a no-op "already enabled" instead of letting it
+# fall through to execute_tool (which would return an "Unknown tool name" error),
+# and continue the burst.
+ENABLE_AUTO_MODE_RESULT = json.dumps(
+    {"status": "enabled", "detail": "Auto mode is already enabled."},
+    ensure_ascii=False,
+)
 
 # Callback the runner invokes to push one SSE byte payload to the run's buffer +
 # bus. It also detects kiln_chat_trace boundaries (buffer reset + index update).
@@ -208,6 +223,19 @@ class AutoChatRunner:
                     self.status = AutoRunStatus.USER_STOPPED
                     return
 
+                # enable_auto_mode no-op: the model called enable_auto_mode while
+                # auto mode is already on. It's a signal, never executed — resolve
+                # it as "already enabled" so the redundant call gets a clean result
+                # (not an "Unknown tool name" error from execute_tool) and the burst
+                # keeps going. The model is instructed to call it alone, but resolve
+                # any siblings normally below.
+                enable_events = [
+                    e for e in client_events if e.toolName == ENABLE_AUTO_MODE_TOOL_NAME
+                ]
+                executable_events = [
+                    e for e in client_events if e.toolName != ENABLE_AUTO_MODE_TOOL_NAME
+                ]
+
                 # AUTO-APPROVE: requires_approval=False makes execute_tool_batch
                 # skip the gate and run every client tool unattended.
                 tool_calls = [
@@ -217,11 +245,13 @@ class AutoChatRunner:
                         input=e.input,
                         requiresApproval=False,
                     )
-                    for e in client_events
+                    for e in executable_events
                 ]
 
-                self._emit(format_tool_exec_start(len(tool_calls)))
+                self._emit(format_tool_exec_start(len(client_events)))
                 results = await execute_tool_batch(tool_calls, {})
+                for e in enable_events:
+                    results[e.toolCallId] = ENABLE_AUTO_MODE_RESULT
                 for tc_id, output in results.items():
                     self._emit(format_tool_output(tc_id, output))
                 self._emit(format_tool_exec_end(len(results)))

--- a/app/desktop/studio_server/chat/auto/test_runner.py
+++ b/app/desktop/studio_server/chat/auto/test_runner.py
@@ -467,6 +467,95 @@ async def test_disable_auto_mode_resolves_tool_result_to_backend():
     assert "tr-2" in traces
 
 
+# ── enable_auto_mode no-op while already on ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enable_auto_mode_while_on_resolves_already_enabled_and_continues():
+    # The model calls enable_auto_mode while auto mode is already on. It's a
+    # signal, never executed — the runner resolves it as "already enabled" (NOT
+    # an "Unknown tool name" error) and the burst continues normally.
+    round1 = [
+        text_delta("enabling auto mode"),
+        tool_input_available("tc_enable", "enable_auto_mode", input={}),
+        trace("tr-1"),
+        finish_tool_calls(),
+    ]
+    round2 = [text_delta("carrying on"), trace("tr-2"), finish("stop")]
+    client = FakeUpstreamClient(
+        [FakeUpstreamResponse(chunks=round1), FakeUpstreamResponse(chunks=round2)]
+    )
+    runner, emitted, _ = _runner(client)
+
+    with patch(
+        "app.desktop.studio_server.chat.stream_session.execute_tool"
+    ) as execute_tool_mock:
+        with patch.object(httpx, "AsyncClient", return_value=client):
+            await runner.run()
+
+    # Burst continues — not disabled, not errored.
+    assert runner.status == AutoRunStatus.IDLE
+    # Never executed as a tool (no "Unknown tool name" path).
+    execute_tool_mock.assert_not_called()
+    # The enable call is resolved as already-enabled on the stream.
+    outputs = [
+        json.loads(e["output"])
+        for e in _events(emitted)
+        if e.get("type") == "tool-output-available"
+    ]
+    assert {"status": "enabled", "detail": "Auto mode is already enabled."} in outputs
+    # A continuation was sent to the backend resolving the enable tool_call_id, so
+    # the persisted trace has no dangling tool call.
+    assert len(client.bodies) == 2
+    enable_tool_msgs = [
+        m
+        for m in client.bodies[1]["messages"]
+        if m.get("role") == "tool" and m.get("tool_call_id") == "tc_enable"
+    ]
+    assert len(enable_tool_msgs) == 1
+    assert json.loads(enable_tool_msgs[0]["content"]) == {
+        "status": "enabled",
+        "detail": "Auto mode is already enabled.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_enable_auto_mode_resolved_alongside_executable_sibling():
+    # Defensive: if enable_auto_mode arrives with a sibling tool call, the sibling
+    # still executes (auto-approved) and the enable call resolves as a no-op.
+    round1 = [
+        text_delta("enabling and computing"),
+        tool_input_available("tc_enable", "enable_auto_mode", input={}),
+        tool_input_available("tc_add", "add", {"a": 2, "b": 3}),
+        trace("tr-1"),
+        finish_tool_calls(),
+    ]
+    round2 = [text_delta("done"), trace("tr-2"), finish("stop")]
+    client = FakeUpstreamClient(
+        [FakeUpstreamResponse(chunks=round1), FakeUpstreamResponse(chunks=round2)]
+    )
+    runner, emitted, _ = _runner(client)
+
+    with patch.object(httpx, "AsyncClient", return_value=client):
+        await runner.run()
+
+    assert runner.status == AutoRunStatus.IDLE
+    raw_outputs = [
+        e["output"]
+        for e in _events(emitted)
+        if e.get("type") == "tool-output-available"
+    ]
+    # The sibling executed (add → "5") and the enable call resolved as a no-op.
+    assert "5" in raw_outputs
+    assert (
+        json.dumps(
+            {"status": "enabled", "detail": "Auto mode is already enabled."},
+            ensure_ascii=False,
+        )
+        in raw_outputs
+    )
+
+
 # ── Graceful stop (functional spec §4.4(1)) ──────────────────────────────────
 
 

--- a/app/desktop/studio_server/chat/routes.py
+++ b/app/desktop/studio_server/chat/routes.py
@@ -102,9 +102,36 @@ class TaskRunSnapshot(BaseModel):
     trace: list[TraceMessage] | None = None
 
 
+class ContextUsage(BaseModel):
+    """Proxy mirror of the kiln_server ``ContextUsage`` value object.
+
+    Carries only the gauge numbers and the ``compacted`` flag — never any trace
+    content — so it is safe to surface to the web UI. Every field is optional so
+    an older upstream that doesn't emit ``context_usage`` (or emits a partial
+    object) never 500s the proxy; the web UI hides the gauge when it's absent.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    context_tokens: int | None = None
+    context_limit: int | None = None
+    context_percent: float | None = None
+    compacted: bool | None = None
+
+
 class ChatSessionSnapshot(BaseModel):
+    # ``extra="ignore"`` (explicit, matching Pydantic v2's default) is the
+    # containment boundary (functional_spec.md §7.3): the upstream JSON is
+    # re-emitted by the generated SDK's ``to_dict()`` and may carry the
+    # server-only ``compacted_trace``; ``ignore`` silently DROPS that unknown key
+    # so the full uncompacted ``task_run.trace`` is the only conversation the web
+    # UI ever receives. Do NOT change to ``extra="forbid"`` — forbid does not
+    # strip, it RAISES ValidationError, which would turn a leaked key into a 500.
+    model_config = ConfigDict(extra="ignore")
+
     id: str
     task_run: TaskRunSnapshot
+    context_usage: ContextUsage | None = None
 
 
 class ChatRequestMessage(BaseModel):

--- a/app/desktop/studio_server/chat/test_routes.py
+++ b/app/desktop/studio_server/chat/test_routes.py
@@ -13,6 +13,7 @@ from app.desktop.studio_server.api_client.kiln_ai_server_client.types import (
     Response as KilnResponse,
 )
 from app.desktop.studio_server.chat.constants import DENIED_TOOL_OUTPUT
+from app.desktop.studio_server.chat.routes import ChatSessionSnapshot
 from app.desktop.studio_server.chat.helpers import (
     PATCH_ASYNC_CLIENT,
     PATCH_EXECUTE_TOOL,
@@ -191,6 +192,142 @@ def test_get_chat_session_forwards_to_kiln(mock_asyncio_detailed, client, mock_a
     call_kwargs = mock_asyncio_detailed.call_args[1]
     assert call_kwargs["session_id"] == "trace-abc"
     assert "client" in call_kwargs
+
+
+@patch(
+    "app.desktop.studio_server.chat.routes.get_session_v1_chat_sessions_session_id_get.asyncio_detailed",
+    new_callable=AsyncMock,
+)
+def test_get_chat_session_round_trips_context_usage(
+    mock_asyncio_detailed, client, mock_api_key
+):
+    # Upstream now emits a top-level ``context_usage`` alongside ``id`` /
+    # ``task_run``. The generated SDK model only declares id + task_run and
+    # stashes extras in ``additional_properties``, which ``to_dict()`` re-emits,
+    # so the field survives into ``ChatSessionSnapshot`` once the field exists.
+    snapshot_dict = {
+        "id": "trace-ctx",
+        "task_run": _make_task_run_dict(trace=[{"role": "user", "content": "yo"}]),
+        "context_usage": {
+            "context_tokens": 1234,
+            "context_limit": 150000,
+            "context_percent": 0.0082,
+            "compacted": True,
+        },
+    }
+    parsed = ChatSnapshot.from_dict(snapshot_dict)
+    mock_asyncio_detailed.return_value = KilnResponse(
+        status_code=HTTPStatus.OK,
+        content=b"{}",
+        headers={"content-type": "application/json"},
+        parsed=parsed,
+    )
+
+    r = client.get("/api/chat/sessions/trace-ctx")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["context_usage"] == {
+        "context_tokens": 1234,
+        "context_limit": 150000,
+        "context_percent": 0.0082,
+        "compacted": True,
+    }
+
+
+def test_chat_session_snapshot_drops_unknown_keys_invariant():
+    # Pin the containment invariant at the model level, independent of the route
+    # round-trip: a valid snapshot carrying the server-only ``compacted_trace``
+    # validates successfully (no 500) AND the unknown key is dropped, so it can
+    # never reach the client (functional_spec.md §7.3). This guards against a
+    # maintainer "tightening" the config to ``extra="forbid"`` (which would raise
+    # instead of drop) or relying on an unstated default.
+    snapshot = ChatSessionSnapshot.model_validate(
+        {
+            "id": "trace-invariant",
+            "task_run": {"trace": [{"role": "user", "content": "hi"}]},
+            "context_usage": {
+                "context_tokens": 1,
+                "context_limit": 2,
+                "context_percent": 0.5,
+                "compacted": False,
+            },
+            "compacted_trace": [{"role": "system", "content": "secret"}],
+        }
+    )
+
+    assert not hasattr(snapshot, "compacted_trace")
+    assert "compacted_trace" not in snapshot.model_dump()
+    assert snapshot.id == "trace-invariant"
+    assert snapshot.context_usage is not None
+
+
+@patch(
+    "app.desktop.studio_server.chat.routes.get_session_v1_chat_sessions_session_id_get.asyncio_detailed",
+    new_callable=AsyncMock,
+)
+def test_get_chat_session_drops_compacted_trace(
+    mock_asyncio_detailed, client, mock_api_key
+):
+    # Defense in depth (functional_spec.md §7.3): even if a regressed upstream
+    # leaked the server-only ``compacted_trace``, ``ChatSessionSnapshot``'s
+    # ``extra="ignore"`` config must drop it at the client boundary. The full
+    # ``task_run.trace`` and the gauge numbers still come through.
+    snapshot_dict = {
+        "id": "trace-leak",
+        "task_run": _make_task_run_dict(trace=[{"role": "user", "content": "hi"}]),
+        "compacted_trace": [{"role": "system", "content": "<compaction_summary>..."}],
+        "context_usage": {
+            "context_tokens": 99,
+            "context_limit": 150000,
+            "context_percent": 0.0007,
+            "compacted": True,
+        },
+    }
+    parsed = ChatSnapshot.from_dict(snapshot_dict)
+    mock_asyncio_detailed.return_value = KilnResponse(
+        status_code=HTTPStatus.OK,
+        content=b"{}",
+        headers={"content-type": "application/json"},
+        parsed=parsed,
+    )
+
+    r = client.get("/api/chat/sessions/trace-leak")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert "compacted_trace" not in body
+    assert body["task_run"]["trace"] == [{"role": "user", "content": "hi"}]
+    assert body["context_usage"]["compacted"] is True
+
+
+@patch(
+    "app.desktop.studio_server.chat.routes.get_session_v1_chat_sessions_session_id_get.asyncio_detailed",
+    new_callable=AsyncMock,
+)
+def test_get_chat_session_tolerates_missing_context_usage(
+    mock_asyncio_detailed, client, mock_api_key
+):
+    # Backward compatibility: an older upstream that omits ``context_usage`` must
+    # not 500 the proxy. ``response_model_exclude_none`` drops the absent field.
+    snapshot_dict = {
+        "id": "trace-old",
+        "task_run": _make_task_run_dict(trace=[{"role": "user", "content": "yo"}]),
+    }
+    parsed = ChatSnapshot.from_dict(snapshot_dict)
+    mock_asyncio_detailed.return_value = KilnResponse(
+        status_code=HTTPStatus.OK,
+        content=b"{}",
+        headers={"content-type": "application/json"},
+        parsed=parsed,
+    )
+
+    r = client.get("/api/chat/sessions/trace-old")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["id"] == "trace-old"
+    assert "context_usage" not in body
 
 
 @patch(

--- a/app/desktop/studio_server/chat/test_sse_parser.py
+++ b/app/desktop/studio_server/chat/test_sse_parser.py
@@ -92,6 +92,20 @@ class TestEventParser:
         assert b'"context_tokens":1234' in forwarded
         assert b'"compacted":true' in forwarded
 
+    def test_kiln_compaction_status_passes_through_untouched(self):
+        # Phase 5: ``kiln_compaction_status`` is a new upstream SSE event the
+        # proxy doesn't model. The parser is a raw passthrough — it forwards
+        # complete lines without reserializing — so an unknown event type must
+        # reach the client verbatim (architecture §4.7). It is neither a chat
+        # trace nor an error, so it leaves the extraction fields untouched.
+        raw = b'data: {"type":"kiln_compaction_status","state":"started"}\n\n'
+        result = EventParser().parse(raw)
+        assert result.chat_trace_id is None
+        assert result.has_error_event is False
+        forwarded = b"\n".join(result.lines_to_forward)
+        assert b"kiln_compaction_status" in forwarded
+        assert b'"state":"started"' in forwarded
+
     def test_kiln_chat_trace_last_wins_in_chunk(self):
         raw = (
             b'data: {"type":"kiln_chat_trace","trace_id":"first-id"}\n'

--- a/app/desktop/studio_server/chat/test_sse_parser.py
+++ b/app/desktop/studio_server/chat/test_sse_parser.py
@@ -72,6 +72,26 @@ class TestEventParser:
         assert result.chat_trace_id == tid
         assert any(b"kiln_chat_trace" in line for line in result.lines_to_forward)
 
+    def test_kiln_chat_trace_with_context_usage_passes_through_untouched(self):
+        # The proxy is a raw passthrough: a new ``context_usage`` field on the
+        # ``kiln_chat_trace`` event must reach the client verbatim (architecture
+        # §7). The parser forwards complete lines without reserializing, so the
+        # whole payload — including ``context_usage`` — survives, and the trace
+        # id is still extracted.
+        tid = "d5804b96-851f-4ed6-acb6-b4107968a85a"
+        raw = (
+            f'data: {{"type":"kiln_chat_trace","trace_id":"{tid}",'
+            f'"context_usage":{{"context_tokens":1234,"context_limit":150000,'
+            f'"context_percent":0.0082,"compacted":true}}}}\n\n'
+        ).encode()
+        result = EventParser().parse(raw)
+        assert result.chat_trace_id == tid
+        forwarded = b"\n".join(result.lines_to_forward)
+        assert b"kiln_chat_trace" in forwarded
+        assert b'"context_usage"' in forwarded
+        assert b'"context_tokens":1234' in forwarded
+        assert b'"compacted":true' in forwarded
+
     def test_kiln_chat_trace_last_wins_in_chunk(self):
         raw = (
             b'data: {"type":"kiln_chat_trace","trace_id":"first-id"}\n'

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -4381,6 +4381,7 @@ export interface components {
             /** Id */
             id: string;
             task_run: components["schemas"]["TaskRunSnapshot"];
+            context_usage?: components["schemas"]["ContextUsage"] | null;
         };
         /**
          * ChatStrategy
@@ -4571,6 +4572,25 @@ export interface components {
             complete_examples: string;
             /** Incomplete Examples */
             incomplete_examples: string;
+        };
+        /**
+         * ContextUsage
+         * @description Proxy mirror of the kiln_server ``ContextUsage`` value object.
+         *
+         *     Carries only the gauge numbers and the ``compacted`` flag — never any trace
+         *     content — so it is safe to surface to the web UI. Every field is optional so
+         *     an older upstream that doesn't emit ``context_usage`` (or emits a partial
+         *     object) never 500s the proxy; the web UI hides the gauge when it's absent.
+         */
+        ContextUsage: {
+            /** Context Tokens */
+            context_tokens?: number | null;
+            /** Context Limit */
+            context_limit?: number | null;
+            /** Context Percent */
+            context_percent?: number | null;
+            /** Compacted */
+            compacted?: boolean | null;
         };
         /** CorrelationResult */
         CorrelationResult: {

--- a/app/web_ui/src/lib/chat/auto_run_store.test.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.test.ts
@@ -6,7 +6,11 @@ import {
   type AutoRunChatSink,
   type AutoRunStore,
 } from "./auto_run_store"
-import type { ChatMessage, ToolCallsPendingItem } from "./streaming_chat"
+import type {
+  ChatMessage,
+  ContextUsage,
+  ToolCallsPendingItem,
+} from "./streaming_chat"
 
 vi.mock("$lib/api_client", () => ({
   base_url: "http://localhost:8757",
@@ -73,6 +77,7 @@ interface SinkCalls {
   idleReasons: (string | null)[]
   offReasons: (string | null)[]
   pendingToolCalls: ToolCallsPendingItem[][]
+  contextUsages: ContextUsage[]
 }
 
 function makeSink(): { sink: AutoRunChatSink; calls: SinkCalls } {
@@ -89,6 +94,7 @@ function makeSink(): { sink: AutoRunChatSink; calls: SinkCalls } {
     idleReasons: [],
     offReasons: [],
     pendingToolCalls: [],
+    contextUsages: [],
   }
   const sink: AutoRunChatSink = {
     beginAssistantTurn: () => {
@@ -100,6 +106,7 @@ function makeSink(): { sink: AutoRunChatSink; calls: SinkCalls } {
       calls.assistantUpdates.push(draft)
     },
     onChatTrace: (tid) => calls.traces.push(tid),
+    onContextUsage: (usage) => calls.contextUsages.push(usage),
     onInlineError: (msg) => calls.errors.push(msg),
     onToolExecutionStart: (n) => calls.toolStart.push(n),
     onToolExecutionEnd: (n) => calls.toolEnd.push(n),

--- a/app/web_ui/src/lib/chat/auto_run_store.test.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.test.ts
@@ -78,6 +78,7 @@ interface SinkCalls {
   offReasons: (string | null)[]
   pendingToolCalls: ToolCallsPendingItem[][]
   contextUsages: ContextUsage[]
+  compactionStatuses: boolean[]
 }
 
 function makeSink(): { sink: AutoRunChatSink; calls: SinkCalls } {
@@ -95,6 +96,7 @@ function makeSink(): { sink: AutoRunChatSink; calls: SinkCalls } {
     offReasons: [],
     pendingToolCalls: [],
     contextUsages: [],
+    compactionStatuses: [],
   }
   const sink: AutoRunChatSink = {
     beginAssistantTurn: () => {
@@ -107,6 +109,7 @@ function makeSink(): { sink: AutoRunChatSink; calls: SinkCalls } {
     },
     onChatTrace: (tid) => calls.traces.push(tid),
     onContextUsage: (usage) => calls.contextUsages.push(usage),
+    onCompactionStatus: (c) => calls.compactionStatuses.push(c),
     onInlineError: (msg) => calls.errors.push(msg),
     onToolExecutionStart: (n) => calls.toolStart.push(n),
     onToolExecutionEnd: (n) => calls.toolEnd.push(n),

--- a/app/web_ui/src/lib/chat/auto_run_store.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.ts
@@ -46,6 +46,11 @@ export interface AutoRunChatSink {
   onChatTrace: (traceId: string) => void
   /** Fired when an auto-burst snapshot event carries ``context_usage``. */
   onContextUsage: (usage: ContextUsage) => void
+  /**
+   * Fired when an auto-burst emits ``kiln_compaction_status`` (Phase 5):
+   * ``true`` to show the "summarizing…" indicator, ``false`` to clear it.
+   */
+  onCompactionStatus: (compacting: boolean) => void
   onInlineError: (message: string, traceId?: string, code?: string) => void
   onToolExecutionStart: (toolCount: number) => void
   onToolExecutionEnd: (toolCount: number) => void
@@ -181,6 +186,7 @@ export function createAutoRunStore(): AutoRunStore {
       onAssistantMessage: (update) => sink?.onAssistantMessage(update),
       onChatTrace: (tid) => sink?.onChatTrace(tid),
       onContextUsage: (usage) => sink?.onContextUsage(usage),
+      onCompactionStatus: (compacting) => sink?.onCompactionStatus(compacting),
       onInlineError: (message, traceId, code) =>
         sink?.onInlineError(message, traceId, code),
       onToolExecutionStart: (count) => sink?.onToolExecutionStart(count),

--- a/app/web_ui/src/lib/chat/auto_run_store.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.ts
@@ -19,6 +19,7 @@ import {
   StreamEventProcessor,
   consumeSseStream,
   type ChatMessage,
+  type ContextUsage,
   type StreamEvent,
   type ToolCallsPendingItem,
 } from "./streaming_chat"
@@ -43,6 +44,8 @@ export interface AutoRunChatSink {
   beginAssistantTurn: () => void
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   onChatTrace: (traceId: string) => void
+  /** Fired when an auto-burst snapshot event carries ``context_usage``. */
+  onContextUsage: (usage: ContextUsage) => void
   onInlineError: (message: string, traceId?: string, code?: string) => void
   onToolExecutionStart: (toolCount: number) => void
   onToolExecutionEnd: (toolCount: number) => void
@@ -177,6 +180,7 @@ export function createAutoRunStore(): AutoRunStore {
     return new StreamEventProcessor({
       onAssistantMessage: (update) => sink?.onAssistantMessage(update),
       onChatTrace: (tid) => sink?.onChatTrace(tid),
+      onContextUsage: (usage) => sink?.onContextUsage(usage),
       onInlineError: (message, traceId, code) =>
         sink?.onInlineError(message, traceId, code),
       onToolExecutionStart: (count) => sink?.onToolExecutionStart(count),

--- a/app/web_ui/src/lib/chat/chat_history_apply.ts
+++ b/app/web_ui/src/lib/chat/chat_history_apply.ts
@@ -1,6 +1,7 @@
-import type { ChatMessage } from "./streaming_chat"
+import type { ChatMessage, ContextUsage } from "./streaming_chat"
 
 export type LoadedChatSessionDetail = {
   messages: ChatMessage[]
   continuationTraceId: string
+  contextUsage: ContextUsage | null
 }

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -1553,3 +1553,74 @@ describe("contextUsage", () => {
     expect(get(store).contextUsage).toBeNull()
   })
 })
+
+describe("compacting (Phase 5)", () => {
+  it("is false initially", async () => {
+    const { createChatSessionStore } = await importFreshWithMock()
+    const store = createChatSessionStore()
+    expect(get(store).compacting).toBe(false)
+  })
+
+  it("is set true via the onCompactionStatus stream callback", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore()
+
+    await store.sendMessage("hi")
+    capture.options!.onCompactionStatus!(true)
+    expect(get(store).compacting).toBe(true)
+
+    capture.options!.onCompactionStatus!(false)
+    expect(get(store).compacting).toBe(false)
+  })
+
+  it("clears compacting on finish", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore()
+
+    await store.sendMessage("hi")
+    capture.options!.onCompactionStatus!(true)
+    expect(get(store).compacting).toBe(true)
+
+    capture.options!.onFinish()
+    expect(get(store).compacting).toBe(false)
+  })
+
+  it("clears compacting on reset", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore()
+
+    await store.sendMessage("hi")
+    capture.options!.onCompactionStatus!(true)
+    expect(get(store).compacting).toBe(true)
+
+    store.reset()
+    expect(get(store).compacting).toBe(false)
+  })
+
+  it("is not persisted to sessionStorage", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore("kiln_chat_test")
+
+    await store.sendMessage("hi")
+    capture.options!.onCompactionStatus!(true)
+    expect(get(store).compacting).toBe(true)
+
+    // ``compacting`` is runtime-only — it must never be written into the
+    // persisted sessionStorage payload.
+    const persisted = storage.store["kiln_chat_test"]
+    expect(persisted).toBeDefined()
+    expect(persisted).not.toContain("compacting")
+  })
+})

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { get, writable } from "svelte/store"
-import type { ChatMessage, StreamChatOptions } from "./streaming_chat"
+import type {
+  ChatMessage,
+  ContextUsage,
+  StreamChatOptions,
+} from "./streaming_chat"
 
 vi.mock("./streaming_chat", () => ({
   streamChat: vi.fn(),
@@ -1464,5 +1468,88 @@ describe("chatSessionStore global instance", () => {
     const state = get(chatSessionStore)
     expect(state.messages).toEqual([])
     expect(state.status).toBe("ready")
+  })
+})
+
+describe("contextUsage", () => {
+  const usage: ContextUsage = {
+    context_tokens: 90_000,
+    context_limit: 150_000,
+    context_percent: 0.6,
+    compacted: false,
+  }
+
+  it("is null initially", async () => {
+    const { createChatSessionStore } = await importFreshWithMock()
+    const store = createChatSessionStore()
+    expect(get(store).contextUsage).toBeNull()
+  })
+
+  it("is set via the onContextUsage stream callback", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore()
+
+    await store.sendMessage("hi")
+    capture.options!.onContextUsage!(usage)
+
+    expect(get(store).contextUsage).toEqual(usage)
+  })
+
+  it("persists contextUsage to sessionStorage", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore("ctx_session")
+
+    await store.sendMessage("hi")
+    capture.options!.onContextUsage!(usage)
+
+    const stored = JSON.parse(storage.store["ctx_session"])
+    expect(stored.contextUsage).toEqual(usage)
+  })
+
+  it("restores persisted contextUsage on a fresh store", async () => {
+    storage.store["ctx_restore"] = JSON.stringify({
+      messages: [],
+      collapsedPartKeys: {},
+      lastSentAppState: null,
+      contextUsage: usage,
+    })
+    const { createChatSessionStore } = await importFreshWithMock()
+    const store = createChatSessionStore("ctx_restore")
+    expect(get(store).contextUsage).toEqual(usage)
+  })
+
+  it("sets contextUsage on loadSession", async () => {
+    const { createChatSessionStore } = await importFreshWithMock()
+    const store = createChatSessionStore()
+    store.loadSession([], "trace-load", usage)
+    expect(get(store).contextUsage).toEqual(usage)
+  })
+
+  it("defaults contextUsage to null when loadSession omits it", async () => {
+    const { createChatSessionStore } = await importFreshWithMock()
+    const store = createChatSessionStore()
+    store.loadSession([], "trace-load")
+    expect(get(store).contextUsage).toBeNull()
+  })
+
+  it("clears contextUsage on reset", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore()
+
+    await store.sendMessage("hi")
+    capture.options!.onContextUsage!(usage)
+    expect(get(store).contextUsage).toEqual(usage)
+
+    store.reset()
+    expect(get(store).contextUsage).toBeNull()
   })
 })

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { get, writable } from "svelte/store"
+import { get, writable, type Writable } from "svelte/store"
 import type {
   ChatMessage,
   ContextUsage,
@@ -417,6 +417,47 @@ describe("createChatSessionStore", () => {
         "Couldn't start auto mode: Too many auto runs",
       )
     })
+
+    it.each([
+      ["on", { autoModeOn: true }],
+      ["armed", { armed: true }],
+    ] as const)(
+      "auto-accepts the enable call without prompting when auto mode is already %s",
+      async (_label, flag) => {
+        const { createChatSessionStore, streamChatMock } =
+          await importFreshWithMock()
+        const capture: { options: StreamChatOptions | null } = { options: null }
+        streamChatMock.mockImplementation(capturingStreamChat(capture))
+
+        // Start the interactive stream while auto mode is still off, so the
+        // store registers its onAutoModeConsentRequired handoff.
+        const requestEnable = vi.fn().mockResolvedValue({ ok: true })
+        const fakeAutoRun = makeFakeAutoRun({ requestEnable })
+        const store = createChatSessionStore(undefined, fakeAutoRun)
+        const autoConsent = vi.fn(() => Promise.resolve(true))
+        store.onAutoModeConsentNeeded = autoConsent
+        await store.sendMessage("hi")
+
+        // The user turns auto mode on themselves (e.g. footer toggle) while the
+        // stream is still resolving the model's enable call.
+        const writableFlag = (
+          fakeAutoRun as unknown as Record<string, Writable<boolean>>
+        )["autoModeOn" in flag ? "autoModeOn" : "armed"]
+        writableFlag.set(true)
+
+        await capture.options!.onAutoModeConsentRequired!({
+          traceId: "trace-1",
+          enableToolCallId: "call_1",
+          reason: null,
+          siblingToolCalls: [],
+        })
+
+        // The consent dialog is never shown; the enable call is accepted
+        // silently so the pending tool call resolves.
+        expect(autoConsent).not.toHaveBeenCalled()
+        expect(requestEnable).toHaveBeenCalledTimes(1)
+      },
+    )
 
     it("skips consent prompt when already acknowledged", async () => {
       const { createChatSessionStore, streamChatMock } =

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -560,9 +560,17 @@ export function createChatSessionStore(
       traceIdForNextChatRequest(get(persisted).messages) ??
       continuationTraceId
     if (!traceId) return
-    const accepted = onAutoModeConsentNeeded
-      ? await onAutoModeConsentNeeded(payload)
-      : false
+    // If auto mode is already on/armed — the user turned it on themselves (e.g.
+    // clicked the footer toggle) while this interactive stream was still
+    // resolving the model's enable call — there is nothing to ask: accept
+    // silently so the pending enable tool call resolves without re-showing the
+    // consent dialog.
+    const alreadyOn = get(autoRunStore.autoModeOn) || get(autoRunStore.armed)
+    const accepted = alreadyOn
+      ? true
+      : onAutoModeConsentNeeded
+        ? await onAutoModeConsentNeeded(payload)
+        : false
     const siblings = payload.siblingToolCalls.map((s) => ({
       toolCallId: s.toolCallId,
       toolName: s.toolName,

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -53,6 +53,12 @@ export interface ChatSessionState extends PersistedChatSession {
   toolExecuting: boolean
   showActivityIndicator: boolean
   /**
+   * The server is summarizing earlier messages (compaction) for this turn
+   * (Phase 5). Runtime-only — NOT persisted. Set by ``kiln_compaction_status``
+   * and cleared on the first content event / turn end / reset.
+   */
+  compacting: boolean
+  /**
    * A server-owned auto-mode burst is actively running. Decoupled from
    * ``status`` (which tracks the interactive client stream) so the chat view
    * can drive the SAME loading affordances during auto bursts while keeping the
@@ -135,6 +141,7 @@ export function createChatSessionStore(
     toolApprovalPicks: {},
     toolExecuting: false,
     showActivityIndicator: false,
+    compacting: false,
     autoWorking: false,
   })
 
@@ -227,6 +234,12 @@ export function createChatSessionStore(
     persisted.update((p) => ({ ...p, contextUsage: usage }))
   }
 
+  // Runtime-only (not persisted): drives the "Summarizing earlier messages…"
+  // indicator while the server compacts the conversation for this turn.
+  function setCompacting(compacting: boolean) {
+    combined.update((s) => ({ ...s, compacting }))
+  }
+
   // Append a fresh empty assistant message so the next streamed burst (auto run
   // or declined-resume) renders into a new turn rather than the prior one.
   function beginAssistantTurn() {
@@ -239,6 +252,7 @@ export function createChatSessionStore(
       ...s,
       toolExecuting: false,
       showActivityIndicator: false,
+      compacting: false,
     }))
   }
 
@@ -262,6 +276,7 @@ export function createChatSessionStore(
     onAssistantMessage: updateLastAssistant,
     onChatTrace: setLastAssistantTraceId,
     onContextUsage: setContextUsage,
+    onCompactionStatus: setCompacting,
     onInlineError: (message, traceId, code) =>
       pushInlineError(message, traceId, code),
     onToolExecutionStart: () =>
@@ -282,6 +297,7 @@ export function createChatSessionStore(
         ...s,
         toolExecuting: false,
         showActivityIndicator: false,
+        compacting: false,
         autoWorking: false,
       })),
     onAutoModeOff: () =>
@@ -289,6 +305,7 @@ export function createChatSessionStore(
         ...s,
         toolExecuting: false,
         showActivityIndicator: false,
+        compacting: false,
         autoWorking: false,
       })),
     onToolCallsPending: handleAutoToolCallsPending,
@@ -334,6 +351,10 @@ export function createChatSessionStore(
         if (isStale()) return
         setContextUsage(usage)
       },
+      onCompactionStatus: (compacting) => {
+        if (isStale()) return
+        setCompacting(compacting)
+      },
       onInlineError: (message, traceId, code) => {
         if (isStale()) return
         pushInlineError(message, traceId, code)
@@ -356,6 +377,7 @@ export function createChatSessionStore(
           ...s,
           toolExecuting: false,
           showActivityIndicator: false,
+          compacting: false,
         }))
       },
       onError: (err) => {
@@ -364,6 +386,7 @@ export function createChatSessionStore(
           ...s,
           toolExecuting: false,
           showActivityIndicator: false,
+          compacting: false,
         }))
         pushInlineError(err.message)
       },
@@ -415,6 +438,7 @@ export function createChatSessionStore(
       ...s,
       toolExecuting: false,
       showActivityIndicator: false,
+      compacting: false,
     }))
 
     const controller = new AbortController()
@@ -468,6 +492,10 @@ export function createChatSessionStore(
         if (isStale()) return
         setContextUsage(usage)
       },
+      onCompactionStatus: (compacting) => {
+        if (isStale()) return
+        setCompacting(compacting)
+      },
       onAutoModeConsentRequired: async (payload) => {
         if (isStale()) return
         await handleAutoModeConsent(payload)
@@ -490,6 +518,7 @@ export function createChatSessionStore(
           ...s,
           toolExecuting: false,
           showActivityIndicator: false,
+          compacting: false,
         }))
         setRuntimeState("ready", null)
       },
@@ -499,6 +528,7 @@ export function createChatSessionStore(
           ...s,
           toolExecuting: false,
           showActivityIndicator: false,
+          compacting: false,
         }))
         const errorMsg: ChatMessage = {
           id: chatGenerateId(),
@@ -702,6 +732,7 @@ export function createChatSessionStore(
       ...s,
       toolExecuting: false,
       showActivityIndicator: false,
+      compacting: false,
     }))
     setRuntimeState("ready", null)
   }
@@ -730,6 +761,7 @@ export function createChatSessionStore(
       ...s,
       toolExecuting: false,
       showActivityIndicator: false,
+      compacting: false,
     }))
     setRuntimeState("ready", null)
   }

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -6,6 +6,7 @@ import {
   chatGenerateId,
   traceIdForNextChatRequest,
   type ChatMessage,
+  type ContextUsage,
   type ToolCallsPendingItem,
   type ToolCallsPendingPayload,
 } from "./streaming_chat"
@@ -33,6 +34,11 @@ export interface PersistedChatSession {
   messages: ChatMessage[]
   collapsedPartKeys: Record<string, boolean>
   lastSentAppState: AppState | null
+  /**
+   * Approximate context-window usage for the gauge. Persisted so a
+   * sessionStorage reload keeps the gauge. ``null`` before the first turn.
+   */
+  contextUsage: ContextUsage | null
 }
 
 export interface ToolApprovalWaiter {
@@ -68,7 +74,11 @@ export interface ChatSessionStore extends Readable<ChatSessionState> {
   stop(): void
   retryLastRequest(): void
   reset(): void
-  loadSession(messages: ChatMessage[], continuationTraceId: string): void
+  loadSession(
+    messages: ChatMessage[],
+    continuationTraceId: string,
+    contextUsage?: ContextUsage | null,
+  ): void
   /**
    * Resync the restored-from-sessionStorage conversation back to its true
    * auto-mode state after a hard refresh. If the conversation has an active
@@ -91,6 +101,7 @@ const EMPTY_PERSISTED: PersistedChatSession = {
   messages: [],
   collapsedPartKeys: {},
   lastSentAppState: null,
+  contextUsage: null,
 }
 
 export function createChatSessionStore(
@@ -136,6 +147,7 @@ export function createChatSessionStore(
       messages: $persisted.messages,
       collapsedPartKeys: $persisted.collapsedPartKeys,
       lastSentAppState: $persisted.lastSentAppState,
+      contextUsage: $persisted.contextUsage,
     }))
   })
 
@@ -211,6 +223,10 @@ export function createChatSessionStore(
     })
   }
 
+  function setContextUsage(usage: ContextUsage) {
+    persisted.update((p) => ({ ...p, contextUsage: usage }))
+  }
+
   // Append a fresh empty assistant message so the next streamed burst (auto run
   // or declined-resume) renders into a new turn rather than the prior one.
   function beginAssistantTurn() {
@@ -245,6 +261,7 @@ export function createChatSessionStore(
     beginAssistantTurn,
     onAssistantMessage: updateLastAssistant,
     onChatTrace: setLastAssistantTraceId,
+    onContextUsage: setContextUsage,
     onInlineError: (message, traceId, code) =>
       pushInlineError(message, traceId, code),
     onToolExecutionStart: () =>
@@ -312,6 +329,10 @@ export function createChatSessionStore(
       onChatTrace: (tid) => {
         if (isStale()) return
         setLastAssistantTraceId(tid)
+      },
+      onContextUsage: (usage) => {
+        if (isStale()) return
+        setContextUsage(usage)
       },
       onInlineError: (message, traceId, code) => {
         if (isStale()) return
@@ -442,6 +463,10 @@ export function createChatSessionStore(
       onChatTrace: (traceId) => {
         if (isStale()) return
         setLastAssistantTraceId(traceId)
+      },
+      onContextUsage: (usage) => {
+        if (isStale()) return
+        setContextUsage(usage)
       },
       onAutoModeConsentRequired: async (payload) => {
         if (isStale()) return
@@ -671,6 +696,7 @@ export function createChatSessionStore(
       messages: [],
       collapsedPartKeys: {},
       lastSentAppState: null,
+      contextUsage: null,
     })
     combined.update((s) => ({
       ...s,
@@ -680,7 +706,11 @@ export function createChatSessionStore(
     setRuntimeState("ready", null)
   }
 
-  function loadSession(messages: ChatMessage[], traceId: string): void {
+  function loadSession(
+    messages: ChatMessage[],
+    traceId: string,
+    contextUsage: ContextUsage | null = null,
+  ): void {
     if (abortController) {
       abortController.abort()
     }
@@ -690,7 +720,12 @@ export function createChatSessionStore(
     autoRunStore.detach()
     clearToolApprovalState()
     continuationTraceId = traceId
-    persisted.set({ messages, collapsedPartKeys: {}, lastSentAppState: null })
+    persisted.set({
+      messages,
+      collapsedPartKeys: {},
+      lastSentAppState: null,
+      contextUsage,
+    })
     combined.update((s) => ({
       ...s,
       toolExecuting: false,
@@ -754,11 +789,14 @@ export function createChatSessionStore(
       // no live stream) in the snapshot-error case while the throw case
       // correctly re-attaches.
       if (!error && snapshot) {
-        const { messages, continuationTraceId: traceId } =
-          hydrateSessionFromSnapshot(snapshot)
+        const {
+          messages,
+          continuationTraceId: traceId,
+          contextUsage,
+        } = hydrateSessionFromSnapshot(snapshot)
         // loadSession detaches any prior observer, sets the messages + trace id,
         // and resets runtime state — identical to the history-restore apply path.
-        loadSession(messages, traceId)
+        loadSession(messages, traceId, contextUsage)
       }
     } catch {
       // Hydration failed (network/parse). Fall back: still attach so the user at

--- a/app/web_ui/src/lib/chat/session_messages.test.ts
+++ b/app/web_ui/src/lib/chat/session_messages.test.ts
@@ -231,3 +231,41 @@ describe("stripAppUiContext", () => {
     expect(stripAppUiContext("")).toBe("")
   })
 })
+
+describe("hydrateSessionFromSnapshot context_usage", () => {
+  it("returns normalized contextUsage from snapshot.context_usage", () => {
+    const snapshot: ChatSessionSnapshot = {
+      id: "trace-ctx",
+      task_run: { trace: [{ role: "user", content: "hi" }] },
+      context_usage: {
+        context_tokens: 120,
+        context_limit: 200,
+        context_percent: 0.6,
+        compacted: true,
+      },
+    }
+    const { contextUsage } = hydrateSessionFromSnapshot(snapshot)
+    expect(contextUsage).toEqual({
+      context_tokens: 120,
+      context_limit: 200,
+      context_percent: 0.6,
+      compacted: true,
+    })
+  })
+
+  it("returns null contextUsage when the field is absent", () => {
+    const { contextUsage } = hydrateSessionFromSnapshot(
+      snap("trace-no-ctx", [{ role: "user", content: "hi" }]),
+    )
+    expect(contextUsage).toBeNull()
+  })
+
+  it("returns null contextUsage when the field carries no numbers", () => {
+    const snapshot: ChatSessionSnapshot = {
+      id: "trace-empty-ctx",
+      task_run: { trace: [{ role: "user", content: "hi" }] },
+      context_usage: { compacted: false },
+    }
+    expect(hydrateSessionFromSnapshot(snapshot).contextUsage).toBeNull()
+  })
+})

--- a/app/web_ui/src/lib/chat/session_messages.ts
+++ b/app/web_ui/src/lib/chat/session_messages.ts
@@ -1,8 +1,10 @@
 import type { components } from "$lib/api_schema"
 import {
   chatGenerateId,
+  normalizeContextUsage,
   type ChatMessage,
   type ChatMessagePart,
+  type ContextUsage,
 } from "./streaming_chat"
 
 type TraceMessage = components["schemas"]["TraceMessage"]
@@ -64,6 +66,7 @@ function buildAssistantParts(msg: TraceMessage): ChatMessagePart[] {
 export function hydrateSessionFromSnapshot(snapshot: ChatSessionSnapshot): {
   messages: ChatMessage[]
   continuationTraceId: string
+  contextUsage: ContextUsage | null
 } {
   const trace = snapshot.task_run.trace ?? []
   const messages: ChatMessage[] = []
@@ -119,5 +122,9 @@ export function hydrateSessionFromSnapshot(snapshot: ChatSessionSnapshot): {
     }
   }
 
-  return { messages, continuationTraceId: snapshot.id }
+  return {
+    messages,
+    continuationTraceId: snapshot.id,
+    contextUsage: normalizeContextUsage(snapshot.context_usage),
+  }
 }

--- a/app/web_ui/src/lib/chat/streaming_chat.test.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.test.ts
@@ -5,7 +5,11 @@ import {
   resumePendingToolCalls,
   chatExecuteToolsUrl,
   traceIdForNextChatRequest,
+  normalizeContextUsage,
+  StreamEventProcessor,
   type ChatMessage,
+  type ContextUsage,
+  type StreamEvent,
 } from "./streaming_chat"
 
 describe("traceIdForNextChatRequest", () => {
@@ -271,5 +275,102 @@ describe("resumePendingToolCalls (graceful-stop handoff)", () => {
     expect(finishSpy).toHaveBeenCalledOnce()
 
     vi.unstubAllGlobals()
+  })
+})
+
+describe("normalizeContextUsage", () => {
+  it("returns null for absent payload", () => {
+    expect(normalizeContextUsage(null)).toBeNull()
+    expect(normalizeContextUsage(undefined)).toBeNull()
+    expect(normalizeContextUsage({})).toBeNull()
+  })
+
+  it("normalizes a full payload", () => {
+    expect(
+      normalizeContextUsage({
+        context_tokens: 100,
+        context_limit: 1000,
+        context_percent: 0.1,
+        compacted: true,
+      }),
+    ).toEqual({
+      context_tokens: 100,
+      context_limit: 1000,
+      context_percent: 0.1,
+      compacted: true,
+    })
+  })
+
+  it("defaults missing numbers to 0 and compacted to false", () => {
+    expect(normalizeContextUsage({ context_percent: 0.5 })).toEqual({
+      context_tokens: 0,
+      context_limit: 0,
+      context_percent: 0.5,
+      compacted: false,
+    })
+  })
+})
+
+describe("StreamEventProcessor context_usage", () => {
+  function makeProcessor(onContextUsage: (u: ContextUsage) => void) {
+    return new StreamEventProcessor({
+      onAssistantMessage: () => {},
+      onContextUsage,
+    })
+  }
+
+  it("fires onContextUsage when kiln_chat_trace carries context_usage", () => {
+    const usages: ContextUsage[] = []
+    const traces: string[] = []
+    const processor = new StreamEventProcessor({
+      onAssistantMessage: () => {},
+      onChatTrace: (t) => traces.push(t),
+      onContextUsage: (u) => usages.push(u),
+    })
+    const event: StreamEvent = {
+      type: "kiln_chat_trace",
+      trace_id: "trace-1",
+      context_usage: {
+        context_tokens: 90,
+        context_limit: 100,
+        context_percent: 0.9,
+        compacted: true,
+      },
+    }
+    processor.handleEvent(event)
+    expect(traces).toEqual(["trace-1"])
+    expect(usages).toEqual([
+      {
+        context_tokens: 90,
+        context_limit: 100,
+        context_percent: 0.9,
+        compacted: true,
+      },
+    ])
+  })
+
+  it("does not fire onContextUsage when context_usage is absent", () => {
+    const usages: ContextUsage[] = []
+    const processor = makeProcessor((u) => usages.push(u))
+    processor.handleEvent({ type: "kiln_chat_trace", trace_id: "trace-2" })
+    expect(usages).toHaveLength(0)
+  })
+
+  it("normalizes a partial context_usage without throwing", () => {
+    const usages: ContextUsage[] = []
+    const processor = makeProcessor((u) => usages.push(u))
+    processor.handleEvent({
+      type: "kiln_chat_trace",
+      trace_id: "trace-3",
+      context_usage: { context_percent: 0.42 },
+    })
+    expect(usages).toEqual([
+      {
+        context_tokens: 0,
+        context_limit: 0,
+        context_percent: 0.42,
+        compacted: false,
+      },
+    ])
   })
 })

--- a/app/web_ui/src/lib/chat/streaming_chat.test.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.test.ts
@@ -374,3 +374,76 @@ describe("StreamEventProcessor context_usage", () => {
     ])
   })
 })
+
+describe("StreamEventProcessor kiln_compaction_status (Phase 5)", () => {
+  function makeProcessor(onCompactionStatus: (c: boolean) => void) {
+    return new StreamEventProcessor({
+      onAssistantMessage: () => {},
+      onCompactionStatus,
+    })
+  }
+
+  it("sets compacting=true on a started status event", () => {
+    const states: boolean[] = []
+    const processor = makeProcessor((c) => states.push(c))
+    processor.handleEvent({ type: "kiln_compaction_status", state: "started" })
+    expect(states).toEqual([true])
+  })
+
+  it("clears compacting on the next text content event", () => {
+    const states: boolean[] = []
+    const processor = makeProcessor((c) => states.push(c))
+    processor.handleEvent({ type: "kiln_compaction_status", state: "started" })
+    processor.handleEvent({ type: "text-start" })
+    processor.handleEvent({ type: "text-delta", delta: "hi" })
+    expect(states[0]).toBe(true)
+    // The first content event clears it; later content events keep it cleared.
+    expect(states.slice(1).every((s) => s === false)).toBe(true)
+    expect(states).toContain(false)
+  })
+
+  it("clears compacting on the snapshot (kiln_chat_trace) event", () => {
+    const states: boolean[] = []
+    const processor = makeProcessor((c) => states.push(c))
+    processor.handleEvent({ type: "kiln_compaction_status", state: "started" })
+    processor.handleEvent({ type: "kiln_chat_trace", trace_id: "trace-1" })
+    expect(states[0]).toBe(true)
+    expect(states[states.length - 1]).toBe(false)
+  })
+
+  it("does NOT clear compacting on a finished status event (stays up until content)", () => {
+    // A fast/buffered started→finished pair must not collapse the visible
+    // window. Only real assistant content clears the indicator, so a "finished"
+    // event on its own is ignored (no clear emitted).
+    const states: boolean[] = []
+    const processor = makeProcessor((c) => states.push(c))
+    processor.handleEvent({ type: "kiln_compaction_status", state: "started" })
+    processor.handleEvent({ type: "kiln_compaction_status", state: "finished" })
+    // Only the "started" → true was emitted; "finished" produced no callback.
+    expect(states).toEqual([true])
+  })
+
+  it("stays compacting through a started→finished pair, clears on first content", () => {
+    const states: boolean[] = []
+    const processor = makeProcessor((c) => states.push(c))
+    processor.handleEvent({ type: "kiln_compaction_status", state: "started" })
+    processor.handleEvent({ type: "kiln_compaction_status", state: "finished" })
+    expect(states).toEqual([true])
+    // The first real assistant content is what clears it.
+    processor.handleEvent({ type: "text-start" })
+    expect(states[states.length - 1]).toBe(false)
+  })
+
+  it("clears compacting on an error event", () => {
+    const states: boolean[] = []
+    const processor = new StreamEventProcessor({
+      onAssistantMessage: () => {},
+      onCompactionStatus: (c) => states.push(c),
+      onInlineError: () => {},
+    })
+    processor.handleEvent({ type: "kiln_compaction_status", state: "started" })
+    processor.handleEvent({ type: "error", message: "boom" })
+    expect(states[0]).toBe(true)
+    expect(states[states.length - 1]).toBe(false)
+  })
+})

--- a/app/web_ui/src/lib/chat/streaming_chat.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.ts
@@ -61,6 +61,53 @@ function toBackendMessage(m: ChatMessage): BackendChatRequest["messages"][0] {
   return { role: m.role, content: m.content ?? "" }
 }
 
+/**
+ * Approximate context-window usage for the conversation, surfaced by the server
+ * on the ``kiln_chat_trace`` snapshot event (and on the session GET). Numbers
+ * and a boolean only — never any trace content. Values are intentionally
+ * approximate (the gauge frames them with "≈").
+ */
+export interface ContextUsage {
+  context_tokens: number
+  context_limit: number
+  context_percent: number
+  compacted: boolean
+}
+
+/** Raw (optional/partial) ``context_usage`` shape as it arrives over the wire. */
+export interface RawContextUsage {
+  context_tokens?: number | null
+  context_limit?: number | null
+  context_percent?: number | null
+  compacted?: boolean | null
+}
+
+/**
+ * Normalize a raw (possibly partial) ``context_usage`` payload into a strict
+ * ``ContextUsage``, or ``null`` when the payload is absent / carries no numbers.
+ * Missing numbers default to 0 and ``compacted`` to ``false`` so an older or
+ * partial upstream never crashes the gauge.
+ */
+export function normalizeContextUsage(
+  raw: RawContextUsage | null | undefined,
+): ContextUsage | null {
+  if (!raw || typeof raw !== "object") return null
+  const hasAnyNumber =
+    typeof raw.context_tokens === "number" ||
+    typeof raw.context_limit === "number" ||
+    typeof raw.context_percent === "number"
+  if (!hasAnyNumber) return null
+  return {
+    context_tokens:
+      typeof raw.context_tokens === "number" ? raw.context_tokens : 0,
+    context_limit:
+      typeof raw.context_limit === "number" ? raw.context_limit : 0,
+    context_percent:
+      typeof raw.context_percent === "number" ? raw.context_percent : 0,
+    compacted: raw.compacted === true,
+  }
+}
+
 /** SSE event from backend (AI SDK stream event shape) */
 export interface StreamEvent {
   type: string
@@ -90,6 +137,8 @@ export interface StreamEvent {
   /** ``auto-mode-state`` (Phase 9) on-subscribe liveness snapshot */
   flag_on?: boolean
   working?: boolean
+  /** Approximate context usage carried on the ``kiln_chat_trace`` snapshot event */
+  context_usage?: RawContextUsage
 }
 
 export interface ToolCallsPendingItem {
@@ -125,6 +174,12 @@ export interface StreamChatOptions {
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   /** Fired when upstream sends ``kiln_chat_trace`` (typically end of a turn) */
   onChatTrace?: (traceId: string) => void
+  /**
+   * Fired when the ``kiln_chat_trace`` snapshot event carries ``context_usage``;
+   * drives the context gauge. Shared by ``StreamChatOptions`` (interactive
+   * stream) and the resume/auto paths via the processor.
+   */
+  onContextUsage?: (usage: ContextUsage) => void
   /** Fired when backend sends an inline error event */
   onInlineError?: (message: string, traceId?: string, code?: string) => void
   /**
@@ -178,6 +233,7 @@ type PartSlot = { kind: "text"; id: string } | { kind: "tool"; id: string }
 export interface StreamEventProcessorOptions {
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   onChatTrace?: (traceId: string) => void
+  onContextUsage?: (usage: ContextUsage) => void
   onInlineError?: (message: string, traceId?: string, code?: string) => void
   onToolExecutionStart?: (toolCount: number) => void
   onToolExecutionEnd?: (toolCount: number) => void
@@ -203,6 +259,7 @@ export class StreamEventProcessor {
 
   private onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   private onChatTrace?: (traceId: string) => void
+  private onContextUsage?: (usage: ContextUsage) => void
   private onInlineError?: (
     message: string,
     traceId?: string,
@@ -217,6 +274,7 @@ export class StreamEventProcessor {
   constructor(opts: StreamEventProcessorOptions) {
     this.onAssistantMessage = opts.onAssistantMessage
     this.onChatTrace = opts.onChatTrace
+    this.onContextUsage = opts.onContextUsage
     this.onInlineError = opts.onInlineError
     this.onToolExecutionStart = opts.onToolExecutionStart
     this.onToolExecutionEnd = opts.onToolExecutionEnd
@@ -392,6 +450,10 @@ export class StreamEventProcessor {
     if (typeof tid === "string" && tid) {
       this.onChatTrace?.(tid)
     }
+    const usage = normalizeContextUsage(event.context_usage)
+    if (usage) {
+      this.onContextUsage?.(usage)
+    }
   }
 
   private handleError(event: StreamEvent): void {
@@ -484,6 +546,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
     traceId,
     onAssistantMessage,
     onChatTrace,
+    onContextUsage,
     onInlineError,
     onToolCallsPending,
     onToolExecutionStart,
@@ -562,6 +625,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
       currentTraceId = tid
       onChatTrace?.(tid)
     },
+    onContextUsage,
     onInlineError,
     onToolExecutionStart,
     onToolExecutionEnd,
@@ -711,6 +775,7 @@ export interface ResumePendingToolCallsOptions {
   ) => Promise<Record<string, boolean>>
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   onChatTrace?: (traceId: string) => void
+  onContextUsage?: (usage: ContextUsage) => void
   onInlineError?: (message: string, traceId?: string, code?: string) => void
   onToolExecutionStart?: (toolCount: number) => void
   onToolExecutionEnd?: (toolCount: number) => void
@@ -744,6 +809,7 @@ export async function resumePendingToolCalls(
     onToolCallsPending,
     onAssistantMessage,
     onChatTrace,
+    onContextUsage,
     onInlineError,
     onToolExecutionStart,
     onToolExecutionEnd,
@@ -761,6 +827,7 @@ export async function resumePendingToolCalls(
       currentTraceId = tid
       onChatTrace?.(tid)
     },
+    onContextUsage,
     onInlineError,
     onToolExecutionStart,
     onToolExecutionEnd,

--- a/app/web_ui/src/lib/chat/streaming_chat.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.ts
@@ -139,6 +139,8 @@ export interface StreamEvent {
   working?: boolean
   /** Approximate context usage carried on the ``kiln_chat_trace`` snapshot event */
   context_usage?: RawContextUsage
+  /** ``kiln_compaction_status`` carries the lifecycle state ("started" / "finished") */
+  state?: string
 }
 
 export interface ToolCallsPendingItem {
@@ -180,6 +182,12 @@ export interface StreamChatOptions {
    * stream) and the resume/auto paths via the processor.
    */
   onContextUsage?: (usage: ContextUsage) => void
+  /**
+   * Fired when the server emits ``kiln_compaction_status`` (Phase 5): ``true``
+   * when compaction starts (so the UI shows a "summarizing…" indicator), and
+   * ``false`` when it finishes or the first normal content event arrives.
+   */
+  onCompactionStatus?: (compacting: boolean) => void
   /** Fired when backend sends an inline error event */
   onInlineError?: (message: string, traceId?: string, code?: string) => void
   /**
@@ -234,6 +242,7 @@ export interface StreamEventProcessorOptions {
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   onChatTrace?: (traceId: string) => void
   onContextUsage?: (usage: ContextUsage) => void
+  onCompactionStatus?: (compacting: boolean) => void
   onInlineError?: (message: string, traceId?: string, code?: string) => void
   onToolExecutionStart?: (toolCount: number) => void
   onToolExecutionEnd?: (toolCount: number) => void
@@ -260,6 +269,7 @@ export class StreamEventProcessor {
   private onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   private onChatTrace?: (traceId: string) => void
   private onContextUsage?: (usage: ContextUsage) => void
+  private onCompactionStatus?: (compacting: boolean) => void
   private onInlineError?: (
     message: string,
     traceId?: string,
@@ -275,6 +285,7 @@ export class StreamEventProcessor {
     this.onAssistantMessage = opts.onAssistantMessage
     this.onChatTrace = opts.onChatTrace
     this.onContextUsage = opts.onContextUsage
+    this.onCompactionStatus = opts.onCompactionStatus
     this.onInlineError = opts.onInlineError
     this.onToolExecutionStart = opts.onToolExecutionStart
     this.onToolExecutionEnd = opts.onToolExecutionEnd
@@ -282,34 +293,57 @@ export class StreamEventProcessor {
 
     this.HANDLERS = {
       "text-start": (e) => {
+        this.clearCompacting()
         this.onShowActivityIndicator?.(false)
         this.handleTextStart(e)
       },
-      "text-delta": (e) => this.handleTextDelta(e),
+      "text-delta": (e) => {
+        this.clearCompacting()
+        this.handleTextDelta(e)
+      },
       "text-end": () => {
         this.onShowActivityIndicator?.(true)
         this.handleTextEnd()
       },
       "tool-input-start": (e) => {
+        this.clearCompacting()
         this.onShowActivityIndicator?.(true)
         this.handleToolInputStart(e)
       },
       "tool-input-delta": (e) => this.handleToolInputDelta(e),
       "tool-input-available": (e) => {
+        this.clearCompacting()
         this.onShowActivityIndicator?.(true)
         this.handleToolInputAvailable(e)
       },
       "tool-output-available": (e) => this.handleToolOutputAvailable(e),
       "tool-output-error": (e) => this.handleToolOutputError(e),
-      kiln_chat_trace: (e) => this.handleChatTrace(e),
+      kiln_chat_trace: (e) => {
+        this.clearCompacting()
+        this.handleChatTrace(e)
+      },
+      kiln_compaction_status: (e) => this.handleCompactionStatus(e),
       "kiln-tool-execution-start": (e) => {
+        this.clearCompacting()
         this.onShowActivityIndicator?.(true)
         this.onToolExecutionStart?.(e.tool_count ?? 0)
       },
       "kiln-tool-execution-end": (e) =>
         this.onToolExecutionEnd?.(e.tool_count ?? 0),
-      error: (e) => this.handleError(e),
+      error: (e) => {
+        this.clearCompacting()
+        this.handleError(e)
+      },
     }
+  }
+
+  /**
+   * Clear the compaction indicator. Called when the first normal content event
+   * of the turn arrives (text/tool/snapshot) or on error — compaction is a
+   * brief pre-turn step, so any real turn output means it's done.
+   */
+  private clearCompacting(): void {
+    this.onCompactionStatus?.(false)
   }
 
   handleEvent(event: StreamEvent): void {
@@ -456,6 +490,18 @@ export class StreamEventProcessor {
     }
   }
 
+  private handleCompactionStatus(event: StreamEvent): void {
+    // Only "started" drives the indicator ON. We deliberately do NOT clear on
+    // "finished": the summarization LLM call can complete and its bytes flush
+    // so fast (or buffered together) that a started→finished pair would collapse
+    // to nothing visible. Instead the indicator stays up until the FIRST real
+    // assistant content of the turn (text/tool/exec-start/snapshot) arrives —
+    // see ``clearCompacting``. A "finished" with no content yet is ignored.
+    if (event.state === "started") {
+      this.onCompactionStatus?.(true)
+    }
+  }
+
   private handleError(event: StreamEvent): void {
     this.onInlineError?.(
       event.message ?? "An error occurred.",
@@ -547,6 +593,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
     onAssistantMessage,
     onChatTrace,
     onContextUsage,
+    onCompactionStatus,
     onInlineError,
     onToolCallsPending,
     onToolExecutionStart,
@@ -626,6 +673,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
       onChatTrace?.(tid)
     },
     onContextUsage,
+    onCompactionStatus,
     onInlineError,
     onToolExecutionStart,
     onToolExecutionEnd,
@@ -776,6 +824,7 @@ export interface ResumePendingToolCallsOptions {
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   onChatTrace?: (traceId: string) => void
   onContextUsage?: (usage: ContextUsage) => void
+  onCompactionStatus?: (compacting: boolean) => void
   onInlineError?: (message: string, traceId?: string, code?: string) => void
   onToolExecutionStart?: (toolCount: number) => void
   onToolExecutionEnd?: (toolCount: number) => void
@@ -810,6 +859,7 @@ export async function resumePendingToolCalls(
     onAssistantMessage,
     onChatTrace,
     onContextUsage,
+    onCompactionStatus,
     onInlineError,
     onToolExecutionStart,
     onToolExecutionEnd,
@@ -828,6 +878,7 @@ export async function resumePendingToolCalls(
       onChatTrace?.(tid)
     },
     onContextUsage,
+    onCompactionStatus,
     onInlineError,
     onToolExecutionStart,
     onToolExecutionEnd,

--- a/app/web_ui/src/lib/ui/context_usage_gauge.svelte
+++ b/app/web_ui/src/lib/ui/context_usage_gauge.svelte
@@ -80,6 +80,7 @@
 </script>
 
 {#if usage}
+  <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
   <div
     bind:this={triggerElement}
     class="flex flex-col items-end gap-0.5 cursor-default"
@@ -89,8 +90,11 @@
     aria-valuenow={displayPercent}
     aria-label={`Approximately ${displayPercent}% of context used`}
     data-testid="context-usage-gauge"
+    tabindex="0"
     on:mouseenter={showTooltip}
     on:mouseleave={hideTooltip}
+    on:focus={showTooltip}
+    on:blur={hideTooltip}
   >
     <span
       class="text-xs font-medium text-base-content/70 tabular-nums whitespace-nowrap leading-none"

--- a/app/web_ui/src/lib/ui/context_usage_gauge.svelte
+++ b/app/web_ui/src/lib/ui/context_usage_gauge.svelte
@@ -6,7 +6,7 @@
     flip,
     shift,
   } from "@floating-ui/dom"
-  import { onDestroy } from "svelte"
+  import { onDestroy, tick } from "svelte"
   import type { ContextUsage } from "$lib/chat/streaming_chat"
 
   // ``null`` before the first assistant turn completes — the gauge is hidden
@@ -30,8 +30,19 @@
   let isVisible = false
   let cleanupAutoUpdate: (() => void) | null = null
 
-  function showTooltip() {
+  async function showTooltip() {
     if (!triggerElement || !tooltipElement) return
+    // Avoid leaking/overwriting a previous autoUpdate registration.
+    if (cleanupAutoUpdate) {
+      cleanupAutoUpdate()
+      cleanupAutoUpdate = null
+    }
+    isVisible = true
+    // Wait for Svelte to render the tooltip (remove ``hidden``) so Floating UI
+    // can measure its real size instead of 0×0.
+    await tick()
+    // The pointer may have left during the await; bail if we hid in the meantime.
+    if (!isVisible) return
     const updatePosition = () => {
       if (!triggerElement || !tooltipElement) return
       computePosition(triggerElement, tooltipElement, {
@@ -53,7 +64,6 @@
       tooltipElement,
       updatePosition,
     )
-    isVisible = true
   }
 
   function hideTooltip() {

--- a/app/web_ui/src/lib/ui/context_usage_gauge.svelte
+++ b/app/web_ui/src/lib/ui/context_usage_gauge.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import {
+    computePosition,
+    autoUpdate,
+    offset,
+    flip,
+    shift,
+  } from "@floating-ui/dom"
+  import { onDestroy } from "svelte"
+  import type { ContextUsage } from "$lib/chat/streaming_chat"
+
+  // ``null`` before the first assistant turn completes — the gauge is hidden
+  // until the first ``context_usage`` arrives.
+  export let usage: ContextUsage | null = null
+
+  // Raw percent may momentarily exceed 100 just before a compaction triggers;
+  // the displayed number is clamped to 100. The bar is a single neutral grey at
+  // all percentages (no color ramp).
+  $: displayPercent = Math.min(
+    100,
+    Math.round((usage?.context_percent ?? 0) * 100),
+  )
+
+  $: tooltipText = usage
+    ? `≈ ${displayPercent}% of context used (≈ ${usage.context_tokens.toLocaleString()} / ${usage.context_limit.toLocaleString()} tokens). Older messages are automatically summarized when the conversation gets long.`
+    : ""
+
+  let triggerElement: HTMLDivElement | undefined
+  let tooltipElement: HTMLDivElement | undefined
+  let isVisible = false
+  let cleanupAutoUpdate: (() => void) | null = null
+
+  function showTooltip() {
+    if (!triggerElement || !tooltipElement) return
+    const updatePosition = () => {
+      if (!triggerElement || !tooltipElement) return
+      computePosition(triggerElement, tooltipElement, {
+        placement: "top",
+        strategy: "fixed",
+        middleware: [offset(6), flip(), shift({ padding: 8 })],
+      }).then(({ x, y }) => {
+        if (tooltipElement) {
+          Object.assign(tooltipElement.style, {
+            left: `${x}px`,
+            top: `${y}px`,
+          })
+        }
+      })
+    }
+    updatePosition()
+    cleanupAutoUpdate = autoUpdate(
+      triggerElement,
+      tooltipElement,
+      updatePosition,
+    )
+    isVisible = true
+  }
+
+  function hideTooltip() {
+    isVisible = false
+    if (cleanupAutoUpdate) {
+      cleanupAutoUpdate()
+      cleanupAutoUpdate = null
+    }
+  }
+
+  onDestroy(() => {
+    if (cleanupAutoUpdate) cleanupAutoUpdate()
+  })
+</script>
+
+{#if usage}
+  <div
+    bind:this={triggerElement}
+    class="flex flex-col items-end gap-0.5 cursor-default"
+    role="meter"
+    aria-valuemin={0}
+    aria-valuemax={100}
+    aria-valuenow={displayPercent}
+    aria-label={`Approximately ${displayPercent}% of context used`}
+    data-testid="context-usage-gauge"
+    on:mouseenter={showTooltip}
+    on:mouseleave={hideTooltip}
+  >
+    <span
+      class="text-xs font-medium text-base-content/70 tabular-nums whitespace-nowrap leading-none"
+      data-testid="context-usage-percent"
+    >
+      ≈{displayPercent}%
+    </span>
+    <div
+      class="w-16 md:w-20 h-1.5 rounded-full bg-base-content/10 overflow-hidden"
+      data-testid="context-usage-track"
+    >
+      <div
+        class="h-full rounded-full bg-base-content/30 transition-[width] duration-300"
+        style="width: {displayPercent}%"
+        data-testid="context-usage-fill"
+      ></div>
+    </div>
+  </div>
+
+  <div
+    bind:this={tooltipElement}
+    class="fixed z-[50] px-3 py-2 text-xs text-base-content bg-stone-200 rounded-md shadow-lg w-64 whitespace-normal {isVisible
+      ? ''
+      : 'hidden'}"
+    role="tooltip"
+    on:mouseenter={showTooltip}
+    on:mouseleave={hideTooltip}
+  >
+    {tooltipText}
+  </div>
+{/if}

--- a/app/web_ui/src/lib/ui/context_usage_gauge.svelte
+++ b/app/web_ui/src/lib/ui/context_usage_gauge.svelte
@@ -14,12 +14,29 @@
   export let usage: ContextUsage | null = null
 
   // Raw percent may momentarily exceed 100 just before a compaction triggers;
-  // the displayed number is clamped to 100. The bar is a single neutral grey at
-  // all percentages (no color ramp).
+  // the displayed number is clamped to 100.
   $: displayPercent = Math.min(
     100,
     Math.round((usage?.context_percent ?? 0) * 100),
   )
+
+  // Tint the bar by how full the context is. Under 50% it's a subtle grey fill
+  // over a subtler grey track. Once it crosses 50% it goes warning (amber) and
+  // at 80% error (red): a STRONG full-strength fill over a muted same-hue track
+  // (strong amber on muted amber; strong red on muted red). Full class strings
+  // (not interpolated) so Tailwind keeps them.
+  $: trackClass =
+    displayPercent >= 80
+      ? "bg-error/20"
+      : displayPercent >= 50
+        ? "bg-warning/20"
+        : "bg-base-content/10"
+  $: fillClass =
+    displayPercent >= 80
+      ? "bg-error"
+      : displayPercent >= 50
+        ? "bg-warning"
+        : "bg-base-content/30"
 
   $: tooltipText = usage
     ? `≈ ${displayPercent}% of context used (≈ ${usage.context_tokens.toLocaleString()} / ${usage.context_limit.toLocaleString()} tokens). Older messages are automatically summarized when the conversation gets long.`
@@ -103,11 +120,11 @@
       ≈{displayPercent}%
     </span>
     <div
-      class="w-16 md:w-20 h-1.5 rounded-full bg-base-content/10 overflow-hidden"
+      class="w-16 md:w-20 h-1.5 rounded-full {trackClass} overflow-hidden transition-colors duration-300"
       data-testid="context-usage-track"
     >
       <div
-        class="h-full rounded-full bg-base-content/30 transition-[width] duration-300"
+        class="h-full rounded-full {fillClass} transition-[width,background-color] duration-300"
         style="width: {displayPercent}%"
         data-testid="context-usage-fill"
       ></div>

--- a/app/web_ui/src/lib/ui/context_usage_gauge.test.ts
+++ b/app/web_ui/src/lib/ui/context_usage_gauge.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, afterEach } from "vitest"
-import { render, cleanup } from "@testing-library/svelte"
+import { render, cleanup, fireEvent } from "@testing-library/svelte"
 import ContextUsageGauge from "./context_usage_gauge.svelte"
 import type { ContextUsage } from "$lib/chat/streaming_chat"
 
@@ -94,6 +94,21 @@ describe("ContextUsageGauge", () => {
     })
     expect(queryByTestId("context-usage-condensed")).toBeNull()
     expect(container.textContent).not.toContain("condensed")
+  })
+
+  it("makes the trigger keyboard-focusable and shows the tooltip on focus", async () => {
+    const { getByTestId, getByRole } = render(ContextUsageGauge, {
+      props: { usage: usage() },
+    })
+    const gauge = getByTestId("context-usage-gauge")
+    // The meter trigger must be reachable via keyboard.
+    expect(gauge.getAttribute("tabindex")).toBe("0")
+
+    // Hidden by default, revealed on focus (mirrors the mouseenter behavior).
+    const tooltip = getByRole("tooltip", { hidden: true })
+    expect(tooltip.getAttribute("class") ?? "").toContain("hidden")
+    await fireEvent.focus(gauge)
+    expect(tooltip.getAttribute("class") ?? "").not.toContain("hidden")
   })
 
   it("tooltip includes the locale-formatted token counts", () => {

--- a/app/web_ui/src/lib/ui/context_usage_gauge.test.ts
+++ b/app/web_ui/src/lib/ui/context_usage_gauge.test.ts
@@ -44,19 +44,41 @@ describe("ContextUsageGauge", () => {
     )
   })
 
-  it("renders a grey-on-grey two-div bar: subtle track + mid-grey fill", () => {
+  it("under 50%: neutral grey two-div bar (light track + mid-grey fill)", () => {
     const { getByTestId } = render(ContextUsageGauge, {
-      props: { usage: usage() },
+      props: { usage: usage({ context_percent: 0.33 }) },
     })
     const track = getByTestId("context-usage-track")
     const fill = getByTestId("context-usage-fill")
     // Delicate low-opacity greys: very light track, slightly stronger but still
-    // light fill — no color-ramp or near-black DaisyUI ``progress`` styling.
+    // light fill — no near-black DaisyUI ``progress`` styling.
     expect(track.getAttribute("class") ?? "").toContain("bg-base-content/10")
     expect(fill.getAttribute("class") ?? "").toContain("bg-base-content/30")
     const allClasses = `${track.getAttribute("class")} ${fill.getAttribute("class")}`
     expect(allClasses).not.toMatch(/progress-(success|warning|error|primary)/)
   })
+
+  it.each([
+    [0.49, "bg-base-content/10", "bg-base-content/30"], // just under 50% → subtle grey
+    [0.5, "bg-warning/20", "bg-warning"], // crosses 50% → muted amber track, strong amber fill
+    [0.79, "bg-warning/20", "bg-warning"], // still under 80% → amber
+    [0.8, "bg-error/20", "bg-error"], // crosses 80% → muted red track, strong red fill
+    [1.2, "bg-error/20", "bg-error"], // clamped to 100% → red
+  ])(
+    "tints by fullness: %d → muted track %s under a strong fill %s",
+    (percent, trackClass, fillClass) => {
+      const { getByTestId } = render(ContextUsageGauge, {
+        props: { usage: usage({ context_percent: percent }) },
+      })
+      // Exact-token match: a strong fill like "bg-warning" must not be satisfied
+      // by the muted "bg-warning/20" track (substring), and vice-versa.
+      const tokens = (id: string) =>
+        (getByTestId(id).getAttribute("class") ?? "").split(/\s+/)
+      expect(tokens("context-usage-track")).toContain(trackClass)
+      expect(tokens("context-usage-fill")).toContain(fillClass)
+      cleanup()
+    },
+  )
 
   it("fill width reflects the (clamped) percent", () => {
     const half = render(ContextUsageGauge, {

--- a/app/web_ui/src/lib/ui/context_usage_gauge.test.ts
+++ b/app/web_ui/src/lib/ui/context_usage_gauge.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/svelte"
+import ContextUsageGauge from "./context_usage_gauge.svelte"
+import type { ContextUsage } from "$lib/chat/streaming_chat"
+
+function usage(overrides: Partial<ContextUsage> = {}): ContextUsage {
+  return {
+    context_tokens: 50_000,
+    context_limit: 150_000,
+    context_percent: 0.33,
+    compacted: false,
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("ContextUsageGauge", () => {
+  it("renders nothing when usage is null", () => {
+    const { queryByTestId } = render(ContextUsageGauge, {
+      props: { usage: null },
+    })
+    expect(queryByTestId("context-usage-gauge")).toBeNull()
+  })
+
+  it("renders the rounded percent label", () => {
+    const { getByTestId } = render(ContextUsageGauge, {
+      props: { usage: usage({ context_percent: 0.336 }) },
+    })
+    expect(getByTestId("context-usage-percent").textContent?.trim()).toBe(
+      "≈34%",
+    )
+  })
+
+  it("clamps the displayed percent to 100 when over the limit", () => {
+    const { getByTestId } = render(ContextUsageGauge, {
+      props: { usage: usage({ context_percent: 1.2 }) },
+    })
+    expect(getByTestId("context-usage-percent").textContent?.trim()).toBe(
+      "≈100%",
+    )
+  })
+
+  it("renders a grey-on-grey two-div bar: subtle track + mid-grey fill", () => {
+    const { getByTestId } = render(ContextUsageGauge, {
+      props: { usage: usage() },
+    })
+    const track = getByTestId("context-usage-track")
+    const fill = getByTestId("context-usage-fill")
+    // Delicate low-opacity greys: very light track, slightly stronger but still
+    // light fill — no color-ramp or near-black DaisyUI ``progress`` styling.
+    expect(track.getAttribute("class") ?? "").toContain("bg-base-content/10")
+    expect(fill.getAttribute("class") ?? "").toContain("bg-base-content/30")
+    const allClasses = `${track.getAttribute("class")} ${fill.getAttribute("class")}`
+    expect(allClasses).not.toMatch(/progress-(success|warning|error|primary)/)
+  })
+
+  it("fill width reflects the (clamped) percent", () => {
+    const half = render(ContextUsageGauge, {
+      props: { usage: usage({ context_percent: 0.5 }) },
+    })
+    expect(
+      half.getByTestId("context-usage-fill").getAttribute("style"),
+    ).toContain("width: 50%")
+    cleanup()
+
+    const over = render(ContextUsageGauge, {
+      props: { usage: usage({ context_percent: 1.2 }) },
+    })
+    expect(
+      over.getByTestId("context-usage-fill").getAttribute("style"),
+    ).toContain("width: 100%")
+  })
+
+  it("stacks the percent label above the bar", () => {
+    const { getByTestId } = render(ContextUsageGauge, {
+      props: { usage: usage() },
+    })
+    const gauge = getByTestId("context-usage-gauge")
+    const label = getByTestId("context-usage-percent")
+    const track = getByTestId("context-usage-track")
+    // Column layout, label rendered before (above) the bar in DOM order.
+    expect(gauge.getAttribute("class") ?? "").toContain("flex-col")
+    const order = Array.from(gauge.children)
+    expect(order.indexOf(label)).toBeLessThan(order.indexOf(track))
+  })
+
+  it("never renders a condensed marker, even when compacted", () => {
+    const { queryByTestId, container } = render(ContextUsageGauge, {
+      props: { usage: usage({ compacted: true }) },
+    })
+    expect(queryByTestId("context-usage-condensed")).toBeNull()
+    expect(container.textContent).not.toContain("condensed")
+  })
+
+  it("tooltip includes the locale-formatted token counts", () => {
+    const { getByRole } = render(ContextUsageGauge, {
+      props: {
+        usage: usage({
+          context_tokens: 93_000,
+          context_limit: 150_000,
+          context_percent: 0.62,
+        }),
+      },
+    })
+    const tooltip = getByRole("tooltip", { hidden: true })
+    const text = tooltip.textContent ?? ""
+    expect(text).toContain("≈ 62% of context used")
+    expect(text).toContain(
+      `${(93_000).toLocaleString()} / ${(150_000).toLocaleString()} tokens`,
+    )
+    expect(text).toContain("automatically summarized")
+  })
+})

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -676,6 +676,7 @@
                                   isLoading={true}
                                   isLastMessage={true}
                                   {showActivityIndicator}
+                                  {compacting}
                                 />
                               </div>
                             </div>
@@ -685,15 +686,17 @@
                               isLoading={isActiveMessage}
                               isLastMessage={message.id === lastMessage?.id}
                               {showActivityIndicator}
+                              {compacting}
                             />
                           {/if}
                         {/if}
                       {/if}
                     {/if}
-                  {:else if message.role === "assistant" && showStreamingCursor && message.id === lastMessage?.id && !compacting}
-                    <!-- While ``compacting`` the standalone summarizing row below
-                       the loop is the only indicator, so suppress the normal
-                       Thinking streaming-cursor here to avoid showing both. -->
+                  {:else if message.role === "assistant" && showStreamingCursor && message.id === lastMessage?.id}
+                    <!-- The single pending indicator for the active assistant
+                       turn. While ``compacting`` it swaps its label in place to
+                       the summarizing copy (instead of a separate row); when
+                       compaction finishes it reverts to Thinking. -->
                     <div class="flex items-start gap-3">
                       <img
                         src="/images/chat_icon_animated.svg"
@@ -706,6 +709,7 @@
                           isLoading={true}
                           isLastMessage={true}
                           {showActivityIndicator}
+                          {compacting}
                         />
                       </div>
                     </div>
@@ -717,16 +721,13 @@
             </div>
           {/if}
         {/each}
-        {#if compacting}
-          <!-- Phase 5: the server is summarizing earlier messages (compaction)
-             BEFORE inference for this turn. This happens before any assistant
-             content exists, so it can't rely on an assistant message bubble or
-             its activity flags being set. Render a standalone activity row
-             (same animated icon + ChatStatusSteps "compacting" markup as the
-             streaming-cursor branch) keyed only on ``compacting`` so it is
-             always mounted during the pre-inference window — it sits where the
-             assistant's Thinking indicator would appear. Cleared by the store
-             when the first real assistant content arrives. -->
+        {#if compacting && lastMessage?.role !== "assistant"}
+          <!-- Fallback compaction indicator for the rare case where there is no
+             active assistant bubble yet to host the in-place indicator above
+             (so the summarizing copy still appears, and never alongside the
+             bubble's Thinking — exactly one shows). When an empty assistant
+             turn exists, the streaming-cursor branch above swaps its own label
+             to the summarizing copy instead. -->
           <div class="flex items-start gap-3" role="status">
             <img
               src="/images/chat_icon_animated.svg"

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -101,6 +101,9 @@
   $: toolApprovalWaiter = $store.toolApprovalWaiter
   $: toolApprovalPicks = $store.toolApprovalPicks
   $: showActivityIndicator = $store.showActivityIndicator
+  // Phase 5: the server is summarizing earlier messages (compaction) for this
+  // turn. Drives the same Thinking-style indicator with a "summarizing…" label.
+  $: compacting = $store.compacting
   // A server-owned auto burst is running. Drives the SAME in-transcript loading
   // affordances (thinking dots / animated icon) as interactive streaming, while
   // leaving the input usable for inject-on-send.
@@ -687,7 +690,10 @@
                         {/if}
                       {/if}
                     {/if}
-                  {:else if message.role === "assistant" && showStreamingCursor && message.id === lastMessage?.id}
+                  {:else if message.role === "assistant" && showStreamingCursor && message.id === lastMessage?.id && !compacting}
+                    <!-- While ``compacting`` the standalone summarizing row below
+                       the loop is the only indicator, so suppress the normal
+                       Thinking streaming-cursor here to avoid showing both. -->
                     <div class="flex items-start gap-3">
                       <img
                         src="/images/chat_icon_animated.svg"
@@ -711,6 +717,32 @@
             </div>
           {/if}
         {/each}
+        {#if compacting}
+          <!-- Phase 5: the server is summarizing earlier messages (compaction)
+             BEFORE inference for this turn. This happens before any assistant
+             content exists, so it can't rely on an assistant message bubble or
+             its activity flags being set. Render a standalone activity row
+             (same animated icon + ChatStatusSteps "compacting" markup as the
+             streaming-cursor branch) keyed only on ``compacting`` so it is
+             always mounted during the pre-inference window — it sits where the
+             assistant's Thinking indicator would appear. Cleared by the store
+             when the first real assistant content arrives. -->
+          <div class="flex items-start gap-3" role="status">
+            <img
+              src="/images/chat_icon_animated.svg"
+              alt=""
+              class="w-9 h-9 shrink-0 -mt-1.5"
+            />
+            <div class="flex flex-col">
+              <ChatStatusSteps
+                parts={[]}
+                isLoading={true}
+                isLastMessage={true}
+                compacting={true}
+              />
+            </div>
+          </div>
+        {/if}
         {#if $autoReconnecting}
           <!-- Transient re-attach affordance (Phase 9): shown while a hard-refresh
              resync or History restore resolves → hydrates → attaches the live

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -5,6 +5,7 @@
   import posthog from "posthog-js"
   import ChatCostDisclaimer from "./chat_cost_disclaimer.svelte"
   import type { ChatMessage, ChatMessagePart } from "$lib/chat/streaming_chat"
+  import type { LoadedChatSessionDetail } from "$lib/chat/chat_history_apply"
   import { CHAT_CLIENT_VERSION_TOO_OLD } from "$lib/error_codes"
   import ChatMarkdown from "$lib/ui/chat/chat_markdown.svelte"
   import ArrowUpIcon from "$lib/ui/icons/arrow_up_icon.svelte"
@@ -22,6 +23,7 @@
   import ChatStatusSteps from "./chat_status_steps.svelte"
   import BrailleSpinner from "./braille_spinner.svelte"
   import ToolStatusLine from "./tool_status_line.svelte"
+  import ContextUsageGauge from "$lib/ui/context_usage_gauge.svelte"
 
   export let store: ChatSessionStore = chatSessionStore
 
@@ -103,6 +105,7 @@
   // affordances (thinking dots / animated icon) as interactive streaming, while
   // leaving the input usable for inject-on-send.
   $: autoWorking = $store.autoWorking
+  $: contextUsage = $store.contextUsage
 
   export let hasMessages = false
   $: messages = $store.messages
@@ -380,13 +383,12 @@
     store.stop()
   }
 
-  function onChatHistoryApply(
-    e: CustomEvent<{
-      messages: ChatMessage[]
-      continuationTraceId: string
-    }>,
-  ) {
-    store.loadSession(e.detail.messages, e.detail.continuationTraceId)
+  function onChatHistoryApply(e: CustomEvent<LoadedChatSessionDetail>) {
+    store.loadSession(
+      e.detail.messages,
+      e.detail.continuationTraceId,
+      e.detail.contextUsage,
+    )
     userNearBottom = true
     tick().then(() => {
       messagesEndRef?.scrollIntoView({ block: "end", behavior: "auto" })
@@ -803,6 +805,11 @@
           <span aria-hidden="true">⏵⏵</span>
           Auto mode
         </button>
+      {/if}
+      {#if contextUsage}
+        <div class="ml-auto">
+          <ContextUsageGauge usage={contextUsage} />
+        </div>
       {/if}
     </div>
   </div>

--- a/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
+++ b/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
@@ -163,4 +163,75 @@ describe("chat.svelte compaction indicator (Phase 5 integration)", () => {
     const { queryByText } = render(Chat, { props: { store } })
     expect(queryByText(SUMMARIZING)).toBeNull()
   })
+
+  it("with an active assistant bubble, swaps Thinking for Summarizing IN PLACE (never both)", () => {
+    // Common case: the empty assistant bubble already exists. The in-bubble
+    // pending indicator must show the summarizing copy instead of "Thinking",
+    // and the standalone fallback row must NOT also render — exactly one.
+    const { store } = makeFakeStore(
+      baseState({
+        messages: [userMsg, { id: "a1", role: "assistant", parts: [] }],
+        compacting: true,
+      }),
+    )
+    const { queryAllByText, queryByText } = render(Chat, { props: { store } })
+    expect(queryAllByText(SUMMARIZING)).toHaveLength(1)
+    expect(queryByText(/^Thinking/)).toBeNull()
+  })
+
+  it("swaps Thinking for Summarizing when compaction kicks in MID-TURN (content already present)", async () => {
+    // The reported regression: the turn already showed "Thinking…" (an
+    // assistant message with content + the activity indicator), then compaction
+    // started. The trailing parts-branch indicator must swap to Summarizing —
+    // not stay stuck on Thinking.
+    const withContent = (compacting: boolean): ChatSessionState =>
+      baseState({
+        messages: [
+          userMsg,
+          {
+            id: "a1",
+            role: "assistant",
+            parts: [{ type: "text", text: "partial" }],
+          },
+        ],
+        status: "streaming",
+        showActivityIndicator: true,
+        compacting,
+      })
+
+    const { store, state } = makeFakeStore(withContent(false))
+    const { queryAllByText, queryByText } = render(Chat, { props: { store } })
+    // Before compaction: Thinking is showing, no Summarizing.
+    expect(queryByText(/^Thinking/)).toBeTruthy()
+    expect(queryByText(SUMMARIZING)).toBeNull()
+
+    // Compaction kicks in mid-turn → swap in place, exactly one indicator.
+    state.set(withContent(true))
+    await Promise.resolve()
+    expect(queryAllByText(SUMMARIZING)).toHaveLength(1)
+    expect(queryByText(/^Thinking/)).toBeNull()
+  })
+
+  it("with an active assistant bubble, shows Thinking (not Summarizing) when compaction ends", async () => {
+    const { store, state } = makeFakeStore(
+      baseState({
+        messages: [userMsg, { id: "a1", role: "assistant", parts: [] }],
+        compacting: true,
+      }),
+    )
+    const { queryByText } = render(Chat, { props: { store } })
+    expect(queryByText(SUMMARIZING)).toBeTruthy()
+
+    // Compaction finished but the turn is still pending (no content yet): the
+    // same in-place indicator reverts to Thinking.
+    state.set(
+      baseState({
+        messages: [userMsg, { id: "a1", role: "assistant", parts: [] }],
+        compacting: false,
+      }),
+    )
+    await Promise.resolve()
+    expect(queryByText(SUMMARIZING)).toBeNull()
+    expect(queryByText(/^Thinking/)).toBeTruthy()
+  })
 })

--- a/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
+++ b/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+//
+// Integration test (Phase 5): the "Summarizing earlier messages…" compaction
+// indicator must be visible during the PRE-INFERENCE window — i.e. when the
+// store's ``compacting`` flag is true even though there is NO assistant message
+// yet (the last message is the just-sent user message) and the assistant
+// activity/streaming flags are not set. A live-testing regression found the
+// indicator never rendered because every per-message mount was gated behind an
+// existing assistant bubble; this test renders the real ``chat.svelte`` against
+// that exact state to guard the standalone activity row.
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, cleanup } from "@testing-library/svelte"
+import { writable, type Readable } from "svelte/store"
+import type { ChatMessage, ContextUsage } from "$lib/chat/streaming_chat"
+import type {
+  ChatSessionState,
+  ChatSessionStore,
+} from "$lib/chat/chat_session_store"
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}))
+
+vi.mock("$lib/api_client", () => ({
+  base_url: "http://localhost:8757",
+  client: { GET: vi.fn(), POST: vi.fn() },
+}))
+
+// chat.svelte reads several readable stores off the auto_run_store singleton at
+// component init; provide inert ones so the component mounts in isolation.
+vi.mock("$lib/chat/auto_run_store", () => ({
+  auto_run_store: {
+    autoModeOn: writable(false),
+    armed: writable(false),
+    working: writable(false),
+    reconnecting: writable(false),
+    runId: writable(null),
+    offReason: writable(null),
+    connection: writable("idle"),
+    bind: vi.fn(),
+    detach: vi.fn(),
+    requestEnable: vi.fn().mockResolvedValue({ ok: true }),
+    decline: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue({ ok: true }),
+    stop: vi.fn().mockResolvedValue(undefined),
+    resolve: vi.fn().mockResolvedValue(null),
+    beginReconnect: vi.fn(),
+    attach: vi.fn(),
+    arm: vi.fn(),
+    disarm: vi.fn(),
+  },
+}))
+
+vi.mock("$lib/stores", () => ({
+  chat_cost_disclaimer_acknowledged: writable(true),
+  projects: writable([]),
+  current_project: writable(null),
+}))
+
+const Chat = (await import("./chat.svelte")).default
+
+afterEach(() => {
+  cleanup()
+})
+
+const SUMMARIZING = /Summarizing earlier messages to free up context/i
+
+function baseState(
+  overrides: Partial<ChatSessionState> = {},
+): ChatSessionState {
+  return {
+    messages: [],
+    collapsedPartKeys: {},
+    lastSentAppState: null,
+    contextUsage: null as ContextUsage | null,
+    status: "submitted",
+    abortController: null,
+    toolApprovalWaiter: null,
+    toolApprovalPicks: {},
+    toolExecuting: false,
+    showActivityIndicator: false,
+    compacting: false,
+    autoWorking: false,
+    ...overrides,
+  }
+}
+
+// A minimal store satisfying ``ChatSessionStore`` with only the surface
+// ``chat.svelte`` touches during render. The state writable is returned so the
+// test can flip ``compacting`` / push content and observe the DOM.
+function makeFakeStore(initial: ChatSessionState): {
+  store: ChatSessionStore
+  state: ReturnType<typeof writable<ChatSessionState>>
+} {
+  const state = writable<ChatSessionState>(initial)
+  const noop = () => {}
+  const store = {
+    subscribe: (state as Readable<ChatSessionState>).subscribe,
+    sendMessage: vi.fn().mockResolvedValue(true),
+    stop: noop,
+    retryLastRequest: noop,
+    reset: noop,
+    loadSession: noop,
+    resyncOnLoad: vi.fn().mockResolvedValue(undefined),
+    togglePartCollapsed: noop,
+    pushInlineError: noop,
+    applyToolApprovalRun: noop,
+    applyToolApprovalSkip: noop,
+    onConsentNeeded: null,
+    onAutoModeConsentNeeded: null,
+  } as unknown as ChatSessionStore
+  return { store, state }
+}
+
+describe("chat.svelte compaction indicator (Phase 5 integration)", () => {
+  const userMsg: ChatMessage = {
+    id: "u1",
+    role: "user",
+    content: "hello",
+  }
+
+  it("renders the summarizing indicator when compacting with NO assistant message", () => {
+    // The exact pre-inference state: a sent user message, an active turn
+    // (status submitted), compacting=true, and crucially NO assistant bubble
+    // and no activity flags set.
+    const { store } = makeFakeStore(
+      baseState({ messages: [userMsg], compacting: true }),
+    )
+    const { getByText } = render(Chat, { props: { store } })
+    expect(getByText(SUMMARIZING)).toBeTruthy()
+  })
+
+  it("clears the indicator once an assistant message with content arrives", async () => {
+    const { store, state } = makeFakeStore(
+      baseState({ messages: [userMsg], compacting: true }),
+    )
+    const { queryByText } = render(Chat, { props: { store } })
+    expect(queryByText(SUMMARIZING)).toBeTruthy()
+
+    // The store clears ``compacting`` when real assistant content streams.
+    state.set(
+      baseState({
+        messages: [
+          userMsg,
+          {
+            id: "a1",
+            role: "assistant",
+            parts: [{ type: "text", text: "response" }],
+          },
+        ],
+        status: "streaming",
+        compacting: false,
+      }),
+    )
+    await Promise.resolve()
+    expect(queryByText(SUMMARIZING)).toBeNull()
+  })
+
+  it("does not render the indicator when not compacting", () => {
+    const { store } = makeFakeStore(
+      baseState({ messages: [userMsg], compacting: false }),
+    )
+    const { queryByText } = render(Chat, { props: { store } })
+    expect(queryByText(SUMMARIZING)).toBeNull()
+  })
+})

--- a/app/web_ui/src/routes/(app)/assistant/chat_history.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat_history.svelte
@@ -77,9 +77,9 @@
         sessionsError = createKilnError(error)
         return
       }
-      const { messages, continuationTraceId } =
+      const { messages, continuationTraceId, contextUsage } =
         hydrateSessionFromSnapshot(snapshot)
-      dispatch("apply", { messages, continuationTraceId })
+      dispatch("apply", { messages, continuationTraceId, contextUsage })
       posthog.capture("chat_history_session_loaded", {
         message_count: messages.length,
         auto_active: !!row.auto_active,

--- a/app/web_ui/src/routes/(app)/assistant/chat_status_steps.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat_status_steps.svelte
@@ -6,6 +6,14 @@
   export let isLoading: boolean = false
   export let isLastMessage: boolean = false
   export let showActivityIndicator: boolean = false
+  /**
+   * Phase 5: the server is summarizing earlier messages (compaction) for this
+   * turn. When true, this same indicator shows the summarizing copy instead of
+   * "Thinking", and takes precedence over the normal thinking gating.
+   */
+  export let compacting: boolean = false
+  export let compactingMessage: string =
+    "Summarizing earlier messages to free up context… this may take a little while."
 
   function isToolPart(p: ChatMessagePart): boolean {
     return typeof p.type === "string" && p.type.startsWith("tool-")
@@ -25,7 +33,20 @@
     (!hasParts || showActivityIndicator)
 </script>
 
-{#if showThinking}
+{#if compacting}
+  <div class="flex items-center gap-1.5 text-sm text-base-content/50 py-0.5">
+    <BrailleSpinner />
+    <span>
+      {compactingMessage}<span class="inline-flex items-baseline gap-px"
+        ><span class="thinking-dot" style="animation-delay: 0ms">.</span><span
+          class="thinking-dot"
+          style="animation-delay: 160ms">.</span
+        ><span class="thinking-dot" style="animation-delay: 320ms">.</span
+        ></span
+      >
+    </span>
+  </div>
+{:else if showThinking}
   <div class="flex items-center gap-1.5 text-sm text-base-content/50 py-0.5">
     <BrailleSpinner />
     <span>

--- a/app/web_ui/src/routes/(app)/assistant/chat_status_steps.test.ts
+++ b/app/web_ui/src/routes/(app)/assistant/chat_status_steps.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/svelte"
+
+const ChatStatusSteps = (await import("./chat_status_steps.svelte")).default
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("ChatStatusSteps compaction indicator (Phase 5)", () => {
+  it("renders the summarizing copy when compacting", () => {
+    const { getByText } = render(ChatStatusSteps, {
+      props: {
+        parts: [],
+        isLoading: true,
+        isLastMessage: true,
+        compacting: true,
+      },
+    })
+    expect(
+      getByText(/Summarizing earlier messages to free up context/i),
+    ).toBeTruthy()
+  })
+
+  it("does not show the normal Thinking copy while compacting", () => {
+    const { queryByText } = render(ChatStatusSteps, {
+      props: {
+        parts: [],
+        isLoading: true,
+        isLastMessage: true,
+        compacting: true,
+      },
+    })
+    // The compacting message takes precedence over "Thinking".
+    expect(queryByText(/^Thinking/)).toBeNull()
+  })
+
+  it("renders the normal Thinking copy when not compacting", () => {
+    const { getByText, queryByText } = render(ChatStatusSteps, {
+      props: {
+        parts: [],
+        isLoading: true,
+        isLastMessage: true,
+        compacting: false,
+      },
+    })
+    expect(getByText(/Thinking/)).toBeTruthy()
+    expect(
+      queryByText(/Summarizing earlier messages to free up context/i),
+    ).toBeNull()
+  })
+
+  it("renders nothing when neither compacting nor loading", () => {
+    const { queryByText } = render(ChatStatusSteps, {
+      props: {
+        parts: [],
+        isLoading: false,
+        isLastMessage: true,
+        compacting: false,
+      },
+    })
+    expect(queryByText(/Thinking/)).toBeNull()
+    expect(
+      queryByText(/Summarizing earlier messages to free up context/i),
+    ).toBeNull()
+  })
+
+  it("shows the compacting message even when there are parts (precedence)", () => {
+    const { getByText } = render(ChatStatusSteps, {
+      props: {
+        parts: [{ type: "text", text: "partial" }],
+        isLoading: true,
+        isLastMessage: true,
+        compacting: true,
+      },
+    })
+    expect(
+      getByText(/Summarizing earlier messages to free up context/i),
+    ).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Client/app-side of **KIL-727** — surface conversation context usage in the Kiln Assistant. Pairs with the corresponding backend change (private `kiln_server`), which owns the token limit, compaction, and the `context_usage` / `kiln_compaction_status` SSE contract.

### What's here (Kiln repo)

**studio_server proxy** (`app/desktop/studio_server/chat/`)
- `ChatSessionSnapshot` gains a `context_usage` field (`context_tokens`, `context_limit`, `context_percent`, `compacted`) so a session reopened from history can render the gauge.
- Containment: the model relies on Pydantic's default `extra="ignore"` (made explicit) to drop any unmodeled upstream keys at the client boundary; the server-only working trace never reaches the web UI. (`extra="forbid"` is deliberately avoided — it would raise/500 on an unknown key instead of dropping it.)
- SSE remains a raw passthrough, so the upstream `context_usage` (on the snapshot event) and the `kiln_compaction_status` event reach the client untouched (passthrough tests added).
- Regenerated `app/web_ui/src/lib/api_schema.d.ts`.

**web_ui** (`app/web_ui/`)
- **Context gauge** (`context_usage_gauge.svelte`): a small, delicate grey bar in the assistant input footer row (opposite Auto mode), with the percentage stacked above and a tooltip showing approximate `used / total` tokens. Hidden before the first turn. Fed by `context_usage` from the stream (live) and from the session GET (history).
- **"Summarizing…" indicator**: when the backend signals it is compacting the conversation, the existing Thinking activity indicator is shown with a "Summarizing earlier messages to free up context…" message during the pre-inference window, cleared once real content streams.
- Wiring through `streaming_chat.ts` / `chat_session_store.ts` / `auto_run_store.ts`, with unit + integration tests.

Token counting is intentionally approximate (overestimate-biased); copy uses "≈".

### Verification
All repo checks green (`./checks.sh`). Verified live in the browser: gauge populates to a real %, tooltip shows token counts, and the summarizing indicator renders during real compactions (guarded by an integration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)