### PR TITLE
feat(chat): hard Stop button for auto mode (drop "waiting for you")

### DIFF
--- a/app/desktop/studio_server/chat/auto/registry.py
+++ b/app/desktop/studio_server/chat/auto/registry.py
@@ -504,26 +504,37 @@ class AutoChatRegistry:
     async def stop(self, run_id: str) -> None:
         """Stop auto mode for the conversation (Stop button). Idempotent.
 
-        Revision R1 + graceful stop (functional spec §4.4(1)): Stop is NOT a hard
-        cancel. A RUNNING burst is asked to stop **gracefully** — the runner
-        finishes the in-flight upstream round (no cut-off), then at the round
-        boundary surfaces any pending client tool calls for normal approval
-        (tool-calls-pending) and ends the burst USER_STOPPED. We only set the stop
-        intent here and return promptly (the endpoint replies 202): the
-        supervising task winds the burst down and publishes auto-mode-off on its
-        own, so observers see the off marker when the round actually ends. An IDLE
-        run has no burst task, so the flag is cleared here directly."""
+        Hard stop: the user pressed Stop to halt the agent completely, so a
+        RUNNING burst is cancelled immediately (mirroring ``disable``) rather than
+        wound down gracefully. We mark the run USER_STOPPED first so the cancelled
+        burst's CancelledError handler in ``_supervise`` preserves that reason and
+        publishes ``auto-mode-off(user_stopped)``; the runner is torn down
+        mid-round and never reaches the point where it would surface this round's
+        pending client tool calls for approval, so nothing further is dispatched.
+        An IDLE run has no burst task, so the flag is cleared here directly."""
         run = self._runs.get(run_id)
-        task = self._tasks.get(run_id)
-        if task is not None:
-            if run is not None:
-                run.runner.request_stop()
-            return
-
-        # No live burst (idle or already off). If the flag is still on, clear it.
         if run is None or run.record.status.is_terminal:
             return
+
+        # Mark USER_STOPPED first so a cancelled burst preserves the reason: the
+        # _supervise CancelledError handler only defaults to USER_STOPPED when the
+        # status isn't already terminal (CR Moderate 2, mirrored from disable()).
         run.record.status = AutoRunStatus.USER_STOPPED
+
+        task = self._tasks.get(run_id)
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.debug(
+                    "Auto run %s raised during stop await", run_id, exc_info=True
+                )
+            return
+
+        # No live burst (idle). Clear the flag directly.
         run.inbound.clear()
         self._publish_off(run)
         self._touch(run)

--- a/app/desktop/studio_server/chat/auto/test_api.py
+++ b/app/desktop/studio_server/chat/auto/test_api.py
@@ -333,10 +333,10 @@ async def test_stop_returns_202_and_is_idempotent(client, registry, mock_api_key
 
 @pytest.mark.asyncio
 async def test_stop_clears_flag_with_user_stopped(client, registry, mock_api_key):
-    # /stop is graceful (functional spec §4.4(1)): it returns 202 promptly and
-    # sets a stop intent WITHOUT cutting off the in-flight round. The flag clears
-    # (USER_STOPPED) + auto-mode-off(user_stopped) is published only once the
-    # current round finishes.
+    # /stop is a hard cancel: it returns 202 and tears the in-flight burst down
+    # immediately rather than waiting for the round to finish. The flag clears
+    # (USER_STOPPED) + auto-mode-off(user_stopped) is published right away, even
+    # though the gated round is never released.
     release = asyncio.Event()
     gated = _GatedClient(release)
     with patch.object(httpx, "AsyncClient", return_value=gated):
@@ -356,16 +356,14 @@ async def test_stop_clears_flag_with_user_stopped(client, registry, mock_api_key
 
         drain_task = asyncio.create_task(_drain())
         await asyncio.sleep(0.02)
+        # The round is still blocked open on the gated client; stop must NOT wait
+        # for it — the burst is cancelled mid-round and goes terminal at once.
         r = await client.post(f"/api/chat/auto/{run_id}/stop")
         assert r.status_code == 202
-        # Not cut off: still RUNNING until the in-flight round finishes.
-        await asyncio.sleep(0.02)
-        assert run.record.status == AutoRunStatus.RUNNING
-        # Let the round finish; the burst now winds down to off.
-        release.set()
         await _wait_terminal(registry, run_id)
         await asyncio.sleep(0.02)
         drain_task.cancel()
+        release.set()  # cleanup: unblock the gated client
 
     assert run.record.status == AutoRunStatus.USER_STOPPED
     decoded = b"".join(received).decode()

--- a/app/desktop/studio_server/chat/auto/test_registry.py
+++ b/app/desktop/studio_server/chat/auto/test_registry.py
@@ -217,19 +217,18 @@ async def test_is_active_for_trace_true_while_running_and_idle_false_when_off():
 
 
 @pytest.mark.asyncio
-async def test_stop_is_graceful_finishes_round_then_publishes_off():
-    # Graceful stop (functional spec §4.4(1)): Stop must NOT hard-cancel / cut off
-    # the in-flight output. It sets a stop intent; the current round finishes
-    # streaming, and only at the round boundary does the burst end USER_STOPPED.
+async def test_stop_is_hard_cancel_ends_immediately():
+    # Hard stop: Stop cancels the in-flight burst immediately rather than waiting
+    # for the round to finish. The run goes terminal (USER_STOPPED) and publishes
+    # auto-mode-off(user_stopped) without the gated round ever being released, and
+    # never surfaces tool-calls-pending for approval.
     reg = AutoChatRegistry()
-    release = asyncio.Event()  # the in-flight round blocks until released
+    release = asyncio.Event()  # the round blocks here until cancelled
     client = _GatedClient(release)
     with patch.object(httpx, "AsyncClient", return_value=client):
         rec = reg.start(_seed("tr-0"), reason=None, upstream_url=URL, headers={})
         run = reg.get(rec.run_id)
         assert run is not None
-        # Subscribe so we can confirm the current turn's output is NOT cut off and
-        # auto-mode-off(user_stopped) is published.
         sub = run.bus.subscribe()
         received: list[bytes] = []
 
@@ -239,23 +238,19 @@ async def test_stop_is_graceful_finishes_round_then_publishes_off():
 
         drain_task = asyncio.create_task(_drain())
         await asyncio.sleep(0.05)  # let the run start + buffer replay
-        # Request stop while the round is still streaming. The run must NOT end
-        # yet — the round hasn't finished.
+        # Stop while the round is still blocked open. The burst is cancelled
+        # mid-round and goes terminal immediately — the gate is never released.
         await reg.stop(rec.run_id)
-        await asyncio.sleep(0.05)
-        assert run.record.status == AutoRunStatus.RUNNING
-        # Let the in-flight round finish; the burst should now wind down to off.
-        release.set()
         await _wait_terminal(reg, rec.run_id)
         await asyncio.sleep(0.02)
         drain_task.cancel()
+        release.set()  # cleanup: unblock the gated client
 
     assert run.record.status == AutoRunStatus.USER_STOPPED
     decoded = b"".join(received).decode()
-    # The current turn's text was delivered (not cut off) before going off.
-    assert "done" in decoded
     assert '"type": "auto-mode-off"' in decoded
     assert '"reason": "user_stopped"' in decoded
+    assert '"type": "tool-calls-pending"' not in decoded
 
 
 @pytest.mark.asyncio

--- a/app/web_ui/src/lib/chat/auto_run_store.test.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.test.ts
@@ -640,7 +640,7 @@ describe("auto_run_store", () => {
     expect(get(store.working)).toBe(true)
     expect(get(store.autoModeOn)).toBe(true)
 
-    // An IDLE run (initialWorking=false) shows "· waiting for you" immediately.
+    // An IDLE run (initialWorking=false) shows the idle (non-pulsing) indicator.
     store.detach()
     store.beginReconnect()
     store.attach("ar_wait", false)

--- a/app/web_ui/src/routes/(app)/assistant/auto_mode_stop_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/auto_mode_stop_dialog.svelte
@@ -56,10 +56,8 @@
   on:cancel={() => dismiss()}
   on:close={() => dismiss()}
 >
-  <div class="text-sm">
-    <p class="leading-relaxed">
-      The agent won't start anything new, but any jobs it already kicked off
-      (like evals) keep running in the background.
-    </p>
-  </div>
+  <p class="text-sm">
+    The agent won't start anything new, but any jobs it already kicked off (like
+    evals) keep running in the background.
+  </p>
 </Dialog>

--- a/app/web_ui/src/routes/(app)/assistant/auto_mode_stop_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/auto_mode_stop_dialog.svelte
@@ -50,7 +50,7 @@
   bind:this={dialog}
   title="Stop the agent?"
   action_buttons={[
-    { label: "Keep running", isCancel: true },
+    { label: "Cancel", isCancel: true },
     { label: "Stop agent", isError: true, action: confirm },
   ]}
   on:cancel={() => dismiss()}

--- a/app/web_ui/src/routes/(app)/assistant/auto_mode_stop_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/auto_mode_stop_dialog.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import posthog from "posthog-js"
+  import Dialog from "$lib/ui/dialog.svelte"
+
+  let dialog: Dialog
+
+  let pendingResolve: ((confirmed: boolean) => void) | null = null
+  let pendingPromise: Promise<boolean> | null = null
+
+  /**
+   * Open the Stop confirmation gate. Resolves ``true`` when the user confirms
+   * the hard stop, ``false`` on cancel / dismiss / Escape / backdrop.
+   *
+   * The point of the dialog is to set expectations: stopping halts the agent
+   * immediately, but any background jobs it already kicked off (evals,
+   * optimization runs) are independent and keep running — Stop does not cancel
+   * them.
+   */
+  export function prompt(): Promise<boolean> {
+    if (pendingPromise) return pendingPromise
+    posthog.capture("chat_auto_mode_stop_shown")
+    pendingPromise = new Promise<boolean>((resolve) => {
+      pendingResolve = resolve
+      dialog.show()
+    })
+    return pendingPromise
+  }
+
+  function settle(confirmed: boolean) {
+    const resolve = pendingResolve
+    pendingResolve = null
+    pendingPromise = null
+    resolve?.(confirmed)
+  }
+
+  function confirm(): boolean {
+    posthog.capture("chat_auto_mode_stop_confirmed")
+    settle(true)
+    return true // close dialog
+  }
+
+  function dismiss() {
+    if (pendingResolve === null) return
+    posthog.capture("chat_auto_mode_stop_cancelled")
+    settle(false)
+  }
+</script>
+
+<Dialog
+  bind:this={dialog}
+  title="Stop the agent?"
+  action_buttons={[
+    { label: "Keep running", isCancel: true },
+    { label: "Stop agent", isError: true, action: confirm },
+  ]}
+  on:cancel={() => dismiss()}
+  on:close={() => dismiss()}
+>
+  <div class="text-sm">
+    <p class="leading-relaxed">
+      The agent won't start anything new, but any jobs it already kicked off
+      (like evals) keep running in the background.
+    </p>
+  </div>
+</Dialog>

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -84,12 +84,23 @@
     }
   }
 
-  async function stopAutoMode() {
-    // A client-armed (no-run) conversation just disarms locally; a real server
-    // run is stopped via the registry. Always clear the armed flag so disable
-    // before the first send returns the toggle to off (functional spec §4.1(2)).
+  async function stopAgent() {
+    // Hard stop: halt the agent completely. Abort any in-flight interactive
+    // stream (e.g. a tool-call continuation or a normal streaming turn), tell the
+    // server to cancel the background run, and detach the observer so nothing
+    // further — including any client tool calls the server might hand back — gets
+    // dispatched from the browser.
+    //
+    // Order matters: auto_run_store.stop() reads the run id synchronously (before
+    // its first await), so calling it before detach() — which clears that id —
+    // guarantees the server actually receives the stop. A client-armed (no-run)
+    // conversation has no server run; disarm()/detach() just clear the local
+    // armed flag so the toggle returns to off (functional spec §4.1(2)).
+    store.stop()
+    const stopping = auto_run_store.stop()
     auto_run_store.disarm()
-    await auto_run_store.stop()
+    auto_run_store.detach()
+    await stopping
   }
 
   let chatHistory: { open: () => void }
@@ -850,16 +861,13 @@
               >⏵⏵</span
             >
             <span>auto mode on</span>
-            {#if !$autoModeWorking}
-              <span class="font-normal text-primary/70">· waiting for you</span>
-            {/if}
           </span>
           <button
             type="button"
             class="btn btn-ghost btn-xs text-error/80 hover:text-error hover:bg-error/10"
-            on:click={stopAutoMode}
-            title="Stop auto mode"
-            aria-label="Stop auto mode"
+            on:click={stopAgent}
+            title="Stop the agent"
+            aria-label="Stop the agent"
           >
             ▸ Stop
           </button>

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -20,6 +20,7 @@
   import ChatWelcome from "./chat_welcome.svelte"
   import ChatHistory from "./chat_history.svelte"
   import AutoModeConsentDialog from "./auto_mode_consent_dialog.svelte"
+  import AutoModeStopDialog from "./auto_mode_stop_dialog.svelte"
   import ToolApprovalBox from "./tool_approval_box.svelte"
   import ChatStatusSteps from "./chat_status_steps.svelte"
   import BrailleSpinner from "./braille_spinner.svelte"
@@ -31,6 +32,7 @@
   let costDisclaimer: ChatCostDisclaimer
   $: store.onConsentNeeded = () => costDisclaimer.prompt()
   let consentDialog: AutoModeConsentDialog
+  let stopDialog: AutoModeStopDialog
   // The store asks here when the model requests auto mode; we just decide
   // accept/decline via the dialog. The store handles enable/decline + handoff.
   $: store.onAutoModeConsentNeeded = (payload) => consentDialog.prompt(payload)
@@ -85,6 +87,18 @@
   }
 
   async function stopAgent() {
+    // Brand-new armed conversation: no server run exists yet, so nothing could
+    // have been kicked off — just disarm without the explainer dialog.
+    if (!get(autoModeOn)) {
+      auto_run_store.disarm()
+      return
+    }
+    // Confirm + set expectations: the hard stop halts the agent immediately, but
+    // jobs it already started (evals, optimization runs) are independent and keep
+    // running. Bail if the user backs out.
+    const confirmed = await stopDialog.prompt()
+    if (!confirmed) return
+
     // Hard stop: halt the agent completely. Abort any in-flight interactive
     // stream (e.g. a tool-call continuation or a normal streaming turn), tell the
     // server to cancel the background run, and detach the observer so nothing
@@ -895,6 +909,7 @@
 
 <ChatCostDisclaimer bind:this={costDisclaimer} />
 <AutoModeConsentDialog bind:this={consentDialog} />
+<AutoModeStopDialog bind:this={stopDialog} />
 
 <style>
   .chat-messages-scroll::-webkit-scrollbar {


### PR DESCRIPTION
## What

In the assistant chat, auto mode used to show **`⏵⏵ auto mode on · waiting for you`** with a subtle Stop control. This:

1. **Removes the redundant "· waiting for you" text** — the footer now just reads `⏵⏵ auto mode on` (the `⏵⏵` still pulses while a burst is working).
2. **Keeps the existing red `▸ Stop` button** look, but makes Stop a **hard stop** instead of a graceful wind-down.

## Hard stop behavior (both sides)

Previously Stop was *graceful* (functional spec §4.4(1)): it let the in-flight round finish, then surfaced that round's pending client tool calls for normal approval. The request was for a Stop that **totally halts** the agent and runs nothing further.

- **Backend** (`registry.stop()`): cancels the in-flight burst task immediately (mirrors `disable()`, reason `USER_STOPPED`) rather than setting a graceful stop intent. The runner is torn down mid-round and never reaches the point where it would emit `tool-calls-pending`, so no client tool calls are handed back.
- **Frontend** (`stopAgent()`): aborts any in-flight interactive stream, POSTs the server stop (run id is read synchronously before detach clears it), then detaches the observer — so even a late `tool-calls-pending` hand-off is ignored and **no Kiln-API tool calls run after Stop**.

## Tests

- Rewrote `test_stop_is_hard_cancel_ends_immediately` (registry) and `test_stop_clears_flag_with_user_stopped` (api) to assert the burst goes terminal (`USER_STOPPED` + `auto-mode-off`) **without releasing the gated round**, and that no `tool-calls-pending` is emitted.
- Backend auto suite: 74 passed. Frontend chat suite: 190 passed. `svelte-check`, `eslint`, `prettier`, `ruff` all clean.

## Note / follow-up

The runner's graceful-stop machinery (`request_stop` / `stop_requested` → `tool-calls-pending`) is now unused by the Stop path (still unit-tested in isolation). Left in place to keep this change tight; it can be removed in a follow-up if we want to fully retire the graceful-stop protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)