### PR TITLE
feat(chat): queue messages sent mid-turn with send-now / edit / cancel

### DIFF
--- a/app/desktop/studio_server/chat/auto/models.py
+++ b/app/desktop/studio_server/chat/auto/models.py
@@ -22,6 +22,14 @@ def _new_run_id() -> str:
     return f"ar_{suffix}"
 
 
+def _new_message_id() -> str:
+    """Mint an injected-message id like ``am_<base32>``. Echoed to observers so
+    the client can render the message idempotently (a buffer replay on re-attach
+    re-emits the echo for an in-flight message the transcript already shows)."""
+    suffix = "".join(secrets.choice(_RUN_ID_ALPHABET) for _ in range(_RUN_ID_LENGTH))
+    return f"am_{suffix}"
+
+
 class AutoRunStatus(str, Enum):
     RUNNING = "running"  # a burst is actively driving the loop
     # Revision R1: a burst settled but the conversation auto-mode flag stays ON
@@ -56,6 +64,9 @@ class InboundMessage(BaseModel):
     (appended to the continuation as a ``role:"user"`` message); when the run is
     idle it seeds a fresh burst."""
 
+    # Stable id minted server-side, echoed to observers (see _new_message_id) so
+    # the client can dedupe the echo on a buffer replay / re-attach.
+    id: str = Field(default_factory=_new_message_id)
     # Fixed to the user role: /message is documented as user-message input only,
     # so the schema enforces it rather than trusting a client-supplied role.
     role: Literal["user"] = "user"

--- a/app/desktop/studio_server/chat/auto/registry.py
+++ b/app/desktop/studio_server/chat/auto/registry.py
@@ -150,8 +150,10 @@ class AutoChatRun:
 
     def echo_user_message(self, message: InboundMessage) -> None:
         """Echo a user message onto the bus + current-turn buffer so observers
-        (including the sender) render it immediately, consistent with replay."""
-        self.emit(format_user_message(message.content))
+        (including the sender) render it immediately, consistent with replay. The
+        message id rides along so a re-attaching client can dedupe the replayed
+        echo against a message it already shows."""
+        self.emit(format_user_message(message.content, message.id))
 
     def emit(self, payload: bytes) -> None:
         """Append to the current-turn buffer and publish to subscribers.

--- a/app/desktop/studio_server/chat/auto/sse.py
+++ b/app/desktop/studio_server/chat/auto/sse.py
@@ -56,10 +56,15 @@ def format_auto_mode_state(run_id: str, *, flag_on: bool, working: bool) -> byte
     )
 
 
-def format_user_message(content: str) -> bytes:
+def format_user_message(content: str, message_id: str | None = None) -> bytes:
     """Echo a user message onto the run stream so observers (including the
-    sender) render it immediately, consistent with re-attach/replay."""
-    return _encode({"type": "user-message", "content": content})
+    sender) render it immediately, consistent with re-attach/replay. ``message_id``
+    is the injected message's stable id, so a client can dedupe the echo if a
+    buffer replay re-emits it for a message it already shows."""
+    payload: dict[str, str] = {"type": "user-message", "content": content}
+    if message_id is not None:
+        payload["id"] = message_id
+    return _encode(payload)
 
 
 def format_tool_exec_start(tool_count: int) -> bytes:

--- a/app/desktop/studio_server/chat/auto/test_registry.py
+++ b/app/desktop/studio_server/chat/auto/test_registry.py
@@ -424,6 +424,41 @@ async def test_send_message_while_running_enqueues():
 
 
 @pytest.mark.asyncio
+async def test_send_message_echo_carries_message_id():
+    # The echoed user-message event carries the injected message's stable id so a
+    # re-attaching client can dedupe a replayed echo against a message it shows.
+    reg = AutoChatRegistry()
+    release = asyncio.Event()
+    client = _GatedClient(release)
+    with patch.object(httpx, "AsyncClient", return_value=client):
+        rec = reg.start(_seed("tr-0"), reason=None, upstream_url=URL, headers={})
+        run = reg.get(rec.run_id)
+        assert run is not None
+        await asyncio.sleep(0.02)
+
+        msg = InboundMessage(content="inject me")
+        assert msg.id.startswith("am_")
+        assert reg.send_message(rec.run_id, msg) is True
+
+        echo = next(
+            e
+            for e in (
+                json.loads(line[6:].strip())
+                for chunk in run.buffer
+                for line in chunk.decode().split("\n")
+                if line.startswith("data: ") and line[6:].strip()
+            )
+            if isinstance(e, dict) and e.get("type") == "user-message"
+        )
+        assert echo["content"] == "inject me"
+        assert echo["id"] == msg.id
+
+        await reg.stop(rec.run_id)
+        release.set()
+        await _wait_terminal(reg, rec.run_id)
+
+
+@pytest.mark.asyncio
 async def test_send_message_while_idle_starts_new_burst():
     reg = AutoChatRegistry()
     # First burst settles IDLE; second burst (from /message) runs to settle too.

--- a/app/web_ui/src/lib/chat/auto_run_store.test.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.test.ts
@@ -635,6 +635,48 @@ describe("auto_run_store", () => {
     expect(text).not.toContain("Round one")
   })
 
