### PR TITLE
Add reasoning on/off toggle for GLM 5.2 on Fireworks

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -586,6 +586,19 @@ FUGU_ULTRA_OPENROUTER_THINKING_LEVELS = {
     "Max": "max",
 }
 
+# GLM 5.2 on Fireworks is the only provider/model pair where reasoning can be
+# disabled: sending reasoning_effort="none" fully stops reasoning (verified:
+# completion drops to ~4 tokens, no reasoning_content). It does not support
+# graded effort — any explicit non-"none" effort suppresses the surfaced
+# reasoning (and "minimal" is rejected outright). So this is a simple on/off
+# toggle: "On" uses the "default" sentinel (omit reasoning_effort, the only mode
+# that reliably surfaces reasoning), "Off" sends reasoning_effort="none".
+# Default is "On" so reasoning stays enabled unless the user opts out.
+GLM_5_2_FIREWORKS_THINKING_LEVELS = {
+    "On (Default)": "default",
+    "Off / None": "none",
+}
+
 
 built_in_models: List[KilnModel] = [
     # Fugu Ultra
@@ -7154,6 +7167,8 @@ built_in_models: List[KilnModel] = [
                 model_id="accounts/fireworks/models/glm-5p2",
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
+                available_thinking_levels=GLM_5_2_FIREWORKS_THINKING_LEVELS,
+                default_thinking_level="default",
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
             ),

--- a/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
@@ -191,6 +191,22 @@ class BaseAdapter(metaclass=ABCMeta):
             )
         return self._model_provider
 
+    def _reasoning_explicitly_disabled(self, provider: KilnModelProvider) -> bool:
+        """True when the effective thinking level turns reasoning off ("none").
+
+        Reasoning-capable models normally require reasoning in the response, but
+        when the user explicitly selects the "off"/"none" thinking level the
+        model legitimately returns no reasoning, so the requirement is waived.
+        """
+        if not provider.available_thinking_levels:
+            return False
+        run_config = as_kiln_agent_run_config(self.run_config)
+        if "thinking_level" in run_config.model_fields_set:
+            thinking_level = run_config.thinking_level
+        else:
+            thinking_level = provider.default_thinking_level
+        return thinking_level == "none"
+
     @staticmethod
     def _normalize_prior_trace(
         prior_trace: list[ChatCompletionMessageParam] | None,
@@ -310,6 +326,7 @@ class BaseAdapter(metaclass=ABCMeta):
                         and self.has_structured_output()
                     )
                     and not trace_has_toolcalls
+                    and not self._reasoning_explicitly_disabled(provider)
                 ):
                     raise RuntimeError(
                         "Reasoning is required for this model, but no reasoning was returned."
@@ -504,6 +521,7 @@ class BaseAdapter(metaclass=ABCMeta):
                     and self.has_structured_output()
                 )
                 and not trace_has_toolcalls
+                and not self._reasoning_explicitly_disabled(provider)
             ):
                 raise RuntimeError(
                     "Reasoning is required for this model, but no reasoning was returned."

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -541,8 +541,15 @@ class LiteLlmAdapter(BaseAdapter):
             thinking_level is not None
             and provider.available_thinking_levels is not None
         ):
+            # "default" sentinel: use the provider's native default reasoning
+            # behavior by omitting reasoning_effort entirely. Used by models that
+            # reason reliably without an explicit effort and only need an explicit
+            # "off" toggle (e.g. GLM 5.2 on Fireworks, where any explicit effort
+            # suppresses the surfaced reasoning).
+            if thinking_level == "default":
+                pass
             # Anthropic models in OpenRouter uses reasoning object. See https://openrouter.ai/docs/use-cases/reasoning-tokens
