### PR TITLE
Chat resilience: transient-error retries (auto + interactive), side-note injection, and indicator polish

### DIFF
--- a/app/desktop/studio_server/chat/auto/runner.py
+++ b/app/desktop/studio_server/chat/auto/runner.py
@@ -51,6 +51,28 @@ ENABLE_AUTO_MODE_RESULT = json.dumps(
     ensure_ascii=False,
 )
 
+# Framing prepended to a user message that arrives WHILE a burst is in flight
+# (drained mid-round). Without it the model treats the message as a fresh
+# conversational turn, replies in plain text, and that text-only turn settles the
+# burst IDLE ("asked_user") — so a quick aside from the user halts the autonomous
+# run. Framed as a side note, the model weaves its reply into a turn that still
+# carries tool calls, so it answers AND keeps working. It does NOT apply to the
+# seed message (the task itself) or to a message that wakes an idle run.
+_SIDE_NOTE_REMINDER = (
+    "<system-reminder>"
+    "This message arrived from the user while you are working autonomously in auto "
+    "mode. Treat it as a side note: weave any acknowledgment or answer into your "
+    "ongoing work and keep going in the same turn — do not end your turn just to "
+    "reply. Stop only if the message explicitly asks you to, or your task is "
+    "already complete."
+    "</system-reminder>"
+)
+
+
+def _wrap_side_note(content: str) -> str:
+    return f"{_SIDE_NOTE_REMINDER}\n\n{content}"
+
+
 # Callback the runner invokes to push one SSE byte payload to the run's buffer +
 # bus. It also detects kiln_chat_trace boundaries (buffer reset + index update).
 EmitCallback = Callable[[bytes], None]
@@ -375,13 +397,20 @@ class AutoChatRunner:
         return self._drain_inbound()
 
     @staticmethod
+    def _side_note_message(msg: InboundMessage) -> dict[str, Any]:
+        """A drained mid-burst message, framed as a side note (see
+        ``_SIDE_NOTE_REMINDER``) so the model answers inline and keeps working."""
+        base = msg.as_chat_message()
+        return {**base, "content": _wrap_side_note(str(base.get("content", "")))}
+
+    @staticmethod
     def _append_user_messages(
         body: dict[str, Any], messages: list[InboundMessage]
     ) -> dict[str, Any]:
         """Append injected user messages after the tool results in a continuation
         body (they come last so the backend reads them as the latest input)."""
         existing = list(body.get("messages", []))