+  it("opens a fresh assistant turn for the in-flight round on re-attach (openInflightTurn)", () => {
+    // Re-attach with openInflightTurn: the replayed in-flight round must render
+    // into its OWN turn instead of overwriting the last hydrated bubble.
+    store.attach("ar_reattach", true, true)
+    const source = FakeEventSource.latest()
+    // No turn opened until the in-flight round actually produces content.
+    expect(calls.beginAssistantTurn).toBe(0)
+    source.message({ type: "text-start" })
+    source.message({ type: "text-delta", delta: "in-flight" })
+    expect(calls.beginAssistantTurn).toBe(1)
+  })
+
+  it("does not open an in-flight turn on re-attach to an idle run (no content)", () => {
+    store.attach("ar_idle_reattach", false, true)
+    const source = FakeEventSource.latest()
+    source.message({
+      type: "auto-mode-idle",
+      run_id: "ar_idle_reattach",
+      reason: "done",
+    })
+    expect(calls.beginAssistantTurn).toBe(0)
+  })
+
+  it("does not open an extra in-flight turn on the initial attach (openInflightTurn omitted)", () => {
+    store.attach("ar_initial")
+    const source = FakeEventSource.latest()
+    source.message({ type: "text-delta", delta: "hi" })
+    expect(calls.beginAssistantTurn).toBe(0)
+  })
+
+  it("an injected-message echo consumes the pending in-flight turn (no double turn)", () => {
+    store.attach("ar_echo_consume", true, true)
+    const source = FakeEventSource.latest()
+    // The echo opens its own turn (via the sink); the subsequent in-flight
+    // content must NOT also trigger the pending fresh turn.
+    source.message({ type: "user-message", content: "hi", id: "am_1" })
+    source.message({ type: "text-delta", delta: "resp" })
+    // The fake sink's onUserMessage doesn't call beginAssistantTurn, so the only
+    // way beginAssistantTurn fires here is the (unwanted) pending in-flight turn.
+    expect(calls.beginAssistantTurn).toBe(0)
+  })
+
   it("resolve returns {run_id, current_trace_id, status} for an active run", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/app/web_ui/src/lib/chat/auto_run_store.test.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.test.ts
@@ -606,6 +606,35 @@ describe("auto_run_store", () => {
     expect(get(store.autoModeOn)).toBe(true)
   })
 
+  it("resets accumulated parts on a user-message echo so the prior round isn't duplicated into the new turn", () => {
+    store.attach("ar_dup")
+    const source = FakeEventSource.latest()
+    source.message({ type: "auto-mode-on", run_id: "ar_dup" })
+
+    // Round 1 renders some assistant text into the current turn.
+    source.message({ type: "text-start" })
+    source.message({ type: "text-delta", delta: "Round one." })
+    source.message({ type: "text-end" })
+
+    // An injected user message opens a fresh assistant turn (beginAssistantTurn).
+    source.message({ type: "user-message", content: "hi there" })
+
+    // Round 2 renders into the new turn.
+    source.message({ type: "text-start" })
+    source.message({ type: "text-delta", delta: "Round two." })
+    source.message({ type: "text-end" })
+
+    const last = calls.assistantUpdates[calls.assistantUpdates.length - 1]
+    const text = (last.parts ?? [])
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map((p) => p.text)
+      .join("")
+    // Without the processor reset, round one's text would be re-flushed into the
+    // new turn alongside round two's.
+    expect(text).toBe("Round two.")
+    expect(text).not.toContain("Round one")
+  })
+
   it("resolve returns {run_id, current_trace_id, status} for an active run", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/app/web_ui/src/lib/chat/auto_run_store.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.ts
@@ -381,7 +381,14 @@ export function createAutoRunStore(): AutoRunStore {
       // Any event other than another retry means the retry window is over (the
       // round recovered, or the burst settled idle/off) — clear the affordance.
       if (event.type !== "kiln-chat-retry") retry.set(null)
-      if (handleControlEvent(event)) return
+      if (handleControlEvent(event)) {
+        // A ``user-message`` echo opens a fresh assistant turn (the sink calls
+        // beginAssistantTurn). Reset the processor so the prior turn's
+        // accumulated parts aren't re-flushed into the new turn (which would
+        // duplicate the previous round's text + tools into it).
+        if (event.type === "user-message") processor.reset()
+        return
+      }
       processor.handleEvent(event)
     }
 

--- a/app/web_ui/src/lib/chat/auto_run_store.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.ts
@@ -154,8 +154,15 @@ export interface AutoRunStore {
    * Open the per-run events SSE and re-attach. ``initialWorking`` (from the
    * resolve response status) drives the thinking indicator immediately on
    * attach; omit it when the liveness isn't known up front (History restore).
+   * ``openInflightTurn`` opens a fresh assistant turn for the replayed in-flight
+   * round so it doesn't overwrite the last hydrated bubble — set on re-attach
+   * (resync / History restore), left false on the initial burst attach.
    */
-  attach(runId: string, initialWorking?: boolean): void
+  attach(
+    runId: string,
+    initialWorking?: boolean,
+    openInflightTurn?: boolean,
+  ): void
   /** Stop observing + clear the indicator without ending the run (navigation). */
   detach(): void
   /**
@@ -190,6 +197,22 @@ export function createAutoRunStore(): AutoRunStore {
 
   let sink: AutoRunChatSink | null = null
   let eventSource: EventSource | null = null
+  // On a re-attach (resync / History restore) the buffer replay carries ONLY the
+  // current in-flight round (the run buffer clears on every snapshot), but the
+  // restored/hydrated transcript's last assistant bubble holds earlier rounds.
+  // Without opening a fresh turn first, the in-flight round's first flush would
+  // overwrite that bubble (``draft.parts = next``) and destroy those rounds. So
+  // on re-attach we open a fresh assistant turn lazily — on the first assistant
+  // content of the in-flight round (or it's consumed by an injected-message echo,
+  // which opens its own turn). Lazy so an idle re-attach leaves no empty bubble.
+  let pendingInflightTurn = false
+
+  function consumeInflightTurn(): void {
+    if (pendingInflightTurn) {
+      pendingInflightTurn = false
+      sink?.beginAssistantTurn()
+    }
+  }
 
   function bind(newSink: AutoRunChatSink): void {
     sink = newSink
@@ -197,7 +220,12 @@ export function createAutoRunStore(): AutoRunStore {
 
   function buildProcessor(): StreamEventProcessor {
     return new StreamEventProcessor({
-      onAssistantMessage: (update) => sink?.onAssistantMessage(update),
+      onAssistantMessage: (update) => {
+        // First assistant content of a re-attached in-flight round: open a fresh
+        // turn so it renders into its own bubble instead of overwriting the last.
+        consumeInflightTurn()
+        sink?.onAssistantMessage(update)
+      },
       onChatTrace: (tid) => sink?.onChatTrace(tid),
       onContextUsage: (usage) => sink?.onContextUsage(usage),
       onCompactionStatus: (compacting) => sink?.onCompactionStatus(compacting),
@@ -214,6 +242,9 @@ export function createAutoRunStore(): AutoRunStore {
       eventSource.close()
       eventSource = null
     }
+    // A pending fresh-turn belongs to the stream we're tearing down; drop it so a
+    // later attach can't open a stray empty bubble.
+    pendingInflightTurn = false
   }
 
   function clearToOff(reason: string | null): void {
@@ -307,6 +338,9 @@ export function createAutoRunStore(): AutoRunStore {
       autoModeOn.set(true)
       setWorking(false)
       reconnecting.set(false)
+      // No in-flight round produced content (idle on/just-after re-attach) — drop
+      // the pending fresh-turn so we don't open an empty bubble.
+      pendingInflightTurn = false
       sink?.onAutoModeIdle(event.reason ?? null)
       return true
     }
@@ -321,6 +355,9 @@ export function createAutoRunStore(): AutoRunStore {
       // echo id lets the sink dedupe a replayed echo (re-attach) against a
       // message it already shows.
       setWorking(true)
+      // The echo opens (or dedupes into) its own assistant turn, so the in-flight
+      // round renders there — consume any pending fresh-turn to avoid a second.
+      pendingInflightTurn = false
       sink?.onUserMessage(event.content ?? "", event.id)
       return true
     }
@@ -337,7 +374,11 @@ export function createAutoRunStore(): AutoRunStore {
     return false
   }
 
-  function attach(newRunId: string, initialWorking?: boolean): void {
+  function attach(
+    newRunId: string,
+    initialWorking?: boolean,
+    openInflightTurn = false,
+  ): void {
     const EventSourceCtor = globalThis.EventSource
     if (!EventSourceCtor) {
       // No SSE support: don't leave a "reconnecting…" affordance stuck on.
@@ -345,6 +386,12 @@ export function createAutoRunStore(): AutoRunStore {
       return
     }
     closeSource()
+
+    // Re-attach (resync / History restore): render the replayed in-flight round
+    // into a fresh assistant turn rather than overwriting the last hydrated one.
+    // (closeSource above cleared any stale value.) Not set on the initial burst
+    // attach, which already opened its turn via requestEnable.
+    pendingInflightTurn = openInflightTurn
 
     runId.set(newRunId)
     autoModeOn.set(true)

--- a/app/web_ui/src/lib/chat/auto_run_store.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.ts
@@ -61,8 +61,12 @@ export interface AutoRunChatSink {
    * streaming while the runner works between events. ``false`` on burst end.
    */
   onWorkingChange: (working: boolean) => void
-  /** The runner echoed an injected user message; render it as a new user turn. */
-  onUserMessage: (content: string) => void
+  /**
+   * The runner echoed an injected user message; render it as a new user turn.
+   * ``echoId`` is the message's stable id, so the sink can render it idempotently
+   * (a buffer replay on re-attach re-emits the echo for a message already shown).
+   */
+  onUserMessage: (content: string, echoId?: string) => void
   /**
    * A burst ended but auto mode stays ON (asked_user / done / error /
    * max_rounds). The indicator persists; only the working sub-state clears.
@@ -313,9 +317,11 @@ export function createAutoRunStore(): AutoRunStore {
     if (event.type === "user-message") {
       // The runner echoed an injected user message. Render it as a fresh user
       // turn (then a new assistant turn for the burst it triggers) so every
-      // observer — including the sender — sees it, consistent with replay.
+      // observer — including the sender — sees it, consistent with replay. The
+      // echo id lets the sink dedupe a replayed echo (re-attach) against a
+      // message it already shows.
       setWorking(true)
-      sink?.onUserMessage(event.content ?? "")
+      sink?.onUserMessage(event.content ?? "", event.id)
       return true
     }
     if (event.type === "tool-calls-pending") {

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -660,23 +660,9 @@ describe("createChatSessionStore", () => {
   })
 
   describe("queued messages", () => {
-    // Reach into the typed-erased fake's writable stores to simulate burst state.
+    // Reach into the type-erased fake's writable store to simulate burst state.
     function workingStore(fake: unknown): Writable<boolean> {
       return (fake as { working: Writable<boolean> }).working
-    }
-
-    function bindSink(fake: unknown): {
-      get: () => import("./auto_run_store").AutoRunChatSink | null
-    } {
-      let sink: import("./auto_run_store").AutoRunChatSink | null = null
-      ;(
-        fake as {
-          bind: (s: import("./auto_run_store").AutoRunChatSink) => void
-        }
-      ).bind = (s) => {
-        sink = s
-      }
-      return { get: () => sink }
     }
 
     it("appends a second queued message to the first instead of replacing it", async () => {
@@ -771,7 +757,7 @@ describe("createChatSessionStore", () => {
       expect(streamChatMock).toHaveBeenCalledTimes(2)
     })
 
-    it("flushes a queued message by injecting when an auto burst goes idle", async () => {
+    it("injects immediately during an active auto burst instead of queuing or waiting for idle", async () => {
       const { createChatSessionStore, streamChatMock } =
         await importFreshWithMock()
       streamChatMock.mockImplementation(noopStreamChat)
@@ -780,41 +766,14 @@ describe("createChatSessionStore", () => {
         autoModeOn: true,
         sendMessage: inject,
       })
-      const sink = bindSink(fakeAutoRun)
       const store = createChatSessionStore(undefined, fakeAutoRun)
 
-      // A burst is running -> the message queues rather than injecting now.
+      // A burst is running, but auto mode never holds client-side — the message
+      // is injected right away so the runner appends it to its next request.
       workingStore(fakeAutoRun).set(true)
       await store.sendMessage("while working")
-      expect(inject).not.toHaveBeenCalled()
-      expect(get(store).queuedMessage).toBe("while working")
-
-      // Burst settles -> the queued message injects (starting the next burst).
-      workingStore(fakeAutoRun).set(false)
-      sink.get()!.onAutoModeIdle("done")
       expect(inject).toHaveBeenCalledTimes(1)
       expect(inject.mock.calls[0][0]).toBe("while working")
-      expect(get(store).queuedMessage).toBeNull()
-    })
-
-    it("sendQueuedNow injects immediately in auto mode without waiting for idle", async () => {
-      const { createChatSessionStore, streamChatMock } =
-        await importFreshWithMock()
-      streamChatMock.mockImplementation(noopStreamChat)
-      const inject = vi.fn().mockResolvedValue({ ok: true })
-      const fakeAutoRun = makeFakeAutoRun({
-        autoModeOn: true,
-        sendMessage: inject,
-      })
-      const store = createChatSessionStore(undefined, fakeAutoRun)
-
-      workingStore(fakeAutoRun).set(true)
-      await store.sendMessage("urgent")
-      expect(inject).not.toHaveBeenCalled()
-
-      store.sendQueuedNow()
-      expect(inject).toHaveBeenCalledTimes(1)
-      expect(inject.mock.calls[0][0]).toBe("urgent")
       expect(get(store).queuedMessage).toBeNull()
     })
 

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -665,6 +665,22 @@ describe("createChatSessionStore", () => {
       return (fake as { working: Writable<boolean> }).working
     }
 
+    // Capture the sink the store binds into the auto-run store so tests can
+    // drive the runner's control/round events (onToolExecutionEnd, idle, off).
+    function bindSink(fake: unknown): {
+      get: () => import("./auto_run_store").AutoRunChatSink | null
+    } {
+      let sink: import("./auto_run_store").AutoRunChatSink | null = null
+      ;(
+        fake as {
+          bind: (s: import("./auto_run_store").AutoRunChatSink) => void
+        }
+      ).bind = (s) => {
+        sink = s
+      }
+      return { get: () => sink }
+    }
+
     it("appends a second queued message to the first instead of replacing it", async () => {
       const { createChatSessionStore, streamChatMock } =
         await importFreshWithMock()
@@ -757,7 +773,34 @@ describe("createChatSessionStore", () => {
       expect(streamChatMock).toHaveBeenCalledTimes(2)
     })
 
-    it("injects immediately during an active auto burst instead of queuing or waiting for idle", async () => {
+    it("queues during an active auto burst and injects at the next round boundary", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      const inject = vi.fn().mockResolvedValue({ ok: true })
+      const fakeAutoRun = makeFakeAutoRun({
+        autoModeOn: true,
+        sendMessage: inject,
+      })
+      const sink = bindSink(fakeAutoRun)
+      const store = createChatSessionStore(undefined, fakeAutoRun)
+
+      // A burst is running -> hold client-side (no immediate inject, so the echo
+      // doesn't jump into the transcript mid-round).
+      workingStore(fakeAutoRun).set(true)
+      await store.sendMessage("while working")
+      expect(inject).not.toHaveBeenCalled()
+      expect(get(store).queuedMessage).toBe("while working")
+
+      // Round boundary (a tool round finished) -> inject so it rides the next
+      // request.
+      sink.get()!.onToolExecutionEnd(1)
+      expect(inject).toHaveBeenCalledTimes(1)
+      expect(inject.mock.calls[0][0]).toBe("while working")
+      expect(get(store).queuedMessage).toBeNull()
+    })
+
+    it("injects immediately when auto mode is idle (no in-flight round to wait for)", async () => {
       const { createChatSessionStore, streamChatMock } =
         await importFreshWithMock()
       streamChatMock.mockImplementation(noopStreamChat)
@@ -768,13 +811,76 @@ describe("createChatSessionStore", () => {
       })
       const store = createChatSessionStore(undefined, fakeAutoRun)
 
-      // A burst is running, but auto mode never holds client-side — the message
-      // is injected right away so the runner appends it to its next request.
-      workingStore(fakeAutoRun).set(true)
-      await store.sendMessage("while working")
+      // working defaults false -> auto mode is idle ("waiting for you").
+      await store.sendMessage("go")
       expect(inject).toHaveBeenCalledTimes(1)
-      expect(inject.mock.calls[0][0]).toBe("while working")
+      expect(inject.mock.calls[0][0]).toBe("go")
       expect(get(store).queuedMessage).toBeNull()
+    })
+
+    it("flushes a queued message by injecting when the burst goes idle", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      const inject = vi.fn().mockResolvedValue({ ok: true })
+      const fakeAutoRun = makeFakeAutoRun({
+        autoModeOn: true,
+        sendMessage: inject,
+      })
+      const sink = bindSink(fakeAutoRun)
+      const store = createChatSessionStore(undefined, fakeAutoRun)
+
+      workingStore(fakeAutoRun).set(true)
+      await store.sendMessage("at idle")
+      expect(inject).not.toHaveBeenCalled()
+
+      workingStore(fakeAutoRun).set(false)
+      sink.get()!.onAutoModeIdle("done")
+      expect(inject).toHaveBeenCalledTimes(1)
+      expect(inject.mock.calls[0][0]).toBe("at idle")
+      expect(get(store).queuedMessage).toBeNull()
+    })
+
+    it("sendQueuedNow injects immediately in auto mode without waiting for a round boundary", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      const inject = vi.fn().mockResolvedValue({ ok: true })
+      const fakeAutoRun = makeFakeAutoRun({
+        autoModeOn: true,
+        sendMessage: inject,
+      })
+      const store = createChatSessionStore(undefined, fakeAutoRun)
+
+      workingStore(fakeAutoRun).set(true)
+      await store.sendMessage("urgent")
+      expect(inject).not.toHaveBeenCalled()
+
+      store.sendQueuedNow()
+      expect(inject).toHaveBeenCalledTimes(1)
+      expect(inject.mock.calls[0][0]).toBe("urgent")
+      expect(get(store).queuedMessage).toBeNull()
+    })
+
+    it("clears the queued message when auto mode stops (auto-mode-off)", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      const inject = vi.fn().mockResolvedValue({ ok: true })
+      const fakeAutoRun = makeFakeAutoRun({
+        autoModeOn: true,
+        sendMessage: inject,
+      })
+      const sink = bindSink(fakeAutoRun)
+      const store = createChatSessionStore(undefined, fakeAutoRun)
+
+      workingStore(fakeAutoRun).set(true)
+      await store.sendMessage("pending")
+      expect(get(store).queuedMessage).toBe("pending")
+
+      sink.get()!.onAutoModeOff("user_stopped")
+      expect(get(store).queuedMessage).toBeNull()
+      expect(inject).not.toHaveBeenCalled()
     })
 
     it("clears the queue on reset", async () => {

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -1801,61 +1801,13 @@ describe("resyncOnLoad (hard-refresh resync)", () => {
       { params: { path: { session_id: "t_now" } } },
     )
     // Phase 9: attach is driven by the resolved liveness (RUNNING → working) and
-    // the reconnecting affordance is shown for the connecting window.
+    // the reconnecting affordance is shown for the connecting window. The third
+    // arg opens a fresh assistant turn for the replayed in-flight round so it
+    // doesn't overwrite the last hydrated bubble.
     expect(beginReconnect).toHaveBeenCalled()
-    expect(attach).toHaveBeenCalledWith("ar_live", true)
+    expect(attach).toHaveBeenCalledWith("ar_live", true, true)
     // The caught-up messages replaced the stale restored view.
     expect(get(store).messages).toEqual(hydratedMessages)
-  })
-
-  it("keeps the optimistic transcript when the resolved leaf is already rendered (injected-message lag)", async () => {
-    const { createChatSessionStore, streamChatMock } =
-      await importFreshWithMock()
-    streamChatMock.mockImplementation(noopStreamChat)
-
-    const streaming = await import("./streaming_chat")
-    vi.mocked(streaming.traceIdForNextChatRequest).mockReturnValue("t_now")
-
-    // The run resolves to t_now, but the client already rendered t_now plus a
-    // just-injected message + its in-flight response — current_trace_id lags one
-    // round behind the optimistic transcript.
-    const resolve = vi.fn().mockResolvedValue({
-      run_id: "ar_live",
-      current_trace_id: "t_now",
-      status: "running",
-    })
-    const attach = vi.fn()
-    const beginReconnect = vi.fn()
-    const auto = makeFakeAutoRun({ resolve, attach, beginReconnect })
-
-    const optimistic: ChatMessage[] = [
-      { id: "a0", role: "assistant", parts: [], traceId: "t_now" },
-      { id: "u_inj", role: "user", content: "my name is bobby" },
-      {
-        id: "a_resp",
-        role: "assistant",
-        parts: [{ type: "text", text: "Hey Bobby!" }],
-      },
-    ]
-    // Seed the restored-from-sessionStorage transcript.
-    storage.store["resync_lag"] = JSON.stringify({
-      messages: optimistic,
-      collapsedPartKeys: {},
-      lastSentAppState: null,
-      contextUsage: null,
-    })
-
-    const store = createChatSessionStore("resync_lag", auto)
-    await store.resyncOnLoad()
-
-    // The stale snapshot was neither fetched nor applied — the optimistic
-    // transcript (with the just-sent message + response) is preserved...
-    expect(mockClientGet).not.toHaveBeenCalled()
-    expect(mockHydrate).not.toHaveBeenCalled()
-    expect(get(store).messages).toEqual(optimistic)
-    // ...and we still re-attach the live run.
-    expect(beginReconnect).toHaveBeenCalled()
-    expect(attach).toHaveBeenCalledWith("ar_live", true)
   })
 
   it("attaches even when snapshot hydration returns a structured error (CR Moderate item 1)", async () => {
@@ -1890,8 +1842,8 @@ describe("resyncOnLoad (hard-refresh resync)", () => {
     // Hydration did not happen (no messages to apply)...
     expect(mockHydrate).not.toHaveBeenCalled()
     // ...but we STILL attach so the conversation isn't left looking dead (IDLE
-    // status → not working).
-    expect(attach).toHaveBeenCalledWith("ar_live", false)
+    // status → not working), opening a fresh in-flight turn.
+    expect(attach).toHaveBeenCalledWith("ar_live", false, true)
   })
 
   it("bails without hydrating/attaching if the user switches conversations mid-resync", async () => {

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -1757,6 +1757,56 @@ describe("resyncOnLoad (hard-refresh resync)", () => {
     expect(get(store).messages).toEqual(hydratedMessages)
   })
 
+  it("keeps the optimistic transcript when the resolved leaf is already rendered (injected-message lag)", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    streamChatMock.mockImplementation(noopStreamChat)
+
+    const streaming = await import("./streaming_chat")
+    vi.mocked(streaming.traceIdForNextChatRequest).mockReturnValue("t_now")
+
+    // The run resolves to t_now, but the client already rendered t_now plus a
+    // just-injected message + its in-flight response — current_trace_id lags one
+    // round behind the optimistic transcript.
+    const resolve = vi.fn().mockResolvedValue({
+      run_id: "ar_live",
+      current_trace_id: "t_now",
+      status: "running",
+    })
+    const attach = vi.fn()
+    const beginReconnect = vi.fn()
+    const auto = makeFakeAutoRun({ resolve, attach, beginReconnect })
+
+    const optimistic: ChatMessage[] = [
+      { id: "a0", role: "assistant", parts: [], traceId: "t_now" },
+      { id: "u_inj", role: "user", content: "my name is bobby" },
+      {
+        id: "a_resp",
+        role: "assistant",
+        parts: [{ type: "text", text: "Hey Bobby!" }],
+      },
+    ]
+    // Seed the restored-from-sessionStorage transcript.
+    storage.store["resync_lag"] = JSON.stringify({
+      messages: optimistic,
+      collapsedPartKeys: {},
+      lastSentAppState: null,
+      contextUsage: null,
+    })
+
+    const store = createChatSessionStore("resync_lag", auto)
+    await store.resyncOnLoad()
+
+    // The stale snapshot was neither fetched nor applied — the optimistic
+    // transcript (with the just-sent message + response) is preserved...
+    expect(mockClientGet).not.toHaveBeenCalled()
+    expect(mockHydrate).not.toHaveBeenCalled()
+    expect(get(store).messages).toEqual(optimistic)
+    // ...and we still re-attach the live run.
+    expect(beginReconnect).toHaveBeenCalled()
+    expect(attach).toHaveBeenCalledWith("ar_live", true)
+  })
+
   it("attaches even when snapshot hydration returns a structured error (CR Moderate item 1)", async () => {
     // resolve() already proved the run is live; a snapshot error/empty response
     // must NOT short-circuit — fall through to attach so the indicator + live

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -192,7 +192,7 @@ describe("createChatSessionStore", () => {
       expect(get(store).status).toBe("ready")
     })
 
-    it("guards against sending when not ready", async () => {
+    it("queues a second message sent while a turn is in flight instead of dispatching it", async () => {
       const { createChatSessionStore, streamChatMock } =
         await importFreshWithMock()
       streamChatMock.mockImplementation(noopStreamChat)
@@ -202,8 +202,11 @@ describe("createChatSessionStore", () => {
       expect(get(store).status).toBe("submitted")
 
       await store.sendMessage("second")
+      // The second send is held client-side: no new conversation messages, no
+      // second stream — just the queued buffer.
       expect(get(store).messages).toHaveLength(2)
       expect(streamChatMock).toHaveBeenCalledTimes(1)
+      expect(get(store).queuedMessage).toBe("second")
     })
 
     it("transitions to streaming when onAssistantMessage is called", async () => {
@@ -653,6 +656,180 @@ describe("createChatSessionStore", () => {
       expect(sent).toBe(false)
       const errorMsg = get(store).messages.find((m) => m.role === "error")
       expect(errorMsg?.content).toBe("Couldn't send the message: Run is gone")
+    })
+  })
+
+  describe("queued messages", () => {
+    // Reach into the typed-erased fake's writable stores to simulate burst state.
+    function workingStore(fake: unknown): Writable<boolean> {
+      return (fake as { working: Writable<boolean> }).working
+    }
+
+    function bindSink(fake: unknown): {
+      get: () => import("./auto_run_store").AutoRunChatSink | null
+    } {
+      let sink: import("./auto_run_store").AutoRunChatSink | null = null
+      ;(
+        fake as {
+          bind: (s: import("./auto_run_store").AutoRunChatSink) => void
+        }
+      ).bind = (s) => {
+        sink = s
+      }
+      return { get: () => sink }
+    }
+
+    it("appends a second queued message to the first instead of replacing it", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      const store = createChatSessionStore()
+
+      await store.sendMessage("first") // status -> submitted
+      await store.sendMessage("second")
+      await store.sendMessage("third")
+
+      expect(get(store).queuedMessage).toBe("second\n\nthird")
+      expect(streamChatMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("coalesces a new send into an already-queued message even after the turn ends", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      const capture: { options: StreamChatOptions | null } = { options: null }
+      streamChatMock.mockImplementation(capturingStreamChat(capture))
+      const store = createChatSessionStore()
+
+      await store.sendMessage("first")
+      await store.sendMessage("queued")
+      // The turn errors, leaving the message queued (not auto-flushed on error).
+      capture.options!.onError(new Error("boom"))
+      expect(get(store).status).toBe("ready")
+      expect(get(store).queuedMessage).toBe("queued")
+
+      // A follow-up send appends to the pending message instead of dispatching a
+      // separate stream alongside it.
+      await store.sendMessage("more")
+      expect(get(store).queuedMessage).toBe("queued\n\nmore")
+      expect(streamChatMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("flushes the queued message when the interactive turn finishes", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      const capture: { options: StreamChatOptions | null } = { options: null }
+      streamChatMock.mockImplementation(capturingStreamChat(capture))
+      const store = createChatSessionStore()
+
+      await store.sendMessage("first")
+      await store.sendMessage("queued")
+      expect(get(store).queuedMessage).toBe("queued")
+
+      // Turn ends -> the queued message dispatches as a fresh stream.
+      capture.options!.onFinish()
+
+      expect(get(store).queuedMessage).toBeNull()
+      expect(streamChatMock).toHaveBeenCalledTimes(2)
+      const secondCall = streamChatMock.mock.calls[1][0] as StreamChatOptions
+      expect(secondCall.messages[0].content).toBe("queued")
+    })
+
+    it("clearQueued discards the queued message without sending", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      const store = createChatSessionStore()
+
+      await store.sendMessage("first")
+      await store.sendMessage("queued")
+      expect(get(store).queuedMessage).toBe("queued")
+
+      store.clearQueued()
+      expect(get(store).queuedMessage).toBeNull()
+      // Still mid-turn, and only the original stream was ever dispatched.
+      expect(streamChatMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("sendQueuedNow stops the interactive turn so the queue flushes on finish", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      const capture: { options: StreamChatOptions | null } = { options: null }
+      streamChatMock.mockImplementation(capturingStreamChat(capture))
+      const store = createChatSessionStore()
+
+      await store.sendMessage("first")
+      await store.sendMessage("queued")
+      const controller = get(store).abortController
+      const abortSpy = vi.spyOn(controller!, "abort")
+
+      store.sendQueuedNow()
+      // Interactive send-now terminates the turn; streamChat reports the abort
+      // as a finish, which flushes the queued message.
+      expect(abortSpy).toHaveBeenCalled()
+      capture.options!.onFinish()
+      expect(get(store).queuedMessage).toBeNull()
+      expect(streamChatMock).toHaveBeenCalledTimes(2)
+    })
+
+    it("flushes a queued message by injecting when an auto burst goes idle", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      const inject = vi.fn().mockResolvedValue({ ok: true })
+      const fakeAutoRun = makeFakeAutoRun({
+        autoModeOn: true,
+        sendMessage: inject,
+      })
+      const sink = bindSink(fakeAutoRun)
+      const store = createChatSessionStore(undefined, fakeAutoRun)
+
+      // A burst is running -> the message queues rather than injecting now.
+      workingStore(fakeAutoRun).set(true)
+      await store.sendMessage("while working")
+      expect(inject).not.toHaveBeenCalled()
+      expect(get(store).queuedMessage).toBe("while working")
+
+      // Burst settles -> the queued message injects (starting the next burst).
+      workingStore(fakeAutoRun).set(false)
+      sink.get()!.onAutoModeIdle("done")
+      expect(inject).toHaveBeenCalledTimes(1)
+      expect(inject.mock.calls[0][0]).toBe("while working")
+      expect(get(store).queuedMessage).toBeNull()
+    })
+
+    it("sendQueuedNow injects immediately in auto mode without waiting for idle", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      const inject = vi.fn().mockResolvedValue({ ok: true })
+      const fakeAutoRun = makeFakeAutoRun({
+        autoModeOn: true,
+        sendMessage: inject,
+      })
+      const store = createChatSessionStore(undefined, fakeAutoRun)
+
+      workingStore(fakeAutoRun).set(true)
+      await store.sendMessage("urgent")
+      expect(inject).not.toHaveBeenCalled()
+
+      store.sendQueuedNow()
+      expect(inject).toHaveBeenCalledTimes(1)
+      expect(inject.mock.calls[0][0]).toBe("urgent")
+      expect(get(store).queuedMessage).toBeNull()
+    })
+
+    it("clears the queue on reset", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      const store = createChatSessionStore()
+
+      await store.sendMessage("first")
+      await store.sendMessage("queued")
+      expect(get(store).queuedMessage).toBe("queued")
+
+      store.reset()
+      expect(get(store).queuedMessage).toBeNull()
     })
   })
 

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -883,6 +883,32 @@ describe("createChatSessionStore", () => {
       expect(inject).not.toHaveBeenCalled()
     })
 
+    it("restores the queued message if a flush dispatch is rejected (no silent data loss)", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      // The inject fails — the queued text must not vanish.
+      const inject = vi
+        .fn()
+        .mockResolvedValue({ ok: false, error: "run is gone" })
+      const fakeAutoRun = makeFakeAutoRun({
+        autoModeOn: true,
+        sendMessage: inject,
+      })
+      const sink = bindSink(fakeAutoRun)
+      const store = createChatSessionStore(undefined, fakeAutoRun)
+
+      workingStore(fakeAutoRun).set(true)
+      await store.sendMessage("keep me")
+      expect(get(store).queuedMessage).toBe("keep me")
+
+      // Round boundary triggers a flush that fails to dispatch.
+      sink.get()!.onToolExecutionEnd(1)
+      expect(inject).toHaveBeenCalledTimes(1)
+      // Cleared optimistically, then restored once the failed send resolves.
+      await vi.waitFor(() => expect(get(store).queuedMessage).toBe("keep me"))
+    })
+
     it("clears the queue on reset", async () => {
       const { createChatSessionStore, streamChatMock } =
         await importFreshWithMock()

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -642,6 +642,31 @@ describe("createChatSessionStore", () => {
       expect(msgs[msgs.length - 1].role).toBe("assistant")
     })
 
+    it("renders an echoed user message once per echo id (dedupes a replayed echo)", async () => {
+      const { createChatSessionStore, streamChatMock } =
+        await importFreshWithMock()
+      streamChatMock.mockImplementation(noopStreamChat)
+      let boundSink: import("./auto_run_store").AutoRunChatSink | null = null
+      const fakeAutoRun = makeFakeAutoRun({ autoModeOn: true })
+      ;(
+        fakeAutoRun as unknown as {
+          bind: (s: import("./auto_run_store").AutoRunChatSink) => void
+        }
+      ).bind = (s) => {
+        boundSink = s
+      }
+      const store = createChatSessionStore(undefined, fakeAutoRun)
+
+      // Live echo + a buffer-replay echo on re-attach carry the SAME id.
+      boundSink!.onUserMessage("hello there", "am_1")
+      boundSink!.onUserMessage("hello there", "am_1")
+
+      const users = get(store).messages.filter((m) => m.role === "user")
+      expect(users).toHaveLength(1)
+      expect(users[0].content).toBe("hello there")
+      expect(users[0].echoId).toBe("am_1")
+    })
+
     it("surfaces an inline error when injecting a message fails", async () => {
       const { createChatSessionStore, streamChatMock } =
         await importFreshWithMock()

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -1000,37 +1000,51 @@ export function createChatSessionStore(
     // clears it once the stream is established; off/idle/error paths also clear it.
     autoRunStore.beginReconnect()
 
-    // Hydrate from the run's CURRENT leaf so the user catches up on rounds that
-    // completed while the tab was gone, then attach for live events + buffer
-    // replay + the indicator/working state.
-    try {
-      const { data: snapshot, error } = await client.GET(
-        "/api/chat/sessions/{session_id}",
-        { params: { path: { session_id: resolved.current_trace_id } } },
-      )
-      // Switched conversations while the snapshot was fetching: bail before the
-      // destructive loadSession() so we don't overwrite the now-current session.
-      if (!isStillCurrent()) return
-      // A structured error / empty snapshot must NOT short-circuit the attach:
-      // resolve() already proved the run is live, so fall through to attach on
-      // the restored (stale) view — same as the thrown-exception fallback below.
-      // Returning here would leave the conversation looking dead (no indicator,
-      // no live stream) in the snapshot-error case while the throw case
-      // correctly re-attaches.
-      if (!error && snapshot) {
-        const {
-          messages,
-          continuationTraceId: traceId,
-          contextUsage,
-        } = hydrateSessionFromSnapshot(snapshot)
-        // loadSession detaches any prior observer, sets the messages + trace id,
-        // and resets runtime state — identical to the history-restore apply path.
-        loadSession(messages, traceId, contextUsage)
+    // Only hydrate from the run's CURRENT leaf when it's a round the client
+    // hasn't rendered yet — a genuine catch-up after the tab was away. If
+    // ``current_trace_id`` is already present in the restored transcript, the
+    // run's registered leaf is BEHIND our optimistic state, which happens right
+    // after a message is injected mid-burst: it's echoed + persisted locally,
+    // but ``current_trace_id`` only advances to the round that incorporates it
+    // one round later. Hydrating would drop that just-sent message (and its
+    // in-flight response) until a full History reload — so skip it and just
+    // re-attach; the live stream + buffer replay reconcile the in-flight round.
+    const clientHasLeaf = get(persisted).messages.some(
+      (m) => m.traceId === resolved.current_trace_id,
+    )
+    if (!clientHasLeaf) {
+      // Hydrate from the current leaf so the user catches up on rounds that
+      // completed while the tab was gone, then attach for live events + buffer
+      // replay + the indicator/working state.
+      try {
+        const { data: snapshot, error } = await client.GET(
+          "/api/chat/sessions/{session_id}",
+          { params: { path: { session_id: resolved.current_trace_id } } },
+        )
+        // Switched conversations while the snapshot was fetching: bail before the
+        // destructive loadSession() so we don't overwrite the now-current session.
+        if (!isStillCurrent()) return
+        // A structured error / empty snapshot must NOT short-circuit the attach:
+        // resolve() already proved the run is live, so fall through to attach on
+        // the restored (stale) view — same as the thrown-exception fallback below.
+        // Returning here would leave the conversation looking dead (no indicator,
+        // no live stream) in the snapshot-error case while the throw case
+        // correctly re-attaches.
+        if (!error && snapshot) {
+          const {
+            messages,
+            continuationTraceId: traceId,
+            contextUsage,
+          } = hydrateSessionFromSnapshot(snapshot)
+          // loadSession detaches any prior observer, sets the messages + trace
+          // id, and resets runtime state — identical to the history-restore path.
+          loadSession(messages, traceId, contextUsage)
+        }
+      } catch {
+        // Hydration failed (network/parse). Fall back: still attach so the user
+        // at least gets the live indicator + events on the restored (stale) view.
+        if (!isStillCurrent()) return
       }
-    } catch {
-      // Hydration failed (network/parse). Fall back: still attach so the user at
-      // least gets the live indicator + events on the restored (stale) view.
-      if (!isStillCurrent()) return
     }
     // Re-assert reconnecting: loadSession() detaches the prior observer, which
     // clears the flag, so re-mark it for the brief connecting window. attach()

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -84,6 +84,13 @@ export interface ChatSessionState extends PersistedChatSession {
    * the composer rather than as a conversation message. Runtime-only.
    */
   versionRequired: boolean
+  /**
+   * A user message typed while a turn was in flight (interactive stream or auto
+   * burst), held client-side until the turn yields — then auto-sent — or sent
+   * immediately via send-now. ``null`` when nothing is queued. A second send
+   * while one is queued appends to it. Runtime-only, not persisted.
+   */
+  queuedMessage: string | null
 }
 
 /**
@@ -96,6 +103,16 @@ export type AutoModeConsentDecision = (
 
 export interface ChatSessionStore extends Readable<ChatSessionState> {
   sendMessage(text: string): Promise<boolean>
+  /**
+   * Send the currently queued message right now instead of waiting for the
+   * in-flight turn to end. Interactive: stops the turn (it then auto-sends on
+   * the ready transition). Auto mode: injects immediately, keeping auto mode
+   * running (the runner picks it up at the next round boundary). No-op when
+   * nothing is queued.
+   */
+  sendQueuedNow(): void
+  /** Discard the queued message without sending it. */
+  clearQueued(): void
   stop(): void
   retryLastRequest(): void
   reset(): void
@@ -168,6 +185,7 @@ export function createChatSessionStore(
     retry: null,
     upgradeNudgeVersion: null,
     versionRequired: false,
+    queuedMessage: null,
   })
 
   // Intentionally never unsubscribed — this store is a module-level singleton
@@ -317,14 +335,18 @@ export function createChatSessionStore(
     onUserMessage: appendEchoedUserMessage,
     // Idle: a burst ended but the flag stays on. Stop the working affordances;
     // the green indicator persists (it binds to autoModeOn, not autoWorking).
-    onAutoModeIdle: () =>
+    onAutoModeIdle: () => {
       combined.update((s) => ({
         ...s,
         toolExecuting: false,
         showActivityIndicator: false,
         compacting: false,
         autoWorking: false,
-      })),
+      }))
+      // The burst settled and auto mode is waiting for the user — the moment to
+      // flush a queued message (injects it, which starts the next burst).
+      maybeFlush()
+    },
     onAutoModeOff: () =>
       combined.update((s) => ({
         ...s,
@@ -572,6 +594,9 @@ export function createChatSessionStore(
           retry: null,
         }))
         setRuntimeState("ready", null)
+        // The interactive turn ended (normal completion or a Stop/abort, which
+        // streamChat reports as a finish) — flush any queued message now.
+        maybeFlush()
       },
       onError: (err) => {
         if (isStale()) return
@@ -658,7 +683,85 @@ export function createChatSessionStore(
     }
   }
 