-            if (
+            elif (
                 provider.name == ModelProviderName.openrouter
                 and provider.openrouter_reasoning_object
             ):

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -1614,6 +1614,33 @@ class TestFinalizeStream:
         with pytest.raises(RuntimeError, match="Reasoning is required"):
             finalize_adapter._finalize_stream(adapter_stream, "test input", None)
 
+    def test_finalize_stream_reasoning_not_required_when_thinking_off(self, base_task):
+        """When the user explicitly selects the "none"/off thinking level, a
+        reasoning-capable model legitimately returns no reasoning, so the
+        reasoning-required guard is waived (e.g. GLM 5.2 on Fireworks with
+        reasoning disabled)."""
+        adapter = MockAdapter(
+            task=base_task,
+            run_config=KilnAgentRunConfigProperties(
+                model_name="test_model",
+                model_provider_name="fireworks_ai",
+                prompt_id="simple_prompt_builder",
+                structured_output_mode="json_schema",
+                thinking_level="none",
+            ),
+        )
+        provider = MagicMock()
+        provider.parser = None
+        provider.reasoning_capable = True
+        provider.reasoning_optional_for_structured_output = False
+        provider.available_thinking_levels = {"On (Default)": "default", "Off / None": "none"}
+        provider.default_thinking_level = "default"
+        adapter.model_provider = MagicMock(return_value=provider)
+
+        adapter_stream = self._make_adapter_stream("output")
+        run = adapter._finalize_stream(adapter_stream, "test input", None)
+        assert isinstance(run, TaskRun)
+
     def test_finalize_stream_reasoning_not_required_with_tool_calls(
         self, finalize_adapter
     ):

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -1633,7 +1633,10 @@ class TestFinalizeStream:
         provider.parser = None
         provider.reasoning_capable = True
         provider.reasoning_optional_for_structured_output = False
-        provider.available_thinking_levels = {"On (Default)": "default", "Off / None": "none"}
+        provider.available_thinking_levels = {
+            "On (Default)": "default",
+            "Off / None": "none",
+        }
         provider.default_thinking_level = "default"
         adapter.model_provider = MagicMock(return_value=provider)
 

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -620,7 +620,10 @@ def test_build_extra_body_thinking_level_default_sentinel(config, mock_task):
     mock_provider = Mock()
     mock_provider.name = ModelProviderName.fireworks_ai
     mock_provider.model_id = "accounts/fireworks/models/glm-5p2"
-    mock_provider.available_thinking_levels = {"On (Default)": "default", "Off / None": "none"}
+    mock_provider.available_thinking_levels = {
+        "On (Default)": "default",
+        "Off / None": "none",
+    }
     mock_provider.default_thinking_level = "default"
     mock_provider.openrouter_reasoning_object = False
     mock_provider.require_openrouter_reasoning = False
@@ -646,7 +649,10 @@ def test_build_extra_body_thinking_level_fireworks_none_disables(config, mock_ta
     mock_provider = Mock()
     mock_provider.name = ModelProviderName.fireworks_ai
     mock_provider.model_id = "accounts/fireworks/models/glm-5p2"
-    mock_provider.available_thinking_levels = {"On (Default)": "default", "Off / None": "none"}
+    mock_provider.available_thinking_levels = {
+        "On (Default)": "default",
+        "Off / None": "none",
+    }
     mock_provider.default_thinking_level = "default"
     mock_provider.openrouter_reasoning_object = False
     mock_provider.require_openrouter_reasoning = False

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -610,6 +610,58 @@ def test_build_extra_body_thinking_level_anthropic_none(config, mock_task):
     assert "reasoning" not in extra_body
 
 
+def test_build_extra_body_thinking_level_default_sentinel(config, mock_task):
+    """The "default" sentinel level means: use the provider's native default
+    reasoning behavior by omitting reasoning_effort (e.g. GLM 5.2 on Fireworks,
+    where reasoning is only surfaced reliably when no explicit effort is sent)."""
+    config.run_config_properties.thinking_level = "default"
+    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+
+    mock_provider = Mock()
+    mock_provider.name = ModelProviderName.fireworks_ai
+    mock_provider.model_id = "accounts/fireworks/models/glm-5p2"
+    mock_provider.available_thinking_levels = {"On (Default)": "default", "Off / None": "none"}
+    mock_provider.default_thinking_level = "default"
+    mock_provider.openrouter_reasoning_object = False
+    mock_provider.require_openrouter_reasoning = False
+    mock_provider.gemini_reasoning_enabled = False
+    mock_provider.anthropic_extended_thinking = False
+    mock_provider.r1_openrouter_options = False
+    mock_provider.logprobs_openrouter_options = False
+    mock_provider.openrouter_skip_required_parameters = False
+    mock_provider.siliconflow_enable_thinking = None
+
+    extra_body = adapter.build_extra_body(mock_provider)
+
+    assert "reasoning_effort" not in extra_body
+    assert "reasoning" not in extra_body
+
+
+def test_build_extra_body_thinking_level_fireworks_none_disables(config, mock_task):
+    """The "none" level on Fireworks sends reasoning_effort="none", which fully
+    disables reasoning on GLM 5.2."""
+    config.run_config_properties.thinking_level = "none"
+    adapter = LiteLlmAdapter(config=config, kiln_task=mock_task)
+
+    mock_provider = Mock()
+    mock_provider.name = ModelProviderName.fireworks_ai
+    mock_provider.model_id = "accounts/fireworks/models/glm-5p2"
+    mock_provider.available_thinking_levels = {"On (Default)": "default", "Off / None": "none"}
+    mock_provider.default_thinking_level = "default"
+    mock_provider.openrouter_reasoning_object = False
+    mock_provider.require_openrouter_reasoning = False
+    mock_provider.gemini_reasoning_enabled = False
+    mock_provider.anthropic_extended_thinking = False
+    mock_provider.r1_openrouter_options = False
+    mock_provider.logprobs_openrouter_options = False
+    mock_provider.openrouter_skip_required_parameters = False
+    mock_provider.siliconflow_enable_thinking = None
+
+    extra_body = adapter.build_extra_body(mock_provider)
+
+    assert extra_body.get("reasoning_effort") == "none"
+
+
 def test_build_extra_body_thinking_level_run_config_override(config, mock_task):
     """Test that the thinking level in the run config overrides the provider's default"""
     config.run_config_properties.thinking_level = "low"

--- a/libs/core/kiln_ai/adapters/model_adapters/test_thinking_level_paid.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_thinking_level_paid.py
@@ -97,6 +97,7 @@ def get_all_model_providers_with_thinking_levels(
             ModelProviderName.openai,
             ModelProviderName.anthropic,
             ModelProviderName.gemini_api,
+            ModelProviderName.fireworks_ai,
         ]
     ),
 )


