### PR TITLE
Add reusable OptionList picker component

### DIFF
--- a/app/web_ui/src/lib/ui/option_list.svelte
+++ b/app/web_ui/src/lib/ui/option_list.svelte
@@ -1,48 +1,70 @@
 <script lang="ts">
-  export let options: {
-    id: string
-    name: string
-    description: string
-    recommended?: boolean
-    highlight_title?: string
-    disabled?: boolean
-  }[]
+  import type { OptionListItem } from "./option_list_types"
 
+  export let options: OptionListItem[]
   export let select_option: (id: string) => void
 </script>
 
-<div class="flex flex-col gap-6 max-w-[500px]">
+<div class="flex flex-col gap-3">
   {#each options as option}
     <button
-      class="cursor-pointer text-left"
-      on:click={() => {
-        select_option(option.id)
-      }}
+      type="button"
+      class="card card-bordered border-base-300 bg-base-100 shadow-md hover:shadow-lg hover:border-primary/50 transition-all duration-200 w-full text-left p-4 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-md disabled:hover:border-base-300 disabled:hover:shadow-md"
+      on:click={() => select_option(option.id)}
       disabled={option.disabled}
     >
-      <div
-        class="card card-bordered border-base-300 bg-base-200 shadow-md w-full p-6 indicator"
-        class:opacity-50={option.disabled}
-        class:cursor-not-allowed={option.disabled}
-      >
-        {#if option.recommended}
-          <div class="indicator-item indicator-center badge badge-primary">
-            Recommended
-          </div>
-        {:else if option.highlight_title}
-          <div class="indicator-item indicator-center badge badge-secondary">
-            {option.highlight_title}
+      <div class="flex items-center gap-4 w-full">
+        {#if option.icon}
+          <div
+            class="option-icon flex items-center justify-center rounded-[10px] flex-none w-11 h-11 p-[9px] bg-blue-50 text-[#628BD9]"
+          >
+            <svelte:component this={option.icon} />
           </div>
         {/if}
-        <div class="flex flex-col">
-          <div class="font-medium">
-            {option.name}
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="font-medium">{option.name}</span>
+            {#if option.recommended}
+              <span class="badge badge-sm badge-primary whitespace-nowrap"
+                >&#9733; Recommended</span
+              >
+            {/if}
+            {#each option.tags ?? [] as tag}
+              <span
+                class="badge badge-sm badge-outline whitespace-nowrap {tag.tone ===
+                'beta'
+                  ? 'badge-primary'
+                  : ''}">{tag.label}</span
+              >
+            {/each}
           </div>
-          <div class="font-light pt-1">
+          <div class="text-sm text-gray-500 mt-0.5">
             {option.description}
           </div>
         </div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+          class="flex-none ml-auto text-gray-500"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"
+          />
+        </svg>
       </div>
     </button>
   {/each}
 </div>
+
+<style>
+  .option-icon :global(svg) {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>

--- a/app/web_ui/src/lib/ui/option_list.svelte
+++ b/app/web_ui/src/lib/ui/option_list.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { OptionListItem } from "./option_list_types"
 
-  export let options: OptionListItem[]
+  export let options: OptionListItem[] = []
   export let select_option: (id: string) => void
 </script>
 
@@ -9,7 +9,7 @@
   {#each options as option}
     <button
       type="button"
-      class="card card-bordered border-base-300 bg-base-100 shadow-md hover:shadow-lg hover:border-primary/50 transition-all duration-200 w-full text-left p-4 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-md disabled:hover:border-base-300 disabled:hover:shadow-md"
+      class="card card-bordered border-base-300 bg-base-100 shadow-md hover:shadow-lg hover:border-primary/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 transition-all duration-200 w-full text-left p-4 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-md disabled:hover:border-base-300 disabled:hover:shadow-md"
       on:click={() => select_option(option.id)}
       disabled={option.disabled}
     >
@@ -26,7 +26,7 @@
             <span class="font-medium">{option.name}</span>
             {#if option.recommended}
               <span class="badge badge-sm badge-primary whitespace-nowrap"
-                >&#9733; Recommended</span
+                ><span aria-hidden="true">&#9733;</span> Recommended</span
               >
             {/if}
             {#each option.tags ?? [] as tag}

--- a/app/web_ui/src/lib/ui/option_list.test.ts
+++ b/app/web_ui/src/lib/ui/option_list.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, fireEvent, cleanup } from "@testing-library/svelte"
+import OptionList from "./option_list.svelte"
+import type { OptionListItem } from "./option_list_types"
+
+afterEach(() => {
+  cleanup()
+})
+
+const base_options: OptionListItem[] = [
+  { id: "a", name: "Option A", description: "First option." },
+  { id: "b", name: "Option B", description: "Second option." },
+]
+
+describe("OptionList", () => {
+  it("renders every option's name and description", () => {
+    const { container } = render(OptionList, {
+      props: { options: base_options, select_option: () => {} },
+    })
+    expect(container.textContent).toContain("Option A")
+    expect(container.textContent).toContain("First option.")
+    expect(container.textContent).toContain("Option B")
+    expect(container.textContent).toContain("Second option.")
+    // One button per option.
+    expect(container.querySelectorAll("button").length).toBe(2)
+  })
+
+  it("calls select_option with the option id on click", async () => {
+    const select_option = vi.fn()
+    const { getByText } = render(OptionList, {
+      props: { options: base_options, select_option },
+    })
+    await fireEvent.click(getByText("Option B"))
+    expect(select_option).toHaveBeenCalledTimes(1)
+    expect(select_option).toHaveBeenCalledWith("b")
+  })
+
+  it("shows a Recommended badge only on recommended options", () => {
+    const { container } = render(OptionList, {
+      props: {
+        options: [{ ...base_options[0], recommended: true }, base_options[1]],
+        select_option: () => {},
+      },
+    })
+    const badges = container.querySelectorAll(".badge")
+    expect(badges.length).toBe(1)
+    expect(badges[0].textContent).toContain("Recommended")
+  })
+
+  it("renders tag badges from the tags array", () => {
+    const { container } = render(OptionList, {
+      props: {
+        options: [
+          { ...base_options[0], tags: [{ label: "Beta", tone: "beta" }] },
+        ],
+        select_option: () => {},
+      },
+    })
+    const badge = container.querySelector(".badge")
+    expect(badge?.textContent?.trim()).toBe("Beta")
+    expect(badge?.classList.contains("badge-primary")).toBe(true)
+  })
+
+  it("does not render an icon square when no icon is provided", () => {
+    const { container } = render(OptionList, {
+      props: { options: base_options, select_option: () => {} },
+    })
+    expect(container.querySelector(".option-icon")).toBeNull()
+  })
+
+  it("disables the button for disabled options", () => {
+    // The browser blocks clicks on disabled buttons natively, so we assert the
+    // disabled attribute rather than click behavior (jsdom still dispatches
+    // events to disabled elements).
+    const { getByText } = render(OptionList, {
+      props: {
+        options: [{ ...base_options[0], disabled: true }],
+        select_option: () => {},
+      },
+    })
+    const button = getByText("Option A").closest("button")
+    expect(button?.disabled).toBe(true)
+  })
+})

--- a/app/web_ui/src/lib/ui/option_list_types.ts
+++ b/app/web_ui/src/lib/ui/option_list_types.ts
@@ -1,0 +1,19 @@
+import type { ComponentType } from "svelte"
+
+export type OptionListTag = {
+  label: string
+  // "beta" gives the tag a primary (blue) outline, "default" is a plain gray outline.
+  tone?: "default" | "beta"
+}
+
+export type OptionListItem = {
+  id: string
+  name: string
+  description: string
+  // Optional icon component rendered inside the colored square. Should be an
+  // SVG that uses `currentColor` so it inherits the icon color.
+  icon?: ComponentType
+  recommended?: boolean
+  tags?: OptionListTag[]
+  disabled?: boolean
+}

--- a/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/add_data/+page.svelte
+++ b/app/web_ui/src/routes/(app)/dataset/[project_id]/[task_id]/add_data/+page.svelte
@@ -187,10 +187,12 @@
       button_text={completed_button_text || "View Dataset"}
     />
   {:else}
-    <OptionList
-      options={data_source_descriptions}
-      select_option={select_data_source}
-    />
+    <div class="max-w-[600px]">
+      <OptionList
+        options={data_source_descriptions}
+        select_option={select_data_source}
+      />
+    </div>
   {/if}
 </AppPage>
 


### PR DESCRIPTION

<img width="956" height="205" alt="Screenshot 2026-06-30 at 12 40 15 PM" src="https://github.com/user-attachments/assets/55bb597a-4ad5-47b1-9054-5fa9ef304174" />

<img width="715" height="494" alt="Screenshot 2026-06-30 at 12 40 35 PM" src="https://github.com/user-attachments/assets/394de35a-2bd7-4393-96f2-db1cc57d5fa8" />

Example icon (not actually using for this option in the branch just took a screenshot of an example icon to show how it looks): 

<img width="307" height="67" alt="Screenshot 2026-06-30 at 12 41 10 PM" src="https://github.com/user-attachments/assets/66895c67-70ed-495d-a903-5ea9c4dcc3fe" />

## Description

Two in-flight branches — `sfierro/data-guide-v2-jobs` and `scosman/evals_v2` — each independently built a very similar "picker" UI (a vertical list of selectable option cards: icon square, title, description, chevron, optional badge). Rather than picking one implementation and forcing the other branch to depend on it, this PR lands a single reusable component on `main`. Both branches can then merge `main` and swap their hand-rolled markup for `<OptionList>`.

This consolidates into the existing shared `option_list.svelte` (already used by the dataset add-data and finetune select-dataset flows) so there's one canonical picker.

### Design
- **Card outline, chevron, drop shadow, and hover** taken from `scosman/evals_v2`.
- **Blue icon square** (`bg-blue-50` / `#628BD9`, optional per option) taken from `sfierro/data-guide-v2-jobs`.
- **Recommended** options get a `★ Recommended` badge only — the row style/size is unchanged (we did not adopt evals_v2's enlarged/restyled recommended row).
- Added a general `tags` array (e.g. `Beta`) alongside the `recommended` flag.

### Changes
- Rewrote `app/web_ui/src/lib/ui/option_list.svelte` with the unified design; icons are optional so existing icon-less consumers keep working.
- Extracted `OptionListItem` / `OptionListTag` types into `option_list_types.ts` (matching the repo's `*_types.ts` convention).
- Migrated the two existing consumers (`dataset/add_data`, `finetune/select_finetune_dataset`); the finetune picker now spans its full container and the dataset picker is width-capped at 600px.
- Added `option_list.test.ts` covering rendering, selection callback, recommended badge, tags, optional icon, and disabled state.

### How the feature branches adopt it
```svelte
<OptionList
  options={[
    { id: "llm_judge", name: "LLM as Judge", description: "...",
      icon: LlmJudgeIcon, recommended: true },
    { id: "code", name: "Code", description: "...",
      icon: CodeIcon, tags: [{ label: "Beta", tone: "beta" }] },
  ]}
  select_option={(id) => goto(`.../${id}`)}
/>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)