### PR TITLE
fix(jobs): surface original eval error instead of generic wrapper

### DIFF
--- a/app/desktop/studio_server/jobs/workers/eval.py
+++ b/app/desktop/studio_server/jobs/workers/eval.py
@@ -18,6 +18,21 @@ from ...eval_api import eval_config_from_id, task_run_config_from_id
 from ..models import JobContext, JobDerivedState, JobWorker
 
 
+def _safe_str(exc: Exception) -> str:
+    """str(exc), falling back to the class name when it's empty or __str__ raises.
+
+    This runs in the error-logging path, which must never itself crash the run:
+    AsyncJobRunner awaits the observer's on_error unguarded, so a buggy __str__
+    here would take down the whole eval. Mirrors errors._safe_str, but prefers
+    the class name over a generic message since this log is developer-facing.
+    """
+    try:
+        result = str(exc)
+    except Exception:
+        return type(exc).__name__
+    return result or type(exc).__name__
+
+
 def _error_detail(error: Exception) -> str:
     """The most informative message for a failed dataset item's error log.
 
@@ -27,10 +42,9 @@ def _error_detail(error: Exception) -> str:
     exception survives on `.original`, so for the developer-facing eval error log
     we surface that underlying detail instead of the genericized wrapper message.
     """
-    if isinstance(error, KilnRunError):
-        original = error.original
-        return str(original) or original.__class__.__name__
-    return str(error) or error.__class__.__name__
+    if isinstance(error, KilnRunError) and error.original is not None:
+        return _safe_str(error.original)
+    return _safe_str(error)
 
 
 class _EvalErrorLogObserver(AsyncJobRunnerObserver[EvalJob]):

--- a/app/desktop/studio_server/jobs/workers/eval.py
+++ b/app/desktop/studio_server/jobs/workers/eval.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 
 from app.desktop.git_sync.save_context import save_context_for_project
+from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.eval.eval_runner import EvalJob, EvalRunner
 from kiln_ai.datamodel.dataset_filters import dataset_filter_from_id
 from kiln_ai.datamodel.eval import Eval, EvalConfig
@@ -15,6 +16,21 @@ from pydantic import BaseModel
 
 from ...eval_api import eval_config_from_id, task_run_config_from_id
 from ..models import JobContext, JobDerivedState, JobWorker
+
+
+def _error_detail(error: Exception) -> str:
+    """The most informative message for a failed dataset item's error log.
+
+    The model adapter wraps failures in `KilnRunError`, whose own message is the
+    user-friendly `format_error_message` text — often the generic "An unexpected
+    error occurred." for exception types it doesn't recognize. The original
+    exception survives on `.original`, so for the developer-facing eval error log
+    we surface that underlying detail instead of the genericized wrapper message.
+    """
+    if isinstance(error, KilnRunError):
+        original = error.original
+        return str(original) or original.__class__.__name__
+    return str(error) or error.__class__.__name__
 
 
 class _EvalErrorLogObserver(AsyncJobRunnerObserver[EvalJob]):
@@ -31,7 +47,7 @@ class _EvalErrorLogObserver(AsyncJobRunnerObserver[EvalJob]):
 
     async def on_error(self, job: EvalJob, error: Exception) -> None:
         await self._ctx.report_error(
-            str(error) or error.__class__.__name__,
+            _error_detail(error),
             dataset_id=job.item.id,
             run_config_id=job.task_run_config.id if job.task_run_config else None,
         )

--- a/app/desktop/studio_server/jobs/workers/test_eval.py
+++ b/app/desktop/studio_server/jobs/workers/test_eval.py
@@ -33,7 +33,7 @@ from kiln_ai.datamodel.eval import (
 )
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.task import StructuredOutputMode, TaskRunConfig
-from kiln_ai.utils.async_job_runner import Progress
+from kiln_ai.utils.async_job_runner import Progress, RetryableError
 
 
 @pytest.fixture