### PR DESCRIPTION
## Summary

GLM 5.2 reasons by default but had no way to turn reasoning off. This adds a simple **on/off reasoning toggle** for the **Fireworks** provider of GLM 5.2.

I established the behavior empirically with `@pytest.mark.paid` probes:

| | `reasoning_effort` sent | result |
|---|---|---|
| **On (baseline)** | _(none)_ | reasoning on, surfaced into `intermediate_outputs`, reliable |
| **Off** | `none` | reasoning fully **disabled** — completion drops to ~4 tokens, no `reasoning_content` |
| graded (`low`/`medium`/`high`/`xhigh`/`max`) | the value | reasoning **not surfaced** (lands only in the trace, not `intermediate_outputs`), so it fails the reasoning-required guard |
| `minimal` | `minimal` | **rejected** by Fireworks (`invalid_request_error`) |

So GLM 5.2 does **not** support graded thinking levels — only a binary on/off. And reasoning is only reliably surfaced when **no** `reasoning_effort` is sent. On **OpenRouter** `none` is ignored (reasoning can't be disabled), so the toggle is **Fireworks-only**.

## Implementation

- **`build_extra_body`**: a `"default"` thinking-level sentinel omits `reasoning_effort` entirely (uses the provider's native default reasoning — the only mode that reliably surfaces GLM 5.2's reasoning on Fireworks).
- **`base_adapter`**: waive the "reasoning is required" guard when the effective thinking level is `"none"`, so a `reasoning_capable` model is allowed to return no reasoning when reasoning is explicitly turned off. (General correctness fix — selecting "off" should never error for lack of reasoning.)
- **`ml_model_list`**: GLM 5.2's Fireworks provider gets:
  ```python
  available_thinking_levels = {"On (Default)": "default", "Off / None": "none"}
  default_thinking_level = "default"   # default is On, per request
  ```

## Tests

- Unit: `"default"` sentinel omits `reasoning_effort`; Fireworks `"none"` sends `reasoning_effort="none"`; guard is waived when thinking is off.
- Paid: added `fireworks_ai` to the parametrized `test_thinking_level_reasoning_content`, which now covers GLM 5.2 `default` (reasoning present) and `none` (reasoning absent). Both pass live:
  ```
  test_thinking_level_reasoning_content[ModelProviderName.fireworks_ai/glm_5_2/default] PASSED
  test_thinking_level_reasoning_content[ModelProviderName.fireworks_ai/glm_5_2/none]    PASSED
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)