### PR TITLE
Fix Fugu Ultra model ordering on OpenRouter

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -588,36 +588,6 @@ FUGU_ULTRA_OPENROUTER_THINKING_LEVELS = {
 
 
 built_in_models: List[KilnModel] = [
-    # Fugu Ultra
-    KilnModel(
-        family=ModelFamily.sakana,
-        name=ModelName.fugu_ultra,
-        friendly_name="Fugu Ultra",
-        editorial_notes="Sakana's Fable-tier model from Japan. A learned multi-agent orchestrator that routes across a pool of models, including recursive instances of itself. 1M context, with vision and configurable reasoning.",
-        providers=[
-            KilnModelProvider(
-                name=ModelProviderName.openrouter,
-                model_id="sakana/fugu-ultra",
-                supports_structured_output=True,
-                supports_data_gen=True,
-                structured_output_mode=StructuredOutputMode.json_schema,
-                available_thinking_levels=FUGU_ULTRA_OPENROUTER_THINKING_LEVELS,
-                default_thinking_level="xhigh",
-                openrouter_reasoning_object=True,
-                multimodal_capable=True,
-                supports_doc_extraction=True,
-                supports_vision=True,
-                multimodal_requires_pdf_as_image=True,
-                multimodal_mime_types=[
-                    KilnMimeType.PDF,
-                    KilnMimeType.TXT,
-                    KilnMimeType.MD,
-                    KilnMimeType.JPG,
-                    KilnMimeType.PNG,
-                ],
-            ),
-        ],
-    ),
     # GPT 5.5
     KilnModel(
         family=ModelFamily.gpt,
@@ -8317,6 +8287,36 @@ built_in_models: List[KilnModel] = [
                 supports_vision=True,
                 multimodal_capable=True,
                 multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+    # Fugu Ultra
+    KilnModel(
+        family=ModelFamily.sakana,
+        name=ModelName.fugu_ultra,
+        friendly_name="Fugu Ultra",
+        editorial_notes="Sakana's Fable-tier model from Japan. A learned multi-agent orchestrator that routes across a pool of models, including recursive instances of itself. 1M context, with vision and configurable reasoning.",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="sakana/fugu-ultra",
+                supports_structured_output=True,
+                supports_data_gen=True,
+                structured_output_mode=StructuredOutputMode.json_schema,
+                available_thinking_levels=FUGU_ULTRA_OPENROUTER_THINKING_LEVELS,
+                default_thinking_level="xhigh",
+                openrouter_reasoning_object=True,
+                multimodal_capable=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_requires_pdf_as_image=True,
+                multimodal_mime_types=[
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
                     KilnMimeType.JPG,
                     KilnMimeType.PNG,
                 ],


### PR DESCRIPTION
## Problem

Sakana Fugu Ultra appears at the **top** of the model list on OpenRouter, when it should appear later with the other recently-added models.

## Cause

The model list renders in `built_in_models` order (there's no separate sort step — see `provider_api.py` `get_available_models`, which iterates `built_in_models` directly). PR #1516 inserted the Fugu Ultra `KilnModel` entry at the very top of `built_in_models` instead of appending it, so it sorted to the front.

## Fix

Move the Fugu Ultra `KilnModel` block to the end of the list (after `MiMo-V2-Omni`), matching the convention that new models are appended. The `ModelFamily.sakana` / `ModelName.fugu_ultra` enums and the thinking-levels dict are unchanged — only the list position moves.

Pure move: `30 insertions, 30 deletions`, no behavior change beyond ordering. Fugu Ultra goes from index 0 → last (220/221).

## Testing

- `built_in_models` imports cleanly; first model is now GPT-5.5, last is Fugu Ultra.
- `pytest kiln_ai/adapters/test_ml_model_list.py` — 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)