@@ -810,7 +810,7 @@ async def test_run_logs_original_error_for_kiln_run_error(
     # The model adapter wraps failures in KilnRunError, whose own message is the
     # genericized format_error_message text. The error log must surface the
     # underlying .original detail, not "An unexpected error occurred."
-    _make_task_run(task, data_source, "eval_set")
+    task_run = _make_task_run(task, data_source, "eval_set")
 
     original = RuntimeError("provider 500: model is overloaded right now")
 
@@ -841,9 +841,11 @@ async def test_run_logs_original_error_for_kiln_run_error(
 
     assert result.error == 1
     assert len(logged) == 1
-    message, _ = logged[0]
+    message, extra = logged[0]
     assert message == "provider 500: model is overloaded right now"
     assert "An unexpected error occurred." not in message
+    assert extra["dataset_id"] == task_run.id
+    assert extra["run_config_id"] == run_config.id
 
 
 def test_error_detail_unwraps_kiln_run_error():
@@ -868,6 +870,14 @@ def test_error_detail_falls_back_to_original_class_name_when_empty():
 
 def test_error_detail_passes_through_plain_exception():
     assert _error_detail(ValueError("scoring exploded")) == "scoring exploded"
+
+
+def test_error_detail_surfaces_retryable_error_message():
+    # The most common real eval failure path: EvalRunner.run_job re-raises transient
+    # failures (rate limits, 5xx, schema errors) as RetryableError(str(original)).
+    # After retries are exhausted, that instance — not a KilnRunError — reaches
+    # _error_detail, which must surface the wrapped message, not a generic one.
+    assert _error_detail(RetryableError("rate limit exceeded")) == "rate limit exceeded"
 
 
 def test_error_detail_falls_back_to_class_name_for_empty_plain_exception():

--- a/app/desktop/studio_server/jobs/workers/test_eval.py
+++ b/app/desktop/studio_server/jobs/workers/test_eval.py
@@ -874,6 +874,29 @@ def test_error_detail_falls_back_to_class_name_for_empty_plain_exception():
     assert _error_detail(ValueError("")) == "ValueError"
 
 
+def test_error_detail_does_not_crash_on_buggy_str():
+    # The observer runs in AsyncJobRunner's unguarded on_error path, so a buggy
+    # __str__ must degrade to the class name rather than take down the run.
+    class BoomError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("str blew up")
+
+    assert _error_detail(BoomError()) == "BoomError"
+
+
+def test_error_detail_handles_kiln_run_error_with_buggy_original_str():
+    class BoomError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("str blew up")
+
+    wrapped = KilnRunError(
+        message="An unexpected error occurred.",
+        partial_trace=None,
+        original=BoomError(),
+    )
+    assert _error_detail(wrapped) == "BoomError"
+
+
 # -- save_context wiring -----------------------------------------------------
 
 

--- a/app/desktop/studio_server/jobs/workers/test_eval.py
+++ b/app/desktop/studio_server/jobs/workers/test_eval.py
@@ -12,7 +12,9 @@ from app.desktop.studio_server.jobs.workers.eval import (
     EvalJobProperties,
     EvalJobResult,
     EvalJobWorker,
+    _error_detail,
 )
+from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.datamodel import (
     DataSource,
@@ -799,6 +801,77 @@ async def test_run_logs_failed_items_to_error_log(
     assert "scoring exploded" in message
     assert extra["dataset_id"] == task_run.id
     assert extra["run_config_id"] == run_config.id
+
+
+@pytest.mark.asyncio
+async def test_run_logs_original_error_for_kiln_run_error(
+    resolve_project, task, eval_config, run_config, data_source, params
+):
+    # The model adapter wraps failures in KilnRunError, whose own message is the
+    # genericized format_error_message text. The error log must surface the
+    # underlying .original detail, not "An unexpected error occurred."
+    _make_task_run(task, data_source, "eval_set")
+
+    original = RuntimeError("provider 500: model is overloaded right now")
+
+    async def failing_run_job(self, job) -> bool:
+        raise KilnRunError(
+            message="An unexpected error occurred.",
+            partial_trace=None,
+            original=original,
+        )
+
+    logged: list[tuple[str, dict]] = []
+
+    class FakeCtx:
+        job_id = "j_test"
+        run_id = "run_test"
+
+        async def report_progress(self, success, error=0, total=None, message=None):
+            pass
+
+        async def report_error(self, error_message, **extra):
+            logged.append((error_message, extra))
+
+    with patch(
+        "kiln_ai.adapters.eval.eval_runner.EvalRunner.run_job",
+        new=failing_run_job,
+    ):
+        result = await EvalJobWorker().run(params, FakeCtx())
+
+    assert result.error == 1
+    assert len(logged) == 1
+    message, _ = logged[0]
+    assert message == "provider 500: model is overloaded right now"
+    assert "An unexpected error occurred." not in message
+
+
+def test_error_detail_unwraps_kiln_run_error():
+    original = ValueError("real underlying detail")
+    wrapped = KilnRunError(
+        message="An unexpected error occurred.",
+        partial_trace=None,
+        original=original,
+    )
+    assert _error_detail(wrapped) == "real underlying detail"
+
+
+def test_error_detail_falls_back_to_original_class_name_when_empty():
+    original = RuntimeError("")
+    wrapped = KilnRunError(
+        message="An unexpected error occurred.",
+        partial_trace=None,
+        original=original,
+    )
+    assert _error_detail(wrapped) == "RuntimeError"
+
+
+def test_error_detail_passes_through_plain_exception():
+    assert _error_detail(ValueError("scoring exploded")) == "scoring exploded"
+
+
+def test_error_detail_falls_back_to_class_name_for_empty_plain_exception():
+    assert _error_detail(ValueError("")) == "ValueError"
 
 
 # -- save_context wiring -----------------------------------------------------


### PR DESCRIPTION
## Problem

Errors from the eval worker were being swallowed and surfaced to `/api/jobs/{id}/errors` as the generic **"An unexpected error occurred."** instead of the real failure.

## Root cause

The error collector *was* wired into the async job runner — `_EvalErrorLogObserver.on_error` correctly forwards each final failure to `ctx.report_error`. The loss happens one layer down:

- The model adapter wraps run failures in `KilnRunError`, setting its message to `format_error_message(original)` (`base_adapter.py:356`, also `mcp_adapter.py:217`).
- For any exception type `format_error_message` doesn't recognize, that message is the generic fallback `"An unexpected error occurred."` — the original detail survives only on `KilnRunError.original` / `__cause__`.
- The observer recorded `str(error)`, which for a `KilnRunError` is exactly that genericized message.

So the original error was available all along — just unused.

## Fix

Unwrap `KilnRunError` in the observer (via a small `_error_detail` helper): when the error is a `KilnRunError`, surface `str(error.original)` (falling back to its class name), instead of the user-friendly wrapper message. The eval error log is developer-facing, so it should show the real underlying error rather than the client-safe genericized text. Plain exceptions are passed through unchanged.

## Tests

- `test_run_logs_original_error_for_kiln_run_error` — end-to-end through `EvalJobWorker.run`: a `KilnRunError` with a generic message but a real `.original` now logs the underlying detail.
- Unit tests for `_error_detail`: unwraps `KilnRunError`, falls back to the original's class name when its message is empty, and passes plain exceptions through.

All 31 tests in `test_eval.py` pass; `ruff check` / `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EArRrPGYh4f3Lgs8f6QD1C