-        existing.extend(m.as_chat_message() for m in messages)
+        existing.extend(AutoChatRunner._side_note_message(m) for m in messages)
         return {**body, "messages": existing}
 
     def _continue_with_user_messages(
@@ -391,7 +420,7 @@ class AutoChatRunner:
         (the trace advanced, no pending tool results to carry)."""
         return {
             **body,
-            "messages": [m.as_chat_message() for m in messages],
+            "messages": [self._side_note_message(m) for m in messages],
         }
 
     async def _build_seed_body(self) -> dict[str, Any]:

--- a/app/desktop/studio_server/chat/auto/runner.py
+++ b/app/desktop/studio_server/chat/auto/runner.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import random
 from typing import Any, Awaitable, Callable
 
 import httpx
@@ -25,6 +27,7 @@ from kiln_ai.tools.built_in_tools.enable_auto_mode_tool import (
 from .models import AutoChatSeed, AutoRunStatus, InboundMessage
 from .sse import (
     format_auto_mode_on,
+    format_auto_mode_retry,
     format_error,
     format_tool_exec_end,
     format_tool_exec_start,
@@ -34,6 +37,22 @@ from .sse import (
 logger = logging.getLogger(__name__)
 
 MAX_TOOL_ROUNDS_MESSAGE = "Maximum tool rounds exceeded. Please start a new message."
+
+# Auto mode runs unattended, so a transient upstream failure (rate limit, 5xx,
+# connection blip) should be retried with backoff rather than parking the burst
+# until a human returns. Bounded so a persistent outage still settles IDLE.
+MAX_AUTO_RETRIES = 10
+_RETRY_BASE_SECONDS = 1.0
+_RETRY_MAX_SECONDS = 30.0
+
+
+def _retry_backoff_seconds(attempt: int) -> float:
+    """Full-jitter exponential backoff. ``attempt`` is 1-based; the delay is a
+    random value in [0, min(cap, base * 2**(attempt-1))] to spread retries and
+    avoid thundering-herd alignment across runs."""
+    ceiling = min(_RETRY_MAX_SECONDS, _RETRY_BASE_SECONDS * (2 ** (attempt - 1)))
+    return random.uniform(0, ceiling)
+
 
 # The tool result the app server resolves an intercepted disable_auto_mode call
 # to, fed back to the backend so it continues interactively.
@@ -149,25 +168,18 @@ class AutoChatRunner:
         trace_id_for_error: str | None = self._seed.trace_id
         async with httpx.AsyncClient(timeout=CHAT_TIMEOUT) as client:
             for _ in range(MAX_TOOL_ROUNDS):
-                round_state = RoundState(trace_id_for_error=trace_id_for_error)
-
-                async for payload in iter_upstream_round(
-                    client, self._url, self._headers, body, round_state
-                ):
-                    self._emit(payload)
+                round_state = await self._stream_round_with_retries(
+                    client, body, trace_id_for_error
+                )
+                if round_state is None:
+                    # Retries exhausted or a non-retryable upstream error: the
+                    # helper already emitted the error and set IDLE("error").
+                    return
 
                 trace_id_for_error = round_state.trace_id_for_error
 
                 if round_state.trace_id and self._on_trace is not None:
                     await self._on_trace(round_state.trace_id)
-
-                if round_state.is_terminal_upstream_error:
-                    # An unrecoverable upstream error ends the burst, but the
-                    # conversation flag stays on (the supervisor routes this to
-                    # IDLE with reason "error" so the user can retry or stop).
-                    self.idle_reason = "error"
-                    self.status = AutoRunStatus.IDLE
-                    return
 
                 if round_state.trace_id:
                     body = {
@@ -317,6 +329,82 @@ class AutoChatRunner:
         self._emit(format_error(MAX_TOOL_ROUNDS_MESSAGE, trace_id_for_error))
         self.idle_reason = "max_rounds"
         self.status = AutoRunStatus.IDLE
+
+    async def _stream_round_with_retries(
+        self,
+        client: httpx.AsyncClient,
+        body: dict[str, Any],
+        trace_id_for_error: str | None,
+    ) -> RoundState | None:
+        """Stream one upstream round, retrying transient failures with backoff.
+
+        Returns the completed ``RoundState`` on success. Returns ``None`` when the
+        round ends on a terminal upstream error that is either non-retryable or
+        has exhausted ``MAX_AUTO_RETRIES`` — in that case it has already emitted
+        the error payload and set ``idle_reason="error"`` + status IDLE, so the
+        caller just returns.
+
+        Only failures that streamed NO content this attempt are retried (a
+        non-200 caught before any bytes, or a pre-response connection error), so a
+        retry can never duplicate already-emitted output. Backoff uses
+        ``defer_terminal_error`` so the error is held back until we give up.
+        """
+        attempt = 0
+        while True:
+            round_state = RoundState(trace_id_for_error=trace_id_for_error)
+            emitted_any = False
+            transport_error = False
+            try:
+                async for payload in iter_upstream_round(
+                    client,
+                    self._url,
+                    self._headers,
+                    body,
+                    round_state,
+                    defer_terminal_error=True,
+                ):
+                    emitted_any = True
+                    self._emit(payload)
+            except httpx.HTTPError:
+                # Pre-response connection/timeout failure (RemoteProtocolError is
+                # handled inside iter_upstream_round). Safe to retry only if no
+                # bytes were forwarded this attempt.
+                transport_error = True
+
+            if not transport_error and not round_state.is_terminal_upstream_error:
+                return round_state
+
+            streamed_content = (
+                emitted_any
+                or round_state.trace_id is not None
+                or bool(round_state.assistant_text)
+                or bool(round_state.tool_input_events)
+            )
+            retryable = not streamed_content and (
+                transport_error or round_state.error_retryable
+            )
+            if retryable and attempt < MAX_AUTO_RETRIES and not self.stop_requested:
+                attempt += 1
+                self._emit(
+                    format_auto_mode_retry(
+                        self.run_id,
+                        attempt=attempt,
+                        max_attempts=MAX_AUTO_RETRIES,
+                        status_code=round_state.error_status_code,
+                    )
+                )
+                await asyncio.sleep(_retry_backoff_seconds(attempt))
+                continue
+
+            # Give up: surface the held-back error (or a generic one for a
+            # transport failure with nothing deferred) and settle IDLE("error").
+            if round_state.deferred_error_payload is not None:
+                self._emit(round_state.deferred_error_payload)
+            elif transport_error:
+                self._emit(format_error("Something went wrong.", trace_id_for_error))
+            self.idle_reason = "error"
+            self.status = AutoRunStatus.IDLE
+            return None
 
     async def _resolve_disable(
         self,

--- a/app/desktop/studio_server/chat/auto/runner.py
+++ b/app/desktop/studio_server/chat/auto/runner.py
@@ -92,6 +92,13 @@ def _wrap_side_note(content: str) -> str:
     return f"{_SIDE_NOTE_REMINDER}\n\n{content}"
 
 
+def _side_note_message(msg: InboundMessage) -> dict[str, Any]:
+    """A drained mid-burst message, framed as a side note (see
+    ``_SIDE_NOTE_REMINDER``) so the model answers inline and keeps working."""
+    base = msg.as_chat_message()
+    return {**base, "content": _wrap_side_note(str(base.get("content", "")))}
+
+
 # Callback the runner invokes to push one SSE byte payload to the run's buffer +
 # bus. It also detects kiln_chat_trace boundaries (buffer reset + index update).
 EmitCallback = Callable[[bytes], None]
@@ -338,11 +345,12 @@ class AutoChatRunner:
     ) -> RoundState | None:
         """Stream one upstream round, retrying transient failures with backoff.
 
-        Returns the completed ``RoundState`` on success. Returns ``None`` when the
-        round ends on a terminal upstream error that is either non-retryable or
-        has exhausted ``MAX_AUTO_RETRIES`` — in that case it has already emitted
-        the error payload and set ``idle_reason="error"`` + status IDLE, so the
-        caller just returns.
+        Returns the completed ``RoundState`` on success. Returns ``None`` on a
+        terminal outcome — in which case it has set ``self.status`` and the caller
+        just returns. Two terminal cases: a Stop requested while retrying settles
+        ``USER_STOPPED`` (no error surfaced); otherwise a non-retryable or
+        retry-exhausted error settles ``IDLE("error")`` after surfacing the
+        held-back error (the suppressed-duplicate terminal case surfaces nothing).
 
         Only failures that streamed NO content this attempt are retried (a
         non-200 caught before any bytes, or a pre-response connection error), so a
@@ -368,7 +376,10 @@ class AutoChatRunner:
             except httpx.HTTPError:
                 # Pre-response connection/timeout failure (RemoteProtocolError is
                 # handled inside iter_upstream_round). Safe to retry only if no
-                # bytes were forwarded this attempt.
+                # bytes were forwarded this attempt. A ReadTimeout after the POST
+                # was sent may re-trigger a duplicate LLM generation upstream, but
+                # the runner executes no tools until bytes stream, so the accepted
+                # blast radius is a wasted generation, never duplicated side effects.
                 transport_error = True
 
             if not transport_error and not round_state.is_terminal_upstream_error:
@@ -396,8 +407,18 @@ class AutoChatRunner:
                 await asyncio.sleep(_retry_backoff_seconds(attempt))
                 continue
 
+            # Stop pressed while retrying a persistent failure: honor the
+            # graceful-stop contract — settle USER_STOPPED (surface no error) so
+            # the supervisor publishes auto-mode-off, matching every other stop
+            # path. Checked before the error paths since stop takes precedence.
+            if self.stop_requested:
+                self.status = AutoRunStatus.USER_STOPPED
+                return None
+
             # Give up: surface the held-back error (or a generic one for a
-            # transport failure with nothing deferred) and settle IDLE("error").
+            # transport failure with nothing deferred; the suppressed-duplicate
+            # terminal case has nothing deferred and emits nothing) and settle
+            # IDLE("error").
             if round_state.deferred_error_payload is not None:
                 self._emit(round_state.deferred_error_payload)
             elif transport_error:
@@ -485,20 +506,13 @@ class AutoChatRunner:
         return self._drain_inbound()
 
     @staticmethod
-    def _side_note_message(msg: InboundMessage) -> dict[str, Any]:
-        """A drained mid-burst message, framed as a side note (see
-        ``_SIDE_NOTE_REMINDER``) so the model answers inline and keeps working."""
-        base = msg.as_chat_message()
-        return {**base, "content": _wrap_side_note(str(base.get("content", "")))}
-
-    @staticmethod
     def _append_user_messages(
         body: dict[str, Any], messages: list[InboundMessage]
     ) -> dict[str, Any]:
         """Append injected user messages after the tool results in a continuation
         body (they come last so the backend reads them as the latest input)."""
         existing = list(body.get("messages", []))
-        existing.extend(AutoChatRunner._side_note_message(m) for m in messages)
+        existing.extend(_side_note_message(m) for m in messages)
         return {**body, "messages": existing}
 
     def _continue_with_user_messages(
@@ -508,7 +522,7 @@ class AutoChatRunner:
         (the trace advanced, no pending tool results to carry)."""
         return {
             **body,
-            "messages": [self._side_note_message(m) for m in messages],
+            "messages": [_side_note_message(m) for m in messages],
         }
 
     async def _build_seed_body(self) -> dict[str, Any]:

--- a/app/desktop/studio_server/chat/auto/runner.py
+++ b/app/desktop/studio_server/chat/auto/runner.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
-import random
 from typing import Any, Awaitable, Callable
 
 import httpx
 from app.desktop.studio_server.chat.constants import CHAT_TIMEOUT, MAX_TOOL_ROUNDS
 from app.desktop.studio_server.chat.stream_session import (
+    RetryRoundResult,
     RoundState,
     ToolCallInfo,
     _build_openai_tool_continuation,
     _format_tool_calls_pending_sse,
     execute_tool_batch,
+    iter_round_with_retries,
     iter_upstream_round,
 )
 from app.desktop.studio_server.chat.tool_metadata import tool_input_executor_is_server
@@ -27,7 +27,6 @@ from kiln_ai.tools.built_in_tools.enable_auto_mode_tool import (
 from .models import AutoChatSeed, AutoRunStatus, InboundMessage
 from .sse import (
     format_auto_mode_on,
-    format_auto_mode_retry,
     format_error,
     format_tool_exec_end,
     format_tool_exec_start,
@@ -37,21 +36,6 @@ from .sse import (
 logger = logging.getLogger(__name__)
 
 MAX_TOOL_ROUNDS_MESSAGE = "Maximum tool rounds exceeded. Please start a new message."
-
-# Auto mode runs unattended, so a transient upstream failure (rate limit, 5xx,
-# connection blip) should be retried with backoff rather than parking the burst
-# until a human returns. Bounded so a persistent outage still settles IDLE.
-MAX_AUTO_RETRIES = 10
-_RETRY_BASE_SECONDS = 1.0
-_RETRY_MAX_SECONDS = 30.0
-
-
-def _retry_backoff_seconds(attempt: int) -> float:
-    """Full-jitter exponential backoff. ``attempt`` is 1-based; the delay is a
-    random value in [0, min(cap, base * 2**(attempt-1))] to spread retries and
-    avoid thundering-herd alignment across runs."""
-    ceiling = min(_RETRY_MAX_SECONDS, _RETRY_BASE_SECONDS * (2 ** (attempt - 1)))
-    return random.uniform(0, ceiling)
 
 
 # The tool result the app server resolves an intercepted disable_auto_mode call
@@ -345,95 +329,36 @@ class AutoChatRunner:
         body: dict[str, Any],
         trace_id_for_error: str | None,
     ) -> RoundState | None:
-        """Stream one upstream round, retrying transient failures with backoff.
+        """Stream one upstream round via the shared retry helper, translating its
+        outcome into the runner's terminal status.
 
         Returns the completed ``RoundState`` on success. Returns ``None`` on a
-        terminal outcome — in which case it has set ``self.status`` and the caller
-        just returns. Two terminal cases: a Stop requested while retrying settles
-        ``USER_STOPPED`` (no error surfaced); otherwise a non-retryable or
-        retry-exhausted error settles ``IDLE("error")`` after surfacing the
-        held-back error (the suppressed-duplicate terminal case surfaces nothing).
-
-        Only failures that streamed NO content this attempt are retried (a
-        non-200 caught before any bytes, or a pre-response connection error), so a
-        retry can never duplicate already-emitted output. Backoff uses
-        ``defer_terminal_error`` so the error is held back until we give up.
+        terminal outcome: a Stop requested while retrying settles ``USER_STOPPED``
+        (the helper surfaced no error); a non-retryable or retry-exhausted error
+        settles ``IDLE("error")`` (the helper already yielded the error).
         """
-        attempt = 0
-        while True:
-            round_state = RoundState(trace_id_for_error=trace_id_for_error)
-            emitted_any = False
-            transport_error = False
-            try:
-                async for payload in iter_upstream_round(
-                    client,
-                    self._url,
-                    self._headers,
-                    body,
-                    round_state,
-                    defer_terminal_error=True,
-                ):
-                    emitted_any = True
-                    self._emit(payload)
-            except httpx.HTTPError:
-                # Pre-response connection/timeout failure (RemoteProtocolError is
-                # handled inside iter_upstream_round). Safe to retry only if no
-                # bytes were forwarded this attempt. A ReadTimeout after the POST
-                # was sent may re-trigger a duplicate LLM generation upstream, but
-                # the runner executes no tools until bytes stream, so the accepted
-                # blast radius is a wasted generation, never duplicated side effects.
-                transport_error = True
+        result = RetryRoundResult()
+        async for payload in iter_round_with_retries(
+            client,
+            self._url,
+            self._headers,
+            body,
+            trace_id_for_error,
+            result,
+            run_id=self.run_id,
+            stop_requested=lambda: self.stop_requested,
+        ):
+            self._emit(payload)
 
-            if not transport_error and not round_state.is_terminal_upstream_error:
-                return round_state
-
-            streamed_content = (
-                emitted_any
-                or round_state.trace_id is not None
-                or bool(round_state.assistant_text)
-                or bool(round_state.tool_input_events)
-            )
-            retryable = not streamed_content and (
-                transport_error or round_state.error_retryable
-            )
-            if retryable and attempt < MAX_AUTO_RETRIES and not self.stop_requested:
-                attempt += 1
-                self._emit(
-                    format_auto_mode_retry(
-                        self.run_id,
-                        attempt=attempt,
-                        max_attempts=MAX_AUTO_RETRIES,
-                        status_code=round_state.error_status_code,
-                    )
-                )
-                await asyncio.sleep(_retry_backoff_seconds(attempt))
-                continue
-
-            # Stop pressed while retrying a persistent failure: honor the
-            # graceful-stop contract — settle USER_STOPPED (surface no error) so
-            # the supervisor publishes auto-mode-off, matching every other stop
-            # path. Checked before the error paths since stop takes precedence.
-            if self.stop_requested:
-                self.status = AutoRunStatus.USER_STOPPED
-                return None
-
-            # Give up: surface the held-back error (or a generic one for a
-            # transport failure with nothing deferred; the suppressed-duplicate
-            # terminal case has nothing deferred and emits nothing) and settle
-            # IDLE("error").
-            if round_state.deferred_error_payload is not None:
-                self._emit(round_state.deferred_error_payload)
-            elif transport_error:
-                # Prefer the round's latest trace id: a newer one may have streamed
-                # in before the transport error struck mid-round.
-                self._emit(
-                    format_error(
-                        "Something went wrong.", round_state.trace_id_for_error
-                    )
-                )
-            self.idle_reason = "error"
-            self.status = AutoRunStatus.IDLE
+        if result.status == "ok":
+            return result.round_state
+        if result.status == "stopped":
+            self.status = AutoRunStatus.USER_STOPPED
             return None
+        # status == "error"
+        self.idle_reason = "error"
+        self.status = AutoRunStatus.IDLE
+        return None
 
     async def _resolve_disable(
         self,

--- a/app/desktop/studio_server/chat/auto/runner.py
+++ b/app/desktop/studio_server/chat/auto/runner.py
@@ -96,7 +96,9 @@ def _side_note_message(msg: InboundMessage) -> dict[str, Any]:
     """A drained mid-burst message, framed as a side note (see
     ``_SIDE_NOTE_REMINDER``) so the model answers inline and keeps working."""
     base = msg.as_chat_message()
-    return {**base, "content": _wrap_side_note(str(base.get("content", "")))}
+    # `or ""` (not a default arg) so an explicit None content can't become "None".
+    content = base.get("content") or ""
+    return {**base, "content": _wrap_side_note(str(content))}
 
 
 # Callback the runner invokes to push one SSE byte payload to the run's buffer +
@@ -422,7 +424,13 @@ class AutoChatRunner:
             if round_state.deferred_error_payload is not None:
                 self._emit(round_state.deferred_error_payload)
             elif transport_error:
-                self._emit(format_error("Something went wrong.", trace_id_for_error))
+                # Prefer the round's latest trace id: a newer one may have streamed
+                # in before the transport error struck mid-round.
+                self._emit(
+                    format_error(
+                        "Something went wrong.", round_state.trace_id_for_error
+                    )
+                )
             self.idle_reason = "error"
             self.status = AutoRunStatus.IDLE
             return None

--- a/app/desktop/studio_server/chat/auto/sse.py
+++ b/app/desktop/studio_server/chat/auto/sse.py
@@ -4,6 +4,7 @@ import json
 
 from app.desktop.studio_server.chat.constants import (
     SSE_TYPE_AUTO_MODE_IDLE,
+    SSE_TYPE_AUTO_MODE_RETRY,
     SSE_TYPE_AUTO_MODE_STATE,
     SSE_TYPE_TOOL_EXEC_END,
     SSE_TYPE_TOOL_EXEC_START,
@@ -35,6 +36,23 @@ def format_auto_mode_idle(run_id: str, reason: str) -> bytes:
     return _encode(
         {"type": SSE_TYPE_AUTO_MODE_IDLE, "run_id": run_id, "reason": reason}
     )
+
+
+def format_auto_mode_retry(
+    run_id: str, *, attempt: int, max_attempts: int, status_code: int | None = None
+) -> bytes:
+    """Emitted between retry attempts after a transient upstream failure, so the
+    UI can show "retrying N/M…" rather than a hard error. ``status_code`` is the
+    upstream HTTP status (omitted for a connection-level failure)."""
+    payload: dict = {
+        "type": SSE_TYPE_AUTO_MODE_RETRY,
+        "run_id": run_id,
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+    }
+    if status_code is not None:
+        payload["status_code"] = status_code
+    return _encode(payload)
 
 
 def format_auto_mode_state(run_id: str, *, flag_on: bool, working: bool) -> bytes:

--- a/app/desktop/studio_server/chat/auto/sse.py
+++ b/app/desktop/studio_server/chat/auto/sse.py
@@ -4,7 +4,6 @@ import json
 
 from app.desktop.studio_server.chat.constants import (
     SSE_TYPE_AUTO_MODE_IDLE,
-    SSE_TYPE_AUTO_MODE_RETRY,
     SSE_TYPE_AUTO_MODE_STATE,
     SSE_TYPE_TOOL_EXEC_END,
     SSE_TYPE_TOOL_EXEC_START,
@@ -36,23 +35,6 @@ def format_auto_mode_idle(run_id: str, reason: str) -> bytes:
     return _encode(
         {"type": SSE_TYPE_AUTO_MODE_IDLE, "run_id": run_id, "reason": reason}
     )
-
-
-def format_auto_mode_retry(
-    run_id: str, *, attempt: int, max_attempts: int, status_code: int | None = None
-) -> bytes:
-    """Emitted between retry attempts after a transient upstream failure, so the
-    UI can show "retrying N/M…" rather than a hard error. ``status_code`` is the
-    upstream HTTP status (omitted for a connection-level failure)."""
-    payload: dict = {
-        "type": SSE_TYPE_AUTO_MODE_RETRY,
-        "run_id": run_id,
-        "attempt": attempt,
-        "max_attempts": max_attempts,
-    }
-    if status_code is not None:
-        payload["status_code"] = status_code
-    return _encode(payload)
 
 
 def format_auto_mode_state(run_id: str, *, flag_on: bool, working: bool) -> bytes:

--- a/app/desktop/studio_server/chat/auto/test_fakes.py
+++ b/app/desktop/studio_server/chat/auto/test_fakes.py
@@ -74,12 +74,14 @@ class FakeUpstreamResponse:
         body: bytes = b"",
         raise_protocol_error: bool = False,
         raise_connect_error: bool = False,
+        raise_transport_error_after_chunks: bool = False,
     ) -> None:
         self.status_code = status_code
         self._chunks = chunks or []
         self._body = body
         self._raise_protocol_error = raise_protocol_error
         self._raise_connect_error = raise_connect_error
+        self._raise_transport_error_after_chunks = raise_transport_error_after_chunks
 
     async def aread(self) -> bytes:
         return self._body
@@ -89,6 +91,11 @@ class FakeUpstreamResponse:
             yield chunk
         if self._raise_protocol_error:
             raise httpx.RemoteProtocolError("Server disconnected")
+        if self._raise_transport_error_after_chunks:
+            # A mid-stream transport failure that is NOT a RemoteProtocolError
+            # (e.g. a read timeout), so it propagates out of iter_upstream_round
+            # for the runner to classify — after content was already forwarded.
+            raise httpx.ReadError("Connection dropped mid-stream")
 
     async def __aenter__(self):
         # Simulate a pre-response connection failure (raised before any status /

--- a/app/desktop/studio_server/chat/auto/test_fakes.py
+++ b/app/desktop/studio_server/chat/auto/test_fakes.py
@@ -73,11 +73,13 @@ class FakeUpstreamResponse:
         status_code: int = 200,
         body: bytes = b"",
         raise_protocol_error: bool = False,
+        raise_connect_error: bool = False,
     ) -> None:
         self.status_code = status_code
         self._chunks = chunks or []
         self._body = body
         self._raise_protocol_error = raise_protocol_error
+        self._raise_connect_error = raise_connect_error
 
     async def aread(self) -> bytes:
         return self._body
@@ -89,6 +91,10 @@ class FakeUpstreamResponse:
             raise httpx.RemoteProtocolError("Server disconnected")
 
     async def __aenter__(self):
+        # Simulate a pre-response connection failure (raised before any status /
+        # bytes), distinct from a mid-stream RemoteProtocolError.
+        if self._raise_connect_error:
+            raise httpx.ConnectError("connection refused")
         return self
 
     async def __aexit__(self, *args):

--- a/app/desktop/studio_server/chat/auto/test_iter_upstream_round.py
+++ b/app/desktop/studio_server/chat/auto/test_iter_upstream_round.py
@@ -99,10 +99,12 @@ async def test_golden_client_tool_round_executes_and_continues():
 
 @pytest.mark.asyncio
 async def test_golden_non_200_emits_error_and_stops():
+    # 400 (non-retryable): surfaces immediately and stops. Retryable statuses
+    # (5xx/429) go through the retry loop instead (see test_stream_session.py).
     client = FakeUpstreamClient(
         [
             FakeUpstreamResponse(
-                status_code=500, body=b'{"message": "boom", "code": "X"}'
+                status_code=400, body=b'{"message": "boom", "code": "X"}'
             )
         ]
     )

--- a/app/desktop/studio_server/chat/auto/test_registry.py
+++ b/app/desktop/studio_server/chat/auto/test_registry.py
@@ -675,10 +675,13 @@ async def test_inject_during_active_burst_echoes_message_exactly_once():
         await asyncio.sleep(0.02)
         drain_task.cancel()
 
-    # The message was appended to the round-2 continuation (drained by the runner).
+    # The message was appended to the round-2 continuation (drained by the runner),
+    # framed as a side note so the model answers inline and keeps working.
     second_body = client.bodies[1]
     user_messages = [m for m in second_body["messages"] if m.get("role") == "user"]
-    assert user_messages == [{"role": "user", "content": "inject me"}]
+    assert len(user_messages) == 1
+    assert "inject me" in user_messages[0]["content"]
+    assert "<system-reminder>" in user_messages[0]["content"]
 
     # The user-message echo appears EXACTLY ONCE across the whole observer stream
     # (registry echoes on enqueue; the runner must not re-echo on drain).

--- a/app/desktop/studio_server/chat/auto/test_runner.py
+++ b/app/desktop/studio_server/chat/auto/test_runner.py
@@ -9,7 +9,12 @@ import httpx
 import pytest
 
 from .models import AutoChatSeed, AutoRunStatus, InboundMessage
-from .runner import MAX_TOOL_ROUNDS_MESSAGE, AutoChatRunner
+from .runner import (
+    MAX_AUTO_RETRIES,
+    MAX_TOOL_ROUNDS_MESSAGE,
+    AutoChatRunner,
+    _side_note_message,
+)
 from .test_fakes import (
     FakeUpstreamClient,
     FakeUpstreamResponse,
@@ -270,25 +275,27 @@ async def test_retryable_upstream_error_retries_then_succeeds():
         patch.object(httpx, "AsyncClient", return_value=client),
         patch(
             "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
-            new=AsyncMock(),
-        ),
+            new_callable=AsyncMock,
+        ) as sleep_mock,
     ):
         await runner.run()
 
-    decoded = _decoded(emitted)
-    assert decoded.count('"type": "auto-mode-retry"') == 2
-    assert '"status_code": 503' in decoded
+    # Parse structurally: a retry event per failed attempt, numbered 1, 2.
+    retry_events = [e for e in _events(emitted) if e["type"] == "auto-mode-retry"]
+    assert [e["attempt"] for e in retry_events] == [1, 2]
+    assert all(e["max_attempts"] == MAX_AUTO_RETRIES for e in retry_events)
+    assert all(e["status_code"] == 503 for e in retry_events)
+    # Backoff actually ran between attempts (not a tight spin).
+    assert sleep_mock.await_count == 2
     # Recovered: the transient error was never surfaced; the burst settled on the
     # successful round (text-only → asked_user).
-    assert "rate limited" not in decoded
+    assert "rate limited" not in _decoded(emitted)
     assert runner.idle_reason == "asked_user"
     assert len(client.bodies) == 3
 
 
 @pytest.mark.asyncio
 async def test_retryable_upstream_error_exhausts_retries_then_idle_error():
-    from .runner import MAX_AUTO_RETRIES
-
     client = FakeUpstreamClient(
         [
             FakeUpstreamResponse(status_code=500, body=b'{"message": "boom"}')
@@ -342,6 +349,77 @@ async def test_connection_error_retries_then_succeeds():
     assert decoded.count('"type": "auto-mode-retry"') == 1
     assert runner.idle_reason == "asked_user"
     assert len(client.bodies) == 2
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_transport_error_after_content_is_not_retried():
+    # The central anti-duplication guard: a transport failure that strikes AFTER
+    # bytes were already forwarded must NOT be retried (a re-POST would duplicate
+    # the streamed output). Here a text delta streams, then the stream drops with
+    # a non-RemoteProtocolError transport error.
+    client = FakeUpstreamClient(
+        [
+            FakeUpstreamResponse(
+                chunks=[text_delta("partial answer")],
+                raise_transport_error_after_chunks=True,
+            ),
+            # A second response is queued to prove it is never requested.
+            FakeUpstreamResponse(
+                chunks=[text_delta("dupe"), trace("tr-x"), finish("stop")]
+            ),
+        ]
+    )
+    runner, emitted, _ = _runner(client)
+
+    with (
+        patch.object(httpx, "AsyncClient", return_value=client),
+        patch(
+            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep_mock,
+    ):
+        await runner.run()
+
+    decoded = _decoded(emitted)
+    # No retry, no backoff, exactly one upstream request — the guard held.
+    assert '"type": "auto-mode-retry"' not in decoded
+    assert sleep_mock.await_count == 0
+    assert len(client.bodies) == 1
+    # The already-streamed content appears exactly once (never duplicated).
+    assert decoded.count("partial answer") == 1
+    assert "dupe" not in decoded
+    # A single generic error is surfaced and the burst settles IDLE("error").
+    assert runner.status == AutoRunStatus.IDLE
+    assert runner.idle_reason == "error"
+
+
+@pytest.mark.asyncio
+async def test_stop_requested_during_retry_settles_user_stopped():
+    # Stop pressed while retrying a persistent transient failure must honor the
+    # graceful-stop contract: settle USER_STOPPED (so the supervisor publishes
+    # auto-mode-off), not IDLE("error") with the flag left on.
+    client = FakeUpstreamClient(
+        [FakeUpstreamResponse(status_code=503, body=b'{"message": "rate limited"}')]
+    )
+    runner, emitted, _ = _runner(client)
+    runner.stop_requested = True
+
+    with (
+        patch.object(httpx, "AsyncClient", return_value=client),
+        patch(
+            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await runner.run()
+
+    decoded = _decoded(emitted)
+    # Stop abandons retries: no retry event, and the transient error is NOT
+    # surfaced as a hard error to the user.
+    assert '"type": "auto-mode-retry"' not in decoded
+    assert "rate limited" not in decoded
+    assert runner.status == AutoRunStatus.USER_STOPPED
+    assert len(client.bodies) == 1
 
 
 class TestSeedBody:
@@ -415,7 +493,7 @@ def test_side_note_message_frames_content_to_continue_working():
     # A drained mid-burst message is wrapped so the model answers inline and keeps
     # working (does not stop just to reply), but the original text is preserved.
     msg = InboundMessage(content="also handle edge case Y")
-    wrapped = AutoChatRunner._side_note_message(msg)
+    wrapped = _side_note_message(msg)
     assert wrapped["role"] == "user"
     assert "also handle edge case Y" in wrapped["content"]
     assert "<system-reminder>" in wrapped["content"]

--- a/app/desktop/studio_server/chat/auto/test_runner.py
+++ b/app/desktop/studio_server/chat/auto/test_runner.py
@@ -316,6 +316,18 @@ class TestSeedBody:
         assert ("sib1", "3") in roles
 
 
+def test_side_note_message_frames_content_to_continue_working():
+    # A drained mid-burst message is wrapped so the model answers inline and keeps
+    # working (does not stop just to reply), but the original text is preserved.
+    msg = InboundMessage(content="also handle edge case Y")
+    wrapped = AutoChatRunner._side_note_message(msg)
+    assert wrapped["role"] == "user"
+    assert "also handle edge case Y" in wrapped["content"]
+    assert "<system-reminder>" in wrapped["content"]
+    assert "side note" in wrapped["content"].lower()
+    assert "do not end your turn just to reply" in wrapped["content"]
+
+
 # ── Revision R1: message injection ────────────────────────────────────────────
 
 
@@ -346,7 +358,11 @@ async def test_injected_message_appended_to_continuation():
     # auto_mode set once on the seed propagates through every {**body} continuation.
     assert second_body["auto_mode"] is True
     user_messages = [m for m in second_body["messages"] if m.get("role") == "user"]
-    assert user_messages == [{"role": "user", "content": "also do X"}]
+    # Mid-burst injected messages are framed as a side note so the model answers
+    # inline and keeps working instead of halting on a text-only reply.
+    assert len(user_messages) == 1
+    assert "also do X" in user_messages[0]["content"]
+    assert "<system-reminder>" in user_messages[0]["content"]
     # The runner does NOT echo on drain — the registry already echoed the message
     # onto the bus/buffer at enqueue time (CR Moderate 1). Double-echo would
     # render the message twice; the combined registry+runner echo-once behaviour
@@ -373,7 +389,11 @@ async def test_drain_before_idle_continues_with_queued_message():
     # It did NOT stop after round1 — a second upstream round ran, seeded with the
     # queued user message as a fresh turn.
     assert len(client.bodies) == 2
-    assert client.bodies[1]["messages"] == [{"role": "user", "content": "keep going"}]
+    assert len(client.bodies[1]["messages"]) == 1
+    queued_msg = client.bodies[1]["messages"][0]
+    assert queued_msg["role"] == "user"
+    assert "keep going" in queued_msg["content"]
+    assert "<system-reminder>" in queued_msg["content"]
     # Eventually settled IDLE once the queue was empty.
     assert runner.status == AutoRunStatus.IDLE
 

--- a/app/desktop/studio_server/chat/auto/test_runner.py
+++ b/app/desktop/studio_server/chat/auto/test_runner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -233,20 +233,115 @@ async def test_max_rounds_backstop_emits_error():
 
 
 @pytest.mark.asyncio
-async def test_upstream_error_sets_error_status():
+async def test_non_retryable_upstream_error_sets_error_status_without_retry():
+    # A 4xx (here 400) is non-retryable: the burst ends immediately, flag stays on
+    # (IDLE, reason "error"), and no retry is attempted.
     client = FakeUpstreamClient(
-        [FakeUpstreamResponse(status_code=500, body=b'{"message": "boom"}')]
+        [FakeUpstreamResponse(status_code=400, body=b'{"message": "boom"}')]
     )
     runner, emitted, _ = _runner(client)
 
     with patch.object(httpx, "AsyncClient", return_value=client):
         await runner.run()
 
-    # Revision R1: an unrecoverable upstream error ends the burst but the flag
-    # stays on (IDLE, reason "error").
     assert runner.status == AutoRunStatus.IDLE
     assert runner.idle_reason == "error"
     assert "boom" in _decoded(emitted)
+    # No retry attempted for a non-retryable status, and only one upstream request.
+    assert '"type": "auto-mode-retry"' not in _decoded(emitted)
+    assert len(client.bodies) == 1
+
+
+@pytest.mark.asyncio
+async def test_retryable_upstream_error_retries_then_succeeds():
+    # Two transient 503s, then a normal round. The runner retries with backoff,
+    # emits a retry event per attempt, recovers, and never surfaces the error.
+    round_ok = [text_delta("done"), trace("tr-1"), finish("stop")]
+    client = FakeUpstreamClient(
+        [
+            FakeUpstreamResponse(status_code=503, body=b'{"message": "rate limited"}'),
+            FakeUpstreamResponse(status_code=503, body=b'{"message": "rate limited"}'),
+            FakeUpstreamResponse(chunks=round_ok),
+        ]
+    )
+    runner, emitted, _ = _runner(client)
+
+    with (
+        patch.object(httpx, "AsyncClient", return_value=client),
+        patch(
+            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+    ):
+        await runner.run()
+
+    decoded = _decoded(emitted)
+    assert decoded.count('"type": "auto-mode-retry"') == 2
+    assert '"status_code": 503' in decoded
+    # Recovered: the transient error was never surfaced; the burst settled on the
+    # successful round (text-only → asked_user).
+    assert "rate limited" not in decoded
+    assert runner.idle_reason == "asked_user"
+    assert len(client.bodies) == 3
+
+
+@pytest.mark.asyncio
+async def test_retryable_upstream_error_exhausts_retries_then_idle_error():
+    from .runner import MAX_AUTO_RETRIES
+
+    client = FakeUpstreamClient(
+        [
+            FakeUpstreamResponse(status_code=500, body=b'{"message": "boom"}')
+            for _ in range(MAX_AUTO_RETRIES + 1)
+        ]
+    )
+    runner, emitted, _ = _runner(client)
+
+    with (
+        patch.object(httpx, "AsyncClient", return_value=client),
+        patch(
+            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+    ):
+        await runner.run()
+
+    decoded = _decoded(emitted)
+    # One retry event per attempt up to the cap, then give up.
+    assert decoded.count('"type": "auto-mode-retry"') == MAX_AUTO_RETRIES
+    # On give-up the held-back error is finally surfaced.
+    assert "boom" in decoded
+    assert runner.status == AutoRunStatus.IDLE
+    assert runner.idle_reason == "error"
+    assert len(client.bodies) == MAX_AUTO_RETRIES + 1
+
+
+@pytest.mark.asyncio
+async def test_connection_error_retries_then_succeeds():
+    # A pre-response connection failure (no status code) is retried just like a
+    # transient 5xx, as long as nothing was streamed.
+    round_ok = [text_delta("done"), trace("tr-1"), finish("stop")]
+    client = FakeUpstreamClient(
+        [
+            FakeUpstreamResponse(raise_connect_error=True),
+            FakeUpstreamResponse(chunks=round_ok),
+        ]
+    )
+    runner, emitted, _ = _runner(client)
+
+    with (
+        patch.object(httpx, "AsyncClient", return_value=client),
+        patch(
+            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+    ):
+        await runner.run()
+
+    decoded = _decoded(emitted)
+    assert decoded.count('"type": "auto-mode-retry"') == 1
+    assert runner.idle_reason == "asked_user"
+    assert len(client.bodies) == 2
 
 
 class TestSeedBody:

--- a/app/desktop/studio_server/chat/auto/test_runner.py
+++ b/app/desktop/studio_server/chat/auto/test_runner.py
@@ -428,7 +428,9 @@ async def test_stop_requested_during_retry_settles_user_stopped():
     assert decoded.count('"type": "kiln-chat-retry"') == 1
     assert "rate limited" not in decoded
     assert runner.status == AutoRunStatus.USER_STOPPED
-    assert len(client.bodies) == 2
+    # The stop landed during the backoff sleep, so the retry is abandoned BEFORE
+    # re-POSTing — only the initial request was made (no extra round streamed).
+    assert len(client.bodies) == 1
 
 
 class TestSeedBody:

--- a/app/desktop/studio_server/chat/auto/test_runner.py
+++ b/app/desktop/studio_server/chat/auto/test_runner.py
@@ -395,31 +395,39 @@ async def test_mid_stream_transport_error_after_content_is_not_retried():
 
 @pytest.mark.asyncio
 async def test_stop_requested_during_retry_settles_user_stopped():
-    # Stop pressed while retrying a persistent transient failure must honor the
-    # graceful-stop contract: settle USER_STOPPED (so the supervisor publishes
-    # auto-mode-off), not IDLE("error") with the flag left on.
+    # Stop pressed *while actively retrying* a persistent transient failure must
+    # honor the graceful-stop contract: settle USER_STOPPED (so the supervisor
+    # publishes auto-mode-off), not IDLE("error") with the flag left on.
     client = FakeUpstreamClient(
-        [FakeUpstreamResponse(status_code=503, body=b'{"message": "rate limited"}')]
+        [
+            FakeUpstreamResponse(status_code=503, body=b'{"message": "rate limited"}'),
+            FakeUpstreamResponse(status_code=503, body=b'{"message": "rate limited"}'),
+        ]
     )
     runner, emitted, _ = _runner(client)
-    runner.stop_requested = True
+
+    # Request Stop from inside the backoff sleep, so one retry has already been
+    # emitted and the run is genuinely mid-retry when the stop lands — exercising
+    # the in-retry transition (not the pre-run stop path).
+    async def _stop_mid_backoff(*args, **kwargs):
+        runner.stop_requested = True
 
     with (
         patch.object(httpx, "AsyncClient", return_value=client),
         patch(
             "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
-            new_callable=AsyncMock,
+            new=AsyncMock(side_effect=_stop_mid_backoff),
         ),
     ):
         await runner.run()
 
     decoded = _decoded(emitted)
-    # Stop abandons retries: no retry event, and the transient error is NOT
-    # surfaced as a hard error to the user.
-    assert '"type": "auto-mode-retry"' not in decoded
+    # It DID enter the retry branch (one retry emitted) before the stop landed,
+    # then settled USER_STOPPED without surfacing the transient error.
+    assert decoded.count('"type": "auto-mode-retry"') == 1
     assert "rate limited" not in decoded
     assert runner.status == AutoRunStatus.USER_STOPPED
-    assert len(client.bodies) == 1
+    assert len(client.bodies) == 2
 
 
 class TestSeedBody:

--- a/app/desktop/studio_server/chat/auto/test_runner.py
+++ b/app/desktop/studio_server/chat/auto/test_runner.py
@@ -9,8 +9,9 @@ import httpx
 import pytest
 
 from .models import AutoChatSeed, AutoRunStatus, InboundMessage
+from app.desktop.studio_server.chat.stream_session import MAX_CHAT_RETRIES
+
 from .runner import (
-    MAX_AUTO_RETRIES,
     MAX_TOOL_ROUNDS_MESSAGE,
     AutoChatRunner,
     _side_note_message,
@@ -253,7 +254,7 @@ async def test_non_retryable_upstream_error_sets_error_status_without_retry():
     assert runner.idle_reason == "error"
     assert "boom" in _decoded(emitted)
     # No retry attempted for a non-retryable status, and only one upstream request.
-    assert '"type": "auto-mode-retry"' not in _decoded(emitted)
+    assert '"type": "kiln-chat-retry"' not in _decoded(emitted)
     assert len(client.bodies) == 1
 
 
@@ -274,16 +275,16 @@ async def test_retryable_upstream_error_retries_then_succeeds():
     with (
         patch.object(httpx, "AsyncClient", return_value=client),
         patch(
-            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            "app.desktop.studio_server.chat.stream_session.asyncio.sleep",
             new_callable=AsyncMock,
         ) as sleep_mock,
     ):
         await runner.run()
 
     # Parse structurally: a retry event per failed attempt, numbered 1, 2.
-    retry_events = [e for e in _events(emitted) if e["type"] == "auto-mode-retry"]
+    retry_events = [e for e in _events(emitted) if e["type"] == "kiln-chat-retry"]
     assert [e["attempt"] for e in retry_events] == [1, 2]
-    assert all(e["max_attempts"] == MAX_AUTO_RETRIES for e in retry_events)
+    assert all(e["max_attempts"] == MAX_CHAT_RETRIES for e in retry_events)
     assert all(e["status_code"] == 503 for e in retry_events)
     # Backoff actually ran between attempts (not a tight spin).
     assert sleep_mock.await_count == 2
@@ -299,7 +300,7 @@ async def test_retryable_upstream_error_exhausts_retries_then_idle_error():
     client = FakeUpstreamClient(
         [
             FakeUpstreamResponse(status_code=500, body=b'{"message": "boom"}')
-            for _ in range(MAX_AUTO_RETRIES + 1)
+            for _ in range(MAX_CHAT_RETRIES + 1)
         ]
     )
     runner, emitted, _ = _runner(client)
@@ -307,7 +308,7 @@ async def test_retryable_upstream_error_exhausts_retries_then_idle_error():
     with (
         patch.object(httpx, "AsyncClient", return_value=client),
         patch(
-            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            "app.desktop.studio_server.chat.stream_session.asyncio.sleep",
             new=AsyncMock(),
         ),
     ):
@@ -315,12 +316,12 @@ async def test_retryable_upstream_error_exhausts_retries_then_idle_error():
 
     decoded = _decoded(emitted)
     # One retry event per attempt up to the cap, then give up.
-    assert decoded.count('"type": "auto-mode-retry"') == MAX_AUTO_RETRIES
+    assert decoded.count('"type": "kiln-chat-retry"') == MAX_CHAT_RETRIES
     # On give-up the held-back error is finally surfaced.
     assert "boom" in decoded
     assert runner.status == AutoRunStatus.IDLE
     assert runner.idle_reason == "error"
-    assert len(client.bodies) == MAX_AUTO_RETRIES + 1
+    assert len(client.bodies) == MAX_CHAT_RETRIES + 1
 
 
 @pytest.mark.asyncio
@@ -339,14 +340,14 @@ async def test_connection_error_retries_then_succeeds():
     with (
         patch.object(httpx, "AsyncClient", return_value=client),
         patch(
-            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            "app.desktop.studio_server.chat.stream_session.asyncio.sleep",
             new=AsyncMock(),
         ),
     ):
         await runner.run()
 
     decoded = _decoded(emitted)
-    assert decoded.count('"type": "auto-mode-retry"') == 1
+    assert decoded.count('"type": "kiln-chat-retry"') == 1
     assert runner.idle_reason == "asked_user"
     assert len(client.bodies) == 2
 
@@ -374,7 +375,7 @@ async def test_mid_stream_transport_error_after_content_is_not_retried():
     with (
         patch.object(httpx, "AsyncClient", return_value=client),
         patch(
-            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            "app.desktop.studio_server.chat.stream_session.asyncio.sleep",
             new_callable=AsyncMock,
         ) as sleep_mock,
     ):
@@ -382,7 +383,7 @@ async def test_mid_stream_transport_error_after_content_is_not_retried():
 
     decoded = _decoded(emitted)
     # No retry, no backoff, exactly one upstream request — the guard held.
-    assert '"type": "auto-mode-retry"' not in decoded
+    assert '"type": "kiln-chat-retry"' not in decoded
     assert sleep_mock.await_count == 0
     assert len(client.bodies) == 1
     # The already-streamed content appears exactly once (never duplicated).
@@ -415,7 +416,7 @@ async def test_stop_requested_during_retry_settles_user_stopped():
     with (
         patch.object(httpx, "AsyncClient", return_value=client),
         patch(
-            "app.desktop.studio_server.chat.auto.runner.asyncio.sleep",
+            "app.desktop.studio_server.chat.stream_session.asyncio.sleep",
             new=AsyncMock(side_effect=_stop_mid_backoff),
         ),
     ):
@@ -424,7 +425,7 @@ async def test_stop_requested_during_retry_settles_user_stopped():
     decoded = _decoded(emitted)
     # It DID enter the retry branch (one retry emitted) before the stop landed,
     # then settled USER_STOPPED without surfacing the transient error.
-    assert decoded.count('"type": "auto-mode-retry"') == 1
+    assert decoded.count('"type": "kiln-chat-retry"') == 1
     assert "rate limited" not in decoded
     assert runner.status == AutoRunStatus.USER_STOPPED
     assert len(client.bodies) == 2

--- a/app/desktop/studio_server/chat/constants.py
+++ b/app/desktop/studio_server/chat/constants.py
@@ -15,6 +15,10 @@ SSE_TYPE_AUTO_MODE_CONSENT_REQUIRED = "auto-mode-consent-required"
 # Revision R1: a burst settled but the conversation auto-mode flag stays on. This
 # is distinct from auto-mode-off (which is published only on explicit disable).
 SSE_TYPE_AUTO_MODE_IDLE = "auto-mode-idle"
+# Emitted by the auto runner between retry attempts after a transient upstream
+# failure, so the UI can show "retrying N/M…" instead of a hard error. Carries
+# {attempt, max_attempts, status_code?}.
+SSE_TYPE_AUTO_MODE_RETRY = "auto-mode-retry"
 # Phase 9: an on-subscribe snapshot of the run's CURRENT liveness so a
 # re-attaching client immediately reflects working-vs-idle (instead of looking
 # idle until the next event happens to arrive). Carries {flag_on, working}.

--- a/app/desktop/studio_server/chat/constants.py
+++ b/app/desktop/studio_server/chat/constants.py
@@ -15,10 +15,11 @@ SSE_TYPE_AUTO_MODE_CONSENT_REQUIRED = "auto-mode-consent-required"
 # Revision R1: a burst settled but the conversation auto-mode flag stays on. This
 # is distinct from auto-mode-off (which is published only on explicit disable).
 SSE_TYPE_AUTO_MODE_IDLE = "auto-mode-idle"
-# Emitted by the auto runner between retry attempts after a transient upstream
-# failure, so the UI can show "retrying N/M…" instead of a hard error. Carries
-# {attempt, max_attempts, status_code?}.
-SSE_TYPE_AUTO_MODE_RETRY = "auto-mode-retry"
+# Emitted between retry attempts after a transient upstream failure (by BOTH the
+# interactive chat stream and the auto runner — they share the retry helper), so
+# the UI can show "retrying N/M…" instead of a hard error. Carries
+# {attempt, max_attempts, status_code?, run_id?}.
+SSE_TYPE_CHAT_RETRY = "kiln-chat-retry"
 # Phase 9: an on-subscribe snapshot of the run's CURRENT liveness so a
 # re-attaching client immediately reflects working-vs-idle (instead of looking
 # idle until the next event happens to arrive). Carries {flag_on, working}.

--- a/app/desktop/studio_server/chat/stream_session.py
+++ b/app/desktop/studio_server/chat/stream_session.py
@@ -1,8 +1,10 @@
+import asyncio
 import json
 import logging
+import random
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Callable, Literal
 
 import httpx
 from app.desktop.studio_server.chat.constants import (
@@ -11,6 +13,7 @@ from app.desktop.studio_server.chat.constants import (
     FUNCTION_NAME_TO_TOOL_ID,
     MAX_TOOL_ROUNDS,
     SSE_TYPE_AUTO_MODE_CONSENT_REQUIRED,
+    SSE_TYPE_CHAT_RETRY,
     SSE_TYPE_TOOL_CALLS_PENDING,
     SSE_TYPE_TOOL_EXEC_END,
     SSE_TYPE_TOOL_EXEC_START,
@@ -157,6 +160,44 @@ def _format_consent_required_sse(
 # 401, 403, 404, 422) are deliberately excluded — they won't self-heal.
 RETRYABLE_UPSTREAM_STATUS: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 
+# A transient upstream failure is retried with bounded full-jitter exponential
+# backoff rather than surfaced immediately, on BOTH the interactive chat stream
+# and the unattended auto runner (they share ``iter_round_with_retries``). Bounded
+# so a persistent outage still settles instead of hanging forever.
+MAX_CHAT_RETRIES = 10
+_RETRY_BASE_SECONDS = 1.0
+_RETRY_MAX_SECONDS = 30.0
+
+
+def _retry_backoff_seconds(attempt: int) -> float:
+    """Full-jitter exponential backoff. ``attempt`` is 1-based; the delay is a
+    random value in [0, min(cap, base * 2**(attempt-1))] to spread retries and
+    avoid thundering-herd alignment across concurrent streams."""
+    ceiling = min(_RETRY_MAX_SECONDS, _RETRY_BASE_SECONDS * (2 ** (attempt - 1)))
+    return random.uniform(0, ceiling)
+
+
+def format_chat_retry(
+    *,
+    attempt: int,
+    max_attempts: int,
+    status_code: int | None = None,
+    run_id: str | None = None,
+) -> bytes:
+    """SSE event emitted between retry attempts so the UI can show "retrying
+    N/M…". ``status_code`` is the upstream HTTP status (omitted for a
+    connection-level failure); ``run_id`` is present only on the auto stream."""
+    payload: dict[str, Any] = {
+        "type": SSE_TYPE_CHAT_RETRY,
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+    }
+    if status_code is not None:
+        payload["status_code"] = status_code
+    if run_id is not None:
+        payload["run_id"] = run_id
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n".encode()
+
 
 async def iter_upstream_round(
     client: httpx.AsyncClient,
@@ -276,6 +317,113 @@ async def iter_upstream_round(
                 )
 
 
+@dataclass
+class RetryRoundResult:
+    """Outcome of ``iter_round_with_retries``, reported back to the caller after
+    the generator is exhausted (an async generator can't return a value):
+
+    - ``status == "ok"``: ``round_state`` is the successful attempt's state —
+      the caller continues its round loop.
+    - ``status == "stopped"``: a Stop was requested mid-retry (auto runner only)
+      — the caller settles ``USER_STOPPED``.
+    - ``status == "error"``: a non-retryable or retry-exhausted failure; the
+      error was already yielded — the caller ends the stream.
+    """
+
+    status: Literal["ok", "stopped", "error"] = "error"
+    round_state: RoundState | None = None
+
+
+async def iter_round_with_retries(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    trace_id_for_error: str | None,
+    result: RetryRoundResult,
+    *,
+    run_id: str | None = None,
+    stop_requested: Callable[[], bool] | None = None,
+) -> AsyncIterator[bytes]:
+    """Stream one upstream round, retrying transient failures with backoff.
+
+    Shared by the interactive ``ChatStreamSession.stream()`` and the unattended
+    ``AutoChatRunner`` so both get identical retry behavior. Yields forward bytes
+    as they stream, plus a ``kiln-chat-retry`` event between attempts and, on
+    give-up, the held-back error. The terminal outcome is reported via ``result``.
+
+    Only failures that streamed NO content this attempt are retried (a non-200
+    caught before any bytes, or a pre-response connection error), so a retry can
+    never duplicate already-emitted output. ``defer_terminal_error`` holds the
+    error back until we either retry past it or give up.
+
+    ``stop_requested`` (auto runner only) is polled each round so a Stop pressed
+    mid-retry abandons the loop with ``status == "stopped"``.
+    """
+    attempt = 0
+    while True:
+        round_state = RoundState(trace_id_for_error=trace_id_for_error)
+        result.round_state = round_state
+        emitted_any = False
+        transport_error = False
+        try:
+            async for payload in iter_upstream_round(
+                client, url, headers, body, round_state, defer_terminal_error=True
+            ):
+                emitted_any = True
+                yield payload
+        except httpx.HTTPError:
+            # Pre-response connection/timeout failure (RemoteProtocolError is
+            # handled inside iter_upstream_round). A ReadTimeout after the POST
+            # may re-trigger a duplicate upstream generation, but no tools run
+            # until bytes stream, so the accepted blast radius is a wasted
+            # generation, never duplicated side effects.
+            transport_error = True
+
+        if not transport_error and not round_state.is_terminal_upstream_error:
+            result.status = "ok"
+            return
+
+        streamed_content = (
+            emitted_any
+            or round_state.trace_id is not None
+            or bool(round_state.assistant_text)
+            or bool(round_state.tool_input_events)
+        )
+        retryable = not streamed_content and (
+            transport_error or round_state.error_retryable
+        )
+        stop = stop_requested() if stop_requested is not None else False
+        if retryable and attempt < MAX_CHAT_RETRIES and not stop:
+            attempt += 1
+            yield format_chat_retry(
+                attempt=attempt,
+                max_attempts=MAX_CHAT_RETRIES,
+                status_code=round_state.error_status_code,
+                run_id=run_id,
+            )
+            await asyncio.sleep(_retry_backoff_seconds(attempt))
+            continue
+
+        # Stop takes precedence over surfacing the error (auto runner only).
+        if stop:
+            result.status = "stopped"
+            return
+        # Give up: surface the held-back error (the suppressed-duplicate terminal
+        # case has nothing deferred and yields nothing) and end the stream.
+        if round_state.deferred_error_payload is not None:
+            yield round_state.deferred_error_payload
+        elif transport_error:
+            error_payload = {
+                "type": "error",
+                "message": "Something went wrong.",
+                "trace_id": round_state.trace_id_for_error or str(uuid.uuid4()),
+            }
+            yield f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n".encode()
+        result.status = "error"
+        return
+
+
 async def execute_tool_batch(
     tool_calls: list[ToolCallInfo],
     decisions: dict[str, bool],
@@ -311,25 +459,28 @@ class ChatStreamSession:
         trace_id_for_error: str | None = self._initial_trace_id
         async with httpx.AsyncClient(timeout=CHAT_TIMEOUT) as client:
             for _ in range(MAX_TOOL_ROUNDS):
-                round_state = RoundState(trace_id_for_error=trace_id_for_error)
-
-                async for forward_bytes in iter_upstream_round(
+                # Retry transient upstream failures (rate limit / 5xx / connection)
+                # with backoff, emitting kiln-chat-retry events the UI renders as
+                # "retrying N/M…", instead of surfacing the error immediately.
+                result = RetryRoundResult()
+                async for forward_bytes in iter_round_with_retries(
                     client,
                     self._upstream_url,
                     self._headers,
                     self._body,
-                    round_state,
+                    trace_id_for_error,
+                    result,
                 ):
                     yield forward_bytes
 
-                trace_id_for_error = round_state.trace_id_for_error
+                round_state = result.round_state
+                if round_state is not None:
+                    trace_id_for_error = round_state.trace_id_for_error
 
-                # A terminal upstream error (iter_upstream_round already emitted
-                # the error SSE, or a forwarded upstream error followed by a
-                # connection close with no finish boundary) means there's nothing
-                # more to drive — end the stream, matching the pre-refactor
-                # `return`s.
-                if round_state.is_terminal_upstream_error:
+                # A non-retryable or retry-exhausted upstream error: the error SSE
+                # was already yielded — nothing more to drive, end the stream.
+                # ("stopped" is auto-runner-only and never occurs here.)
+                if result.status != "ok" or round_state is None:
                     return
 
                 if round_state.trace_id:

--- a/app/desktop/studio_server/chat/stream_session.py
+++ b/app/desktop/studio_server/chat/stream_session.py
@@ -376,6 +376,14 @@ async def iter_round_with_retries(
     """
     attempt = 0
     while True:
+        # A Stop requested during the backoff sleep must abandon the retry before
+        # re-POSTing — otherwise one more upstream round would stream after the
+        # user stopped. (attempt > 0 ⇒ this is a retry continuation, not the
+        # first round; the no-stop interactive path passes stop_requested=None.)
+        if attempt > 0 and stop_requested is not None and stop_requested():
+            result.status = "stopped"
+            return
+
         round_state = RoundState(trace_id_for_error=trace_id_for_error)
         result.round_state = round_state
         emitted_any = False

--- a/app/desktop/studio_server/chat/stream_session.py
+++ b/app/desktop/studio_server/chat/stream_session.py
@@ -61,11 +61,21 @@ class RoundState:
     trace_id: str | None = None
     trace_id_for_error: str | None = None
     seen_upstream_error: bool = False
-    # Set when iter_upstream_round itself yielded a terminal `error` SSE payload
-    # (non-200 response, or a RemoteProtocolError with no finish boundary). The
-    # caller uses this to stop the loop — distinct from a forwarded upstream
-    # `error` event, which is non-terminal and leaves the loop free to continue.
+    # Set when iter_upstream_round hit a terminal `error` (non-200 response, or a
+    # RemoteProtocolError with no finish boundary). The caller uses this to stop
+    # the loop — distinct from a forwarded upstream `error` event, which is
+    # non-terminal and leaves the loop free to continue. The payload is normally
+    # yielded inline; in ``defer_terminal_error`` mode it is held on
+    # ``deferred_error_payload`` instead so the caller can decide whether to retry.
     emitted_terminal_error: bool = False
+    # Populated only in ``defer_terminal_error`` mode (the auto runner): the error
+    # SSE bytes that would have been yielded, plus the classification the runner
+    # needs to decide on a retry. ``error_status_code`` is the upstream HTTP status
+    # (None for a connection-level failure); ``error_retryable`` is True for a
+    # transient non-200 (429/5xx) that streamed no content and is safe to re-POST.
+    deferred_error_payload: bytes | None = None
+    error_status_code: int | None = None
+    error_retryable: bool = False
 
     @property
     def is_terminal_upstream_error(self) -> bool:
@@ -142,12 +152,19 @@ def _format_consent_required_sse(
     return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n".encode()
 
 
+# Transient upstream HTTP statuses worth retrying in auto mode (the request never
+# produced a streamed response, so re-POSTing is safe). 4xx client errors (400,
+# 401, 403, 404, 422) are deliberately excluded — they won't self-heal.
+RETRYABLE_UPSTREAM_STATUS: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+
 async def iter_upstream_round(
     client: httpx.AsyncClient,
     url: str,
     headers: dict[str, str],
     body: dict[str, Any],
     round_state: RoundState,
+    defer_terminal_error: bool = False,
 ) -> AsyncIterator[bytes]:
     """POST one upstream round; yield forward-bytes as they stream; mutate
     ``round_state`` in place.
@@ -193,7 +210,21 @@ async def iter_upstream_round(
             if round_state.trace_id_for_error:
                 error_payload["trace_id"] = round_state.trace_id_for_error
             round_state.emitted_terminal_error = True
-            yield f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n".encode()
+            error_bytes = (
+                f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n".encode()
+            )
+            if defer_terminal_error:
+                # Don't surface the error yet — hand it to the caller (the auto
+                # runner) with the status so it can retry transient failures and
+                # only emit on give-up. No content streamed at this point, so a
+                # retryable status is safe to re-POST.
+                round_state.deferred_error_payload = error_bytes
+                round_state.error_status_code = upstream.status_code
+                round_state.error_retryable = (
+                    upstream.status_code in RETRYABLE_UPSTREAM_STATUS
+                )
+                return
+            yield error_bytes
             return
 
         try:
@@ -231,7 +262,14 @@ async def iter_upstream_round(
                     "trace_id": trace_id,
                 }
                 round_state.emitted_terminal_error = True
-                yield f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n".encode()
+                error_bytes = f"data: {json.dumps(error_payload, ensure_ascii=False)}\n\n".encode()
+                if defer_terminal_error:
+                    # Hold for the caller. error_retryable stays False: the stream
+                    # already dropped mid-round (possibly after partial content),
+                    # so re-POSTing is not safe to do blindly.
+                    round_state.deferred_error_payload = error_bytes
+                else:
+                    yield error_bytes
                 logger.exception(
                     "RemoteProtocolError during streaming (trace_id=%s)",
                     trace_id,

--- a/app/desktop/studio_server/chat/stream_session.py
+++ b/app/desktop/studio_server/chat/stream_session.py
@@ -160,21 +160,35 @@ def _format_consent_required_sse(
 # 401, 403, 404, 422) are deliberately excluded — they won't self-heal.
 RETRYABLE_UPSTREAM_STATUS: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 
-# A transient upstream failure is retried with bounded full-jitter exponential
-# backoff rather than surfaced immediately, on BOTH the interactive chat stream
-# and the unattended auto runner (they share ``iter_round_with_retries``). Bounded
-# so a persistent outage still settles instead of hanging forever.
-MAX_CHAT_RETRIES = 10
-_RETRY_BASE_SECONDS = 1.0
-_RETRY_MAX_SECONDS = 30.0
+# A transient upstream failure is retried with backoff rather than surfaced
+# immediately, on BOTH the interactive chat stream and the unattended auto runner
+# (they share ``iter_round_with_retries``). The schedule ramps up and caps at 60s
+# so the run rides out a real remote/network blip (~5 min total) instead of
+# burning all attempts in seconds, but still settles instead of hanging forever.
+# Per-attempt seconds, 1-based: attempt N uses index N-1, clamped to the last.
+_RETRY_BACKOFF_SCHEDULE: tuple[float, ...] = (
+    1.0,
+    2.0,
+    5.0,
+    10.0,
+    20.0,
+    30.0,
+    60.0,
+    60.0,
+    60.0,
+    60.0,
+)
+MAX_CHAT_RETRIES = len(_RETRY_BACKOFF_SCHEDULE)
+# ±15% jitter so retries don't align across concurrent streams.
+_RETRY_JITTER = 0.15
 
 
 def _retry_backoff_seconds(attempt: int) -> float:
-    """Full-jitter exponential backoff. ``attempt`` is 1-based; the delay is a
-    random value in [0, min(cap, base * 2**(attempt-1))] to spread retries and
-    avoid thundering-herd alignment across concurrent streams."""
-    ceiling = min(_RETRY_MAX_SECONDS, _RETRY_BASE_SECONDS * (2 ** (attempt - 1)))
-    return random.uniform(0, ceiling)
+    """Backoff before retry ``attempt`` (1-based), from the fixed schedule with
+    light jitter. Attempts past the schedule clamp to its last (capped) entry."""
+    idx = min(attempt, len(_RETRY_BACKOFF_SCHEDULE)) - 1
+    base = _RETRY_BACKOFF_SCHEDULE[max(idx, 0)]
+    return base * random.uniform(1.0 - _RETRY_JITTER, 1.0 + _RETRY_JITTER)
 
 
 def format_chat_retry(

--- a/app/desktop/studio_server/chat/test_routes.py
+++ b/app/desktop/studio_server/chat/test_routes.py
@@ -74,7 +74,10 @@ class TestChatStreaming:
         assert response.status_code == 401
 
     def test_handles_upstream_error(self, client, mock_api_key):
-        mock_class, _, _ = make_httpx_mock(status_code=500)
+        # 404 (non-retryable) surfaces immediately as an SSE error. Retryable
+        # statuses (5xx/429) go through the retry loop instead (covered in
+        # test_stream_session.py), so they'd block on backoff here.
+        mock_class, _, _ = make_httpx_mock(status_code=404)
 
         with patch(PATCH_ASYNC_CLIENT, mock_class):
             response = client.post(

--- a/app/desktop/studio_server/chat/test_stream_session.py
+++ b/app/desktop/studio_server/chat/test_stream_session.py
@@ -24,6 +24,8 @@ from app.desktop.studio_server.chat.stream_session import (
     ChatStreamSession,
     ToolCallInfo,
     _format_tool_calls_pending_sse,
+    _RETRY_BACKOFF_SCHEDULE,
+    _retry_backoff_seconds,
     execute_tool_batch,
 )
 from kiln_ai.adapters.model_adapters.stream_events import ToolInputAvailableEvent
@@ -245,6 +247,21 @@ async def test_stream_retries_exhausted_then_surfaces_error():
     assert raw.count('"type": "kiln-chat-retry"') == MAX_CHAT_RETRIES
     assert "boom" in raw  # the held-back error is surfaced on give-up
     assert len(client.bodies) == MAX_CHAT_RETRIES + 1
+
+
+def test_retry_backoff_schedule_ramps_and_caps():
+    # Each attempt's delay sits within the ±15% jitter band of its scheduled base.
+    for attempt, base in enumerate(_RETRY_BACKOFF_SCHEDULE, start=1):
+        delay = _retry_backoff_seconds(attempt)
+        assert base * 0.85 <= delay <= base * 1.15
+    # Early retries are a second or two; the tail caps at ~60s (so the full run
+    # rides out a real outage over minutes, not seconds).
+    assert _retry_backoff_seconds(1) < 2
+    assert 50 <= _retry_backoff_seconds(MAX_CHAT_RETRIES) <= 70
+    # Attempts beyond the schedule clamp to the last (capped) entry.
+    assert 50 <= _retry_backoff_seconds(MAX_CHAT_RETRIES + 5) <= 70
+    # The schedule is monotonically non-decreasing (ignoring jitter).
+    assert list(_RETRY_BACKOFF_SCHEDULE) == sorted(_RETRY_BACKOFF_SCHEDULE)
 
 
 class TestBuildOpenAIToolContinuation:

--- a/app/desktop/studio_server/chat/test_stream_session.py
+++ b/app/desktop/studio_server/chat/test_stream_session.py
@@ -11,8 +11,16 @@ from app.desktop.studio_server.chat import execute_tool
 from app.desktop.studio_server.chat.stream_session import (
     _build_openai_tool_continuation,
 )
+from app.desktop.studio_server.chat.auto.test_fakes import (
+    FakeUpstreamClient,
+    FakeUpstreamResponse,
+    finish,
+    text_delta,
+    trace,
+)
 from app.desktop.studio_server.chat.constants import SSE_TYPE_TOOL_CALLS_PENDING
 from app.desktop.studio_server.chat.stream_session import (
+    MAX_CHAT_RETRIES,
     ChatStreamSession,
     ToolCallInfo,
     _format_tool_calls_pending_sse,
@@ -162,7 +170,9 @@ async def test_stream_error_includes_code_field():
 @pytest.mark.asyncio
 async def test_stream_error_without_code_omits_code_field():
     error_body = json.dumps({"message": "Something failed"}).encode()
-    fake_resp = _FakeResponse(500, error_body)
+    # 404 (non-retryable): surfaces immediately so this stays a pure error-shape
+    # test. Retryable statuses (5xx/429) are covered by the retry tests below.
+    fake_resp = _FakeResponse(404, error_body)
     fake_client = _FakeClient(fake_resp)
 
     session = _make_session()
@@ -177,6 +187,64 @@ async def test_stream_error_without_code_omits_code_field():
     assert payload["type"] == "error"
     assert payload["message"] == "Something failed"
     assert "code" not in payload
+
+
+@pytest.mark.asyncio
+async def test_stream_retries_transient_error_then_succeeds():
+    # The interactive path (not just auto mode) retries a transient upstream
+    # failure with backoff, emitting kiln-chat-retry events the UI renders, and
+    # recovers without ever surfacing the transient error.
+    ok_round = [text_delta("hi there"), trace("tr-1"), finish("stop")]
+    client = FakeUpstreamClient(
+        [
+            FakeUpstreamResponse(status_code=503, body=b'{"message": "busy"}'),
+            FakeUpstreamResponse(status_code=503, body=b'{"message": "busy"}'),
+            FakeUpstreamResponse(chunks=ok_round),
+        ]
+    )
+    session = _make_session()
+
+    with (
+        patch.object(httpx, "AsyncClient", return_value=client),
+        patch(
+            "app.desktop.studio_server.chat.stream_session.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sleep_mock,
+    ):
+        raw = "".join([c.decode() async for c in session.stream()])
+
+    assert raw.count('"type": "kiln-chat-retry"') == 2
+    assert '"status_code": 503' in raw
+    assert "hi there" in raw  # recovered round streamed through
+    assert "busy" not in raw  # the transient error was never surfaced
+    assert sleep_mock.await_count == 2
+    assert len(client.bodies) == 3
+
+
+@pytest.mark.asyncio
+async def test_stream_retries_exhausted_then_surfaces_error():
+    # A persistent retryable failure exhausts the bounded retries, then the error
+    # is surfaced (so the stream still terminates instead of hanging forever).
+    client = FakeUpstreamClient(
+        [
+            FakeUpstreamResponse(status_code=500, body=b'{"message": "boom"}')
+            for _ in range(MAX_CHAT_RETRIES + 1)
+        ]
+    )
+    session = _make_session()
+
+    with (
+        patch.object(httpx, "AsyncClient", return_value=client),
+        patch(
+            "app.desktop.studio_server.chat.stream_session.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
+    ):
+        raw = "".join([c.decode() async for c in session.stream()])
+
+    assert raw.count('"type": "kiln-chat-retry"') == MAX_CHAT_RETRIES
+    assert "boom" in raw  # the held-back error is surfaced on give-up
+    assert len(client.bodies) == MAX_CHAT_RETRIES + 1
 
 
 class TestBuildOpenAIToolContinuation:

--- a/app/web_ui/src/lib/chat/auto_run_store.test.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.test.ts
@@ -486,7 +486,7 @@ describe("auto_run_store", () => {
     expect(calls.working).toEqual([true, true, false])
   })
 
-  it("auto-mode-retry surfaces retrying progress and clears on the next event", async () => {
+  it("kiln-chat-retry surfaces retrying progress and clears on the next event", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ run_id: "ar_retry" }),
@@ -497,7 +497,7 @@ describe("auto_run_store", () => {
     source.message({ type: "auto-mode-on", run_id: "ar_retry" })
 
     source.message({
-      type: "auto-mode-retry",
+      type: "kiln-chat-retry",
       run_id: "ar_retry",
       attempt: 3,
       max_attempts: 10,
@@ -510,7 +510,7 @@ describe("auto_run_store", () => {
 
     // A second retry updates the counter.
     source.message({
-      type: "auto-mode-retry",
+      type: "kiln-chat-retry",
       run_id: "ar_retry",
       attempt: 4,
       max_attempts: 10,

--- a/app/web_ui/src/lib/chat/auto_run_store.test.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.test.ts
@@ -486,6 +486,46 @@ describe("auto_run_store", () => {
     expect(calls.working).toEqual([true, true, false])
   })
 
+  it("auto-mode-retry surfaces retrying progress and clears on the next event", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ run_id: "ar_retry" }),
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    await store.requestEnable({ trace_id: "t" })
+    const source = FakeEventSource.latest()
+    source.message({ type: "auto-mode-on", run_id: "ar_retry" })
+
+    source.message({
+      type: "auto-mode-retry",
+      run_id: "ar_retry",
+      attempt: 3,
+      max_attempts: 10,
+      status_code: 503,
+    })
+    // Retry affordance is set; the burst still reads as working, stream open.
+    expect(get(store.retry)).toEqual({ attempt: 3, max: 10 })
+    expect(get(store.working)).toBe(true)
+    expect(source.closed).toBe(false)
+
+    // A second retry updates the counter.
+    source.message({
+      type: "auto-mode-retry",
+      run_id: "ar_retry",
+      attempt: 4,
+      max_attempts: 10,
+    })
+    expect(get(store.retry)).toEqual({ attempt: 4, max: 10 })
+
+    // The next non-retry event (here the burst settling idle) clears it.
+    source.message({
+      type: "auto-mode-idle",
+      run_id: "ar_retry",
+      reason: "asked_user",
+    })
+    expect(get(store.retry)).toBe(null)
+  })
+
   it("only auto-mode-off clears the indicator after an idle burst", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/app/web_ui/src/lib/chat/auto_run_store.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.ts
@@ -174,7 +174,7 @@ export function createAutoRunStore(): AutoRunStore {
   const runId = writable<string | null>(null)
   const offReason = writable<string | null>(null)
   const connection = writable<AutoConnection>("idle")
-  // Transient "retrying N/M…" affordance: set on each auto-mode-retry event,
+  // Transient "retrying N/M…" affordance: set on each kiln-chat-retry event,
   // cleared by the next event of any other kind (the recovered round's first
   // event, or an idle/off marker). Null when no retry is in flight.
   const retry = writable<{ attempt: number; max: number } | null>(null)
@@ -285,7 +285,7 @@ export function createAutoRunStore(): AutoRunStore {
       offReason.set(null)
       return true
     }
-    if (event.type === "auto-mode-retry") {
+    if (event.type === "kiln-chat-retry") {
       // A transient upstream failure is being retried with backoff. The burst is
       // still working — keep the indicator on and surface "retrying N/M…" so the
       // user sees progress rather than a hard error. Cleared by the next event.
@@ -380,7 +380,7 @@ export function createAutoRunStore(): AutoRunStore {
       }
       // Any event other than another retry means the retry window is over (the
       // round recovered, or the burst settled idle/off) — clear the affordance.
-      if (event.type !== "auto-mode-retry") retry.set(null)
+      if (event.type !== "kiln-chat-retry") retry.set(null)
       if (handleControlEvent(event)) return
       processor.handleEvent(event)
     }

--- a/app/web_ui/src/lib/chat/auto_run_store.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.ts
@@ -105,6 +105,12 @@ export interface AutoRunStore {
    * normal (non-reattach) enable flow.
    */
   reconnecting: Readable<boolean>
+  /**
+   * Transient retry affordance: ``{ attempt, max }`` while a transient upstream
+   * failure is being retried with backoff, else ``null``. Lets the transcript
+   * show "retrying N/M…" instead of stalling silently or erroring.
+   */
+  retry: Readable<{ attempt: number; max: number } | null>
   runId: Readable<string | null>
   offReason: Readable<string | null>
   connection: Readable<AutoConnection>
@@ -168,6 +174,10 @@ export function createAutoRunStore(): AutoRunStore {
   const runId = writable<string | null>(null)
   const offReason = writable<string | null>(null)
   const connection = writable<AutoConnection>("idle")
+  // Transient "retrying N/M…" affordance: set on each auto-mode-retry event,
+  // cleared by the next event of any other kind (the recovered round's first
+  // event, or an idle/off marker). Null when no retry is in flight.
+  const retry = writable<{ attempt: number; max: number } | null>(null)
 
   function setWorking(next: boolean): void {
     working.set(next)
@@ -208,6 +218,7 @@ export function createAutoRunStore(): AutoRunStore {
     armed.set(false)
     setWorking(false)
     reconnecting.set(false)
+    retry.set(null)
     runId.set(null)
     offReason.set(reason)
     connection.set("closed")
@@ -233,6 +244,7 @@ export function createAutoRunStore(): AutoRunStore {
     armed.set(false)
     setWorking(false)
     reconnecting.set(false)
+    retry.set(null)
     runId.set(null)
     offReason.set(null)
     connection.set("idle")
@@ -271,6 +283,17 @@ export function createAutoRunStore(): AutoRunStore {
       reconnecting.set(false)
       if (event.run_id) runId.set(event.run_id)
       offReason.set(null)
+      return true
+    }
+    if (event.type === "auto-mode-retry") {
+      // A transient upstream failure is being retried with backoff. The burst is
+      // still working — keep the indicator on and surface "retrying N/M…" so the
+      // user sees progress rather than a hard error. Cleared by the next event.
+      setWorking(true)
+      retry.set({
+        attempt: event.attempt ?? 0,
+        max: event.max_attempts ?? 0,
+      })
       return true
     }
     if (event.type === "auto-mode-idle") {
@@ -355,6 +378,9 @@ export function createAutoRunStore(): AutoRunStore {
       } catch {
         return
       }
+      // Any event other than another retry means the retry window is over (the
+      // round recovered, or the burst settled idle/off) — clear the affordance.
+      if (event.type !== "auto-mode-retry") retry.set(null)
       if (handleControlEvent(event)) return
       processor.handleEvent(event)
     }
@@ -551,6 +577,7 @@ export function createAutoRunStore(): AutoRunStore {
     armed: { subscribe: armed.subscribe },
     working: { subscribe: working.subscribe },
     reconnecting: { subscribe: reconnecting.subscribe },
+    retry: { subscribe: retry.subscribe },
     runId: { subscribe: runId.subscribe },
     offReason: { subscribe: offReason.subscribe },
     connection: { subscribe: connection.subscribe },

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -67,6 +67,13 @@ export interface ChatSessionState extends PersistedChatSession {
    */
   autoWorking: boolean
   /**
+   * A transient upstream failure is being retried with backoff during the
+   * interactive stream (``kiln-chat-retry``): ``{ attempt, max }`` while retrying,
+   * else null. Drives the "retrying N/M…" affordance for non-auto chat. (Auto
+   * mode surfaces the same affordance via ``auto_run_store.retry``.) Runtime-only.
+   */
+  retry: { attempt: number; max: number } | null
+  /**
    * Preferred version from a server upgrade nudge (non-blocking), or null when
    * no nudge is active or the user dismissed it. Runtime-only, not persisted.
    */
@@ -158,6 +165,7 @@ export function createChatSessionStore(
     showActivityIndicator: false,
     compacting: false,
     autoWorking: false,
+    retry: null,
     upgradeNudgeVersion: null,
     versionRequired: false,
   })
@@ -494,6 +502,14 @@ export function createChatSessionStore(
           showActivityIndicator: show,
         }))
       },
+      onRetry: (attempt, max) => {
+        if (isStale()) return
+        combined.update((s) => ({ ...s, retry: { attempt, max } }))
+      },
+      onRetryClear: () => {
+        if (isStale()) return
+        combined.update((s) => ({ ...s, retry: null }))
+      },
       onAssistantMessage: (update) => {
         if (isStale()) return
         if (status !== "streaming") {
@@ -553,6 +569,7 @@ export function createChatSessionStore(
           toolExecuting: false,
           showActivityIndicator: false,
           compacting: false,
+          retry: null,
         }))
         setRuntimeState("ready", null)
       },
@@ -563,6 +580,7 @@ export function createChatSessionStore(
           toolExecuting: false,
           showActivityIndicator: false,
           compacting: false,
+          retry: null,
         }))
         const errorMsg: ChatMessage = {
           id: chatGenerateId(),

--- a/app/web_ui/src/lib/chat/streaming_chat.test.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.test.ts
@@ -485,3 +485,68 @@ describe("StreamEventProcessor kiln_compaction_status (Phase 5)", () => {
     expect(states[states.length - 1]).toBe(false)
   })
 })
+
+describe("StreamEventProcessor kiln-chat-retry", () => {
+  function makeProcessor(
+    onRetry: (attempt: number, max: number) => void,
+    onRetryClear: () => void,
+  ) {
+    return new StreamEventProcessor({
+      onAssistantMessage: () => {},
+      onRetry,
+      onRetryClear,
+    })
+  }
+
+  it("fires onRetry with attempt/max on a kiln-chat-retry event", () => {
+    const retries: Array<[number, number]> = []
+    let clears = 0
+    const processor = makeProcessor(
+      (a, m) => retries.push([a, m]),
+      () => {
+        clears += 1
+      },
+    )
+    processor.handleEvent({
+      type: "kiln-chat-retry",
+      attempt: 3,
+      max_attempts: 10,
+      status_code: 503,
+    })
+    expect(retries).toEqual([[3, 10]])
+    expect(clears).toBe(0)
+  })
+
+  it("clears exactly once on the next non-retry event (not per token)", () => {
+    const retries: Array<[number, number]> = []
+    let clears = 0
+    const processor = makeProcessor(
+      (a, m) => retries.push([a, m]),
+      () => {
+        clears += 1
+      },
+    )
+    processor.handleEvent({
+      type: "kiln-chat-retry",
+      attempt: 1,
+      max_attempts: 10,
+    })
+    // The recovered round streams several tokens — clear must fire just once.
+    processor.handleEvent({ type: "text-start" })
+    processor.handleEvent({ type: "text-delta", delta: "a" })
+    processor.handleEvent({ type: "text-delta", delta: "b" })
+    expect(clears).toBe(1)
+  })
+
+  it("does not clear when no retry is active", () => {
+    let clears = 0
+    const processor = makeProcessor(
+      () => {},
+      () => {
+        clears += 1
+      },
+    )
+    processor.handleEvent({ type: "text-delta", delta: "hi" })
+    expect(clears).toBe(0)
+  })
+})

--- a/app/web_ui/src/lib/chat/streaming_chat.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.ts
@@ -137,6 +137,10 @@ export interface StreamEvent {
   /** ``auto-mode-state`` (Phase 9) on-subscribe liveness snapshot */
   flag_on?: boolean
   working?: boolean
+  /** ``auto-mode-retry`` carries the current/limit attempt + the upstream status */
+  attempt?: number
+  max_attempts?: number
+  status_code?: number
   /** Approximate context usage carried on the ``kiln_chat_trace`` snapshot event */
   context_usage?: RawContextUsage
   /** ``kiln_compaction_status`` carries the lifecycle state ("started" / "finished") */

--- a/app/web_ui/src/lib/chat/streaming_chat.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.ts
@@ -213,6 +213,13 @@ export interface StreamChatOptions {
   onToolExecutionEnd?: (toolCount: number) => void
   onShowActivityIndicator?: (show: boolean) => void
   /**
+   * A transient upstream failure is being retried with backoff (kiln-chat-retry).
+   * Drives the interactive "retrying N/M…" affordance; ``onRetryClear`` fires on
+   * the next non-retry event (recovered round, or terminal error).
+   */
+  onRetry?: (attempt: number, maxAttempts: number) => void
+  onRetryClear?: () => void
+  /**
    * After ``auto-mode-consent-required`` the stream ends; the handler decides
    * whether to enable auto mode (accept) or resume interactively (decline).
    * Both outcomes are handled outside this stream, so it simply returns.
@@ -260,6 +267,13 @@ export interface StreamEventProcessorOptions {
   onToolExecutionStart?: (toolCount: number) => void
   onToolExecutionEnd?: (toolCount: number) => void
   onShowActivityIndicator?: (show: boolean) => void
+  /**
+   * A transient upstream failure is being retried with backoff (kiln-chat-retry).
+   * Drives the "retrying N/M…" affordance. ``onRetryClear`` fires on the next
+   * non-retry event (the recovered round, or the terminal error).
+   */
+  onRetry?: (attempt: number, maxAttempts: number) => void
+  onRetryClear?: () => void
 }
 
 export class StreamEventProcessor {
@@ -292,6 +306,11 @@ export class StreamEventProcessor {
   private onToolExecutionStart?: (toolCount: number) => void
   private onToolExecutionEnd?: (toolCount: number) => void
   private onShowActivityIndicator?: (show: boolean) => void
+  private onRetry?: (attempt: number, maxAttempts: number) => void
+  private onRetryClear?: () => void
+  // True while a kiln-chat-retry is the most recent event, so we clear the
+  // affordance exactly once on the next non-retry event (not per streamed token).
+  private retryActive = false
 
   private HANDLERS: Record<string, (event: StreamEvent) => void>
 
@@ -305,6 +324,8 @@ export class StreamEventProcessor {
     this.onToolExecutionStart = opts.onToolExecutionStart
     this.onToolExecutionEnd = opts.onToolExecutionEnd
     this.onShowActivityIndicator = opts.onShowActivityIndicator
+    this.onRetry = opts.onRetry
+    this.onRetryClear = opts.onRetryClear
 
     this.HANDLERS = {
       "text-start": (e) => {
@@ -350,6 +371,10 @@ export class StreamEventProcessor {
         this.clearCompacting()
         this.handleError(e)
       },
+      "kiln-chat-retry": (e) => {
+        this.retryActive = true
+        this.onRetry?.(e.attempt ?? 0, e.max_attempts ?? 0)
+      },
     }
   }
 
@@ -363,6 +388,12 @@ export class StreamEventProcessor {
   }
 
   handleEvent(event: StreamEvent): void {
+    // The retry affordance clears as soon as the round recovers (or fails) — the
+    // next event of any other kind. Guarded so it fires once, not per token.
+    if (this.retryActive && event.type !== "kiln-chat-retry") {
+      this.retryActive = false
+      this.onRetryClear?.()
+    }
     const handler = this.HANDLERS[event.type]
     if (handler) {
       handler(event)
@@ -623,6 +654,8 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
     onToolExecutionStart,
     onToolExecutionEnd,
     onShowActivityIndicator,
+    onRetry,
+    onRetryClear,
     onAutoModeConsentRequired,
     onFinish,
     onError,
@@ -703,6 +736,8 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
     onToolExecutionStart,
     onToolExecutionEnd,
     onShowActivityIndicator,
+    onRetry,
+    onRetryClear,
   })
 
   try {

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -535,7 +535,7 @@
                           ? segment.items.slice(-MAX_VISIBLE_STEPS)
                           : segment.items}
                         <div class="flex items-start gap-3 min-w-0">
-                          {#if groupLoading}
+                          {#if groupLoading && !activeRetry}
                             <img
                               src="/images/chat_icon_animated.svg"
                               alt=""
@@ -645,6 +645,8 @@
                                     message.id === lastMessage?.id}
                                   isLastMessage={message.id === lastMessage?.id}
                                   {showActivityIndicator}
+                                  {compacting}
+                                  retrying={activeRetry}
                                 />
                               {/if}
                             {/if}
@@ -671,11 +673,13 @@
                         {#if !hasVisibleApproval}
                           {#if isActiveMessage && showActivityIndicator}
                             <div class="flex items-start gap-3">
-                              <img
-                                src="/images/chat_icon_animated.svg"
-                                alt=""
-                                class="w-9 h-9 shrink-0 -mt-1.5"
-                              />
+                              {#if !activeRetry}
+                                <img
+                                  src="/images/chat_icon_animated.svg"
+                                  alt=""
+                                  class="w-9 h-9 shrink-0 -mt-1.5"
+                                />
+                              {/if}
                               <div class="flex flex-col">
                                 <ChatStatusSteps
                                   parts={message.parts ?? []}
@@ -683,6 +687,7 @@
                                   isLastMessage={true}
                                   {showActivityIndicator}
                                   {compacting}
+                                  retrying={activeRetry}
                                 />
                               </div>
                             </div>
@@ -693,6 +698,7 @@
                               isLastMessage={message.id === lastMessage?.id}
                               {showActivityIndicator}
                               {compacting}
+                              retrying={activeRetry}
                             />
                           {/if}
                         {/if}
@@ -704,11 +710,13 @@
                        the summarizing copy (instead of a separate row); when
                        compaction finishes it reverts to Thinking. -->
                     <div class="flex items-start gap-3">
-                      <img
-                        src="/images/chat_icon_animated.svg"
-                        alt=""
-                        class="w-9 h-9 shrink-0 -mt-1.5"
-                      />
+                      {#if !activeRetry}
+                        <img
+                          src="/images/chat_icon_animated.svg"
+                          alt=""
+                          class="w-9 h-9 shrink-0 -mt-1.5"
+                        />
+                      {/if}
                       <div class="flex flex-col">
                         <ChatStatusSteps
                           parts={[]}
@@ -716,6 +724,7 @@
                           isLastMessage={true}
                           {showActivityIndicator}
                           {compacting}
+                          retrying={activeRetry}
                         />
                       </div>
                     </div>
@@ -727,25 +736,27 @@
             </div>
           {/if}
         {/each}
-        {#if compacting && lastMessage?.role !== "assistant"}
-          <!-- Fallback compaction indicator for the rare case where there is no
-             active assistant bubble yet to host the in-place indicator above
-             (so the summarizing copy still appears, and never alongside the
-             bubble's Thinking — exactly one shows). When an empty assistant
-             turn exists, the streaming-cursor branch above swaps its own label
-             to the summarizing copy instead. -->
+        {#if (compacting || activeRetry) && lastMessage?.role !== "assistant"}
+          <!-- Fallback compaction/retry indicator for when there is no active
+             assistant bubble yet to host the in-place indicator above (so the
+             summarizing / retrying copy still appears, and never alongside the
+             bubble's Thinking — exactly one shows). When an empty assistant turn
+             exists, the streaming-cursor branch above hosts the indicator. -->
           <div class="flex items-start gap-3" role="status">
-            <img
-              src="/images/chat_icon_animated.svg"
-              alt=""
-              class="w-9 h-9 shrink-0 -mt-1.5"
-            />
+            {#if !activeRetry}
+              <img
+                src="/images/chat_icon_animated.svg"
+                alt=""
+                class="w-9 h-9 shrink-0 -mt-1.5"
+              />
+            {/if}
             <div class="flex flex-col">
               <ChatStatusSteps
                 parts={[]}
                 isLoading={true}
                 isLastMessage={true}
-                compacting={true}
+                {compacting}
+                retrying={activeRetry}
               />
             </div>
           </div>
@@ -761,25 +772,6 @@
           >
             <BrailleSpinner />
             <span>Reconnecting…</span>
-          </div>
-        {/if}
-        {#if activeRetry}
-          <!-- Transient retry affordance (both auto and interactive): a transient
-             upstream failure is being retried with backoff. Show progress so the
-             turn reads as "still working" rather than stalled or errored. Clears
-             on the next event (recovered round, or settled error). -->
-          <div
-            class="flex items-center gap-1.5 text-sm text-base-content/50 py-0.5"
-            role="status"
-          >
-            <BrailleSpinner />
-            <span>
-              {#if activeRetry.max > 0}
-                Temporary issue — retrying {activeRetry.attempt}/{activeRetry.max}…
-              {:else}
-                Temporary issue — retrying…
-              {/if}
-            </span>
           </div>
         {/if}
         <div

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -44,6 +44,9 @@
   // Transient "reconnecting…" window while a re-attach (hard-refresh resync or
   // History restore) resolves → hydrates → attaches the live observer (Phase 9).
   const autoReconnecting = auto_run_store.reconnecting
+  // Transient "retrying N/M…" affordance while the runner retries a transient
+  // upstream failure (rate limit / 5xx / connection blip) with backoff.
+  const autoRetry = auto_run_store.retry
 
   // The footer "Auto mode" toggle is shown whenever auto mode is off (the {:else}
   // branch), and is ALWAYS clickable (Revision R2) — including on a brand-new
@@ -754,6 +757,21 @@
           >
             <BrailleSpinner />
             <span>Reconnecting…</span>
+          </div>
+        {/if}
+        {#if $autoRetry}
+          <!-- Transient retry affordance: the runner hit a transient upstream
+             failure and is retrying with backoff. Show progress so an unattended
+             run reads as "still working" rather than stalled or errored. Clears
+             on the next event (recovered round, or settled idle/off). -->
+          <div
+            class="flex items-center gap-1.5 text-sm text-base-content/50 py-0.5"
+            role="status"
+          >
+            <BrailleSpinner />
+            <span
+              >Connection issue — retrying {$autoRetry.attempt}/{$autoRetry.max}…</span
+            >
           </div>
         {/if}
         <div

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -769,9 +769,13 @@
             role="status"
           >
             <BrailleSpinner />
-            <span
-              >Connection issue — retrying {$autoRetry.attempt}/{$autoRetry.max}…</span
-            >
+            <span>
+              {#if $autoRetry.max > 0}
+                Temporary issue — retrying {$autoRetry.attempt}/{$autoRetry.max}…
+              {:else}
+                Temporary issue — retrying…
+              {/if}
+            </span>
           </div>
         {/if}
         <div

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -44,8 +44,10 @@
   // Transient "reconnecting…" window while a re-attach (hard-refresh resync or
   // History restore) resolves → hydrates → attaches the live observer (Phase 9).
   const autoReconnecting = auto_run_store.reconnecting
-  // Transient "retrying N/M…" affordance while the runner retries a transient
-  // upstream failure (rate limit / 5xx / connection blip) with backoff.
+  // Transient "retrying N/M…" affordance while a transient upstream failure
+  // (rate limit / 5xx / connection blip) is retried with backoff. Auto mode
+  // surfaces it via auto_run_store; interactive chat via the session store. Only
+  // one can be active at a time, so prefer whichever is set.
   const autoRetry = auto_run_store.retry
 
   // The footer "Auto mode" toggle is shown whenever auto mode is off (the {:else}
@@ -112,6 +114,8 @@
   // affordances (thinking dots / animated icon) as interactive streaming, while
   // leaving the input usable for inject-on-send.
   $: autoWorking = $store.autoWorking
+  // Retry affordance from either source (auto burst or interactive stream).
+  $: activeRetry = $autoRetry ?? $store.retry
   $: contextUsage = $store.contextUsage
   $: upgradeNudgeVersion = $store.upgradeNudgeVersion
   $: versionRequired = $store.versionRequired
@@ -759,19 +763,19 @@
             <span>Reconnecting…</span>
           </div>
         {/if}
-        {#if $autoRetry}
-          <!-- Transient retry affordance: the runner hit a transient upstream
-             failure and is retrying with backoff. Show progress so an unattended
-             run reads as "still working" rather than stalled or errored. Clears
-             on the next event (recovered round, or settled idle/off). -->
+        {#if activeRetry}
+          <!-- Transient retry affordance (both auto and interactive): a transient
+             upstream failure is being retried with backoff. Show progress so the
+             turn reads as "still working" rather than stalled or errored. Clears
+             on the next event (recovered round, or settled error). -->
           <div
             class="flex items-center gap-1.5 text-sm text-base-content/50 py-0.5"
             role="status"
           >
             <BrailleSpinner />
             <span>
-              {#if $autoRetry.max > 0}
-                Temporary issue — retrying {$autoRetry.attempt}/{$autoRetry.max}…
+              {#if activeRetry.max > 0}
+                Temporary issue — retrying {activeRetry.attempt}/{activeRetry.max}…
               {:else}
                 Temporary issue — retrying…
               {/if}

--- a/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
+++ b/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
@@ -81,6 +81,7 @@ function baseState(
     showActivityIndicator: false,
     compacting: false,
     autoWorking: false,
+    retry: null,
     upgradeNudgeVersion: null,
     versionRequired: false,
     ...overrides,

--- a/app/web_ui/src/routes/(app)/assistant/chat_status_steps.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat_status_steps.svelte
@@ -14,6 +14,13 @@
   export let compacting: boolean = false
   export let compactingMessage: string =
     "Summarizing earlier messages to free up context… this may take a little while."
+  /**
+   * A transient upstream failure is being retried (kiln-chat-retry):
+   * ``{ attempt, max }`` while retrying, else null. Rendered here (error-styled)
+   * in place of "Thinking"/compacting so exactly one busy indicator shows in the
+   * row — no dangling spinner with no message.
+   */
+  export let retrying: { attempt: number; max: number } | null = null
 
   function isToolPart(p: ChatMessagePart): boolean {
     return typeof p.type === "string" && p.type.startsWith("tool-")
@@ -30,10 +37,25 @@
     isLoading &&
     isLastMessage &&
     !hasActiveTools &&
-    (!hasParts || showActivityIndicator)
+    (!hasParts || showActivityIndicator) &&
+    !retrying
 </script>
 
-{#if compacting}
+{#if retrying}
+  <div
+    class="flex items-center gap-1.5 text-sm text-error py-0.5"
+    role="status"
+  >
+    <BrailleSpinner />
+    <span>
+      {#if retrying.max > 0}
+        Temporary issue — retrying {retrying.attempt}/{retrying.max}…
+      {:else}
+        Temporary issue — retrying…
+      {/if}
+    </span>
+  </div>
+{:else if compacting}
   <div class="flex items-center gap-1.5 text-sm text-base-content/50 py-0.5">
     <BrailleSpinner />
     <span>

--- a/app/web_ui/src/routes/(app)/assistant/chat_status_steps.test.ts
+++ b/app/web_ui/src/routes/(app)/assistant/chat_status_steps.test.ts
@@ -80,3 +80,45 @@ describe("ChatStatusSteps compaction indicator (Phase 5)", () => {
     ).toBeTruthy()
   })
 })
+
+describe("ChatStatusSteps retry indicator", () => {
+  it("renders the retry copy with attempt/max when retrying", () => {
+    const { getByText } = render(ChatStatusSteps, {
+      props: {
+        parts: [],
+        isLoading: true,
+        isLastMessage: true,
+        retrying: { attempt: 3, max: 10 },
+      },
+    })
+    expect(getByText(/Temporary issue — retrying 3\/10/)).toBeTruthy()
+  })
+
+  it("takes precedence over Thinking and compacting", () => {
+    const { queryByText } = render(ChatStatusSteps, {
+      props: {
+        parts: [],
+        isLoading: true,
+        isLastMessage: true,
+        compacting: true,
+        retrying: { attempt: 1, max: 10 },
+      },
+    })
+    expect(queryByText(/^Thinking/)).toBeNull()
+    expect(
+      queryByText(/Summarizing earlier messages to free up context/i),
+    ).toBeNull()
+  })
+
+  it("omits the counter when max is 0 (degraded event)", () => {
+    const { getByText } = render(ChatStatusSteps, {
+      props: {
+        parts: [],
+        isLoading: true,
+        isLastMessage: true,
+        retrying: { attempt: 0, max: 0 },
+      },
+    })
+    expect(getByText(/Temporary issue — retrying…/)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Resilience and UX improvements for the assistant chat, spanning both the unattended auto-mode runner and the normal (interactive) chat stream. Builds on the `auto_mode` flag + reminder already on the base branch (`cb6c34bb8`). Kiln-side only — no `kiln_server` changes required.

~18 files, +935/−73.

## 1. Side-note framing for mid-burst user messages (auto mode)
A message sent while an auto-mode burst is in flight was appended as a raw user turn. The model would reply to it in plain text, and that text-only turn settles the burst `IDLE("asked_user")` — so a quick aside from the user **halted the autonomous run**. Drained mid-burst messages are now wrapped in a `<system-reminder>` telling the model to weave its reply into ongoing work and keep going in the same turn (stop only if explicitly asked, or the task is complete). Applies to both injection sites; the seed and idle-wake messages are unaffected, and the live observer echo still shows the raw message.

## 2. Retry transient upstream errors — in BOTH auto and interactive chat
Previously only the auto-mode runner retried; a normal chat request surfaced the backend's error (e.g. a 500 "contact support with trace_id") immediately with no retry. The retry loop is now a **single shared helper** (`iter_round_with_retries` in `stream_session.py`) used by both `AutoChatRunner` and `ChatStreamSession.stream()`, so both get identical resilience.

- Retryable: `429 / 500 / 502 / 503 / 504`, connection/timeout. Fail-fast: `400 / 401 / 403 / 404 / 422`.
- **Content-streamed safety guard**: only failures that streamed no content are retried, so a retry can never duplicate already-emitted output (covered by a mid-stream-transport-error test).
- **Backoff schedule** ramps and caps at 60s — `1, 2, 5, 10, 20, 30, 60, 60, 60, 60` (±15% jitter), ~5 min total — so a real remote/network blip is ridden out over minutes rather than burning all attempts in seconds. `MAX_CHAT_RETRIES` derives from the schedule length.
- **Stop-aware**: a Stop pressed during a backoff sleep abandons the retry before re-POSTing (no extra round streamed after stop); in the runner it settles `USER_STOPPED`.
- The SSE event is generalized `auto-mode-retry` → `kiln-chat-retry` (no longer auto-specific). The interactive path is otherwise unchanged when no error occurs (`defer_terminal_error` defaults off).

## 3. Retry indicator in the transcript (both modes)
A transient retry now shows **"Temporary issue — retrying N/M…"** (error-styled, `text-error`) rendered inside `ChatStatusSteps` in place of "Thinking", with the big animated chat icon suppressed — so it reads as a single inline status (braille spinner + message), not a floating loader. `StreamEventProcessor` handles `kiln-chat-retry` for interactive (`chat_session_store` exposes a `retry` state); `auto_run_store` continues to drive it for auto mode; `chat.svelte` renders whichever source is active.

## 4. Fix: compaction indicator on follow-up turns
Pre-existing bug — the indicator at the tail of the last assistant message was missing the `compacting` prop, so on a **follow-up** turn it showed "Thinking" instead of "Summarizing…" (it only worked on the very first message, where the no-bubble fallback rendered). Threaded `compacting` (and `retrying`) there and extended the fallback to cover both.

## Earlier review feedback (addressed)
A deep code review and the PR bots surfaced: the original auto-only stop-during-retry contract (→ `USER_STOPPED`), the untested no-duplicate guard, a trace-id-on-error and `None`-safe content tweak, and the stop-before-re-POST window — all fixed in-branch with regression tests.

## Tests
Interactive retry-then-succeed / exhaust-then-error (`test_stream_session.py`); backoff-schedule shape; stop-during-retry; mid-stream-transport-error no-duplicate guard; the renamed event/constant across the auto runner tests; web tests for the `kiln-chat-retry` processor handling and the `ChatStatusSteps` retry rendering. All green: Kiln chat suite + web chat tests + svelte-check (0 errors) + build + OpenAPI schema up to date.

## Known follow-up (not in this PR)
The side-note reminder is carried **in-band** in the persisted user content, so it leaks into the trace (shows on hard-refresh, re-enters model context on later turns). The clean fix is out-of-band delivery (a `kiln_server` change) — deferred pending a decision; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
