### PR TITLE
Quality: Unbounded split on "::" in split_global_chunk_id crashes on multi-separator document IDs

### DIFF
--- a/libs/core/kiln_ai/utils/rag_utils.py
+++ b/libs/core/kiln_ai/utils/rag_utils.py
@@ -9,7 +9,7 @@ def global_chunk_id(document_id: str, chunk_idx: int) -> str:
 
 
 def split_global_chunk_id(global_chunk_id: str) -> Tuple[str, int]:
-    document_id, chunk_idx = global_chunk_id.split("::")
+    document_id, chunk_idx = global_chunk_id.rsplit("::", 1)
     return document_id, int(chunk_idx)
 
 


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`split_global_chunk_id` uses `global_chunk_id.split("::")` without a maxsplit argument, then unpacks into exactly two variables. If a `document_id` contains the substring "::" (e.g. a UUID variant, namespaced ID, or any string with that sequence), `global_chunk_id()` would produce "doc::with::colons::0", and `split("::")` returns 4 elements, crashing with `ValueError: too many values to unpack`. The inverse function `global_chunk_id` doesn't guard against this either, so it's possible to create IDs that cannot be parsed back.


**Severity**: `high`
**File**: `libs/core/kiln_ai/utils/rag_utils.py`

### Solution
`split_global_chunk_id` uses `global_chunk_id.split("::")` without a maxsplit argument, then unpacks into exactly two variables. If a `document_id` contains the substring "::" (e.g. a UUID variant, namespaced ID, or any string with that sequence), `global_chunk_id()` would produce "doc::with::colons::0", and `split("::")` returns 4 elements, crashing with `ValueError: too many values to unpack`. The inverse function `global_chunk_id` doesn't guard against this either, so it's possible to create IDs that cannot be parsed back.


### Changes
- `libs/core/kiln_ai/utils/rag_utils.py` (modified)

## What does this PR do?



## Related Issues



## Contributor License Agreement

I, @<your-github-username>, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [ ] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1524