+  // A turn is "in flight" — sending should queue rather than dispatch — when the
+  // interactive stream is active, a tool approval is open (waiting on the user
+  // mid-turn), or a server-owned auto burst is running / re-attaching.
+  function turnActive(): boolean {
+    if (status !== "ready") return true
+    if (get(combined).toolApprovalWaiter) return true
+    if (get(autoRunStore.working)) return true
+    if (get(autoRunStore.reconnecting)) return true
+    return false
+  }
+
+  // Hold a message client-side while a turn is in flight. A second send while one
+  // is queued appends (blank line between) so the coalesced text sends as one.
+  function enqueue(text: string): void {
+    combined.update((s) => ({
+      ...s,
+      queuedMessage: s.queuedMessage ? `${s.queuedMessage}\n\n${text}` : text,
+    }))
+  }
+
+  function clearQueued(): void {
+    combined.update((s) => ({ ...s, queuedMessage: null }))
+  }
+
+  // Auto-send the queued message once the turn has yielded. Guards on
+  // ``turnActive`` (re-check: a flush hook can fire mid-transition) and
+  // ``versionRequired`` (sending would just be rejected). Clears the queue
+  // before dispatching so a re-entrant flush can't double-send.
+  function maybeFlush(): void {
+    const queued = get(combined).queuedMessage
+    if (!queued) return
+    if (turnActive()) return
+    if (get(combined).versionRequired) return
+    clearQueued()
+    void actuallySend(queued)
+  }
+
+  // Send the queued message right away instead of waiting for the turn to end.
+  function sendQueuedNow(): void {
+    const queued = get(combined).queuedMessage
+    if (!queued) return
+    if (get(combined).versionRequired) return
+    // Auto mode: inject immediately and keep auto mode running — the runner
+    // picks the message up at its next round boundary (it can't interrupt a turn
+    // mid-round). Covers a live burst and the idle "waiting for you" state.
+    if (get(autoRunStore.autoModeOn) || get(autoRunStore.armed)) {
+      clearQueued()
+      void actuallySend(queued)
+      return
+    }
+    // Interactive turn in flight: terminate it. The resulting ready transition
+    // (abort → onFinish) flushes the queued message via ``maybeFlush``.
+    if (status !== "ready") {
+      stop()
+      return
+    }
+    // Nothing in flight (e.g. the turn already finished/errored): just send it.
+    clearQueued()
+    void actuallySend(queued)
+  }
+
   async function sendMessage(text: string): Promise<boolean> {
+    const trimmed = text.trim()
+    if (!trimmed) return false
+    // Queue when a turn is in flight (the composer surfaces it above the input
+    // with send-now / edit / cancel and it auto-sends when the turn yields), or
+    // whenever something is already queued so a follow-up send coalesces into
+    // the pending message rather than dispatching alongside it.
+    if (get(combined).queuedMessage !== null || turnActive()) {
+      enqueue(trimmed)
+      return true
+    }
+    return actuallySend(trimmed)
+  }
+
+  // Dispatch a message to its real transport: armed-first-send (creates the
+  // run), inject-on-send (auto flag on), or the interactive stream. Assumes no
+  // turn is in flight — callers gate on ``turnActive`` or flush on a turn ending.
+  async function actuallySend(text: string): Promise<boolean> {
     const trimmed = text.trim()
     if (!trimmed) return false
     const autoOn = get(autoRunStore.autoModeOn)
@@ -793,6 +896,7 @@ export function createChatSessionStore(
       toolExecuting: false,
       showActivityIndicator: false,
       compacting: false,
+      queuedMessage: null,
     }))
     setRuntimeState("ready", null)
   }
