### PR TITLE
docs(jobs): add Field descriptions to job API models

### DIFF
--- a/app/desktop/studio_server/jobs/events.py
+++ b/app/desktop/studio_server/jobs/events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, AsyncGenerator, Callable, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .models import JobRecord
 
@@ -11,8 +11,14 @@ from .models import JobRecord
 class JobEvent(BaseModel):
     """A single bus event. Per-job events carry the full record (idempotent snapshot)."""
 
-    event: Literal["snapshot", "job", "deleted", "ping"]
-    data: dict[str, Any]
+    event: Literal["snapshot", "job", "deleted", "ping"] = Field(
+        description="Event kind: an initial 'snapshot' of all jobs, a per-job 'job' "
+        "update, a 'deleted' notification, or a 'ping' keepalive."
+    )
+    data: dict[str, Any] = Field(
+        description="Event payload. For 'snapshot' and 'job' events this is the full "
+        "job record(s); for 'deleted' it identifies the removed job."
+    )
 
 
 class _CloseSentinel:

--- a/app/desktop/studio_server/jobs/models.py
+++ b/app/desktop/studio_server/jobs/models.py
@@ -47,54 +47,136 @@ class JobProgress(BaseModel):
     field is a count only — the actual messages live in the per-run error log.
     """
 
-    total: int | None = None
-    success: int = 0
-    error: int = 0
-    message: str | None = None
-    updated_at: datetime = Field(default_factory=_utc_now)
+    total: int | None = Field(
+        default=None,
+        description="Total number of items to process, or null when the size is not yet known.",
+    )
+    success: int = Field(
+        default=0, description="Number of items processed successfully so far."
+    )
+    error: int = Field(
+        default=0,
+        description="Number of items that failed so far. A count only — the actual "
+        "messages live in the per-run error log.",
+    )
+    message: str | None = Field(
+        default=None,
+        description="Optional human-readable status line describing the current step.",
+    )
+    updated_at: datetime = Field(
+        default_factory=_utc_now,
+        description="UTC timestamp of the most recent progress update.",
+    )
 
 
 class JobDerivedState(BaseModel):
     """A worker's view of the operation's true state, read from source-of-truth entities."""
 
-    total: int | None = None
-    success: int = 0
-    error: int = 0
-    is_complete: bool = False
-    message: str | None = None
+    total: int | None = Field(
+        default=None,
+        description="Total number of items to process, or null when the size is not yet known.",
+    )
+    success: int = Field(
+        default=0,
+        description="Number of items confirmed complete by reading source-of-truth entities.",
+    )
+    error: int = Field(
+        default=0,
+        description="Number of items confirmed failed by reading source-of-truth entities.",
+    )
+    is_complete: bool = Field(
+        default=False,
+        description="Whether the operation is fully complete according to source-of-truth entities.",
+    )
+    message: str | None = Field(
+        default=None,
+        description="Optional human-readable status line describing the derived state.",
+    )
 
 
 class JobError(BaseModel):
     """Small failure summary stamped on the record. Detail lives in the error log."""
 
-    error: str | None = None
-    detail: dict[str, Any] | None = None
+    error: str | None = Field(
+        default=None,
+        description="Short human-readable summary of why the job failed.",
+    )
+    detail: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional structured context for the failure. Fuller detail lives in the error log.",
+    )
 
 
 class JobRecord(BaseModel):
     """Ephemeral, in-memory bookkeeping for a single job. Never persisted to disk."""
 
-    id: str
-    type: str
-    status: BackgroundJobStatus
-    run_id: str | None = None
-    progress: JobProgress = Field(default_factory=JobProgress)
+    id: str = Field(description="Unique identifier for this job.")
+    type: str = Field(
+        description="Registered job type name, determining which worker runs it."
+    )
+    status: BackgroundJobStatus = Field(
+        description="Current lifecycle status: pending, running, paused, succeeded, "
+        "failed, or cancelled."
+    )
+    run_id: str | None = Field(
+        default=None,
+        description="Identifier of the current (or most recent) run attempt, used to "
+        "locate its error log. Null before the job first starts.",
+    )
+    progress: JobProgress = Field(
+        default_factory=JobProgress,
+        description="Generic count-based progress snapshot for the job.",
+    )
     # Typed, per-worker progress detail (validated against the worker's
     # `progress_model`). The generic `progress` above is the universal counter;
     # this carries the rich per-kind shape a worker needs the UI to render
     # (e.g. RAG's four-phase breakdown). Kept as a dict on the wire so the core
     # stays worker-agnostic; the frontend casts it to the worker's model.
-    progress_detail: dict[str, Any] | None = None
-    params: dict[str, Any] = Field(default_factory=dict)
-    result: dict[str, Any] | None = None
-    error: JobError | None = None
-    metadata: dict[str, Any] = Field(default_factory=dict)
-    project_id: str | None = None
-    supports_pause: bool = False
-    created_at: datetime = Field(default_factory=_utc_now)
-    updated_at: datetime = Field(default_factory=_utc_now)
-    started_at: datetime | None = None
-    ended_at: datetime | None = None
+    progress_detail: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional typed, worker-specific progress detail (validated against "
+        "the worker's progress_model). Null for workers whose generic count progress is enough.",
+    )
+    params: dict[str, Any] = Field(
+        default_factory=dict,
+        description="The validated parameters this job was created with.",
+    )
+    result: dict[str, Any] | None = Field(
+        default=None,
+        description="The job's output, present only once it has succeeded. Null otherwise.",
+    )
+    error: JobError | None = Field(
+        default=None,
+        description="Failure summary, present only when the job has failed. Null otherwise.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Free-form attribution passed in at creation, stored verbatim.",
+    )
+    project_id: str | None = Field(
+        default=None,
+        description="Project this job is scoped to, used for filtering and visibility.",
+    )
+    supports_pause: bool = Field(
+        default=False,
+        description="Whether this job type can be paused and resumed.",
+    )
+    created_at: datetime = Field(
+        default_factory=_utc_now,
+        description="UTC timestamp of when the job was created.",
+    )
+    updated_at: datetime = Field(
+        default_factory=_utc_now,
+        description="UTC timestamp of the most recent change to the job record.",
+    )
+    started_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp of when the job first started running. Null until it starts.",
+    )
+    ended_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp of when the job reached a terminal state. Null until it ends.",
+    )
 
 
 ReportProgress = Callable[["JobProgressUpdate"], Awaitable[None]]
@@ -103,10 +185,18 @@ ReportError = Callable[[str, dict[str, Any]], Awaitable[None]]
 
 
 class JobProgressUpdate(BaseModel):
-    success: int
-    error: int = 0
-    total: int | None = None
-    message: str | None = None
+    success: int = Field(
+        description="Cumulative number of items processed successfully."
+    )
+    error: int = Field(default=0, description="Cumulative number of items that failed.")
+    total: int | None = Field(
+        default=None,
+        description="Total number of items to process, or null when the size is not yet known.",
+    )
+    message: str | None = Field(
+        default=None,
+        description="Optional human-readable status line describing the current step.",
+    )
 
 
 class JobContext:

--- a/app/desktop/studio_server/jobs/workers/noop.py
+++ b/app/desktop/studio_server/jobs/workers/noop.py
@@ -2,20 +2,32 @@ from __future__ import annotations
 
 import asyncio
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ..models import JobContext, JobDerivedState, JobWorker
 
 
 class NoopJobParams(BaseModel):
-    steps: int = 10
-    sleep_per_step_seconds: float = 0.5
-    fail_at_step: int | None = None
-    error_at_steps: list[int] = []
+    steps: int = Field(default=10, description="Number of steps to simulate.")
+    sleep_per_step_seconds: float = Field(
+        default=0.5, description="Seconds to sleep between each simulated step."
+    )
+    fail_at_step: int | None = Field(
+        default=None,
+        description="Step index at which to raise a fatal error, failing the whole job. "
+        "Null to never fail.",
+    )
+    error_at_steps: list[int] = Field(
+        default=[],
+        description="Step indices at which to report a non-fatal per-item error without "
+        "stopping the run.",
+    )
 
 
 class NoopJobResult(BaseModel):
-    completed_steps: int
+    completed_steps: int = Field(
+        description="Total number of steps processed (successes plus non-fatal errors)."
+    )
 
 
 class NoopJobWorker(JobWorker[NoopJobParams, NoopJobResult]):

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -7056,9 +7056,15 @@ export interface components {
          * @description Small failure summary stamped on the record. Detail lives in the error log.
          */
         JobError: {
-            /** Error */
+            /**
+             * Error
+             * @description Short human-readable summary of why the job failed.
+             */
             error?: string | null;
-            /** Detail */
+            /**
+             * Detail
+             * @description Optional structured context for the failure. Fuller detail lives in the error log.
+             */
             detail?: {
                 [key: string]: unknown;
             } | null;
@@ -7071,23 +7077,32 @@ export interface components {
          *     field is a count only — the actual messages live in the per-run error log.
          */
         JobProgress: {
-            /** Total */
+            /**
+             * Total
+             * @description Total number of items to process, or null when the size is not yet known.
+             */
             total?: number | null;
             /**
              * Success
+             * @description Number of items processed successfully so far.
              * @default 0
              */
             success: number;
             /**
              * Error
+             * @description Number of items that failed so far. A count only — the actual messages live in the per-run error log.
              * @default 0
              */
             error: number;
-            /** Message */
+            /**
+             * Message
+             * @description Optional human-readable status line describing the current step.
+             */
             message?: string | null;
             /**
              * Updated At
              * Format: date-time
+             * @description UTC timestamp of the most recent progress update.
              */
             updated_at?: string;
         };
@@ -7096,51 +7111,87 @@ export interface components {
          * @description Ephemeral, in-memory bookkeeping for a single job. Never persisted to disk.
          */
         JobRecord: {
-            /** Id */
+            /**
+             * Id
+             * @description Unique identifier for this job.
+             */
             id: string;
-            /** Type */
+            /**
+             * Type
+             * @description Registered job type name, determining which worker runs it.
+             */
             type: string;
+            /** @description Current lifecycle status: pending, running, paused, succeeded, failed, or cancelled. */
             status: components["schemas"]["BackgroundJobStatus"];
-            /** Run Id */
+            /**
+             * Run Id
+             * @description Identifier of the current (or most recent) run attempt, used to locate its error log. Null before the job first starts.
+             */
             run_id?: string | null;
+            /** @description Generic count-based progress snapshot for the job. */
             progress?: components["schemas"]["JobProgress"];
-            /** Progress Detail */
+            /**
+             * Progress Detail
+             * @description Optional typed, worker-specific progress detail (validated against the worker's progress_model). Null for workers whose generic count progress is enough.
+             */
             progress_detail?: {
                 [key: string]: unknown;
             } | null;
-            /** Params */
+            /**
+             * Params
+             * @description The validated parameters this job was created with.
+             */
             params?: {
                 [key: string]: unknown;
             };
-            /** Result */
+            /**
+             * Result
+             * @description The job's output, present only once it has succeeded. Null otherwise.
+             */
             result?: {
                 [key: string]: unknown;
             } | null;
+            /** @description Failure summary, present only when the job has failed. Null otherwise. */
             error?: components["schemas"]["JobError"] | null;
-            /** Metadata */
+            /**
+             * Metadata
+             * @description Free-form attribution passed in at creation, stored verbatim.
+             */
             metadata?: {
                 [key: string]: unknown;
             };
-            /** Project Id */
+            /**
+             * Project Id
+             * @description Project this job is scoped to, used for filtering and visibility.
+             */
             project_id?: string | null;
             /**
              * Supports Pause
+             * @description Whether this job type can be paused and resumed.
              * @default false
              */
             supports_pause: boolean;
             /**
              * Created At
              * Format: date-time
+             * @description UTC timestamp of when the job was created.
              */
             created_at?: string;
             /**
              * Updated At
              * Format: date-time
+             * @description UTC timestamp of the most recent change to the job record.
              */
             updated_at?: string;
-            /** Started At */
+            /**
+             * Started At
+             * @description UTC timestamp of when the job first started running. Null until it starts.
+             */
             started_at?: string | null;
-            /** Ended At */
+            /**
+             * Ended At
+             * @description UTC timestamp of when the job reached a terminal state. Null until it ends.
+             */
             ended_at?: string | null;
         };
         /**


### PR DESCRIPTION
## What

Adds `Field(description=...)` to every previously-blank field on the jobs-API Pydantic models so the generated OpenAPI schema — and the `openapi2skill` docs downstream — carry per-field meaning instead of blank cells.

Models updated:
- `jobs/models.py` — `JobRecord`, `JobProgress`, `JobDerivedState`, `JobError`, `JobProgressUpdate`
- `jobs/events.py` — `JobEvent`
- `jobs/workers/noop.py` — `NoopJobParams`, `NoopJobResult`

`CreateJobRequest`/`CreateJobResponse` already had descriptions and were left as-is. Existing `default_factory` values were preserved.

Regenerated `app/web_ui/src/lib/api_schema.d.ts` so the typed client picks up the descriptions.

## Why

The regenerated jobs API docs had blank field descriptions because the models didn't carry `Field(description=...)`. Fixing it at the model level means rich field docs generate automatically on every regen, with no hand-editing.

## Testing
- `ruff format` ✅ · `ty check` ✅
- Jobs test suite: 99 passed ✅
- Confirmed descriptions flow through to the generated OpenAPI schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Conw7oxpDtZTfhtEtVS9gT