### PR TITLE
feat(jobs): publish worker properties, render eval summary in jobs table

### DIFF
--- a/app/desktop/studio_server/jobs/models.py
+++ b/app/desktop/studio_server/jobs/models.py
@@ -88,6 +88,12 @@ class JobRecord(BaseModel):
     # (e.g. RAG's four-phase breakdown). Kept as a dict on the wire so the core
     # stays worker-agnostic; the frontend casts it to the worker's model.
     progress_detail: dict[str, Any] | None = None
+    # Static, worker-published descriptive properties for this job (validated
+    # against the worker's `properties_model`). Derived once from params at
+    # create time; unlike `progress`, it does not change over the run. Kept as a
+    # dict on the wire so the core stays worker-agnostic; the frontend casts it
+    # to the worker's model.
+    properties: dict[str, Any] | None = None
     params: dict[str, Any] = Field(default_factory=dict)
     result: dict[str, Any] | None = None
     error: JobError | None = None
@@ -187,7 +193,22 @@ class JobWorker(Generic[TParams, TResult]):
     # JobContext.report_progress_detail(); stamped on JobRecord.progress_detail.
     # Leave None for workers whose generic count progress is enough.
     progress_model: ClassVar[type[BaseModel] | None] = None
+    # Optional typed model for static, worker-published descriptive properties
+    # returned by describe() and stamped on JobRecord.properties. Leave None for
+    # workers that have nothing descriptive to publish.
+    properties_model: ClassVar[type[BaseModel] | None] = None
     supports_pause: ClassVar[bool] = False
+
+    async def describe(self, params: TParams) -> BaseModel | None:
+        """Return static, worker-specific descriptive properties for the UI.
+
+        MUST be a pure read — no side effects, idempotent, safe to call any time.
+        Derived from params only (the result does not change over the run). The
+        registry calls this once at create time and stamps the serialized result
+        on JobRecord.properties. Returns an instance of the worker's
+        `properties_model`, or None when there is nothing to publish (default).
+        """
+        return None
 
     async def compute_state(self, params: TParams) -> JobDerivedState | None:
         """Read source-of-truth Kiln entities and return the operation's true state.

--- a/app/desktop/studio_server/jobs/registry.py
+++ b/app/desktop/studio_server/jobs/registry.py
@@ -164,12 +164,14 @@ class JobRegistry:
     ) -> JobRecord:
         worker = self.worker_for(type_name)
         validated = self._validate_params(worker, params)
+        properties = await self._describe(worker, validated)
         job_id = self._fresh_job_id()
         job = JobRecord(
             id=job_id,
             type=type_name,
             status=BackgroundJobStatus.PENDING,
             params=validated.model_dump(mode="json"),
+            properties=properties,
             metadata=metadata or {},
             project_id=project_id,
             supports_pause=worker.supports_pause,
@@ -194,6 +196,35 @@ class JobRegistry:
         if isinstance(params, BaseModel):
             params = params.model_dump()
         return worker.params_model.model_validate(params)
+
+    async def _describe(
+        self, worker: JobWorker, params: BaseModel
+    ) -> dict[str, Any] | None:
+        """Compute a worker's static display properties, guarded and serialized.
+
+        describe() is a pure read that may touch on-disk entities (project/task/
+        eval) that could be deleted or transiently unavailable — a failure here
+        must never break job creation, so we fall back to no properties. Also
+        guards the worker's contract: the result must be the model the worker
+        declared, so properties' shape is predictable for the frontend.
+        """
+        try:
+            detail = await worker.describe(params)
+        except Exception:
+            logger.exception("Failed to describe job of type %s", worker.type_name)
+            return None
+        if detail is None:
+            return None
+        expected = worker.properties_model
+        if expected is not None and not isinstance(detail, expected):
+            logger.error(
+                "describe() for job type %s returned %s, expected %s",
+                worker.type_name,
+                type(detail).__name__,
+                expected.__name__,
+            )
+            return None
+        return detail.model_dump(mode="json")
 
     # -- dispatch / supervision ---------------------------------------------
 

--- a/app/desktop/studio_server/jobs/registry.py
+++ b/app/desktop/studio_server/jobs/registry.py
@@ -206,25 +206,34 @@ class JobRegistry:
         eval) that could be deleted or transiently unavailable — a failure here
         must never break job creation, so we fall back to no properties. Also
         guards the worker's contract: the result must be the model the worker
-        declared, so properties' shape is predictable for the frontend.
+        declared (so properties' shape is predictable for the frontend), and the
+        whole path — describe(), the type check, and serialization — is wrapped
+        so a bad payload or a model_dump failure can never break create().
         """
         try:
             detail = await worker.describe(params)
+            if detail is None:
+                return None
+            expected = worker.properties_model
+            if expected is None:
+                logger.error(
+                    "describe() for job type %s returned properties but no "
+                    "properties_model is declared",
+                    worker.type_name,
+                )
+                return None
+            if not isinstance(detail, expected):
+                logger.error(
+                    "describe() for job type %s returned %s, expected %s",
+                    worker.type_name,
+                    type(detail).__name__,
+                    expected.__name__,
+                )
+                return None
+            return detail.model_dump(mode="json")
         except Exception:
             logger.exception("Failed to describe job of type %s", worker.type_name)
             return None
-        if detail is None:
-            return None
-        expected = worker.properties_model
-        if expected is not None and not isinstance(detail, expected):
-            logger.error(
-                "describe() for job type %s returned %s, expected %s",
-                worker.type_name,
-                type(detail).__name__,
-                expected.__name__,
-            )
-            return None
-        return detail.model_dump(mode="json")
 
     # -- dispatch / supervision ---------------------------------------------
 

--- a/app/desktop/studio_server/jobs/test_registry.py
+++ b/app/desktop/studio_server/jobs/test_registry.py
@@ -988,8 +988,13 @@ async def test_create_stamps_typed_properties():
     DescribeWorker.gate = asyncio.Event()
     # Properties are computed at create time, before dispatch.
     job = await reg.create("describe", {})
