### PR TITLE
KIL-739 Show legacy evals in SDG "Generate Eval Data" dialog

### DIFF
--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/data_gen_intro.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/data_gen_intro.svelte
@@ -23,6 +23,7 @@
   import EvalIcon from "$lib/ui/icons/eval_icon.svelte"
   import FinetuneIcon from "$lib/ui/icons/finetune_icon.svelte"
   import { encode_splits_for_url } from "$lib/utils/splits_util"
+  import { build_eval_options } from "./eval_options"
 
   export let generate_subtopics: () => void
   export let generate_samples: () => void
@@ -41,6 +42,9 @@
   let evals_by_id: Record<string, Eval> = {}
   let evals_loading: boolean = false
   let evals_error: KilnError | null = null
+
+  // Combined list of selectable evals (specs + legacy evals without a spec).
+  $: eval_options = build_eval_options(specs, evals_by_id)
 
   async function get_specs() {
     try {
@@ -104,8 +108,8 @@
     Promise.all([get_specs(), get_evals()])
   }
 
-  function select_spec(spec: Spec) {
-    const evaluator = spec.eval_id ? evals_by_id[spec.eval_id] : null
+  function select_eval_by_id(eval_id: string) {
+    const evaluator = evals_by_id[eval_id]
     if (!evaluator) {
       alert("This eval is not ready yet. Please configure its judge first.")
       return
@@ -132,7 +136,7 @@
       )
       return
     }
-    const eval_id = evaluator.id
+    const full_eval_id = evaluator.id
       ? `${project_id}::${task_id}::${evaluator.id}`
       : null
     const template_id = evaluator.template ?? null
@@ -140,8 +144,8 @@
     // build URL with parameters and redirect to synth page
     const params = new URLSearchParams()
     params.set("reason", "eval")
-    if (eval_id) {
-      params.set("eval_id", eval_id)
+    if (full_eval_id) {
+      params.set("eval_id", full_eval_id)
     }
     if (template_id) {
       params.set("template_id", template_id)
@@ -353,7 +357,7 @@
     <div class="font-light text-error">
       {specs_error?.message ?? evals_error?.message ?? "Unknown error"}
     </div>
-  {:else if specs.length > 0}
+  {:else if eval_options.length > 0}
     <div class="flex items-center mt-4">
       <a
         href={`/specs/${project_id}/${task_id}/select_template`}
@@ -369,13 +373,13 @@
     </div>
     <div class="font-medium text-center my-6">Select an Existing Eval</div>
     <div class="flex flex-col gap-3">
-      {#each specs as spec}
+      {#each eval_options as option}
         <button
-          on:click={() => select_spec(spec)}
+          on:click={() => select_eval_by_id(option.eval_id)}
           class="card bg-base-100 border border-base-300 hover:border-primary hover:shadow-md transition-all duration-200 cursor-pointer"
         >
           <div class="p-4 text-sm text-left">
-            <div class="">{spec.name}</div>
+            <div class="">{option.name}</div>
           </div>
         </button>
       {/each}

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/eval_options.test.ts
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/eval_options.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest"
+import { build_eval_options } from "./eval_options"
+import type { Eval, Spec } from "$lib/types"
+
+function make_eval(id: string, name: string): Eval {
+  return {
+    id,
+    name,
+    eval_set_filter_id: `tag::eval_set_${id}`,
+  } as Eval
+}
+
+function make_spec(id: string, name: string, eval_id: string | null): Spec {
+  return {
+    id,
+    name,
+    eval_id,
+  } as Spec
+}
+
+describe("build_eval_options", () => {
+  it("returns an empty list when there are no specs or evals", () => {
+    expect(build_eval_options([], {})).toEqual([])
+  })
+
+  it("lists evals from specs, preferring the spec name", () => {
+    const evals_by_id = { e1: make_eval("e1", "Eval One") }
+    const specs = [make_spec("s1", "Spec One", "e1")]
+    expect(build_eval_options(specs, evals_by_id)).toEqual([
+      { name: "Spec One", eval_id: "e1" },
+    ])
+  })
+
+  it("lists legacy evals that have no spec", () => {
+    const evals_by_id = { e1: make_eval("e1", "Legacy Eval") }
+    expect(build_eval_options([], evals_by_id)).toEqual([
+      { name: "Legacy Eval", eval_id: "e1" },
+    ])
+  })
+
+  it("combines specs and legacy evals, de-duped by eval id", () => {
+    const evals_by_id = {
+      e1: make_eval("e1", "Eval One"),
+      e2: make_eval("e2", "Legacy Eval"),
+    }
+    const specs = [make_spec("s1", "Spec One", "e1")]
+    const options = build_eval_options(specs, evals_by_id)
+    expect(options).toEqual([
+      { name: "Spec One", eval_id: "e1" },
+      { name: "Legacy Eval", eval_id: "e2" },
+    ])
+  })
+
+  it("ignores specs without an eval_id", () => {
+    const specs = [make_spec("s1", "No Eval Spec", null)]
+    expect(build_eval_options(specs, {})).toEqual([])
+  })
+
+  it("does not duplicate an eval referenced by multiple specs", () => {
+    const evals_by_id = { e1: make_eval("e1", "Eval One") }
+    const specs = [
+      make_spec("s1", "Spec One", "e1"),
+      make_spec("s2", "Spec Two", "e1"),
+    ]
+    expect(build_eval_options(specs, evals_by_id)).toEqual([
+      { name: "Spec One", eval_id: "e1" },
+    ])
+  })
+
+  it("keeps a spec whose eval is not yet loaded so it stays selectable", () => {
+    const specs = [make_spec("s1", "Spec One", "missing_eval")]
+    expect(build_eval_options(specs, {})).toEqual([
+      { name: "Spec One", eval_id: "missing_eval" },
+    ])
+  })
+})

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/eval_options.ts
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/eval_options.ts
@@ -1,0 +1,40 @@
+import type { Eval, Spec } from "$lib/types"
+
+export type EvalOption = {
+  // Display name for the option. Uses the spec name when the eval is backed by
+  // a spec, otherwise falls back to the eval's own name (legacy evals).
+  name: string
+  eval_id: string
+}
+
+// Build the list of selectable evals for the "Generate Eval Data" dialog.
+//
+// Specs are the newer representation of an eval, but legacy evals have no spec.
+// If we only listed specs, projects whose evals are all legacy would show an
+// empty list. This combines both: specs (preferring the spec name) and any
+// legacy evals not referenced by a spec, de-duplicated by eval id.
+export function build_eval_options(
+  specs: Spec[],
+  evals_by_id: Record<string, Eval>,
+): EvalOption[] {
+  const options: EvalOption[] = []
+  const used_eval_ids = new Set<string>()
+
+  for (const spec of specs) {
+    if (!spec.eval_id || used_eval_ids.has(spec.eval_id)) {
+      continue
+    }
+    used_eval_ids.add(spec.eval_id)
+    options.push({ name: spec.name, eval_id: spec.eval_id })
+  }
+
+  for (const eval_item of Object.values(evals_by_id)) {
+    if (!eval_item.id || used_eval_ids.has(eval_item.id)) {
+      continue
+    }
+    used_eval_ids.add(eval_item.id)
+    options.push({ name: eval_item.name, eval_id: eval_item.id })
+  }
+
+  return options
+}


### PR DESCRIPTION
Linear ticket: https://linear.app/kiln_ai/issue/KIL-739/legacy-evals-dont-show-up-in-sdg-evals-list

## Description

"Generate Eval Data" shows just "Create a new Eval" pop up in SDG tab if every single eval is a legacy eval (no spec). The flow from the other direction works fine still (from eval → add eval data → synthetic).

## Fix

The "Generate Eval Data" dialog (`data_gen_intro.svelte`) listed only **specs** (`specs.filter(s => s.eval_id)`). Legacy evals have no Spec, so when every eval is legacy the spec list is empty and the dialog falls through to the bare "Create a New Eval" empty state — existing legacy evals were unselectable. The reverse flow (eval → Add Eval Data → Synthetic) worked because it operates on the `Eval` object directly.

This change builds a unified list of selectable evals from **both** specs and legacy evals:
- New `eval_options.ts` with a pure `build_eval_options(specs, evals_by_id)` helper that combines spec-backed evals (preferring the spec name) and legacy evals not referenced by any spec, de-duped by eval id.
- The dialog renders "Select an Existing Eval" from this combined list; the empty state only shows when there are genuinely zero evals.
- `select_spec(spec)` → `select_eval_by_id(eval_id)` (downstream logic already ran entirely off the resolved `Eval`).

Frontend-only; no API changes.

## Tests

- New `eval_options.test.ts` (7 tests): specs-only, legacy-only, mixed, de-dup, eval-not-loaded, and null-`eval_id` cases.
- Verified visually in a project whose evals are all legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)