@@ -822,6 +926,7 @@ export function createChatSessionStore(
       toolExecuting: false,
       showActivityIndicator: false,
       compacting: false,
+      queuedMessage: null,
     }))
     setRuntimeState("ready", null)
   }
@@ -1021,6 +1126,8 @@ export function createChatSessionStore(
   return {
     subscribe: combined.subscribe,
     sendMessage,
+    sendQueuedNow,
+    clearQueued,
     stop,
     retryLastRequest,
     reset,

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -716,19 +716,34 @@ export function createChatSessionStore(
     combined.update((s) => ({ ...s, queuedMessage: null }))
   }
 
+  // Dispatch a queued message: clear it, then send. If the send is rejected
+  // (declined consent, a failed auto-mode injection, an armed enable already
+  // pending, …) restore it to the FRONT of whatever has queued since, so a
+  // failed/declined send never silently drops the user's typed text.
+  async function dispatchQueued(queued: string): Promise<void> {
+    clearQueued()
+    const sent = await actuallySend(queued)
+    if (!sent) {
+      combined.update((s) => ({
+        ...s,
+        queuedMessage: s.queuedMessage
+          ? `${queued}\n\n${s.queuedMessage}`
+          : queued,
+      }))
+    }
+  }
+
   // Auto-send the queued message at the next safe point: an interactive turn
   // finishing, or — in auto mode — a round boundary / the burst going idle.
   // Guards on ``interactiveTurnActive`` (never flush mid interactive turn; a
   // flush hook can fire mid-transition) and ``versionRequired`` (sending would
-  // just be rejected). Clears the queue before dispatching so a re-entrant flush
-  // can't double-send.
+  // just be rejected).
   function maybeFlush(): void {
     const queued = get(combined).queuedMessage
     if (!queued) return
     if (interactiveTurnActive()) return
     if (get(combined).versionRequired) return
-    clearQueued()
-    void actuallySend(queued)
+    void dispatchQueued(queued)
   }
 
   // Send the queued message right away instead of waiting for the turn to end.
@@ -741,8 +756,7 @@ export function createChatSessionStore(
     // dispatch immediately, so a queued message here only exists if auto turned
     // on after it was queued interactively; inject it now.)
     if (get(autoRunStore.autoModeOn) || get(autoRunStore.armed)) {
-      clearQueued()
-      void actuallySend(queued)
+      void dispatchQueued(queued)
       return
     }
     // Interactive turn in flight: terminate it. The resulting ready transition
@@ -751,9 +765,13 @@ export function createChatSessionStore(
       stop()
       return
     }
+    // A tool approval can be open while ``status`` is "ready" (a pending-tool
+    // continuation handed off from a graceful auto stop). That's an in-flight
+    // turn too — leave the message queued rather than starting a competing
+    // request; it flushes when that continuation yields.
+    if (get(combined).toolApprovalWaiter) return
     // Nothing in flight (e.g. the turn already finished/errored): just send it.
-    clearQueued()
-    void actuallySend(queued)
+    void dispatchQueued(queued)
   }
 
   async function sendMessage(text: string): Promise<boolean> {

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -1025,60 +1025,50 @@ export function createChatSessionStore(
     // clears it once the stream is established; off/idle/error paths also clear it.
     autoRunStore.beginReconnect()
 
-    // Only hydrate from the run's CURRENT leaf when it's a round the client
-    // hasn't rendered yet — a genuine catch-up after the tab was away. If
-    // ``current_trace_id`` is already present in the restored transcript, the
-    // run's registered leaf is BEHIND our optimistic state, which happens right
-    // after a message is injected mid-burst: it's echoed + persisted locally,
-    // but ``current_trace_id`` only advances to the round that incorporates it
-    // one round later. Hydrating would drop that just-sent message (and its
-    // in-flight response) until a full History reload — so skip it and just
-    // re-attach; the live stream + buffer replay reconcile the in-flight round.
-    const clientHasLeaf = get(persisted).messages.some(
-      (m) => m.traceId === resolved.current_trace_id,
-    )
-    if (!clientHasLeaf) {
-      // Hydrate from the current leaf so the user catches up on rounds that
-      // completed while the tab was gone, then attach for live events + buffer
-      // replay + the indicator/working state.
-      try {
-        const { data: snapshot, error } = await client.GET(
-          "/api/chat/sessions/{session_id}",
-          { params: { path: { session_id: resolved.current_trace_id } } },
-        )
-        // Switched conversations while the snapshot was fetching: bail before the
-        // destructive loadSession() so we don't overwrite the now-current session.
-        if (!isStillCurrent()) return
-        // A structured error / empty snapshot must NOT short-circuit the attach:
-        // resolve() already proved the run is live, so fall through to attach on
-        // the restored (stale) view — same as the thrown-exception fallback below.
-        // Returning here would leave the conversation looking dead (no indicator,
-        // no live stream) in the snapshot-error case while the throw case
-        // correctly re-attaches.
-        if (!error && snapshot) {
-          const {
-            messages,
-            continuationTraceId: traceId,
-            contextUsage,
-          } = hydrateSessionFromSnapshot(snapshot)
-          // loadSession detaches any prior observer, sets the messages + trace
-          // id, and resets runtime state — identical to the history-restore path.
-          loadSession(messages, traceId, contextUsage)
-        }
-      } catch {
-        // Hydration failed (network/parse). Fall back: still attach so the user
-        // at least gets the live indicator + events on the restored (stale) view.
-        if (!isStillCurrent()) return
+    // Hydrate from the run's CURRENT leaf so the user catches up on rounds that
+    // completed while the tab was gone (the server is authoritative for completed
+    // rounds), then attach for live events + buffer replay + the indicator state.
+    // The in-flight round comes from the buffer replay into a fresh turn (see the
+    // openInflightTurn attach arg below), so this snapshot adoption never clobbers
+    // an in-flight response.
+    try {
+      const { data: snapshot, error } = await client.GET(
+        "/api/chat/sessions/{session_id}",
+        { params: { path: { session_id: resolved.current_trace_id } } },
+      )
+      // Switched conversations while the snapshot was fetching: bail before the
+      // destructive loadSession() so we don't overwrite the now-current session.
+      if (!isStillCurrent()) return
+      // A structured error / empty snapshot must NOT short-circuit the attach:
+      // resolve() already proved the run is live, so fall through to attach on
+      // the restored (stale) view — same as the thrown-exception fallback below.
+      // Returning here would leave the conversation looking dead (no indicator,
+      // no live stream) in the snapshot-error case while the throw case
+      // correctly re-attaches.
+      if (!error && snapshot) {
+        const {
+          messages,
+          continuationTraceId: traceId,
+          contextUsage,
+        } = hydrateSessionFromSnapshot(snapshot)
+        // loadSession detaches any prior observer, sets the messages + trace
+        // id, and resets runtime state — identical to the history-restore path.
+        loadSession(messages, traceId, contextUsage)
       }
+    } catch {
+      // Hydration failed (network/parse). Fall back: still attach so the user at
+      // least gets the live indicator + events on the restored (stale) view.
+      if (!isStillCurrent()) return
     }
     // Re-assert reconnecting: loadSession() detaches the prior observer, which
     // clears the flag, so re-mark it for the brief connecting window. attach()
     // clears it on open / first event / off.
     autoRunStore.beginReconnect()
-    // Drive the working sub-state from the resolved status so the thinking
-    // indicator shows immediately when the run is RUNNING (no wait for the first
-    // event); the on-subscribe state marker confirms / corrects it.
-    autoRunStore.attach(resolved.run_id, resolved.status === "running")
+    // initialWorking drives the thinking indicator immediately when RUNNING (no
+    // wait for the first event); openInflightTurn=true renders the replayed
+    // in-flight round into its own assistant turn so it doesn't overwrite the
+    // last hydrated bubble (the buffer replay carries only the current round).
+    autoRunStore.attach(resolved.run_id, resolved.status === "running", true)
   }
 
   function handleToolCallsPending(

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -683,14 +683,15 @@ export function createChatSessionStore(
     }
   }
 
-  // A turn is "in flight" — sending should queue rather than dispatch — when the
-  // interactive stream is active, a tool approval is open (waiting on the user
-  // mid-turn), or a server-owned auto burst is running / re-attaching.
-  function turnActive(): boolean {
+  // An interactive turn is "in flight" — sending should queue rather than
+  // dispatch — when the client stream is active or a tool approval is open
+  // (waiting on the user mid-turn). Auto mode is intentionally NOT consulted
+  // here: it never holds client-side. A message sent during an auto burst is
+  // injected immediately so the runner appends it to its next request (its next
+  // round boundary), rather than waiting for the whole auto run to finish.
+  function interactiveTurnActive(): boolean {
     if (status !== "ready") return true
     if (get(combined).toolApprovalWaiter) return true
-    if (get(autoRunStore.working)) return true
-    if (get(autoRunStore.reconnecting)) return true
     return false
   }
 
@@ -707,14 +708,14 @@ export function createChatSessionStore(
     combined.update((s) => ({ ...s, queuedMessage: null }))
   }
 
-  // Auto-send the queued message once the turn has yielded. Guards on
-  // ``turnActive`` (re-check: a flush hook can fire mid-transition) and
-  // ``versionRequired`` (sending would just be rejected). Clears the queue
+  // Auto-send the queued message once the interactive turn has yielded. Guards
+  // on ``interactiveTurnActive`` (re-check: a flush hook can fire mid-transition)
+  // and ``versionRequired`` (sending would just be rejected). Clears the queue
   // before dispatching so a re-entrant flush can't double-send.
   function maybeFlush(): void {
     const queued = get(combined).queuedMessage
     if (!queued) return
-    if (turnActive()) return
+    if (interactiveTurnActive()) return
     if (get(combined).versionRequired) return
     clearQueued()
     void actuallySend(queued)
@@ -726,8 +727,9 @@ export function createChatSessionStore(
     if (!queued) return
     if (get(combined).versionRequired) return
     // Auto mode: inject immediately and keep auto mode running — the runner
-    // picks the message up at its next round boundary (it can't interrupt a turn
-    // mid-round). Covers a live burst and the idle "waiting for you" state.
+    // picks the message up at its next round boundary. (Auto sends already
+    // dispatch immediately, so a queued message here only exists if auto turned
+    // on after it was queued interactively; inject it now.)
     if (get(autoRunStore.autoModeOn) || get(autoRunStore.armed)) {
       clearQueued()
       void actuallySend(queued)
@@ -747,11 +749,19 @@ export function createChatSessionStore(
   async function sendMessage(text: string): Promise<boolean> {
     const trimmed = text.trim()
     if (!trimmed) return false
-    // Queue when a turn is in flight (the composer surfaces it above the input
-    // with send-now / edit / cancel and it auto-sends when the turn yields), or
-    // whenever something is already queued so a follow-up send coalesces into
-    // the pending message rather than dispatching alongside it.
-    if (get(combined).queuedMessage !== null || turnActive()) {
+    // Auto mode never holds client-side: a message is injected immediately so
+    // the runner appends it to its next request (its next round boundary),
+    // rather than waiting for the whole auto run to finish. Armed likewise
+    // creates the run now. Both are dispatched straight through.
+    if (get(autoRunStore.autoModeOn) || get(autoRunStore.armed)) {
+      return actuallySend(trimmed)
+    }
+    // Interactive: hold the message in the client-side queue while a turn is in
+    // flight (the composer surfaces it above the input with send-now / edit /
+    // cancel and it auto-sends when the turn yields), or whenever something is
+    // already queued so a follow-up send coalesces into the pending message
+    // rather than dispatching alongside it.
+    if (get(combined).queuedMessage !== null || interactiveTurnActive()) {
       enqueue(trimmed)
       return true
     }
@@ -759,8 +769,9 @@ export function createChatSessionStore(
   }
 
   // Dispatch a message to its real transport: armed-first-send (creates the
-  // run), inject-on-send (auto flag on), or the interactive stream. Assumes no
-  // turn is in flight — callers gate on ``turnActive`` or flush on a turn ending.
+  // run), inject-on-send (auto flag on), or the interactive stream. The
+  // interactive stream assumes no client turn is in flight — callers gate on
+  // ``interactiveTurnActive`` or flush on a turn ending.
   async function actuallySend(text: string): Promise<boolean> {
     const trimmed = text.trim()
     if (!trimmed) return false

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -324,8 +324,13 @@ export function createChatSessionStore(
       pushInlineError(message, traceId, code),
     onToolExecutionStart: () =>
       combined.update((s) => ({ ...s, toolExecuting: true })),
-    onToolExecutionEnd: () =>
-      combined.update((s) => ({ ...s, toolExecuting: false })),
+    onToolExecutionEnd: () => {
+      combined.update((s) => ({ ...s, toolExecuting: false }))
+      // Round boundary: the runner just finished a tool round and is about to
+      // make its next request — flush a queued message so it rides that request
+      // (and its echo lands here, at the pause, rather than mid-round).
+      maybeFlush()
+    },
     onShowActivityIndicator: (show) =>
       combined.update((s) => ({ ...s, showActivityIndicator: show })),
     // Burst liveness drives the same thinking-dots/animated-icon path as the
@@ -348,12 +353,15 @@ export function createChatSessionStore(
       maybeFlush()
     },
     onAutoModeOff: () =>
+      // Auto mode stopped — drop any pending queued message (stopping clears the
+      // queue; the user can re-send if they still want it).
       combined.update((s) => ({
         ...s,
         toolExecuting: false,
         showActivityIndicator: false,
         compacting: false,
         autoWorking: false,
+        queuedMessage: null,
       })),
     onToolCallsPending: handleAutoToolCallsPending,
   })
@@ -708,10 +716,12 @@ export function createChatSessionStore(
     combined.update((s) => ({ ...s, queuedMessage: null }))
   }
 
-  // Auto-send the queued message once the interactive turn has yielded. Guards
-  // on ``interactiveTurnActive`` (re-check: a flush hook can fire mid-transition)
-  // and ``versionRequired`` (sending would just be rejected). Clears the queue
-  // before dispatching so a re-entrant flush can't double-send.
+  // Auto-send the queued message at the next safe point: an interactive turn
+  // finishing, or — in auto mode — a round boundary / the burst going idle.
+  // Guards on ``interactiveTurnActive`` (never flush mid interactive turn; a
+  // flush hook can fire mid-transition) and ``versionRequired`` (sending would
+  // just be rejected). Clears the queue before dispatching so a re-entrant flush
+  // can't double-send.
   function maybeFlush(): void {
     const queued = get(combined).queuedMessage
     if (!queued) return
@@ -749,19 +759,30 @@ export function createChatSessionStore(
   async function sendMessage(text: string): Promise<boolean> {
     const trimmed = text.trim()
     if (!trimmed) return false
-    // Auto mode never holds client-side: a message is injected immediately so
-    // the runner appends it to its next request (its next round boundary),
-    // rather than waiting for the whole auto run to finish. Armed likewise
-    // creates the run now. Both are dispatched straight through.
-    if (get(autoRunStore.autoModeOn) || get(autoRunStore.armed)) {
+    // Coalesce into an existing queued message (the queue holds one squashed
+    // entry) so rapid sends accumulate rather than racing each other out.
+    if (get(combined).queuedMessage !== null) {
+      enqueue(trimmed)
+      return true
+    }
+    // Auto mode with a burst running: hold the message in the queue and inject it
+    // at the runner's next round boundary (or immediately via send-now), so it
+    // rides the next request instead of jumping into the transcript mid-round.
+    // Auto idle / armed has no in-flight round, so dispatch now (which starts a
+    // burst immediately — the "as soon as possible" path).
+    if (get(autoRunStore.autoModeOn)) {
+      if (get(autoRunStore.working)) {
+        enqueue(trimmed)
+        return true
+      }
       return actuallySend(trimmed)
     }
-    // Interactive: hold the message in the client-side queue while a turn is in
-    // flight (the composer surfaces it above the input with send-now / edit /
-    // cancel and it auto-sends when the turn yields), or whenever something is
-    // already queued so a follow-up send coalesces into the pending message
-    // rather than dispatching alongside it.
-    if (get(combined).queuedMessage !== null || interactiveTurnActive()) {
+    if (get(autoRunStore.armed)) {
+      return actuallySend(trimmed)
+    }
+    // Interactive: hold while a turn is in flight; it auto-sends when the turn
+    // yields. The composer surfaces it above the input with send-now/edit/cancel.
+    if (interactiveTurnActive()) {
       enqueue(trimmed)
       return true
     }

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -302,11 +302,18 @@ export function createChatSessionStore(
   // Append an echoed (injected) user message, then a fresh assistant turn so the
   // burst it triggers renders into a new turn — mirrors the server's
   // render-immediately + replay model for inject-on-send (functional spec §4.3.2).
-  function appendEchoedUserMessage(content: string) {
+  // Idempotent by echo id: a buffer replay on re-attach (hard-refresh resync /
+  // History restore) re-emits the echo for an in-flight injected message the
+  // restored transcript already shows — skip it (and don't open another assistant
+  // turn) instead of appending a duplicate that would compound on each refresh.
+  function appendEchoedUserMessage(content: string, echoId?: string) {
+    if (echoId && get(persisted).messages.some((m) => m.echoId === echoId)) {
+      return
+    }
     removeErrors()
     updateMessages((msgs) => [
       ...msgs,
-      { id: chatGenerateId(), role: "user", content },
+      { id: chatGenerateId(), role: "user", content, echoId },
     ])
     beginAssistantTurn()
   }

--- a/app/web_ui/src/lib/chat/session_messages.test.ts
+++ b/app/web_ui/src/lib/chat/session_messages.test.ts
@@ -3,6 +3,7 @@ import { traceIdForNextChatRequest } from "./streaming_chat"
 import {
   hydrateSessionFromSnapshot,
   stripAppUiContext,
+  stripInternalFraming,
   type ChatSessionSnapshot,
 } from "./session_messages"
 
@@ -229,6 +230,49 @@ describe("stripAppUiContext", () => {
 
   it("handles empty string", () => {
     expect(stripAppUiContext("")).toBe("")
+  })
+})
+
+describe("stripInternalFraming", () => {
+  it("removes a leading auto-mode side-note <system-reminder> wrapper", () => {
+    const input =
+      "<system-reminder>This message arrived while you are working autonomously…</system-reminder>\n\nmy name is bobby"
+    expect(stripInternalFraming(input)).toBe("my name is bobby")
+  })
+
+  it("removes both an app-UI context block and a system-reminder", () => {
+    const input =
+      "<new_app_ui_context>\nPath: /assistant\n</new_app_ui_context>\n<system-reminder>side note</system-reminder>\n\nhello"
+    expect(stripInternalFraming(input)).toBe("hello")
+  })
+
+  it("leaves a plain message untouched", () => {
+    expect(stripInternalFraming("just text")).toBe("just text")
+  })
+
+  it("handles empty string", () => {
+    expect(stripInternalFraming("")).toBe("")
+  })
+})
+
+describe("hydrateSessionFromSnapshot strips injected-message framing", () => {
+  it("renders the raw user message for a persisted side-note-wrapped inject", () => {
+    const snapshot: ChatSessionSnapshot = {
+      id: "trace-inject",
+      task_run: {
+        trace: [
+          {
+            role: "user",
+            content:
+              "<system-reminder>Treat it as a side note…</system-reminder>\n\nmy name is bobby whats yours?",
+          },
+          { role: "assistant", content: "Hey Bobby!" },
+        ],
+      },
+    } as unknown as ChatSessionSnapshot
+    const { messages } = hydrateSessionFromSnapshot(snapshot)
+    expect(messages[0].role).toBe("user")
+    expect(messages[0].content).toBe("my name is bobby whats yours?")
   })
 })
 

--- a/app/web_ui/src/lib/chat/session_messages.ts
+++ b/app/web_ui/src/lib/chat/session_messages.ts
@@ -25,8 +25,22 @@ function extractTextContent(content: TraceMessage["content"]): string {
 const APP_UI_CONTEXT_RE =
   /<new_app_ui_context>[\s\S]*?<\/new_app_ui_context>\s*/g
 
+// Auto mode wraps a message injected mid-burst in a <system-reminder> "side
+// note" (see _SIDE_NOTE_REMINDER in the auto runner) before sending it upstream,
+// so the framing is persisted in the trace. Strip it on hydration so a reloaded
+// transcript shows the user's actual message — matching the live echo, which
+// renders the raw content.
+const SYSTEM_REMINDER_RE = /<system-reminder>[\s\S]*?<\/system-reminder>\s*/g
+
 export function stripAppUiContext(text: string): string {
   return text.replace(APP_UI_CONTEXT_RE, "")
+}
+
+// Strip the internal framing the client/runner prepend to a user message before
+// sending it to the model (app-UI context header + auto-mode side-note), so the
+// hydrated transcript shows what the user actually typed.
+export function stripInternalFraming(text: string): string {
+  return text.replace(APP_UI_CONTEXT_RE, "").replace(SYSTEM_REMINDER_RE, "")
 }
 
 function traceToolCallToPart(tc: TraceToolCall): ChatMessagePart {
@@ -77,7 +91,7 @@ export function hydrateSessionFromSnapshot(snapshot: ChatSessionSnapshot): {
         messages.push({
           id: chatGenerateId(),
           role: "user",
-          content: stripAppUiContext(extractTextContent(msg.content)),
+          content: stripInternalFraming(extractTextContent(msg.content)),
         })
         break
       }

--- a/app/web_ui/src/lib/chat/streaming_chat.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.ts
@@ -25,6 +25,12 @@ export interface ChatMessage {
   parts?: ChatMessagePart[]
   /** Server-issued id from ``kiln_chat_trace`` for this assistant turn */
   traceId?: string
+  /**
+   * Stable id from the ``user-message`` echo for an auto-mode injected message.
+   * Lets the client render the echo idempotently — a buffer replay on re-attach
+   * re-emits the echo for an in-flight message the transcript already shows.
+   */
+  echoId?: string
   /** Machine-readable error code from upstream (e.g. ``CHAT_CLIENT_VERSION_TOO_OLD``) */
   errorCode?: string
 }

--- a/app/web_ui/src/lib/chat/streaming_chat.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.ts
@@ -400,6 +400,21 @@ export class StreamEventProcessor {
     }
   }
 
+  /**
+   * Drop all accumulated parts so the next events render into a FRESH assistant
+   * turn. Call this when a new assistant message has been opened mid-stream
+   * (e.g. an injected user message during an auto burst calls
+   * ``beginAssistantTurn``). Without it, ``flushAssistant`` keeps re-writing the
+   * prior turn's parts into the newly opened message, duplicating it.
+   */
+  reset(): void {
+    this.partOrder = []
+    this.textBlocks.clear()
+    this.toolMap.clear()
+    this.toolInputBuffer.clear()
+    this.currentTextId = null
+  }
+
   private nextSlotId(): string {
     this.slotIdCounter += 1
     return `slot-${this.slotIdCounter}`

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -885,7 +885,7 @@
           <div class="flex items-start gap-2">
             <div class="flex-1 min-w-0">
               <div class="text-xs text-base-content/50 mb-1">
-                Queued · sends when the assistant finishes
+                Queued · sends as soon as possible
               </div>
               <div
                 class="text-sm whitespace-pre-wrap break-words max-h-32 overflow-y-auto"

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -98,6 +98,7 @@
     // have been kicked off — just disarm without the explainer dialog.
     if (!get(autoModeOn)) {
       auto_run_store.disarm()
+      store.clearQueued()
       return
     }
     // Confirm + set expectations: the hard stop halts the agent immediately, but
@@ -105,6 +106,10 @@
     // running. Bail if the user backs out.
     const confirmed = await stopDialog.prompt()
     if (!confirmed) return
+
+    // Drop any pending queued message — stopping clears the queue. (detach()
+    // below is silent, so onAutoModeOff won't fire to clear it for us.)
+    store.clearQueued()
 
     // Hard stop: halt the agent completely. Abort any in-flight interactive
     // stream (e.g. a tool-call continuation or a normal streaming turn), tell the

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -10,6 +10,8 @@
   import ArrowUpIcon from "$lib/ui/icons/arrow_up_icon.svelte"
   import StopIcon from "$lib/ui/icons/stop_icon.svelte"
   import CloseIcon from "$lib/ui/icons/close_icon.svelte"
+  import TrashIcon from "$lib/ui/icons/trash_icon.svelte"
+  import EditIcon from "$lib/ui/icons/edit_icon.svelte"
   import Warning from "$lib/ui/warning.svelte"
   import {
     chatSessionStore,
@@ -119,6 +121,9 @@
   $: contextUsage = $store.contextUsage
   $: upgradeNudgeVersion = $store.upgradeNudgeVersion
   $: versionRequired = $store.versionRequired
+  // A message typed while a turn was in flight, held client-side and surfaced
+  // above the composer with send-now / edit / cancel until it auto-sends.
+  $: queuedMessage = $store.queuedMessage
 
   export let hasMessages = false
   $: messages = $store.messages
@@ -144,12 +149,14 @@
   // tool lines) show for BOTH the interactive client stream and a live auto
   // burst, AND during a re-attach's brief "reconnecting…" window (Phase 9) so a
   // reattaching conversation doesn't look done/idle before liveness is known.
-  // The input/send/Stop controls stay bound to ``isLoading`` only, so the
-  // textarea remains usable for inject-on-send while auto mode works.
+  // The composer stays usable throughout (see ``inputDisabled``) so a message
+  // typed mid-turn is queued rather than blocked.
   $: transcriptLoading = isLoading || autoWorking || $autoReconnecting
-  // Block input entirely when the client is too old: sending would just 426
-  // again and the message would go nowhere.
-  $: inputDisabled = isLoading || versionRequired
+  // The composer stays usable while a turn is in flight so a message typed mid-
+  // turn is queued (held above the input, auto-sent when the turn yields) rather
+  // than blocked. Only a too-old client disables it entirely — sending would
+  // just 426 again and the message would go nowhere.
+  $: inputDisabled = versionRequired
 
   let prevIsLoading = false
   $: {
@@ -374,7 +381,8 @@
   function handleTextareaKeydown(e: KeyboardEvent): void {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault()
-      if (!isLoading && input.trim()) handleSubmit()
+      // No isLoading guard: submitting mid-turn queues the message.
+      if (input.trim()) handleSubmit()
     }
   }
 
@@ -405,6 +413,28 @@
     store.stop()
   }
 
+  function sendQueuedNow() {
+    store.sendQueuedNow()
+  }
+
+  function cancelQueued() {
+    store.clearQueued()
+  }
+
+  // Pull the queued message back into the composer to edit it (merging with any
+  // in-progress text), then clear the queue so re-sending doesn't double it up.
+  function editQueued() {
+    const queued = $store.queuedMessage
+    if (!queued) return
+    const draft = input.trim()
+    input = draft ? `${queued}\n\n${draft}` : queued
+    store.clearQueued()
+    tick().then(() => {
+      adjustTextareaHeight()
+      textareaRef?.focus({ preventScroll: true })
+    })
+  }
+
   function onChatHistoryApply(e: CustomEvent<LoadedChatSessionDetail>) {
     store.loadSession(
       e.detail.messages,
@@ -432,7 +462,8 @@
   async function handleSubmit(e?: Event) {
     if (e) e.preventDefault()
     const text = input.trim()
-    if (!text || isLoading) return
+    // No isLoading guard: the store queues when a turn is in flight.
+    if (!text) return
     const sent = await store.sendMessage(text)
     if (!sent) return
     input = ""
@@ -820,6 +851,57 @@
       </div>
     {/if}
 
+    {#if queuedMessage}
+      <div class="flex-none w-full md:max-w-3xl md:mx-auto px-1 pt-2">
+        <div
+          class="rounded-xl border border-base-content/10 bg-base-200 px-3 py-2.5"
+          in:fly={{ y: 8, duration: 150 }}
+        >
+          <div class="flex items-start gap-2">
+            <div class="flex-1 min-w-0">
+              <div class="text-xs text-base-content/50 mb-1">
+                Queued · sends when the assistant finishes
+              </div>
+              <div
+                class="text-sm whitespace-pre-wrap break-words max-h-32 overflow-y-auto"
+              >
+                {queuedMessage}
+              </div>
+            </div>
+            <div class="flex items-center gap-1 shrink-0">
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs btn-circle text-base-content/50 hover:text-base-content/80"
+                on:click={editQueued}
+                title="Edit"
+                aria-label="Edit queued message"
+              >
+                <span class="size-4 block"><EditIcon /></span>
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs btn-circle text-base-content/50 hover:text-error"
+                on:click={cancelQueued}
+                title="Discard"
+                aria-label="Discard queued message"
+              >
+                <span class="size-4 block"><TrashIcon /></span>
+              </button>
+              <button
+                type="button"
+                class="btn btn-xs btn-circle btn-primary"
+                on:click={sendQueuedNow}
+                title="Send now"
+                aria-label="Send queued message now"
+              >
+                <span class="size-4 block"><ArrowUpIcon /></span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    {/if}
+
     <form
       class="flex-none relative w-full md:max-w-3xl md:mx-auto px-1 pt-2"
       on:submit|preventDefault={handleSubmit}
@@ -835,7 +917,7 @@
         on:input={() => adjustTextareaHeight()}
         on:keydown={handleTextareaKeydown}
       />
-      {#if isLoading}
+      {#if isLoading && !input.trim()}
         <button
           type="button"
           class="absolute right-3 bottom-6 btn btn-sm btn-circle btn-neutral"

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -884,19 +884,12 @@
     {#if queuedMessage}
       <div class="flex-none w-full md:max-w-3xl md:mx-auto px-1 pt-2">
         <div
-          class="rounded-xl border border-base-content/10 bg-base-200 px-3 py-2.5"
+          class="rounded-xl border border-base-content/10 bg-base-200 py-2.5"
           in:fly={{ y: 8, duration: 150 }}
         >
-          <div class="flex items-start gap-2">
-            <div class="flex-1 min-w-0">
-              <div class="text-xs text-base-content/50 mb-1">
-                Queued · sends as soon as possible
-              </div>
-              <div
-                class="text-sm whitespace-pre-wrap break-words max-h-32 overflow-y-auto"
-              >
-                {queuedMessage}
-              </div>
+          <div class="flex items-center justify-between gap-2 px-3">
+            <div class="text-xs text-base-content/50">
+              Queued · sends as soon as possible
             </div>
             <div class="flex items-center gap-1 shrink-0">
               <button
@@ -927,6 +920,11 @@
                 <span class="size-4 block"><ArrowUpIcon /></span>
               </button>
             </div>
+          </div>
+          <div
+            class="queued-message-scroll mt-1.5 max-h-32 overflow-y-auto px-3 text-sm whitespace-pre-wrap break-words"
+          >
+            {queuedMessage}
           </div>
         </div>
       </div>
@@ -1017,24 +1015,29 @@
 <AutoModeStopDialog bind:this={stopDialog} />
 
 <style>
-  .chat-messages-scroll::-webkit-scrollbar {
+  .chat-messages-scroll::-webkit-scrollbar,
+  .queued-message-scroll::-webkit-scrollbar {
     width: 6px;
   }
 
-  .chat-messages-scroll::-webkit-scrollbar-track {
+  .chat-messages-scroll::-webkit-scrollbar-track,
+  .queued-message-scroll::-webkit-scrollbar-track {
     background: transparent;
   }
 
-  .chat-messages-scroll::-webkit-scrollbar-thumb {
+  .chat-messages-scroll::-webkit-scrollbar-thumb,
+  .queued-message-scroll::-webkit-scrollbar-thumb {
     background-color: oklch(var(--bc) / 0.2);
     border-radius: 3px;
   }
 
-  .chat-messages-scroll::-webkit-scrollbar-thumb:hover {
+  .chat-messages-scroll::-webkit-scrollbar-thumb:hover,
+  .queued-message-scroll::-webkit-scrollbar-thumb:hover {
     background-color: oklch(var(--bc) / 0.35);
   }
 
-  .chat-messages-scroll {
+  .chat-messages-scroll,
+  .queued-message-scroll {
     scrollbar-width: thin;
     scrollbar-color: oklch(var(--bc) / 0.2) transparent;
   }

--- a/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
+++ b/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
@@ -84,6 +84,7 @@ function baseState(
     retry: null,
     upgradeNudgeVersion: null,
     versionRequired: false,
+    queuedMessage: null,
     ...overrides,
   }
 }
@@ -100,6 +101,8 @@ function makeFakeStore(initial: ChatSessionState): {
   const store = {
     subscribe: (state as Readable<ChatSessionState>).subscribe,
     sendMessage: vi.fn().mockResolvedValue(true),
+    sendQueuedNow: noop,
+    clearQueued: noop,
     stop: noop,
     retryLastRequest: noop,
     reset: noop,

--- a/app/web_ui/src/routes/(app)/assistant/chat_history.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat_history.svelte
@@ -92,7 +92,11 @@
       // the on-subscribe state marker reflects working-vs-idle immediately.
       if (row.auto_active && row.auto_run_id) {
         auto_run_store.beginReconnect()
-        auto_run_store.attach(row.auto_run_id)
+        // openInflightTurn: render the replayed in-flight round into its own
+        // assistant turn so it doesn't overwrite the last hydrated bubble. No
+        // initialWorking here (History has no status); attach presumes a live
+        // burst and the on-subscribe marker corrects it.
+        auto_run_store.attach(row.auto_run_id, undefined, true)
       }
       close()
     } catch (e) {

--- a/app/web_ui/src/routes/(app)/assistant/chat_queued_message.test.ts
+++ b/app/web_ui/src/routes/(app)/assistant/chat_queued_message.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+//
+// Integration test for the queued-message composer behavior: a message typed
+// while a turn is in flight is held above the composer (not blocked), with
+// send-now / edit / discard controls, and the textarea stays usable so the next
+// message can be queued. Renders the real ``chat.svelte`` against a fake store.
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, cleanup, fireEvent } from "@testing-library/svelte"
+import { writable, type Readable } from "svelte/store"
+import type { ContextUsage } from "$lib/chat/streaming_chat"
+import type {
+  ChatSessionState,
+  ChatSessionStore,
+} from "$lib/chat/chat_session_store"
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}))
+
+vi.mock("$lib/api_client", () => ({
+  base_url: "http://localhost:8757",
+  client: { GET: vi.fn(), POST: vi.fn() },
+}))
+
+vi.mock("$lib/chat/auto_run_store", () => ({
+  auto_run_store: {
+    autoModeOn: writable(false),
+    armed: writable(false),
+    working: writable(false),
+    reconnecting: writable(false),
+    runId: writable(null),
+    offReason: writable(null),
+    connection: writable("idle"),
+    bind: vi.fn(),
+    detach: vi.fn(),
+    requestEnable: vi.fn().mockResolvedValue({ ok: true }),
+    decline: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue({ ok: true }),
+    stop: vi.fn().mockResolvedValue(undefined),
+    resolve: vi.fn().mockResolvedValue(null),
+    beginReconnect: vi.fn(),
+    attach: vi.fn(),
+    arm: vi.fn(),
+    disarm: vi.fn(),
+  },
+}))
+
+vi.mock("$lib/stores", () => ({
+  chat_cost_disclaimer_acknowledged: writable(true),
+  projects: writable([]),
+  current_project: writable(null),
+}))
+
+const Chat = (await import("./chat.svelte")).default
+
+afterEach(() => {
+  cleanup()
+})
+
+function baseState(
+  overrides: Partial<ChatSessionState> = {},
+): ChatSessionState {
+  return {
+    messages: [],
+    collapsedPartKeys: {},
+    lastSentAppState: null,
+    contextUsage: null as ContextUsage | null,
+    status: "ready",
+    abortController: null,
+    toolApprovalWaiter: null,
+    toolApprovalPicks: {},
+    toolExecuting: false,
+    showActivityIndicator: false,
+    compacting: false,
+    autoWorking: false,
+    retry: null,
+    upgradeNudgeVersion: null,
+    versionRequired: false,
+    queuedMessage: null,
+    ...overrides,
+  }
+}
+
+function makeFakeStore(initial: ChatSessionState) {
+  const state = writable<ChatSessionState>(initial)
+  const noop = () => {}
+  const sendMessage = vi.fn().mockResolvedValue(true)
+  const sendQueuedNow = vi.fn()
+  const clearQueued = vi.fn()
+  const store = {
+    subscribe: (state as Readable<ChatSessionState>).subscribe,
+    sendMessage,
+    sendQueuedNow,
+    clearQueued,
+    stop: noop,
+    retryLastRequest: noop,
+    reset: noop,
+    loadSession: noop,
+    resyncOnLoad: vi.fn().mockResolvedValue(undefined),
+    togglePartCollapsed: noop,
+    pushInlineError: noop,
+    applyToolApprovalRun: noop,
+    applyToolApprovalSkip: noop,
+    dismissUpgradeNudge: noop,
+    checkVersionPolicy: vi.fn().mockResolvedValue(undefined),
+    onConsentNeeded: null,
+    onAutoModeConsentNeeded: null,
+  } as unknown as ChatSessionStore
+  return { store, state, sendMessage, sendQueuedNow, clearQueued }
+}
+
+describe("chat.svelte queued message composer", () => {
+  it("shows the queued message banner with the queued text", () => {
+    const { store } = makeFakeStore(
+      baseState({ status: "submitted", queuedMessage: "hold this for me" }),
+    )
+    const { getByText, getByLabelText } = render(Chat, { props: { store } })
+    expect(getByText("hold this for me")).toBeTruthy()
+    expect(getByLabelText("Send queued message now")).toBeTruthy()
+    expect(getByLabelText("Edit queued message")).toBeTruthy()
+    expect(getByLabelText("Discard queued message")).toBeTruthy()
+  })
+
+  it("does not show the banner when nothing is queued", () => {
+    const { store } = makeFakeStore(baseState({ status: "submitted" }))
+    const { queryByLabelText } = render(Chat, { props: { store } })
+    expect(queryByLabelText("Send queued message now")).toBeNull()
+  })
+
+  it("calls sendQueuedNow when the send-now button is clicked", async () => {
+    const { store, sendQueuedNow } = makeFakeStore(
+      baseState({ status: "submitted", queuedMessage: "go now" }),
+    )
+    const { getByLabelText } = render(Chat, { props: { store } })
+    await fireEvent.click(getByLabelText("Send queued message now"))
+    expect(sendQueuedNow).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls clearQueued when the discard button is clicked", async () => {
+    const { store, clearQueued } = makeFakeStore(
+      baseState({ status: "submitted", queuedMessage: "never mind" }),
+    )
+    const { getByLabelText } = render(Chat, { props: { store } })
+    await fireEvent.click(getByLabelText("Discard queued message"))
+    expect(clearQueued).toHaveBeenCalledTimes(1)
+  })
+
+  it("moves the queued text into the composer when edit is clicked", async () => {
+    const { store, clearQueued } = makeFakeStore(
+      baseState({ status: "submitted", queuedMessage: "let me fix this" }),
+    )
+    const { getByLabelText } = render(Chat, { props: { store } })
+    await fireEvent.click(getByLabelText("Edit queued message"))
+    const textarea = getByLabelText("Chat message") as HTMLTextAreaElement
+    expect(textarea.value).toBe("let me fix this")
+    expect(clearQueued).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the composer enabled while a turn is in flight so messages can queue", () => {
+    const { store } = makeFakeStore(baseState({ status: "streaming" }))
+    const { getByLabelText } = render(Chat, { props: { store } })
+    const textarea = getByLabelText("Chat message") as HTMLTextAreaElement
+    expect(textarea.disabled).toBe(false)
+  })
+
+  it("disables the composer only when a newer client version is required", () => {
+    const { store } = makeFakeStore(
+      baseState({ status: "ready", versionRequired: true }),
+    )
+    const { getByLabelText } = render(Chat, { props: { store } })
+    const textarea = getByLabelText("Chat message") as HTMLTextAreaElement
+    expect(textarea.disabled).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

In Kiln Assistant, a message sent while a turn is in flight is now **queued client-side** and surfaced above the composer with controls, instead of looking clunky (auto mode fired it off immediately with no "queued" affordance; non-auto disabled the textarea entirely).

This applies to **both auto mode and non-auto mode**.

### Behavior

- **Queue**: typing + sending while a turn is in flight (interactive stream, an open tool approval, or a live/reconnecting auto burst) holds the message above the composer in a container with:
  - **Send now** (up arrow): 
    - *Interactive* — stops the current turn so the queued message flushes immediately.
    - *Auto* — injects the message right away and **keeps auto mode running**. The runner picks it up at the next round boundary (the backend can't interrupt a turn mid-round without ending auto mode, so this is the closest "now" available — confirmed as the desired behavior).
  - **Discard** (trash): drops the queued message.
  - **Edit** (pencil): pulls it back into the composer to revise (merging with any in-progress text).
- **Append/coalesce**: sending again while a message is queued appends to it (blank line between) so it goes out as one message.
- **Auto-send "asap"**: the queued message flushes automatically when the turn yields — interactive `onFinish`, or auto burst `auto-mode-idle`. It then renders **in the trace at the point it was actually sent**.
- The composer textarea is **no longer disabled** during a turn (only when a newer client version is required). The Stop button shows only while streaming with an empty composer, so typing reveals the send/queue button.

## Implementation

- `chat_session_store.ts`: new runtime-only `queuedMessage` state; `sendMessage` queues when a turn is active (or something is already queued) and otherwise dispatches via the extracted `actuallySend`; `maybeFlush` hooked into interactive `onFinish` and auto `onAutoModeIdle`; new `sendQueuedNow` / `clearQueued`. Queue cleared on `reset` / `loadSession`.
- `chat.svelte`: queued-message banner with edit / discard / send-now controls; composer kept usable mid-turn; contextual Stop/Send button.

## Tests

- `chat_session_store.test.ts`: queueing, append/coalesce (incl. after a turn ends), flush-on-finish, flush-by-inject on auto idle, send-now (interactive stop + auto inject), discard, reset clears the queue.
- New `chat_queued_message.test.ts`: renders the banner, wires the three controls, edit moves text into the composer, composer stays enabled mid-turn, disabled only on `versionRequired`.
- Full suite: `npm run check`, `lint`, `format_check`, `build`, and `test_run` (1262 web tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)