-    assert job.properties == {"label": "hello"}
-    DescribeWorker.gate.set()
+    try:
+        assert job.properties == {"label": "hello"}
+    finally:
+        # Always release the gated worker, even if the assertion fails, so the
+        # spawned job can finish rather than leaking into teardown.
+        DescribeWorker.gate.set()
+    await wait_for_status(reg, job.id, BackgroundJobStatus.SUCCEEDED)
 
 
 class BadDescribeWorker(JobWorker[_EmptyParams, _EmptyResult]):

--- a/app/desktop/studio_server/jobs/test_registry.py
+++ b/app/desktop/studio_server/jobs/test_registry.py
@@ -1046,3 +1046,32 @@ async def test_create_swallows_describe_failure():
         job.id,
         {BackgroundJobStatus.SUCCEEDED, BackgroundJobStatus.RUNNING},
     )
+
+
+class UndeclaredPropertiesWorker(JobWorker[_EmptyParams, _EmptyResult]):
+    type_name = "undeclared_properties"
+    params_model = _EmptyParams
+    result_model = _EmptyResult
+    # properties_model intentionally left at the default (None).
+
+    async def describe(self, params):
+        return PropertiesModel(label="orphan")
+
+    async def run(self, params, ctx):
+        return _EmptyResult()
+
+
+@pytest.mark.asyncio
+async def test_create_drops_properties_without_declared_model():
+    reg = JobRegistry(max_concurrent=2)
+    reg.register_type(UndeclaredPropertiesWorker)
+    # Returning properties without declaring properties_model is a contract
+    # violation: the payload is dropped (nothing to cast to) and create() still
+    # succeeds rather than serializing an unvalidated shape.
+    job = await reg.create("undeclared_properties", {})
+    assert job.properties is None
+    await wait_for_status(
+        reg,
+        job.id,
+        {BackgroundJobStatus.SUCCEEDED, BackgroundJobStatus.RUNNING},
+    )

--- a/app/desktop/studio_server/jobs/test_registry.py
+++ b/app/desktop/studio_server/jobs/test_registry.py
@@ -957,3 +957,92 @@ async def test_report_progress_detail_rejects_wrong_model():
     # The type guard raises inside run(), routing the job to FAILED.
     await wait_for_status(reg, job.id, BackgroundJobStatus.FAILED)
     assert reg._jobs[job.id].error is not None
+
+
+# -- describe() / properties guard ------------------------------------------
+
+
+class PropertiesModel(BaseModel):
+    label: str
+
+
+class DescribeWorker(JobWorker[_EmptyParams, _EmptyResult]):
+    type_name = "describe"
+    params_model = _EmptyParams
+    result_model = _EmptyResult
+    properties_model = PropertiesModel
+    gate: asyncio.Event
+
+    async def describe(self, params):
+        return PropertiesModel(label="hello")
+
+    async def run(self, params, ctx):
+        await type(self).gate.wait()
+        return _EmptyResult()
+
+
+@pytest.mark.asyncio
+async def test_create_stamps_typed_properties():
+    reg = JobRegistry(max_concurrent=2)
+    reg.register_type(DescribeWorker)
+    DescribeWorker.gate = asyncio.Event()
+    # Properties are computed at create time, before dispatch.
+    job = await reg.create("describe", {})
+    assert job.properties == {"label": "hello"}
+    DescribeWorker.gate.set()
+
+
+class BadDescribeWorker(JobWorker[_EmptyParams, _EmptyResult]):
+    type_name = "bad_describe"
+    params_model = _EmptyParams
+    result_model = _EmptyResult
+    properties_model = PropertiesModel
+
+    async def describe(self, params):
+        # Returns a model that is NOT the declared properties_model.
+        return WrongModel(other="x")
+
+    async def run(self, params, ctx):
+        return _EmptyResult()
+
+
+@pytest.mark.asyncio
+async def test_create_drops_properties_on_wrong_type():
+    reg = JobRegistry(max_concurrent=2)
+    reg.register_type(BadDescribeWorker)
+    # The contract guard logs and drops the bad payload — create still succeeds
+    # (the job is not failed), it just carries no properties.
+    job = await reg.create("bad_describe", {})
+    assert job.properties is None
+    await wait_for_status(
+        reg,
+        job.id,
+        {BackgroundJobStatus.SUCCEEDED, BackgroundJobStatus.RUNNING},
+    )
+
+
+class RaisingDescribeWorker(JobWorker[_EmptyParams, _EmptyResult]):
+    type_name = "raising_describe"
+    params_model = _EmptyParams
+    result_model = _EmptyResult
+    properties_model = PropertiesModel
+
+    async def describe(self, params):
+        raise RuntimeError("boom")
+
+    async def run(self, params, ctx):
+        return _EmptyResult()
+
+
+@pytest.mark.asyncio
+async def test_create_swallows_describe_failure():
+    reg = JobRegistry(max_concurrent=2)
+    reg.register_type(RaisingDescribeWorker)
+    # A describe() that raises must never break job creation.
+    job = await reg.create("raising_describe", {})
+    assert job.properties is None
+    await wait_for_status(
+        reg,
+        job.id,
+        {BackgroundJobStatus.SUCCEEDED, BackgroundJobStatus.RUNNING},
+    )

--- a/app/desktop/studio_server/jobs/workers/eval.py
+++ b/app/desktop/studio_server/jobs/workers/eval.py
@@ -6,7 +6,10 @@ from app.desktop.git_sync.save_context import save_context_for_project
 from kiln_ai.adapters.eval.eval_runner import EvalJob, EvalRunner
 from kiln_ai.datamodel.dataset_filters import dataset_filter_from_id
 from kiln_ai.datamodel.eval import Eval, EvalConfig
-from kiln_ai.datamodel.task import Task
+from kiln_ai.datamodel.prompt_type import generator_label
+from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
+from kiln_ai.datamodel.task import Task, TaskRunConfig
+from kiln_ai.datamodel.tool_id import SKILL_TOOL_ID_PREFIX
 from kiln_ai.utils.async_job_runner import AsyncJobRunnerObserver
 from pydantic import BaseModel
 
@@ -48,6 +51,28 @@ class EvalJobResult(BaseModel):
     error: int
 
 
+class EvalJobProperties(BaseModel):
+    """Static, descriptive info about an eval job, for display in the jobs UI.
+
+    Mirrors the run-config summary and judge info shown elsewhere in the app:
+    which eval, the run config (name, model, prompt, tool/skill counts), and the
+    judge (eval config) algorithm and model. Model/provider fields carry raw ids;
+    the frontend resolves them to display names with its model-name helpers.
+    """
+
+    eval_name: str
+    run_config_name: str
+    run_config_model_name: str
+    run_config_model_provider: str
+    run_config_prompt_name: str
+    run_config_tools_count: int
+    run_config_skills_count: int
+    judge_name: str
+    judge_algorithm: str
+    judge_model_name: str
+    judge_model_provider: str
+
+
 class EvalJobWorker(JobWorker[EvalJobParams, EvalJobResult]):
     """Background worker that runs an eval against a single run config.
 
@@ -60,7 +85,109 @@ class EvalJobWorker(JobWorker[EvalJobParams, EvalJobResult]):
     type_name = "eval"
     params_model = EvalJobParams
     result_model = EvalJobResult
+    properties_model = EvalJobProperties
     supports_pause = True
+
+    async def describe(self, params: EvalJobParams) -> EvalJobProperties:
+        # Loads entities off disk like _compute_state_sync; offload the blocking
+        # IO to a thread so create() stays responsive.
+        return await asyncio.to_thread(self._describe_sync, params)
+
+    def _describe_sync(self, params: EvalJobParams) -> EvalJobProperties:
+        eval_config = eval_config_from_id(
+            params.project_id,
+            params.task_id,
+            params.eval_id,
+            params.eval_config_id,
+        )
+        eval, task = self._eval_and_task(eval_config)
+        run_config = task_run_config_from_id(
+            params.project_id,
+            params.task_id,
+            params.run_config_id,
+        )
+        # Run configs are a union; only the kiln_agent variant carries a model,
+        # prompt, and tools. MCP run configs have none, so leave those fields
+        # blank rather than dropping the whole properties block (eval/judge info
+        # still renders).
+        run_config_properties = run_config.run_config_properties
+        if isinstance(run_config_properties, KilnAgentRunConfigProperties):
+            run_config_model_name = run_config_properties.model_name
+            run_config_model_provider = run_config_properties.model_provider_name
+            prompt_name = self._prompt_display_name(
+                task, run_config, run_config_properties
+            )
+            tool_ids = (
+                run_config_properties.tools_config.tools
+                if run_config_properties.tools_config
+                else []
+            )
+            skills_count = sum(
+                1 for t in tool_ids if t.startswith(SKILL_TOOL_ID_PREFIX)
+            )
+            tools_count = len(tool_ids) - skills_count
+        else:
+            run_config_model_name = ""
+            run_config_model_provider = ""
+            prompt_name = ""
+            tools_count = 0
+            skills_count = 0
+
+        return EvalJobProperties(
+            eval_name=eval.name,
+            run_config_name=run_config.name,
+            run_config_model_name=run_config_model_name,
+            run_config_model_provider=run_config_model_provider,
+            run_config_prompt_name=prompt_name,
+            run_config_tools_count=tools_count,
+            run_config_skills_count=skills_count,
+            judge_name=eval_config.name,
+            judge_algorithm=eval_config.config_type.value,
+            judge_model_name=eval_config.model_name,
+            judge_model_provider=eval_config.model_provider,
+        )
+
+    def _prompt_display_name(
+        self,
+        task: Task,
+        run_config: TaskRunConfig,
+        run_config_properties: KilnAgentRunConfigProperties,
+    ) -> str:
+        """Resolve a prompt id to a human name, mirroring the frontend's
+        prompt_name_from_id: a run config's own frozen prompt carries its name;
+        built-in generators map to a label; custom (id::) and reused frozen
+        (task_run_config::) prompts resolve their name from the task. Falls back
+        to the raw id only when nothing resolves."""
+        # A frozen prompt stored on THIS run config carries its saved name.
+        if run_config.prompt is not None and run_config.prompt.name:
+            return run_config.prompt.name
+
+        prompt_id = run_config_properties.prompt_id
+
+        # Built-in generator (e.g. "few_shot_prompt_builder" -> "Few-Shot").
+        label = generator_label(prompt_id)
+        if label:
+            return label
+
+        if prompt_id.startswith("fine_tune_prompt::"):
+            return "Fine-Tune Prompt"
+
+        # Custom prompt saved under the task: "id::<prompt_id>".
+        if prompt_id.startswith("id::"):
+            target = prompt_id[len("id::") :]
+            for prompt in task.prompts(readonly=True):
+                if prompt.id == target:
+                    return prompt.name
+
+        # Reused frozen prompt referencing another run config's frozen copy:
+        # "task_run_config::<project_id>::<task_id>::<run_config_id>".
+        if prompt_id.startswith("task_run_config::"):
+            target = prompt_id.split("::")[-1]
+            for other in task.run_configs(readonly=True):
+                if other.id == target and other.prompt is not None:
+                    return other.prompt.name
+
+        return prompt_id
 
     async def compute_state(self, params: EvalJobParams) -> JobDerivedState:
         # _compute_state_sync loads entities and enumerates runs/ directories

--- a/app/desktop/studio_server/jobs/workers/test_eval.py
+++ b/app/desktop/studio_server/jobs/workers/test_eval.py
@@ -9,6 +9,7 @@ from app.desktop.studio_server.jobs.models import BackgroundJobStatus
 from app.desktop.studio_server.jobs.registry import JobRegistry
 from app.desktop.studio_server.jobs.workers.eval import (
     EvalJobParams,
+    EvalJobProperties,
     EvalJobResult,
     EvalJobWorker,
 )
@@ -304,6 +305,171 @@ async def test_compute_state_missing_eval_config_raises(
 
     with pytest.raises(Exception):
         await EvalJobWorker().compute_state(bad_params)
+
+
+# -- describe ----------------------------------------------------------------
+
+
+async def test_describe_returns_properties(
+    resolve_project, task, eval_config, run_config, params
+):
+    props = await EvalJobWorker().describe(params)
+
+    assert props == EvalJobProperties(
+        eval_name="Test Eval",
+        run_config_name="Test Run Config",
+        run_config_model_name="gpt-4",
+        run_config_model_provider="openai",
+        # prompt_id "simple_prompt_builder" maps to its generator label.
+        run_config_prompt_name="Basic (Zero Shot)",
+        run_config_tools_count=0,
+        run_config_skills_count=0,
+        judge_name="Test Eval Config",
+        # EvalConfig.config_type defaults to g_eval.
+        judge_algorithm="g_eval",
+        judge_model_name="gpt-4",
+        judge_model_provider="openai",
+    )
+
+
+async def test_describe_counts_tools_skills_and_frozen_prompt(
+    resolve_project, task, eval, eval_config, data_source
+):
+    # A run config with a frozen prompt, one regular tool, and two skills.
+    from kiln_ai.datamodel.prompt import BasePrompt
+    from kiln_ai.datamodel.run_config import ToolsRunConfig
+
+    run_config = TaskRunConfig(
+        id="run_config_tools",
+        name="Tools Run Config",
+        run_config_properties=KilnAgentRunConfigProperties(
+            model_name="gpt-4",
+            model_provider_name=ModelProviderName.openai,
+            prompt_id="task_run_config::p::t::frozen1",
+            structured_output_mode=StructuredOutputMode.json_schema,
+            tools_config=ToolsRunConfig(
+                tools=[
+                    "kiln_tool::add_numbers",
+                    "kiln_tool::skill::abc",
+                    "kiln_tool::skill::def",
+                ],
+            ),
+        ),
+        prompt=BasePrompt(name="Frozen Prompt", prompt="do it"),
+        parent=task,
+    )
+    run_config.save_to_file()
+
+    params = EvalJobParams(
+        project_id="project1",
+        task_id="task1",
+        eval_id="eval1",
+        eval_config_id="eval_config1",
+        run_config_id="run_config_tools",
+    )
+
+    props = await EvalJobWorker().describe(params)
+
+    assert props.run_config_prompt_name == "Frozen Prompt"
+    assert props.run_config_tools_count == 1
+    assert props.run_config_skills_count == 2
+
+
+async def test_describe_resolves_custom_prompt_name(
+    resolve_project, task, eval, eval_config, data_source
+):
+    # A custom prompt saved under the task, referenced by "id::<prompt_id>".
+    from kiln_ai.datamodel.prompt import Prompt
+
+    prompt = Prompt(id="myprompt", name="My Custom Prompt", prompt="do it", parent=task)
+    prompt.save_to_file()
+
+    run_config = TaskRunConfig(
+        id="run_config_custom_prompt",
+        name="Custom Prompt Run Config",
+        run_config_properties=KilnAgentRunConfigProperties(
+            model_name="gpt-4",
+            model_provider_name=ModelProviderName.openai,
+            prompt_id="id::myprompt",
+            structured_output_mode=StructuredOutputMode.json_schema,
+        ),
+        parent=task,
+    )
+    run_config.save_to_file()
+
+    params = EvalJobParams(
+        project_id="project1",
+        task_id="task1",
+        eval_id="eval1",
+        eval_config_id="eval_config1",
+        run_config_id="run_config_custom_prompt",
+    )
+
+    props = await EvalJobWorker().describe(params)
+
+    # Resolved to the saved name, not the raw "id::myprompt".
+    assert props.run_config_prompt_name == "My Custom Prompt"
+
+
+async def test_describe_missing_entity_raises(resolve_project, task, run_config):
+    # Mirrors compute_state: the entity loader raises rather than silently
+    # returning partial info. The registry guard (_describe) swallows this.
+    bad_params = EvalJobParams(
+        project_id="project1",
+        task_id="task1",
+        eval_id="missing_eval",
+        eval_config_id="missing_eval_config",
+        run_config_id="run_config1",
+    )
+
+    with pytest.raises(Exception):
+        await EvalJobWorker().describe(bad_params)
+
+
+async def test_registry_create_populates_properties(
+    resolve_project, task, eval_config, run_config, params
+):
+    registry = JobRegistry()
+    registry.register_type(EvalJobWorker)
+
+    job = await registry.create("eval", params, project_id=params.project_id)
+    await registry._tasks[job.id]
+
+    assert job.properties == {
+        "eval_name": "Test Eval",
+        "run_config_name": "Test Run Config",
+        "run_config_model_name": "gpt-4",
+        "run_config_model_provider": "openai",
+        "run_config_prompt_name": "Basic (Zero Shot)",
+        "run_config_tools_count": 0,
+        "run_config_skills_count": 0,
+        "judge_name": "Test Eval Config",
+        "judge_algorithm": "g_eval",
+        "judge_model_name": "gpt-4",
+        "judge_model_provider": "openai",
+    }
+
+
+async def test_registry_create_guards_describe_failure(
+    resolve_project, task, run_config
+):
+    # describe() raises (eval/eval_config missing): create must still succeed,
+    # leaving properties unset rather than failing the whole job creation.
+    bad_params = EvalJobParams(
+        project_id="project1",
+        task_id="task1",
+        eval_id="missing_eval",
+        eval_config_id="missing_eval_config",
+        run_config_id="run_config1",
+    )
+
+    registry = JobRegistry()
+    registry.register_type(EvalJobWorker)
+
+    job = await registry.create("eval", bad_params, project_id="project1")
+    await registry._tasks[job.id]
+
+    assert job.properties is None
 
 
 # -- run ---------------------------------------------------------------------

--- a/app/desktop/studio_server/jobs/workers/test_eval.py
+++ b/app/desktop/studio_server/jobs/workers/test_eval.py
@@ -411,6 +411,160 @@ async def test_describe_resolves_custom_prompt_name(
     assert props.run_config_prompt_name == "My Custom Prompt"
 
 
+async def test_describe_resolves_reused_frozen_prompt_name(
+    resolve_project, task, eval, eval_config, data_source
+):
+    # One run config carries a frozen prompt; a second run config reuses it via
+    # a "task_run_config::<proj>::<task>::<run_config_id>" prompt_id and has no
+    # own prompt — exercising the cross-run-config resolution branch.
+    from kiln_ai.datamodel.prompt import BasePrompt
+
+    owner = TaskRunConfig(
+        id="frozen_owner",
+        name="Frozen Owner",
+        run_config_properties=KilnAgentRunConfigProperties(
+            model_name="gpt-4",
+            model_provider_name=ModelProviderName.openai,
+            prompt_id="simple_prompt_builder",
+            structured_output_mode=StructuredOutputMode.json_schema,
+        ),
+        prompt=BasePrompt(name="Shared Frozen Prompt", prompt="do it"),
+        parent=task,
+    )
+    owner.save_to_file()
+
+    reuser = TaskRunConfig(
+        id="frozen_reuser",
+        name="Frozen Reuser",
+        run_config_properties=KilnAgentRunConfigProperties(
+            model_name="gpt-4",
+            model_provider_name=ModelProviderName.openai,
+            prompt_id="task_run_config::project1::task1::frozen_owner",
+            structured_output_mode=StructuredOutputMode.json_schema,
+        ),
+        parent=task,
+    )
+    reuser.save_to_file()
+
+    params = EvalJobParams(
+        project_id="project1",
+        task_id="task1",
+        eval_id="eval1",
+        eval_config_id="eval_config1",
+        run_config_id="frozen_reuser",
+    )
+
+    props = await EvalJobWorker().describe(params)
+
+    # Resolved from the owning run config's frozen prompt, not the raw id.
+    assert props.run_config_prompt_name == "Shared Frozen Prompt"
+
+
+async def test_describe_resolves_fine_tune_prompt_name(
+    resolve_project, task, eval, eval_config, data_source
+):
+    run_config = TaskRunConfig(
+        id="run_config_finetune",
+        name="Fine-Tune Run Config",
+        run_config_properties=KilnAgentRunConfigProperties(
+            model_name="gpt-4",
+            model_provider_name=ModelProviderName.openai,
+            prompt_id="fine_tune_prompt::project1::task1::ft123",
+            structured_output_mode=StructuredOutputMode.json_schema,
+        ),
+        parent=task,
+    )
+    run_config.save_to_file()
+
+    params = EvalJobParams(
+        project_id="project1",
+        task_id="task1",
+        eval_id="eval1",
+        eval_config_id="eval_config1",
+        run_config_id="run_config_finetune",
+    )
+
+    props = await EvalJobWorker().describe(params)
+
+    assert props.run_config_prompt_name == "Fine-Tune Prompt"
+
+
+async def test_describe_falls_back_to_raw_id_when_unresolvable(
+    resolve_project, task, eval, eval_config, data_source
+):
+    # An "id::" prompt referencing a prompt that doesn't exist on the task — the
+    # resolver exhausts every branch and falls back to the raw id rather than
+    # raising.
+    run_config = TaskRunConfig(
+        id="run_config_missing_prompt",
+        name="Missing Prompt Run Config",
+        run_config_properties=KilnAgentRunConfigProperties(
+            model_name="gpt-4",
+            model_provider_name=ModelProviderName.openai,
+            prompt_id="id::doesnotexist",
+            structured_output_mode=StructuredOutputMode.json_schema,
+        ),
+        parent=task,
+    )
+    run_config.save_to_file()
+
+    params = EvalJobParams(
+        project_id="project1",
+        task_id="task1",
+        eval_id="eval1",
+        eval_config_id="eval_config1",
+        run_config_id="run_config_missing_prompt",
+    )
+
+    props = await EvalJobWorker().describe(params)
+
+    assert props.run_config_prompt_name == "id::doesnotexist"
+
+
+async def test_describe_mcp_run_config_blanks_agent_fields(
+    resolve_project, task, eval, eval_config, data_source
+):
+    # An MCP (agentless) run config has no model/prompt/tools. describe() must
+    # still return valid properties — eval/judge info intact, agent fields blank.
+    from kiln_ai.datamodel.run_config import (
+        MCPToolReference,
+        McpRunConfigProperties,
+    )
+
+    run_config = TaskRunConfig(
+        id="run_config_mcp",
+        name="MCP Run Config",
+        run_config_properties=McpRunConfigProperties(
+            tool_reference=MCPToolReference(
+                tool_id="mcp::local::my_server::my_tool",
+                tool_name="my_tool",
+            ),
+        ),
+        parent=task,
+    )
+    run_config.save_to_file()
+
+    params = EvalJobParams(
+        project_id="project1",
+        task_id="task1",
+        eval_id="eval1",
+        eval_config_id="eval_config1",
+        run_config_id="run_config_mcp",
+    )
+
+    props = await EvalJobWorker().describe(params)
+
+    # Eval/judge info preserved; agent-specific fields blanked, counts zeroed.
+    assert props.eval_name == "Test Eval"
+    assert props.run_config_name == "MCP Run Config"
+    assert props.judge_name == "Test Eval Config"
+    assert props.run_config_model_name == ""
+    assert props.run_config_model_provider == ""
+    assert props.run_config_prompt_name == ""
+    assert props.run_config_tools_count == 0
+    assert props.run_config_skills_count == 0
+
+
 async def test_describe_missing_entity_raises(resolve_project, task, run_config):
     # Mirrors compute_state: the entity loader raises rather than silently
     # returning partial info. The registry guard (_describe) swallows this.

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -7345,6 +7345,10 @@ export interface components {
             progress_detail?: {
                 [key: string]: unknown;
             } | null;
+            /** Properties */
+            properties?: {
+                [key: string]: unknown;
+            } | null;
             /** Params */
             params?: {
                 [key: string]: unknown;

--- a/app/web_ui/src/lib/components/jobs_table.svelte
+++ b/app/web_ui/src/lib/components/jobs_table.svelte
@@ -238,52 +238,52 @@
       </thead>
       <tbody>
         {#each $jobs as job (job.id)}
+          {@const p = eval_job_properties(job)}
           <tr>
             <td class="align-top">
               <div class="flex flex-col gap-1 max-w-[280px]">
-                {#if eval_job_properties(job)}
-                  {@const p = eval_job_properties(job)}
-                  {@const model = p?.run_config_model_name
+                {#if p}
+                  {@const model = p.run_config_model_name
                     ? getDetailedModelNameFromParts(
                         p.run_config_model_name,
                         p.run_config_model_provider,
                         $model_info,
                       )
                     : ""}
-                  {@const judge_model = p?.judge_model_name
+                  {@const judge_model = p.judge_model_name
                     ? getDetailedModelNameFromParts(
                         p.judge_model_name,
                         p.judge_model_provider,
                         $model_info,
                       )
                     : ""}
-                  <span class="font-medium truncate" title={p?.eval_name}
-                    >Eval: {p?.eval_name}</span
+                  <span class="font-medium truncate" title={p.eval_name}
+                    >Eval: {p.eval_name}</span
                   >
                   <div class="space-y-1 text-xs text-gray-500">
-                    <div class="truncate" title={p?.run_config_name}>
-                      Run config: {p?.run_config_name}
+                    <div class="truncate" title={p.run_config_name}>
+                      Run config: {p.run_config_name}
                     </div>
                     {#if model}
                       <div class="truncate" title={model}>Model: {model}</div>
                     {/if}
-                    {#if p?.run_config_prompt_name}
+                    {#if p.run_config_prompt_name}
                       <div class="truncate" title={p.run_config_prompt_name}>
                         Prompt: {p.run_config_prompt_name}
                       </div>
                     {/if}
                     <div>
-                      Tools: {p && p.run_config_tools_count > 0
+                      Tools: {p.run_config_tools_count > 0
                         ? `${p.run_config_tools_count} available`
                         : "None"}
                     </div>
                     <div>
-                      Skills: {p && p.run_config_skills_count > 0
+                      Skills: {p.run_config_skills_count > 0
                         ? `${p.run_config_skills_count} available`
                         : "None"}
                     </div>
                     <div class="truncate">
-                      Judge: {judge_algorithm_display(p?.judge_algorithm ?? "")}
+                      Judge: {judge_algorithm_display(p.judge_algorithm)}
                     </div>
                     {#if judge_model}
                       <div class="truncate" title={judge_model}>

--- a/app/web_ui/src/lib/components/jobs_table.svelte
+++ b/app/web_ui/src/lib/components/jobs_table.svelte
@@ -282,8 +282,15 @@
                         ? `${p.run_config_skills_count} available`
                         : "None"}
                     </div>
-                    <div class="truncate">
-                      Judge: {judge_algorithm_display(p.judge_algorithm)}
+                    <div
+                      class="truncate"
+                      title="{p.judge_name} ({judge_algorithm_display(
+                        p.judge_algorithm,
+                      )})"
+                    >
+                      Judge: {p.judge_name} ({judge_algorithm_display(
+                        p.judge_algorithm,
+                      )})
                     </div>
                     {#if judge_model}
                       <div class="truncate" title={judge_model}>
@@ -297,8 +304,9 @@
                 <span class="text-[11px] text-gray-400 mt-2"
                   >{formatDate(job.created_at)}</span
                 >
-                <span class="font-mono text-[11px] text-gray-400 truncate"
-                  >{job.id}</span
+                <span
+                  class="font-mono text-[11px] text-gray-400 truncate"
+                  title={job.id}>{job.id}</span
                 >
               </div>
             </td>

--- a/app/web_ui/src/lib/components/jobs_table.svelte
+++ b/app/web_ui/src/lib/components/jobs_table.svelte
@@ -18,6 +18,7 @@
   import {
     cancel_job,
     delete_job,
+    eval_job_properties,
     get_job_errors,
     get_job_result,
     pause_job,
@@ -26,7 +27,14 @@
     type JobErrorEntry,
     type JobRecord,
   } from "$lib/stores/jobs_api"
-  import { formatDate, capitalize } from "$lib/utils/formatters"
+  import {
+    formatDate,
+    capitalize,
+    eval_config_to_ui_name,
+  } from "$lib/utils/formatters"
+  import { getDetailedModelNameFromParts } from "$lib/utils/run_config_formatters"
+  import { model_info } from "$lib/stores"
+  import type { EvalConfigType } from "$lib/types"
   import { KilnError, createKilnError } from "$lib/utils/error_handlers"
 
   let action_error: KilnError | null = null
@@ -85,6 +93,12 @@
       return "No-op"
     }
     return capitalize(type)
+  }
+
+  // UI name for an eval job's judge algorithm. The properties dict carries it as
+  // a plain string; narrow to EvalConfigType here so the markup stays cast-free.
+  function judge_algorithm_display(algorithm: string): string {
+    return eval_config_to_ui_name(algorithm as EvalConfigType)
   }
 
   function has_errors(job: JobRecord): boolean {
@@ -225,12 +239,66 @@
       <tbody>
         {#each $jobs as job (job.id)}
           <tr>
-            <td class="whitespace-nowrap">
-              <div class="flex flex-col gap-1">
-                <span class="font-medium">{job_type_display(job.type)}</span>
-                <span class="font-mono text-xs text-gray-500">{job.id}</span>
-                <span class="text-xs text-gray-500"
+            <td class="align-top">
+              <div class="flex flex-col gap-1 max-w-[280px]">
+                {#if eval_job_properties(job)}
+                  {@const p = eval_job_properties(job)}
+                  {@const model = p?.run_config_model_name
+                    ? getDetailedModelNameFromParts(
+                        p.run_config_model_name,
+                        p.run_config_model_provider,
+                        $model_info,
+                      )
+                    : ""}
+                  {@const judge_model = p?.judge_model_name
+                    ? getDetailedModelNameFromParts(
+                        p.judge_model_name,
+                        p.judge_model_provider,
+                        $model_info,
+                      )
+                    : ""}
+                  <span class="font-medium truncate" title={p?.eval_name}
+                    >Eval: {p?.eval_name}</span
+                  >
+                  <div class="space-y-1 text-xs text-gray-500">
+                    <div class="truncate" title={p?.run_config_name}>
+                      Run config: {p?.run_config_name}
+                    </div>
+                    {#if model}
+                      <div class="truncate" title={model}>Model: {model}</div>
+                    {/if}
+                    {#if p?.run_config_prompt_name}
+                      <div class="truncate" title={p.run_config_prompt_name}>
+                        Prompt: {p.run_config_prompt_name}
+                      </div>
+                    {/if}
+                    <div>
+                      Tools: {p && p.run_config_tools_count > 0
+                        ? `${p.run_config_tools_count} available`
+                        : "None"}
+                    </div>
+                    <div>
+                      Skills: {p && p.run_config_skills_count > 0
+                        ? `${p.run_config_skills_count} available`
+                        : "None"}
+                    </div>
+                    <div class="truncate">
+                      Judge: {judge_algorithm_display(p?.judge_algorithm ?? "")}
+                    </div>
+                    {#if judge_model}
+                      <div class="truncate" title={judge_model}>
+                        Judge model: {judge_model}
+                      </div>
+                    {/if}
+                  </div>
+                {:else}
+                  <span class="font-medium">{job_type_display(job.type)}</span>
+                {/if}
+                <span class="text-[11px] text-gray-400 mt-2"
                   >{formatDate(job.created_at)}</span
+                >
+                <span class="font-mono text-[11px] text-gray-400 truncate"
+                  >{job.id}</span
                 >
               </div>
             </td>

--- a/app/web_ui/src/lib/components/jobs_table.test.ts
+++ b/app/web_ui/src/lib/components/jobs_table.test.ts
@@ -158,9 +158,9 @@ describe("JobsTable", () => {
           run_config_model_name: "gpt-4o",
           run_config_model_provider: "openai",
           run_config_prompt_name: "Few-Shot",
-          run_config_tools_count: 0,
-          run_config_skills_count: 0,
-          judge_name: "G-Eval judge",
+          run_config_tools_count: 2,
+          run_config_skills_count: 1,
+          judge_name: "Magical Yeti",
           judge_algorithm: "g_eval",
           judge_model_name: "claude",
           judge_model_provider: "anthropic",
@@ -168,14 +168,18 @@ describe("JobsTable", () => {
       }),
     ])
     const { getByText } = render(JobsTable)
-    // Eval name is the header; run-config summary lines follow, with g_eval
-    // mapped to its UI name.
+    // Eval name is the header; run-config summary lines follow.
     expect(getByText(/Eval: Toxicity check/)).not.toBeNull()
     expect(getByText(/Run config: GLM run/)).not.toBeNull()
+    // Model line flows through the model-name helper (unknown id -> "Model ID:").
+    expect(getByText(/Model:/)).not.toBeNull()
     expect(getByText(/Prompt: Few-Shot/)).not.toBeNull()
-    expect(getByText(/Tools: None/)).not.toBeNull()
-    expect(getByText(/Skills: None/)).not.toBeNull()
-    expect(getByText(/Judge: G-Eval/)).not.toBeNull()
+    // Non-zero counts render the "N available" branch.
+    expect(getByText(/Tools: 2 available/)).not.toBeNull()
+    expect(getByText(/Skills: 1 available/)).not.toBeNull()
+    // The judge line shows the judge (eval-config) name plus its algorithm.
+    expect(getByText(/Judge: Magical Yeti \(G-Eval\)/)).not.toBeNull()
+    expect(getByText(/Judge model:/)).not.toBeNull()
   })
 
   it("renders no eval properties for non-eval jobs", () => {

--- a/app/web_ui/src/lib/components/jobs_table.test.ts
+++ b/app/web_ui/src/lib/components/jobs_table.test.ts
@@ -22,6 +22,9 @@ const api = {
   delete_job: vi.fn().mockResolvedValue(undefined),
   get_job_errors: vi.fn().mockResolvedValue([]),
   get_job_result: vi.fn().mockResolvedValue({}),
+  // Real-shaped passthrough: the table calls this for every row.
+  eval_job_properties: (job: JobRecord) =>
+    job.type === "eval" && job.properties ? job.properties : null,
 }
 vi.mock("$lib/stores/jobs_api", () => api)
 
@@ -142,5 +145,42 @@ describe("JobsTable", () => {
     connection.set("errored")
     const { getByText } = render(JobsTable)
     expect(getByText("Can't connect to the job stream")).not.toBeNull()
+  })
+
+  it("renders eval job properties inline in the Details cell", () => {
+    jobs.set([
+      makeJob({
+        id: "j_eval",
+        type: "eval",
+        properties: {
+          eval_name: "Toxicity check",
+          run_config_name: "GLM run",
+          run_config_model_name: "gpt-4o",
+          run_config_model_provider: "openai",
+          run_config_prompt_name: "Few-Shot",
+          run_config_tools_count: 0,
+          run_config_skills_count: 0,
+          judge_name: "G-Eval judge",
+          judge_algorithm: "g_eval",
+          judge_model_name: "claude",
+          judge_model_provider: "anthropic",
+        },
+      }),
+    ])
+    const { getByText } = render(JobsTable)
+    // Eval name is the header; run-config summary lines follow, with g_eval
+    // mapped to its UI name.
+    expect(getByText(/Eval: Toxicity check/)).not.toBeNull()
+    expect(getByText(/Run config: GLM run/)).not.toBeNull()
+    expect(getByText(/Prompt: Few-Shot/)).not.toBeNull()
+    expect(getByText(/Tools: None/)).not.toBeNull()
+    expect(getByText(/Skills: None/)).not.toBeNull()
+    expect(getByText(/Judge: G-Eval/)).not.toBeNull()
+  })
+
+  it("renders no eval properties for non-eval jobs", () => {
+    jobs.set([makeJob({ id: "j_noop", type: "noop" })])
+    const { queryByText } = render(JobsTable)
+    expect(queryByText(/Run config:/)).toBeNull()
   })
 })

--- a/app/web_ui/src/lib/stores/jobs_api.test.ts
+++ b/app/web_ui/src/lib/stores/jobs_api.test.ts
@@ -4,12 +4,14 @@ import {
   cancel_job,
   create_job,
   delete_job,
+  eval_job_properties,
   get_job,
   get_job_errors,
   get_job_result,
   list_jobs,
   pause_job,
   resume_job,
+  type JobRecord,
 } from "./jobs_api"
 
 vi.mock("$lib/api_client", () => ({
@@ -146,5 +148,42 @@ describe("jobs_api", () => {
   it("lifecycle calls throw on client error", async () => {
     mockPOST.mockResolvedValue({ data: undefined, error: { detail: "409" } })
     await expect(cancel_job("j_11")).rejects.toEqual({ detail: "409" })
+  })
+
+  describe("eval_job_properties", () => {
+    const base: JobRecord = {
+      id: "j_1",
+      type: "eval",
+      status: "running",
+      supports_pause: true,
+      created_at: "2024-01-01T00:00:00Z",
+    } as JobRecord
+
+    it("casts properties for an eval job", () => {
+      const props = {
+        eval_name: "Toxicity check",
+        run_config_name: "GPT-4o run",
+        run_config_model_name: "gpt-4o",
+        run_config_model_provider: "openai",
+        run_config_prompt_name: "Few-Shot",
+        run_config_tools_count: 0,
+        run_config_skills_count: 0,
+        judge_name: "G-Eval judge",
+        judge_algorithm: "g_eval",
+        judge_model_name: "claude",
+        judge_model_provider: "anthropic",
+      }
+      expect(eval_job_properties({ ...base, properties: props })).toEqual(props)
+    })
+
+    it("returns null for a non-eval job", () => {
+      expect(
+        eval_job_properties({ ...base, type: "noop", properties: {} }),
+      ).toBeNull()
+    })
+
+    it("returns null when properties are absent", () => {
+      expect(eval_job_properties({ ...base, properties: null })).toBeNull()
+    })
   })
 })

--- a/app/web_ui/src/lib/stores/jobs_api.ts
+++ b/app/web_ui/src/lib/stores/jobs_api.ts
@@ -10,6 +10,30 @@ export type JobErrorEntry = {
   error_message?: string
 } & Record<string, unknown>
 
+// Mirror of the backend EvalJobWorker.EvalJobProperties model. JobRecord
+// carries worker-published properties as an untyped dict on the wire (so the
+// core stays worker-agnostic); the frontend casts it per job type.
+export type EvalJobProperties = {
+  eval_name: string
+  run_config_name: string
+  run_config_model_name: string
+  run_config_model_provider: string
+  run_config_prompt_name: string
+  run_config_tools_count: number
+  run_config_skills_count: number
+  judge_name: string
+  judge_algorithm: string
+  judge_model_name: string
+  judge_model_provider: string
+}
+
+export function eval_job_properties(job: JobRecord): EvalJobProperties | null {
+  if (job.type !== "eval" || !job.properties) {
+    return null
+  }
+  return job.properties as EvalJobProperties
+}
+
 export type ListJobsQuery = {
   status?: BackgroundJobStatus
   type?: string


### PR DESCRIPTION
## What & why

Job workers had no way to surface *what* a job is doing — every eval row in the jobs table looked identical (just type, id, date). This adds a generic mechanism for a worker to publish **static descriptive properties** about its work, and renders them in the management table.

## Mechanism (generic, eval-first)

- `JobRecord.properties` + `JobWorker.properties_model` / `describe()` — a pure read derived once from params, mirroring the existing `compute_state` pattern and stored dict-on-the-wire like `progress_detail` (core stays worker-agnostic; frontend casts per type).
- The registry computes properties in `create()` behind a guard, so a failing `describe()` degrades to `properties=null` and never breaks job creation.

## Eval worker

Publishes the eval name, run config (name, model id+provider, resolved prompt name, tool/skill counts), and judge (name, algorithm, model). Prompt ids are resolved to names the same way the frontend does — generator label, custom `id::`, reused frozen `task_run_config::`, fine-tune, and local frozen prompts.

## UI

The Details cell renders a run-config-style summary: `Eval: <name>` header, flat labeled property lines (`Run config / Model / Prompt / Tools / Skills / Judge / Judge model`), then a muted date and id. Model names use the shared `getDetailedModelNameFromParts` helper; long values truncate with tooltips.

## Testing

- Backend: `pytest app/desktop/studio_server/jobs/` — 134 passed (new tests cover describe output, registry population, the failure guard, tool/skill counting, frozen + custom prompt-name resolution). `ruff` + `ty` clean.
- Frontend: `npm run check` 0 errors; `jobs_table` / `jobs_api` vitest pass; lint/format clean.
- Verified live against the running app: created real eval jobs, properties populate end-to-end and the table renders correctly.

> [!NOTE]
> Based on `leonard/kil-686-eval-job` (stacked), so this PR shows only the properties change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)