### PR TITLE
Judge feedback batch: job-backed run of a pre-existing batch (eval parity) + deep-review fixes

### DIFF
--- a/app/desktop/studio_server/jobs/api.py
+++ b/app/desktop/studio_server/jobs/api.py
@@ -196,13 +196,15 @@ def connect_jobs_api(app: FastAPI) -> None:
     async def run_judge_feedback_batch_job(
         params: JudgeFeedbackBatchJobParams,
     ) -> CreateJobResponse:
-        """Create and run a judge feedback batch as a background job, returning immediately.
+        """Run a pre-existing judge feedback batch as a background job, returning immediately.
 
-        The job-backed counterpart to `POST /judge_feedback_batches/run`: lets an agent
-        fire many gates and `POST /api/jobs/wait` on all of them at once instead of
-        blocking on each synchronous call. The aggregate scores/usage/latency are on the
-        job result; the per-item runs (with the judge's feedback) are persisted — fetch
-        them via `GET /judge_feedback_batches/{id}/runs` (the result carries the batch id).
+        Create the batch first via `POST /judge_feedback_batches` (returns its id), then run
+        it here — mirroring how eval jobs run a pre-existing eval, so the batch id lives in the
+        job's params and is retrievable via `GET /api/jobs/{id}` even if the run fails. Lets an
+        agent fire many gates and `POST /api/jobs/wait` on all of them at once instead of
+        blocking on each synchronous call. The aggregate scores/usage/latency are on the job
+        result; the per-item runs (with the judge's feedback) are persisted — fetch them via
+        `GET /judge_feedback_batches/{id}/runs`.
         """
         job = await job_registry.create(
             type_name=JudgeFeedbackBatchJobWorker.type_name,

--- a/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
@@ -216,8 +216,13 @@ class JudgeFeedbackBatchJobWorker(
         async def report_progress(
             num_judged: int, error_count: int, planned_total: int
         ) -> None:
+            # num_judged counts every attempted item (errors included), so subtract the errors to
+            # keep success and error disjoint — the job progress contract is processed = success +
+            # error. Otherwise an errored item is counted in both and the bar overshoots 100%.
             await ctx.report_progress(
-                success=num_judged, error=error_count, total=planned_total
+                success=num_judged - error_count,
+                error=error_count,
+                total=planned_total,
             )
 
         result = await runner.run(progress_callback=report_progress)
@@ -232,13 +237,16 @@ class JudgeFeedbackBatchJobWorker(
                 run_config_id=params.run_config_id,
             )
 
-        # Final snapshot against the planned (capped) count — min(train_set_size,
-        # max_samples) is exactly how many items the run judges, so success ==
-        # total on full coverage (streaming totals use the same denominator).
+        # Final snapshot against the planned (capped) count = min(train_set_size, max_samples), the
+        # number of items the run judges in gate mode (so success + error reaches total on full
+        # coverage). In train-signal mode the run stops early once enough failures are found, so the
+        # bar can legitimately end below total — the job still succeeds. success excludes errors to
+        # keep success + error <= total (see report_progress above).
+        error_count = len(result.errors)
         planned_total = min(result.train_set_size, params.max_samples)
         await ctx.report_progress(
-            success=result.num_judged,
-            error=len(result.errors),
+            success=result.num_judged - error_count,
+            error=error_count,
             total=planned_total or result.num_judged,
         )
 

--- a/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
@@ -9,6 +9,7 @@ from kiln_ai.adapters.eval.judge_feedback_batch_runner import (
 )
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.usage import Usage
+from kiln_ai.utils.git_sync_protocols import default_save_context
 from kiln_server.task_api import task_from_id
 from pydantic import BaseModel, Field
 
@@ -202,18 +203,29 @@ class JudgeFeedbackBatchJobWorker(
         validate_run_config_id(task, params.run_config_id)
 
         judge_feedback_batch = _build_judge_feedback_batch(task, params)
-        judge_feedback_batch.save_to_file()
         batch_id = judge_feedback_batch.id
         if batch_id is None:
             raise ValueError("Judge feedback batch was not assigned an id")
 
+        # Wrap the batch-config write in the git-sync context too — not just the runner's per-item
+        # child writes. A raw save_to_file would leave the new config as dirty working-tree state,
+        # which the first child write's atomic_write ensure_clean() stashes away — losing the config
+        # and orphaning its children under auto git-sync. None coalesces to a no-op context. The
+        # same context is reused for the child writes; each save is a separate (non-nested) block.
+        save_context = (
+            save_context_for_project(
+                params.project_id,
+                context=f"judge feedback batch {batch_id}",
+            )
+            or default_save_context
+        )
+        async with save_context():
+            judge_feedback_batch.save_to_file()
+
         runner = JudgeFeedbackBatchRunner(
             judge_feedback_batch,
             eval_config,
-            save_context=save_context_for_project(
-                params.project_id,
-                context=f"judge feedback batch {judge_feedback_batch.id}",
-            ),
+            save_context=save_context,
         )
 
         async def report_progress(

--- a/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import asyncio
 
 from app.desktop.git_sync.save_context import save_context_for_project
-from kiln_ai.adapters.eval.judge_feedback_batch_runner import JudgeFeedbackBatchRunner
+from kiln_ai.adapters.eval.judge_feedback_batch_runner import (
+    JudgeFeedbackBatchItemError,
+    JudgeFeedbackBatchRunner,
+)
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.usage import Usage
 from kiln_server.task_api import task_from_id
@@ -225,17 +228,19 @@ class JudgeFeedbackBatchJobWorker(
                 total=planned_total,
             )
 
-        result = await runner.run(progress_callback=report_progress)
-
-        # Surface any per-item judge/save errors to the job's error log so they
-        # appear in the View Errors UI (progress.error above already gates the
-        # button; this fills in the messages).
-        for item_error in result.errors:
+        async def report_item_error(item_error: JudgeFeedbackBatchItemError) -> None:
+            # Write each per-item error to the job's error log the moment it happens (not batched to
+            # the end), so "View Errors" shows messages live — the streamed progress error count
+            # gates the button mid-run, and this keeps the log in step with it.
             await ctx.report_error(
                 item_error.error,
                 dataset_id=item_error.task_run_id,
                 run_config_id=params.run_config_id,
             )
+
+        result = await runner.run(
+            progress_callback=report_progress, error_callback=report_item_error
+        )
 
         # Final snapshot against the planned (capped) count = min(train_set_size, max_samples), the
         # number of items the run judges in gate mode (so success + error reaches total on full

--- a/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
@@ -9,31 +9,32 @@ from kiln_ai.adapters.eval.judge_feedback_batch_runner import (
 )
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.usage import Usage
-from kiln_ai.utils.git_sync_protocols import default_save_context
 from kiln_server.task_api import task_from_id
 from pydantic import BaseModel, Field
 
 from ...judge_feedback_batch_api import (
-    CreateJudgeFeedbackBatchRequest,
-    _build_judge_feedback_batch,
     eval_config_from_id,
+    judge_feedback_batch_from_id,
     validate_judge_eval,
     validate_run_config_id,
 )
 from ..models import JobContext, JobWorker
 
 
-class JudgeFeedbackBatchJobParams(CreateJudgeFeedbackBatchRequest):
-    """Create-and-run a judge feedback batch as a background job.
+class JudgeFeedbackBatchJobParams(BaseModel):
+    """Run an existing judge feedback batch as a background job.
 
-    Inherits every CreateJudgeFeedbackBatchRequest field (and its validation) and
-    adds the project/task scope, so the body is the same as the synchronous
-    create-and-run endpoint plus project_id/task_id.
+    The batch config is created first via `POST .../judge_feedback_batches` (which
+    returns its id); the job just runs it — mirroring how `EvalJobParams` runs a
+    pre-existing eval. Because the id is carried in params (not minted inside
+    run()), it's retrievable via `GET /api/jobs/{id}` even if the run fails.
     """
 
     project_id: str = Field(description="The ID of the project the task belongs to.")
-    task_id: str = Field(
-        description="The ID of the task to run the judge feedback batch under."
+    task_id: str = Field(description="The ID of the task the batch belongs to.")
+    judge_feedback_batch_id: str = Field(
+        description="The ID of the judge feedback batch to run. Create it first via "
+        "POST /api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches."
     )
 
 
@@ -49,7 +50,7 @@ class JudgeFeedbackBatchJobResult(BaseModel):
     """
 
     judge_feedback_batch_id: str = Field(
-        description="The ID of the persisted judge feedback batch this job created and ran. "
+        description="The ID of the judge feedback batch this job ran (echoes the id from params). "
         "Fetch its per-item runs (with feedback) via GET /judge_feedback_batches/{id}/runs."
     )
     num_judged: int = Field(
@@ -121,15 +122,17 @@ class JudgeFeedbackBatchJobProperties(BaseModel):
 class JudgeFeedbackBatchJobWorker(
     JobWorker[JudgeFeedbackBatchJobParams, JudgeFeedbackBatchJobResult]
 ):
-    """Background worker that creates and runs a judge feedback batch.
+    """Background worker that runs a pre-existing judge feedback batch.
 
     Wraps `JudgeFeedbackBatchRunner` unchanged (mirrors `EvalJobWorker` wrapping
-    `EvalRunner`). Making the judge run job-backed lets an agent fire many gates
-    at once and `POST /api/jobs/wait` on all of them together, instead of blocking
-    on each synchronous call serially. The runner streams progress per judged
-    chunk. `supports_pause` stays False — re-running creates a fresh batch, so
-    there's nothing to resume, and `compute_state` keeps its default (None): the
-    batch id is minted inside run(), so params alone can't locate it to reconcile.
+    `EvalRunner`). The batch config is created first via the synchronous create
+    endpoint; this job only runs it (the id is in params). Making the judge run
+    job-backed lets an agent fire many gates at once and `POST /api/jobs/wait` on
+    all of them together, instead of blocking on each synchronous call serially.
+    The runner streams progress per judged chunk. `supports_pause` stays False and
+    `compute_state` keeps its default (None) for now — the runner already reuses
+    cached child runs, so a re-run is idempotent, but deriving progress from disk
+    is left as a follow-up.
     """
 
     type_name = "judge_feedback_batch"
@@ -149,7 +152,10 @@ class JudgeFeedbackBatchJobWorker(
         self, params: JudgeFeedbackBatchJobParams
     ) -> JudgeFeedbackBatchJobProperties:
         task = task_from_id(params.project_id, params.task_id)
-        eval_config = eval_config_from_id(task, params.eval_config_id)
+        batch = judge_feedback_batch_from_id(
+            params.project_id, params.task_id, params.judge_feedback_batch_id, task=task
+        )
+        eval_config = eval_config_from_id(task, batch.eval_config_id)
         eval = eval_config.parent_eval()
 
         # The run config only matters when generating fresh outputs; and only the
@@ -158,12 +164,12 @@ class JudgeFeedbackBatchJobWorker(
         run_config_name = ""
         run_config_model_name = ""
         run_config_model_provider = ""
-        if params.run_config_id is not None:
+        if batch.run_config_id is not None:
             run_config = next(
                 (
                     rc
                     for rc in task.run_configs(readonly=True)
-                    if rc.id == params.run_config_id
+                    if rc.id == batch.run_config_id
                 ),
                 None,
             )
@@ -177,55 +183,42 @@ class JudgeFeedbackBatchJobWorker(
                     )
 
         return JudgeFeedbackBatchJobProperties(
-            batch_name=params.name or "Judge Feedback Batch",
+            batch_name=batch.name,
             eval_name=eval.name if eval is not None else "",
             judge_name=eval_config.name,
             judge_algorithm=eval_config.config_type.value,
             judge_model_name=eval_config.model_name,
             judge_model_provider=eval_config.model_provider,
-            generate_outputs=params.generate_outputs,
+            generate_outputs=batch.generate_outputs,
             run_config_name=run_config_name,
             run_config_model_name=run_config_model_name,
             run_config_model_provider=run_config_model_provider,
-            target_tags=list(params.target_tags),
-            max_samples=params.max_samples,
-            stop_after_failures=params.stop_after_failures,
+            target_tags=list(batch.target_tags or []),
+            max_samples=batch.max_samples,
+            stop_after_failures=batch.stop_after_failures,
         )
 
     async def run(
         self, params: JudgeFeedbackBatchJobParams, ctx: JobContext
     ) -> JudgeFeedbackBatchJobResult:
-        # params IS a CreateJudgeFeedbackBatchRequest (plus project/task scope), so
-        # the existing validators + builder accept it directly.
+        # Load the pre-created batch config (the create endpoint already persisted it under the
+        # git-sync write lock), then run it. Nothing is created here, so there is no config write to
+        # wrap — only the runner's per-item child writes, which it wraps in its own save_context.
         task = task_from_id(params.project_id, params.task_id)
-        eval_config = eval_config_from_id(task, params.eval_config_id)
-        validate_judge_eval(eval_config, params.generate_outputs)
-        validate_run_config_id(task, params.run_config_id)
-
-        judge_feedback_batch = _build_judge_feedback_batch(task, params)
-        batch_id = judge_feedback_batch.id
-        if batch_id is None:
-            raise ValueError("Judge feedback batch was not assigned an id")
-
-        # Wrap the batch-config write in the git-sync context too — not just the runner's per-item
-        # child writes. A raw save_to_file would leave the new config as dirty working-tree state,
-        # which the first child write's atomic_write ensure_clean() stashes away — losing the config
-        # and orphaning its children under auto git-sync. None coalesces to a no-op context. The
-        # same context is reused for the child writes; each save is a separate (non-nested) block.
-        save_context = (
-            save_context_for_project(
-                params.project_id,
-                context=f"judge feedback batch {batch_id}",
-            )
-            or default_save_context
+        judge_feedback_batch = judge_feedback_batch_from_id(
+            params.project_id, params.task_id, params.judge_feedback_batch_id, task=task
         )
-        async with save_context():
-            judge_feedback_batch.save_to_file()
+        eval_config = eval_config_from_id(task, judge_feedback_batch.eval_config_id)
+        validate_judge_eval(eval_config, judge_feedback_batch.generate_outputs)
+        validate_run_config_id(task, judge_feedback_batch.run_config_id)
 
         runner = JudgeFeedbackBatchRunner(
             judge_feedback_batch,
             eval_config,
-            save_context=save_context,
+            save_context=save_context_for_project(
+                params.project_id,
+                context=f"judge feedback batch {params.judge_feedback_batch_id}",
+            ),
         )
 
         async def report_progress(
@@ -247,7 +240,7 @@ class JudgeFeedbackBatchJobWorker(
             await ctx.report_error(
                 item_error.error,
                 dataset_id=item_error.task_run_id,
-                run_config_id=params.run_config_id,
+                run_config_id=judge_feedback_batch.run_config_id,
             )
 
         result = await runner.run(
@@ -260,7 +253,7 @@ class JudgeFeedbackBatchJobWorker(
         # bar can legitimately end below total — the job still succeeds. success excludes errors to
         # keep success + error <= total (see report_progress above).
         error_count = len(result.errors)
-        planned_total = min(result.train_set_size, params.max_samples)
+        planned_total = min(result.train_set_size, judge_feedback_batch.max_samples)
         await ctx.report_progress(
             success=result.num_judged - error_count,
             error=error_count,
@@ -268,12 +261,12 @@ class JudgeFeedbackBatchJobWorker(
         )
 
         return JudgeFeedbackBatchJobResult(
-            judge_feedback_batch_id=batch_id,
+            judge_feedback_batch_id=params.judge_feedback_batch_id,
             num_judged=result.num_judged,
             failing_count=result.failing_count,
             train_set_size=result.train_set_size,
             hit_cap=result.hit_cap,
-            error_count=len(result.errors),
+            error_count=error_count,
             mean_normalized_scores=result.mean_normalized_scores,
             mean_normalized_score=result.mean_normalized_score,
             total_usage=result.total_usage,

--- a/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import asyncio
+
 from app.desktop.git_sync.save_context import save_context_for_project
 from kiln_ai.adapters.eval.judge_feedback_batch_runner import JudgeFeedbackBatchRunner
+from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.usage import Usage
 from kiln_server.task_api import task_from_id
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from ...judge_feedback_batch_api import (
     CreateJudgeFeedbackBatchRequest,
@@ -24,8 +27,10 @@ class JudgeFeedbackBatchJobParams(CreateJudgeFeedbackBatchRequest):
     create-and-run endpoint plus project_id/task_id.
     """
 
-    project_id: str
-    task_id: str
+    project_id: str = Field(description="The ID of the project the task belongs to.")
+    task_id: str = Field(
+        description="The ID of the task to run the judge feedback batch under."
+    )
 
 
 class JudgeFeedbackBatchJobResult(BaseModel):
@@ -39,17 +44,74 @@ class JudgeFeedbackBatchJobResult(BaseModel):
     response's aggregate fields.
     """
 
-    judge_feedback_batch_id: str
-    num_judged: int
-    failing_count: int
-    train_set_size: int
-    hit_cap: bool
-    error_count: int
-    mean_normalized_scores: dict[str, float]
-    mean_normalized_score: float | None = None
-    total_usage: Usage | None = None
-    mean_cost: float | None = None
-    mean_latency_ms: float | None = None
+    judge_feedback_batch_id: str = Field(
+        description="The ID of the persisted judge feedback batch this job created and ran. "
+        "Fetch its per-item runs (with feedback) via GET /judge_feedback_batches/{id}/runs."
+    )
+    num_judged: int = Field(
+        description="How many items were examined (judged) during the run."
+    )
+    failing_count: int = Field(
+        description="How many judged items failed the judge (scored below the threshold)."
+    )
+    train_set_size: int = Field(
+        description="Total number of dataset items matching the target tags (before max_samples)."
+    )
+    hit_cap: bool = Field(
+        description="True if coverage was capped: max_samples was reached before "
+        "stop_after_failures, or the matching set exceeded max_samples."
+    )
+    error_count: int = Field(
+        description="Number of per-item judge/save errors collected during the run. The messages "
+        "are in the job's error log (GET /api/jobs/{id}/errors)."
+    )
+    mean_normalized_scores: dict[str, float] = Field(
+        description="Mean normalized (0-1, higher = better) score per output-score dimension over "
+        "the judged items."
+    )
+    mean_normalized_score: float | None = Field(
+        default=None,
+        description="Mean of mean_normalized_scores across dimensions (null if nothing was judged).",
+    )
+    total_usage: Usage | None = Field(
+        default=None,
+        description="Summed token usage, cost (USD), and LLM latency for generating the judged "
+        "outputs (generate_outputs mode only; null when existing outputs were judged).",
+    )
+    mean_cost: float | None = Field(
+        default=None,
+        description="Mean generation cost (USD) per judged item, over items that reported cost "
+        "(generate_outputs mode only; null otherwise).",
+    )
+    mean_latency_ms: float | None = Field(
+        default=None,
+        description="Mean generation LLM latency (ms) per judged item, over items that reported "
+        "latency (generate_outputs mode only; null otherwise).",
+    )
+
+
+class JudgeFeedbackBatchJobProperties(BaseModel):
+    """Static, descriptive info about a judge feedback batch job, for the jobs UI.
+
+    Mirrors EvalJobProperties: which judge (eval config) scores the items, the run
+    config (present only when generating fresh outputs), and the batch's sampling
+    scope. Model/provider fields carry raw ids; the frontend resolves them to
+    display names with its model-name helpers.
+    """
+
+    batch_name: str
+    eval_name: str
+    judge_name: str
+    judge_algorithm: str
+    judge_model_name: str
+    judge_model_provider: str
+    generate_outputs: bool
+    run_config_name: str
+    run_config_model_name: str
+    run_config_model_provider: str
+    target_tags: list[str]
+    max_samples: int
+    stop_after_failures: int | None = None
 
 
 class JudgeFeedbackBatchJobWorker(
@@ -60,16 +122,71 @@ class JudgeFeedbackBatchJobWorker(
     Wraps `JudgeFeedbackBatchRunner` unchanged (mirrors `EvalJobWorker` wrapping
     `EvalRunner`). Making the judge run job-backed lets an agent fire many gates
     at once and `POST /api/jobs/wait` on all of them together, instead of blocking
-    on each synchronous call serially. The runner is single-shot (no incremental
-    progress), so progress is reported once on completion and `supports_pause`
-    stays False. Re-running creates a fresh batch, so there's nothing to resume —
-    `compute_state` keeps its default (None).
+    on each synchronous call serially. The runner streams progress per judged
+    chunk. `supports_pause` stays False — re-running creates a fresh batch, so
+    there's nothing to resume, and `compute_state` keeps its default (None): the
+    batch id is minted inside run(), so params alone can't locate it to reconcile.
     """
 
     type_name = "judge_feedback_batch"
     params_model = JudgeFeedbackBatchJobParams
     result_model = JudgeFeedbackBatchJobResult
+    properties_model = JudgeFeedbackBatchJobProperties
     supports_pause = False
+
+    async def describe(
+        self, params: JudgeFeedbackBatchJobParams
+    ) -> JudgeFeedbackBatchJobProperties:
+        # Loads entities off disk; offload the blocking IO to a thread so create()
+        # stays responsive (mirrors EvalJobWorker.describe).
+        return await asyncio.to_thread(self._describe_sync, params)
+
+    def _describe_sync(
+        self, params: JudgeFeedbackBatchJobParams
+    ) -> JudgeFeedbackBatchJobProperties:
+        task = task_from_id(params.project_id, params.task_id)
+        eval_config = eval_config_from_id(task, params.eval_config_id)
+        eval = eval_config.parent_eval()
+
+        # The run config only matters when generating fresh outputs; and only the
+        # kiln_agent variant carries a model. Leave the fields blank otherwise so
+        # the judge/batch info still renders.
+        run_config_name = ""
+        run_config_model_name = ""
+        run_config_model_provider = ""
+        if params.run_config_id is not None:
+            run_config = next(
+                (
+                    rc
+                    for rc in task.run_configs(readonly=True)
+                    if rc.id == params.run_config_id
+                ),
+                None,
+            )
+            if run_config is not None:
+                run_config_name = run_config.name
+                run_config_properties = run_config.run_config_properties
+                if isinstance(run_config_properties, KilnAgentRunConfigProperties):
+                    run_config_model_name = run_config_properties.model_name
+                    run_config_model_provider = (
+                        run_config_properties.model_provider_name
+                    )
+
+        return JudgeFeedbackBatchJobProperties(
+            batch_name=params.name or "Judge Feedback Batch",
+            eval_name=eval.name if eval is not None else "",
+            judge_name=eval_config.name,
+            judge_algorithm=eval_config.config_type.value,
+            judge_model_name=eval_config.model_name,
+            judge_model_provider=eval_config.model_provider,
+            generate_outputs=params.generate_outputs,
+            run_config_name=run_config_name,
+            run_config_model_name=run_config_model_name,
+            run_config_model_provider=run_config_model_provider,
+            target_tags=list(params.target_tags),
+            max_samples=params.max_samples,
+            stop_after_failures=params.stop_after_failures,
+        )
 
     async def run(
         self, params: JudgeFeedbackBatchJobParams, ctx: JobContext
@@ -95,20 +212,34 @@ class JudgeFeedbackBatchJobWorker(
                 context=f"judge feedback batch {judge_feedback_batch.id}",
             ),
         )
-        result = await runner.run()
 
-        # Single-shot runner: surface any per-item judge/save errors to the job's
-        # error log, then report final progress once (0 -> done).
+        async def report_progress(
+            num_judged: int, error_count: int, planned_total: int
+        ) -> None:
+            await ctx.report_progress(
+                success=num_judged, error=error_count, total=planned_total
+            )
+
+        result = await runner.run(progress_callback=report_progress)
+
+        # Surface any per-item judge/save errors to the job's error log so they
+        # appear in the View Errors UI (progress.error above already gates the
+        # button; this fills in the messages).
         for item_error in result.errors:
             await ctx.report_error(
                 item_error.error,
                 dataset_id=item_error.task_run_id,
                 run_config_id=params.run_config_id,
             )
+
+        # Final snapshot against the planned (capped) count — min(train_set_size,
+        # max_samples) is exactly how many items the run judges, so success ==
+        # total on full coverage (streaming totals use the same denominator).
+        planned_total = min(result.train_set_size, params.max_samples)
         await ctx.report_progress(
             success=result.num_judged,
             error=len(result.errors),
-            total=result.train_set_size or result.num_judged,
+            total=planned_total or result.num_judged,
         )
 
         return JudgeFeedbackBatchJobResult(

--- a/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from unittest.mock import patch
 
 import pytest
@@ -208,6 +208,62 @@ async def test_run_creates_batch_and_maps_result(
     assert batch.target_tags == ["train_set"]
     assert batch.eval_config_id == "eval_config1"
     assert batch.generate_outputs is True
+
+
+async def test_run_wraps_batch_config_save_in_git_context(
+    resolve_project, task, eval_config, run_config, params
+):
+    """The batch-config write must go through the git-sync save_context (not a raw save), fully
+    committed before the runner starts — otherwise auto git-sync's ensure_clean() stashes the
+    untracked config away on the first child write, losing it and orphaning the children."""
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def recording_cm():
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("exit")
+
+    def recording_factory():
+        return recording_cm()
+
+    async def fake_run(
+        self, concurrency=None, progress_callback=None, error_callback=None
+    ) -> JudgeFeedbackBatchRunResult:
+        events.append("run")
+        # The batch config must already be persisted (and its save context closed) by run time.
+        assert (
+            JudgeFeedbackBatch.from_id_and_parent_path(
+                self.judge_feedback_batch.id, task.path
+            )
+            is not None
+        )
+        return _fake_result()
+
+    ctx = _FakeCtx()
+    with (
+        patch(
+            "app.desktop.studio_server.jobs.workers.judge_feedback_batch.save_context_for_project",
+            return_value=recording_factory,
+        ),
+        patch(
+            "kiln_ai.adapters.eval.judge_feedback_batch_runner.JudgeFeedbackBatchRunner.run",
+            new=fake_run,
+        ),
+    ):
+        result = await JudgeFeedbackBatchJobWorker().run(params, ctx)
+
+    # The batch save was wrapped in the git context and its atomic write closed BEFORE the runner
+    # ran (separate, non-nested blocks): enter -> exit -> run.
+    assert events == ["enter", "exit", "run"]
+    assert (
+        JudgeFeedbackBatch.from_id_and_parent_path(
+            result.judge_feedback_batch_id, task.path
+        )
+        is not None
+    )
 
 
 async def test_run_reports_progress_and_per_item_errors(

--- a/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
@@ -156,7 +156,12 @@ def _fake_result() -> JudgeFeedbackBatchRunResult:
 
 @contextmanager
 def _stub_runner(result: JudgeFeedbackBatchRunResult):
-    async def fake_run(self) -> JudgeFeedbackBatchRunResult:
+    async def fake_run(self, progress_callback=None) -> JudgeFeedbackBatchRunResult:
+        # Mimic the real runner streaming one progress tick before returning, so
+        # the worker's live-progress wiring is exercised.
+        if progress_callback is not None:
+            planned = min(result.train_set_size, self.judge_feedback_batch.max_samples)
+            await progress_callback(result.num_judged, len(result.errors), planned)
         return result
 
     with (
@@ -214,6 +219,60 @@ async def test_run_reports_progress_and_per_item_errors(
     assert extra["dataset_id"] == "tr1"
     assert extra["run_config_id"] == "run_config1"
 
-    # Single-shot runner: final progress reported once
-    # (success=num_judged, error=len(errors), total=train_set_size).
+    # Progress streams per chunk (via the callback) and a final snapshot is
+    # reported. Total is the planned (capped) count = min(train_set_size,
+    # max_samples) = min(10, 50) = 10, so success can reach total on full
+    # coverage (success=num_judged, error=len(errors), total=planned).
+    assert len(ctx.progress) >= 2
     assert ctx.progress[-1] == (5, 1, 10)
+
+
+async def test_run_progress_total_is_capped_at_max_samples(
+    resolve_project, task, eval_config, run_config
+):
+    """When train_set_size exceeds max_samples, progress totals against the capped
+    count (max_samples), not the full matching set — so a fully-judged run reads
+    as 100% rather than stalling at max_samples/train_set_size."""
+    params = JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        target_tags=["train_set"],
+        eval_config_id="eval_config1",
+        run_config_id="run_config1",
+        generate_outputs=True,
+        max_samples=20,
+    )
+    result = JudgeFeedbackBatchRunResult(
+        failing_runs=[],
+        judged_runs=[],
+        num_judged=20,
+        failing_count=0,
+        train_set_size=200,
+        hit_cap=True,
+        errors=[],
+    )
+    ctx = _FakeCtx()
+    with _stub_runner(result):
+        await JudgeFeedbackBatchJobWorker().run(params, ctx)
+
+    # planned = min(200, 20) = 20, and all 20 were judged -> success == total.
+    success, error, total = ctx.progress[-1]
+    assert (success, error, total) == (20, 0, 20)
+
+
+async def test_describe_publishes_properties(
+    resolve_project, task, eval_config, run_config, params
+):
+    props = await JudgeFeedbackBatchJobWorker().describe(params)
+
+    assert props.batch_name  # generated or provided, never empty
+    assert props.eval_name == "Test Eval"
+    assert props.judge_name == "Test Eval Config"
+    assert props.judge_model_name == "gpt-4"
+    assert props.judge_model_provider == "openai"
+    assert props.generate_outputs is True
+    # generate_outputs mode: the run config is resolved for display.
+    assert props.run_config_name == "Test Run Config"
+    assert props.run_config_model_name == "gpt-4"
+    assert props.target_tags == ["train_set"]
+    assert props.max_samples == 50

--- a/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
@@ -157,10 +157,13 @@ def _fake_result() -> JudgeFeedbackBatchRunResult:
 @contextmanager
 def _stub_runner(result: JudgeFeedbackBatchRunResult):
     async def fake_run(
-        self, concurrency=None, progress_callback=None
+        self, concurrency=None, progress_callback=None, error_callback=None
     ) -> JudgeFeedbackBatchRunResult:
-        # Mimic the real runner streaming one progress tick before returning, so
-        # the worker's live-progress wiring is exercised.
+        # Mimic the real runner: surface each per-item error live via error_callback, then stream one
+        # progress tick before returning, so the worker's live error + progress wiring is exercised.
+        if error_callback is not None:
+            for item_error in result.errors:
+                await error_callback(item_error)
         if progress_callback is not None:
             planned = min(result.train_set_size, self.judge_feedback_batch.max_samples)
             await progress_callback(result.num_judged, len(result.errors), planned)

--- a/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
+from fastapi import HTTPException
 from app.desktop.studio_server.jobs.workers.judge_feedback_batch import (
     JudgeFeedbackBatchJobParams,
     JudgeFeedbackBatchJobResult,
@@ -101,15 +102,28 @@ def run_config(task):
 
 
 @pytest.fixture
-def params():
-    return JudgeFeedbackBatchJobParams(
-        project_id="project1",
-        task_id="task1",
+def batch(task, eval_config, run_config):
+    """A pre-created judge feedback batch on disk — the job runs an existing one."""
+    batch = JudgeFeedbackBatch(
+        id="batch1",
+        name="Test Batch",
         target_tags=["train_set"],
         eval_config_id="eval_config1",
         run_config_id="run_config1",
         generate_outputs=True,
         max_samples=50,
+        parent=task,
+    )
+    batch.save_to_file()
+    return batch
+
+
+@pytest.fixture
+def params(batch):
+    return JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        judge_feedback_batch_id=batch.id,
     )
 
 
@@ -182,14 +196,16 @@ def _stub_runner(result: JudgeFeedbackBatchRunResult):
         yield
 
 
-async def test_run_creates_batch_and_maps_result(
-    resolve_project, task, eval_config, run_config, params
+async def test_run_loads_existing_batch_and_maps_result(
+    resolve_project, task, eval_config, run_config, batch, params
 ):
     ctx = _FakeCtx()
     with _stub_runner(_fake_result()):
         result = await JudgeFeedbackBatchJobWorker().run(params, ctx)
 
     assert isinstance(result, JudgeFeedbackBatchJobResult)
+    # The job runs the PRE-EXISTING batch named in params; the id round-trips into the result.
+    assert result.judge_feedback_batch_id == batch.id
     assert result.num_judged == 5
     assert result.failing_count == 2
     assert result.train_set_size == 10
@@ -200,70 +216,18 @@ async def test_run_creates_batch_and_maps_result(
     assert result.mean_cost == 0.01
     assert result.mean_latency_ms == 120.0
 
-    # The job created + persisted a batch under the task; its id round-trips.
-    batch = JudgeFeedbackBatch.from_id_and_parent_path(
-        result.judge_feedback_batch_id, task.path
-    )
-    assert batch is not None
-    assert batch.target_tags == ["train_set"]
-    assert batch.eval_config_id == "eval_config1"
-    assert batch.generate_outputs is True
 
-
-async def test_run_wraps_batch_config_save_in_git_context(
-    resolve_project, task, eval_config, run_config, params
-):
-    """The batch-config write must go through the git-sync save_context (not a raw save), fully
-    committed before the runner starts — otherwise auto git-sync's ensure_clean() stashes the
-    untracked config away on the first child write, losing it and orphaning the children."""
-    events: list[str] = []
-
-    @asynccontextmanager
-    async def recording_cm():
-        events.append("enter")
-        try:
-            yield
-        finally:
-            events.append("exit")
-
-    def recording_factory():
-        return recording_cm()
-
-    async def fake_run(
-        self, concurrency=None, progress_callback=None, error_callback=None
-    ) -> JudgeFeedbackBatchRunResult:
-        events.append("run")
-        # The batch config must already be persisted (and its save context closed) by run time.
-        assert (
-            JudgeFeedbackBatch.from_id_and_parent_path(
-                self.judge_feedback_batch.id, task.path
-            )
-            is not None
-        )
-        return _fake_result()
-
+async def test_run_missing_batch_raises(resolve_project, task, eval_config):
+    # No batch persisted for this id -> the run fails cleanly (the registry marks the job failed).
     ctx = _FakeCtx()
-    with (
-        patch(
-            "app.desktop.studio_server.jobs.workers.judge_feedback_batch.save_context_for_project",
-            return_value=recording_factory,
-        ),
-        patch(
-            "kiln_ai.adapters.eval.judge_feedback_batch_runner.JudgeFeedbackBatchRunner.run",
-            new=fake_run,
-        ),
-    ):
-        result = await JudgeFeedbackBatchJobWorker().run(params, ctx)
-
-    # The batch save was wrapped in the git context and its atomic write closed BEFORE the runner
-    # ran (separate, non-nested blocks): enter -> exit -> run.
-    assert events == ["enter", "exit", "run"]
-    assert (
-        JudgeFeedbackBatch.from_id_and_parent_path(
-            result.judge_feedback_batch_id, task.path
-        )
-        is not None
+    params = JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        judge_feedback_batch_id="does_not_exist",
     )
+    with pytest.raises(HTTPException) as exc_info:
+        await JudgeFeedbackBatchJobWorker().run(params, ctx)
+    assert exc_info.value.status_code == 404
 
 
 async def test_run_reports_progress_and_per_item_errors(
@@ -294,14 +258,21 @@ async def test_run_progress_total_is_capped_at_max_samples(
     """When train_set_size exceeds max_samples, progress totals against the capped
     count (max_samples), not the full matching set — so a fully-judged run reads
     as 100% rather than stalling at max_samples/train_set_size."""
-    params = JudgeFeedbackBatchJobParams(
-        project_id="project1",
-        task_id="task1",
+    capped_batch = JudgeFeedbackBatch(
+        id="batch_capped",
+        name="Capped Batch",
         target_tags=["train_set"],
         eval_config_id="eval_config1",
         run_config_id="run_config1",
         generate_outputs=True,
         max_samples=20,
+        parent=task,
+    )
+    capped_batch.save_to_file()
+    params = JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        judge_feedback_batch_id=capped_batch.id,
     )
     result = JudgeFeedbackBatchRunResult(
         failing_runs=[],
@@ -322,11 +293,12 @@ async def test_run_progress_total_is_capped_at_max_samples(
 
 
 async def test_describe_publishes_properties(
-    resolve_project, task, eval_config, run_config, params
+    resolve_project, task, eval_config, run_config, batch, params
 ):
     props = await JudgeFeedbackBatchJobWorker().describe(params)
 
-    assert props.batch_name  # generated or provided, never empty
+    # Derived from the persisted batch, not from params.
+    assert props.batch_name == "Test Batch"
     assert props.eval_name == "Test Eval"
     assert props.judge_name == "Test Eval Config"
     assert props.judge_model_name == "gpt-4"
@@ -344,12 +316,19 @@ async def test_describe_judge_only_mode_leaves_run_config_blank(
 ):
     # Judge-only mode (generate_outputs=False, no run_config_id): the run-config display fields are
     # left blank, but the judge/eval/batch info still resolves.
-    params = JudgeFeedbackBatchJobParams(
-        project_id="project1",
-        task_id="task1",
+    judge_only_batch = JudgeFeedbackBatch(
+        id="batch_judge_only",
+        name="Judge Only Batch",
         target_tags=["train_set"],
         eval_config_id="eval_config1",
         generate_outputs=False,
+        parent=task,
+    )
+    judge_only_batch.save_to_file()
+    params = JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        judge_feedback_batch_id=judge_only_batch.id,
     )
     props = await JudgeFeedbackBatchJobWorker().describe(params)
 

--- a/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
@@ -156,7 +156,9 @@ def _fake_result() -> JudgeFeedbackBatchRunResult:
 
 @contextmanager
 def _stub_runner(result: JudgeFeedbackBatchRunResult):
-    async def fake_run(self, progress_callback=None) -> JudgeFeedbackBatchRunResult:
+    async def fake_run(
+        self, concurrency=None, progress_callback=None
+    ) -> JudgeFeedbackBatchRunResult:
         # Mimic the real runner streaming one progress tick before returning, so
         # the worker's live-progress wiring is exercised.
         if progress_callback is not None:
@@ -221,10 +223,10 @@ async def test_run_reports_progress_and_per_item_errors(
 
     # Progress streams per chunk (via the callback) and a final snapshot is
     # reported. Total is the planned (capped) count = min(train_set_size,
-    # max_samples) = min(10, 50) = 10, so success can reach total on full
-    # coverage (success=num_judged, error=len(errors), total=planned).
+    # max_samples) = min(10, 50) = 10. success excludes errors so success + error
+    # stays <= total: 5 judged, 1 errored -> success=4, error=1, total=10.
     assert len(ctx.progress) >= 2
-    assert ctx.progress[-1] == (5, 1, 10)
+    assert ctx.progress[-1] == (4, 1, 10)
 
 
 async def test_run_progress_total_is_capped_at_max_samples(
@@ -276,3 +278,25 @@ async def test_describe_publishes_properties(
     assert props.run_config_model_name == "gpt-4"
     assert props.target_tags == ["train_set"]
     assert props.max_samples == 50
+
+
+async def test_describe_judge_only_mode_leaves_run_config_blank(
+    resolve_project, task, eval_config, run_config
+):
+    # Judge-only mode (generate_outputs=False, no run_config_id): the run-config display fields are
+    # left blank, but the judge/eval/batch info still resolves.
+    params = JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        target_tags=["train_set"],
+        eval_config_id="eval_config1",
+        generate_outputs=False,
+    )
+    props = await JudgeFeedbackBatchJobWorker().describe(params)
+
+    assert props.generate_outputs is False
+    assert props.run_config_name == ""
+    assert props.run_config_model_name == ""
+    assert props.run_config_model_provider == ""
+    assert props.judge_name == "Test Eval Config"
+    assert props.eval_name == "Test Eval"

--- a/app/desktop/studio_server/judge_feedback_batch_api.py
+++ b/app/desktop/studio_server/judge_feedback_batch_api.py
@@ -13,6 +13,7 @@ from kiln_ai.datamodel.judge_feedback_batch import (
 )
 from kiln_ai.datamodel.task import Task
 from kiln_ai.datamodel.usage import Usage
+from kiln_ai.utils.git_sync_protocols import default_save_context
 from kiln_ai.utils.name_generator import generate_memorable_name
 from kiln_server.git_sync_decorators import build_save_context, no_write_lock
 from kiln_server.task_api import task_from_id
@@ -335,7 +336,12 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         validate_judge_eval(eval_config, body.generate_outputs)
         validate_run_config_id(task, body.run_config_id)
         judge_feedback_batch = _build_judge_feedback_batch(task, body)
-        judge_feedback_batch.save_to_file()
+        # This endpoint is @no_write_lock, so wrap the batch-config write in the git-sync context
+        # ourselves. Otherwise the raw save leaves dirty working-tree state that the runner's first
+        # child atomic_write ensure_clean() stashes away, losing the config under auto git-sync.
+        save_context = build_save_context(request) or default_save_context
+        async with save_context():
+            judge_feedback_batch.save_to_file()
         return await _run_judge_feedback_batch(
             judge_feedback_batch, eval_config, request
         )

--- a/app/desktop/studio_server/judge_feedback_batch_api.py
+++ b/app/desktop/studio_server/judge_feedback_batch_api.py
@@ -245,7 +245,9 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches",
         summary="Create Judge Feedback Batch",
         tags=["Judge Feedback Batches"],
-        openapi_extra=DENY_AGENT,
+        # Agent-callable: the agent creates the batch here, then runs it via the job endpoint
+        # (POST /api/jobs/judge_feedback_batch/run). Creating is cheap and makes no model calls.
+        openapi_extra=ALLOW_AGENT,
     )
     async def create_judge_feedback_batch(
         project_id: Annotated[

--- a/app/desktop/studio_server/judge_feedback_batch_api.py
+++ b/app/desktop/studio_server/judge_feedback_batch_api.py
@@ -24,16 +24,21 @@ from pydantic import BaseModel, Field, model_validator
 
 
 def judge_feedback_batch_from_id(
-    project_id: str, task_id: str, judge_feedback_batch_id: str
+    project_id: str,
+    task_id: str,
+    judge_feedback_batch_id: str,
+    task: Task | None = None,
 ) -> JudgeFeedbackBatch:
-    task = task_from_id(project_id, task_id)
+    # Accept an already-resolved task to avoid a redundant disk load when the caller has one.
+    if task is None:
+        task = task_from_id(project_id, task_id)
     judge_feedback_batch = JudgeFeedbackBatch.from_id_and_parent_path(
         judge_feedback_batch_id, task.path
     )
     if judge_feedback_batch is None:
         raise HTTPException(
             status_code=404,
-            detail=f"Judge job not found. ID: {judge_feedback_batch_id}",
+            detail=f"Judge feedback batch not found. ID: {judge_feedback_batch_id}",
         )
     return judge_feedback_batch
 
@@ -283,8 +288,9 @@ def connect_judge_feedback_batch_api(app: FastAPI):
             str, Path(description="The unique identifier of the judge feedback batch.")
         ],
     ) -> JudgeFeedbackBatchRunResponse:
-        """Run a judge feedback batch: sample tagged dataset items, judge their existing outputs, and return
-        the failing examples + feedback.
+        """Run a judge feedback batch: sample tagged dataset items, judge their outputs (existing, or
+        freshly generated when the batch has generate_outputs=true), and return the failing examples
+        + feedback.
 
         Runs synchronously and returns once judging completes. Each result is persisted as a child
         run (fetch them later via `GET /judge_feedback_batches/{id}/runs`); the returned counts
@@ -294,7 +300,7 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         """
         task = task_from_id(project_id, task_id)
         judge_feedback_batch = judge_feedback_batch_from_id(
-            project_id, task_id, judge_feedback_batch_id
+            project_id, task_id, judge_feedback_batch_id, task=task
         )
         eval_config = eval_config_from_id(task, judge_feedback_batch.eval_config_id)
         validate_judge_eval(eval_config, judge_feedback_batch.generate_outputs)

--- a/app/desktop/studio_server/judge_feedback_batch_api.py
+++ b/app/desktop/studio_server/judge_feedback_batch_api.py
@@ -19,7 +19,7 @@ from kiln_server.git_sync_decorators import build_save_context, no_write_lock
 from kiln_server.task_api import task_from_id
 from kiln_server.utils.agent_checks.policy import (
     ALLOW_AGENT,
-    agent_policy_require_approval,
+    DENY_AGENT,
 )
 from pydantic import BaseModel, Field, model_validator
 
@@ -245,7 +245,7 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches",
         summary="Create Judge Feedback Batch",
         tags=["Judge Feedback Batches"],
-        openapi_extra=ALLOW_AGENT,
+        openapi_extra=DENY_AGENT,
     )
     async def create_judge_feedback_batch(
         project_id: Annotated[
@@ -271,9 +271,7 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches/{judge_feedback_batch_id}/run",
         summary="Run Judge Feedback Batch",
         tags=["Judge Feedback Batches"],
-        openapi_extra=agent_policy_require_approval(
-            "Run judge feedback batch? It makes model calls over the sampled dataset items."
-        ),
+        openapi_extra=DENY_AGENT,
     )
     @no_write_lock
     async def run_judge_feedback_batch(
@@ -313,9 +311,7 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches/run",
         summary="Create And Run Judge Feedback Batch",
         tags=["Judge Feedback Batches"],
-        openapi_extra=agent_policy_require_approval(
-            "Create and run judge feedback batch? It makes model calls over the sampled dataset items."
-        ),
+        openapi_extra=DENY_AGENT,
     )
     @no_write_lock
     async def create_and_run_judge_feedback_batch(

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2139,8 +2139,9 @@ export interface paths {
         put?: never;
         /**
          * Run Judge Feedback Batch
-         * @description Run a judge feedback batch: sample tagged dataset items, judge their existing outputs, and return
-         *     the failing examples + feedback.
+         * @description Run a judge feedback batch: sample tagged dataset items, judge their outputs (existing, or
+         *     freshly generated when the batch has generate_outputs=true), and return the failing examples
+         *     + feedback.
          *
          *     Runs synchronously and returns once judging completes. Each result is persisted as a child
          *     run (fetch them later via `GET /judge_feedback_batches/{id}/runs`); the returned counts

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -3490,13 +3490,15 @@ export interface paths {
         put?: never;
         /**
          * Run Judge Feedback Batch Job
-         * @description Create and run a judge feedback batch as a background job, returning immediately.
+         * @description Run a pre-existing judge feedback batch as a background job, returning immediately.
          *
-         *     The job-backed counterpart to `POST /judge_feedback_batches/run`: lets an agent
-         *     fire many gates and `POST /api/jobs/wait` on all of them at once instead of
-         *     blocking on each synchronous call. The aggregate scores/usage/latency are on the
-         *     job result; the per-item runs (with the judge's feedback) are persisted — fetch
-         *     them via `GET /judge_feedback_batches/{id}/runs` (the result carries the batch id).
+         *     Create the batch first via `POST /judge_feedback_batches` (returns its id), then run
+         *     it here — mirroring how eval jobs run a pre-existing eval, so the batch id lives in the
+         *     job's params and is retrievable via `GET /api/jobs/{id}` even if the run fails. Lets an
+         *     agent fire many gates and `POST /api/jobs/wait` on all of them at once instead of
+         *     blocking on each synchronous call. The aggregate scores/usage/latency are on the job
+         *     result; the per-item runs (with the judge's feedback) are persisted — fetch them via
+         *     `GET /judge_feedback_batches/{id}/runs`.
          */
         post: operations["run_judge_feedback_batch_job_api_jobs_judge_feedback_batch_run_post"];
         delete?: never;
@@ -7745,61 +7747,14 @@ export interface components {
         };
         /**
          * JudgeFeedbackBatchJobParams
-         * @description Create-and-run a judge feedback batch as a background job.
+         * @description Run an existing judge feedback batch as a background job.
          *
-         *     Inherits every CreateJudgeFeedbackBatchRequest field (and its validation) and
-         *     adds the project/task scope, so the body is the same as the synchronous
-         *     create-and-run endpoint plus project_id/task_id.
+         *     The batch config is created first via `POST .../judge_feedback_batches` (which
+         *     returns its id); the job just runs it — mirroring how `EvalJobParams` runs a
+         *     pre-existing eval. Because the id is carried in params (not minted inside
+         *     run()), it's retrievable via `GET /api/jobs/{id}` even if the run fails.
          */
         JudgeFeedbackBatchJobParams: {
-            /**
-             * Name
-             * @description The name of the judge feedback batch. A memorable name is generated if omitted.
-             */
-            name?: string | null;
-            /**
-             * Description
-             * @description A description of the judge feedback batch.
-             */
-            description?: string | null;
-            /**
-             * Target Tags
-             * @description Dataset items must carry all of these tags to be sampled. At least one required.
-             */
-            target_tags: string[];
-            /**
-             * Eval Config Id
-             * @description The ID of the eval config (the judge) used to score sampled items.
-             */
-            eval_config_id: string;
-            /**
-             * Run Config Id
-             * @description The ID of the run config. Metadata when judging existing outputs; required and run on each item when generate_outputs=true.
-             */
-            run_config_id?: string | null;
-            /**
-             * Generate Outputs
-             * @description If true, run run_config_id on each sampled item to generate a fresh output and judge that (gate a candidate, scoped to the tagged items). If false, judge existing outputs.
-             * @default false
-             */
-            generate_outputs: boolean;
-            /**
-             * Stop After Failures
-             * @description If set, stop once this many failing examples are found (a cheap minibatch for the train signal). If null (default), judge the whole matching set up to max_samples (full coverage — required for a val gate paired by task_run_id).
-             */
-            stop_after_failures?: number | null;
-            /**
-             * Max Samples
-             * @description The maximum number of items to judge.
-             * @default 50
-             */
-            max_samples: number;
-            /**
-             * Threshold
-             * @description The normalized (0-1) pass bar. A score below this counts as failing.
-             * @default 0.75
-             */
-            threshold: number;
             /**
              * Project Id
              * @description The ID of the project the task belongs to.
@@ -7807,9 +7762,14 @@ export interface components {
             project_id: string;
             /**
              * Task Id
-             * @description The ID of the task to run the judge feedback batch under.
+             * @description The ID of the task the batch belongs to.
              */
             task_id: string;
+            /**
+             * Judge Feedback Batch Id
+             * @description The ID of the judge feedback batch to run. Create it first via POST /api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches.
+             */
+            judge_feedback_batch_id: string;
         };
         /**
          * JudgeFeedbackBatchRun

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -7730,9 +7730,15 @@ export interface components {
              * @default 0.75
              */
             threshold: number;
-            /** Project Id */
+            /**
+             * Project Id
+             * @description The ID of the project the task belongs to.
+             */
             project_id: string;
-            /** Task Id */
+            /**
+             * Task Id
+             * @description The ID of the task to run the judge feedback batch under.
+             */
             task_id: string;
         };
         /**

--- a/app/web_ui/src/lib/components/jobs_table.svelte
+++ b/app/web_ui/src/lib/components/jobs_table.svelte
@@ -19,6 +19,7 @@
     cancel_job,
     delete_job,
     eval_job_properties,
+    judge_feedback_batch_job_properties,
     get_job_errors,
     get_job_result,
     pause_job,
@@ -91,6 +92,9 @@
   function job_type_display(type: string): string {
     if (type === "noop") {
       return "No-op"
+    }
+    if (type === "judge_feedback_batch") {
+      return "Judge Feedback Batch"
     }
     return capitalize(type)
   }
@@ -239,6 +243,7 @@
       <tbody>
         {#each $jobs as job (job.id)}
           {@const p = eval_job_properties(job)}
+          {@const jp = judge_feedback_batch_job_properties(job)}
           <tr>
             <td class="align-top">
               <div class="flex flex-col gap-1 max-w-[280px]">
@@ -297,6 +302,62 @@
                         Judge model: {judge_model}
                       </div>
                     {/if}
+                  </div>
+                {:else if jp}
+                  {@const judge_model = jp.judge_model_name
+                    ? getDetailedModelNameFromParts(
+                        jp.judge_model_name,
+                        jp.judge_model_provider,
+                        $model_info,
+                      )
+                    : ""}
+                  {@const run_config_model = jp.run_config_model_name
+                    ? getDetailedModelNameFromParts(
+                        jp.run_config_model_name,
+                        jp.run_config_model_provider,
+                        $model_info,
+                      )
+                    : ""}
+                  <span class="font-medium truncate" title={jp.batch_name}
+                    >{jp.batch_name}</span
+                  >
+                  <div class="space-y-1 text-xs text-gray-500">
+                    <div
+                      class="truncate"
+                      title="{jp.judge_name} ({judge_algorithm_display(
+                        jp.judge_algorithm,
+                      )})"
+                    >
+                      Judge: {jp.judge_name} ({judge_algorithm_display(
+                        jp.judge_algorithm,
+                      )})
+                    </div>
+                    {#if judge_model}
+                      <div class="truncate" title={judge_model}>
+                        Judge model: {judge_model}
+                      </div>
+                    {/if}
+                    <div>
+                      Mode: {jp.generate_outputs
+                        ? "Generate & judge"
+                        : "Judge existing outputs"}
+                    </div>
+                    {#if jp.generate_outputs && jp.run_config_name}
+                      <div class="truncate" title={jp.run_config_name}>
+                        Run config: {jp.run_config_name}
+                      </div>
+                    {/if}
+                    {#if jp.generate_outputs && run_config_model}
+                      <div class="truncate" title={run_config_model}>
+                        Model: {run_config_model}
+                      </div>
+                    {/if}
+                    {#if jp.target_tags.length > 0}
+                      <div class="truncate" title={jp.target_tags.join(", ")}>
+                        Tags: {jp.target_tags.join(", ")}
+                      </div>
+                    {/if}
+                    <div>Max samples: {jp.max_samples}</div>
                   </div>
                 {:else}
                   <span class="font-medium">{job_type_display(job.type)}</span>

--- a/app/web_ui/src/lib/components/jobs_table.svelte
+++ b/app/web_ui/src/lib/components/jobs_table.svelte
@@ -357,7 +357,7 @@
                         Model: {run_config_model}
                       </div>
                     {/if}
-                    {#if jp.target_tags.length > 0}
+                    {#if jp.target_tags?.length}
                       <div class="truncate" title={jp.target_tags.join(", ")}>
                         Tags: {jp.target_tags.join(", ")}
                       </div>

--- a/app/web_ui/src/lib/components/jobs_table.svelte
+++ b/app/web_ui/src/lib/components/jobs_table.svelte
@@ -322,6 +322,11 @@
                     >{jp.batch_name}</span
                   >
                   <div class="space-y-1 text-xs text-gray-500">
+                    {#if jp.eval_name}
+                      <div class="truncate" title={jp.eval_name}>
+                        Eval: {jp.eval_name}
+                      </div>
+                    {/if}
                     <div
                       class="truncate"
                       title="{jp.judge_name} ({judge_algorithm_display(
@@ -358,6 +363,9 @@
                       </div>
                     {/if}
                     <div>Max samples: {jp.max_samples}</div>
+                    {#if jp.stop_after_failures != null}
+                      <div>Stop after failures: {jp.stop_after_failures}</div>
+                    {/if}
                   </div>
                 {:else}
                   <span class="font-medium">{job_type_display(job.type)}</span>

--- a/app/web_ui/src/lib/components/jobs_table.test.ts
+++ b/app/web_ui/src/lib/components/jobs_table.test.ts
@@ -25,6 +25,10 @@ const api = {
   // Real-shaped passthrough: the table calls this for every row.
   eval_job_properties: (job: JobRecord) =>
     job.type === "eval" && job.properties ? job.properties : null,
+  judge_feedback_batch_job_properties: (job: JobRecord) =>
+    job.type === "judge_feedback_batch" && job.properties
+      ? job.properties
+      : null,
 }
 vi.mock("$lib/stores/jobs_api", () => api)
 
@@ -186,5 +190,37 @@ describe("JobsTable", () => {
     jobs.set([makeJob({ id: "j_noop", type: "noop" })])
     const { queryByText } = render(JobsTable)
     expect(queryByText(/Run config:/)).toBeNull()
+  })
+
+  it("renders judge feedback batch job properties inline", () => {
+    jobs.set([
+      makeJob({
+        id: "j_judge",
+        type: "judge_feedback_batch",
+        properties: {
+          batch_name: "Nightly gate",
+          eval_name: "Toxicity check",
+          judge_name: "Magical Yeti",
+          judge_algorithm: "g_eval",
+          judge_model_name: "claude",
+          judge_model_provider: "anthropic",
+          generate_outputs: true,
+          run_config_name: "Candidate run",
+          run_config_model_name: "gpt-4o",
+          run_config_model_provider: "openai",
+          target_tags: ["val_set"],
+          max_samples: 25,
+          stop_after_failures: null,
+        },
+      }),
+    ])
+    const { getByText } = render(JobsTable)
+    expect(getByText(/Nightly gate/)).not.toBeNull()
+    expect(getByText(/Judge: Magical Yeti \(G-Eval\)/)).not.toBeNull()
+    // generate_outputs=true -> "Generate & judge" mode + candidate run config.
+    expect(getByText(/Mode: Generate & judge/)).not.toBeNull()
+    expect(getByText(/Run config: Candidate run/)).not.toBeNull()
+    expect(getByText(/Tags: val_set/)).not.toBeNull()
+    expect(getByText(/Max samples: 25/)).not.toBeNull()
   })
 })

--- a/app/web_ui/src/lib/components/jobs_table.test.ts
+++ b/app/web_ui/src/lib/components/jobs_table.test.ts
@@ -216,6 +216,7 @@ describe("JobsTable", () => {
     ])
     const { getByText } = render(JobsTable)
     expect(getByText(/Nightly gate/)).not.toBeNull()
+    expect(getByText(/Eval: Toxicity check/)).not.toBeNull()
     expect(getByText(/Judge: Magical Yeti \(G-Eval\)/)).not.toBeNull()
     // generate_outputs=true -> "Generate & judge" mode + candidate run config.
     expect(getByText(/Mode: Generate & judge/)).not.toBeNull()

--- a/app/web_ui/src/lib/stores/jobs_api.ts
+++ b/app/web_ui/src/lib/stores/jobs_api.ts
@@ -34,6 +34,33 @@ export function eval_job_properties(job: JobRecord): EvalJobProperties | null {
   return job.properties as EvalJobProperties
 }
 
+// Mirror of the backend JudgeFeedbackBatchJobWorker.JudgeFeedbackBatchJobProperties
+// model. Cast per job type, same as eval_job_properties.
+export type JudgeFeedbackBatchJobProperties = {
+  batch_name: string
+  eval_name: string
+  judge_name: string
+  judge_algorithm: string
+  judge_model_name: string
+  judge_model_provider: string
+  generate_outputs: boolean
+  run_config_name: string
+  run_config_model_name: string
+  run_config_model_provider: string
+  target_tags: string[]
+  max_samples: number
+  stop_after_failures: number | null
+}
+
+export function judge_feedback_batch_job_properties(
+  job: JobRecord,
+): JudgeFeedbackBatchJobProperties | null {
+  if (job.type !== "judge_feedback_batch" || !job.properties) {
+    return null
+  }
+  return job.properties as JudgeFeedbackBatchJobProperties
+}
+
 export type ListJobsQuery = {
   status?: BackgroundJobStatus
   type?: string

--- a/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
@@ -212,6 +212,11 @@ class _ScoredItem:
 # max_samples). Lets a background job stream live progress instead of only a final snapshot.
 JudgeProgressCallback = Callable[[int, int, int], Awaitable[None]]
 
+# Called once per item error the moment it's collected (not batched to the end), so a background
+# job can write it to its error log live — otherwise the "View Errors" button appears mid-run (the
+# streamed error count is non-zero) but the log is still empty until the run finishes.
+JudgeErrorCallback = Callable[["JudgeFeedbackBatchItemError"], Awaitable[None]]
+
 
 class JudgeFeedbackBatchRunner:
     """Runs a JudgeFeedbackBatch: judges tagged dataset items and persists per-item results."""
@@ -283,6 +288,7 @@ class JudgeFeedbackBatchRunner:
         self,
         concurrency: int | None = None,
         progress_callback: JudgeProgressCallback | None = None,
+        error_callback: JudgeErrorCallback | None = None,
     ) -> JudgeFeedbackBatchRunResult:
         """Judge tagged dataset items and persist each result as a JudgeFeedbackBatchRun child.
 
@@ -293,7 +299,9 @@ class JudgeFeedbackBatchRunner:
 
         `progress_callback`, if given, is awaited after each judged chunk with
         (num_judged, error_count, planned_total) so a background job can stream live progress;
-        the synchronous endpoint leaves it None.
+        the synchronous endpoint leaves it None. `error_callback`, if given, is awaited once per
+        item error the moment it's collected, so a job can log errors live (they still appear in the
+        returned result too); the synchronous endpoint leaves it None and reads result.errors.
 
         Returns the failing runs, all judged runs, counts, and any per-item errors. Per-item errors
         are collected (not raised), so one bad item never aborts the run; the item is left
@@ -363,15 +371,18 @@ class JudgeFeedbackBatchRunner:
                         self.judge_feedback_batch.id,
                         exc_info=scored,
                     )
-                    errors.append(
-                        JudgeFeedbackBatchItemError(
-                            task_run_id=str(task_run.id),
-                            error=f"Unexpected error judging item: {_error_detail(scored)}",
-                        )
+                    unexpected_error = JudgeFeedbackBatchItemError(
+                        task_run_id=str(task_run.id),
+                        error=f"Unexpected error judging item: {_error_detail(scored)}",
                     )
+                    errors.append(unexpected_error)
+                    if error_callback is not None:
+                        await error_callback(unexpected_error)
                     continue
                 if scored.error is not None:
                     errors.append(scored.error)
+                    if error_callback is not None:
+                        await error_callback(scored.error)
                 if scored.run is not None:
                     judged_runs.append(scored.run)
                     if not scored.passed:

--- a/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
@@ -15,10 +15,12 @@ import asyncio
 import logging
 import random
 from dataclasses import dataclass, field
+from typing import Awaitable, Callable
 
 from pydantic import BaseModel, Field
 
 from kiln_ai.adapters.adapter_registry import load_skills_for_task
+from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.eval.base_eval import BaseEval
 from kiln_ai.adapters.eval.eval_runner import _is_retryable_error
 from kiln_ai.adapters.eval.registry import eval_adapter_from_type
@@ -46,6 +48,18 @@ logger = logging.getLogger(__name__)
 # Default "pass" bar on the normalized 0-1 scale. 0.75 matches the four-star / is_high_quality
 # threshold for five_star scores (normalize_rating(4, five_star) == 0.75).
 DEFAULT_FAILURE_THRESHOLD = 0.75
+
+
+def _error_detail(error: BaseException) -> str:
+    """The most informative message for a failed item's error log.
+
+    The model adapter wraps failures in `KilnRunError`, whose own message is the user-friendly
+    (often generic) `format_error_message` text; the underlying cause survives on `.original`, so
+    surface that for the developer-facing error log. Mirrors `EvalJobWorker._error_detail`.
+    """
+    if isinstance(error, KilnRunError) and error.original is not None:
+        return str(error.original)
+    return str(error)
 
 
 def score_passes(
@@ -190,6 +204,12 @@ class _ScoredItem:
     error: JudgeFeedbackBatchItemError | None = None
 
 
+# Called after each judged chunk with (num_judged, error_count, planned_total), where
+# planned_total is the number of items this run will judge (the tag-matched set capped at
+# max_samples). Lets a background job stream live progress instead of only a final snapshot.
+JudgeProgressCallback = Callable[[int, int, int], Awaitable[None]]
+
+
 class JudgeFeedbackBatchRunner:
     """Runs a JudgeFeedbackBatch: judges tagged dataset items and persists per-item results."""
 
@@ -256,13 +276,21 @@ class JudgeFeedbackBatchRunner:
             task_run.tags or []
         )
 
-    async def run(self, concurrency: int | None = None) -> JudgeFeedbackBatchRunResult:
+    async def run(
+        self,
+        concurrency: int | None = None,
+        progress_callback: JudgeProgressCallback | None = None,
+    ) -> JudgeFeedbackBatchRunResult:
         """Judge tagged dataset items and persist each result as a JudgeFeedbackBatchRun child.
 
         Two modes, set by `stop_after_failures`:
         - None (gate): judge the WHOLE matching set up to `max_samples` — full coverage, so the
           caller can pair `judged_runs` by task_run_id against another run.
         - set (train signal): stop early once that many failures are found (a cheap minibatch).
+
+        `progress_callback`, if given, is awaited after each judged chunk with
+        (num_judged, error_count, planned_total) so a background job can stream live progress;
+        the synchronous endpoint leaves it None.
 
         Returns the failing runs, all judged runs, counts, and any per-item errors. Per-item errors
         are collected (not raised), so one bad item never aborts the run; the item is left
@@ -324,7 +352,7 @@ class JudgeFeedbackBatchRunner:
                     errors.append(
                         JudgeFeedbackBatchItemError(
                             task_run_id=str(task_run.id),
-                            error=f"Unexpected error judging item: {scored}",
+                            error=f"Unexpected error judging item: {_error_detail(scored)}",
                         )
                     )
                     continue
@@ -334,6 +362,10 @@ class JudgeFeedbackBatchRunner:
                     judged_runs.append(scored.run)
                     if not scored.passed:
                         failing_runs.append(scored.run)
+            # Stream live progress against the planned (capped) count so a background job's bar
+            # advances per chunk and reaches 100% on full coverage.
+            if progress_callback is not None:
+                await progress_callback(num_judged, len(errors), len(candidates))
             # Gate mode (stop_after is None) judges the whole set; only the train signal stops early.
             if stop_after is not None and len(failing_runs) >= stop_after:
                 break
@@ -400,7 +432,7 @@ class JudgeFeedbackBatchRunner:
             return _ScoredItem(
                 error=JudgeFeedbackBatchItemError(
                     task_run_id=str(task_run.id),
-                    error=f"Error judging item: {e}",
+                    error=f"Error judging item: {_error_detail(e)}",
                 )
             )
 

--- a/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
@@ -178,6 +178,9 @@ class JudgeFeedbackBatchRunResult:
 
     failing_runs: list[JudgeFeedbackBatchRun]
     judged_runs: list[JudgeFeedbackBatchRun]
+    # num_judged counts every item ATTEMPTED this run (errored and cached items included), so it can
+    # exceed len(judged_runs) when items errored. For a scored-item count (e.g. a fail rate), use
+    # failing_count / len(judged_runs), NOT failing_count / num_judged.
     num_judged: int
     failing_count: int
     train_set_size: int
@@ -224,7 +227,7 @@ class JudgeFeedbackBatchRunner:
     ):
         task = judge_feedback_batch.parent_task()
         if task is None:
-            raise ValueError("Judge job must have a parent task")
+            raise ValueError("Judge feedback batch must have a parent task")
         eval = eval_config.parent_eval()
         if eval is None:
             raise ValueError("Eval config must have a parent eval")
@@ -302,12 +305,23 @@ class JudgeFeedbackBatchRunner:
         # a smaller concurrency in that mode.
         if concurrency is None:
             concurrency = 5 if job.generate_outputs else 25
+        # A caller-supplied concurrency of 0 would make range() raise; negatives would mis-chunk.
+        concurrency = max(1, concurrency)
 
         candidates = [
             run for run in self.task.runs(readonly=True) if self._matches_tags(run)
         ]
         train_set_size = len(candidates)
-        self._rng.shuffle(candidates)
+        if stop_after is None:
+            # Gate mode: select deterministically (sorted by id) before capping, so two runs over
+            # the same tag set (e.g. candidate vs baseline batch) cover the SAME task_run_ids and can
+            # be paired. A random sample would pick disjoint subsets whenever the matching set
+            # exceeds max_samples, silently defeating the pairing this mode exists for.
+            candidates.sort(key=lambda run: str(run.id))
+        else:
+            # Train-signal mode: a random minibatch is fine (and desirable for variety), since the
+            # caller only wants some failing examples, not a stable paired subset.
+            self._rng.shuffle(candidates)
         candidates = candidates[: job.max_samples]
 
         # Reuse previously-judged results to avoid re-paying the judge — but only when judging
@@ -382,6 +396,9 @@ class JudgeFeedbackBatchRunner:
         per_dimension = aggregate_normalized_scores(
             judged_runs, self.eval.output_scores
         )
+        # Mean-of-means: each dimension is weighted equally regardless of how many runs carried a
+        # value for it (a dimension scored on 2 runs counts as much as one scored on 50). This is a
+        # simple overall gate signal, not a flat mean over every individual score.
         overall = (
             sum(per_dimension.values()) / len(per_dimension) if per_dimension else None
         )
@@ -469,7 +486,7 @@ class JudgeFeedbackBatchRunner:
             )
             save_error = JudgeFeedbackBatchItemError(
                 task_run_id=str(task_run.id),
-                error=f"Error saving judge result: {e}",
+                error=f"Error saving judge result: {_error_detail(e)}",
             )
 
         return _ScoredItem(

--- a/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
@@ -419,6 +419,69 @@ async def test_hit_cap_when_failures_sparse(mock_task, data_source):
 
 
 @pytest.mark.asyncio
+async def test_gate_mode_hit_cap_when_set_exceeds_max_samples(mock_task, data_source):
+    # Gate mode (stop_after_failures=None) with more matching items than max_samples: judge exactly
+    # max_samples, report hit_cap=True (coverage was capped), and select deterministically so the
+    # capped subset is stable/pairable across runs.
+    eval = make_eval(mock_task)
+    eval_config = make_eval_config(eval)
+    job = make_judge_feedback_batch(
+        mock_task, eval_config, stop_after_failures=None, max_samples=3
+    )
+    for i in range(8):
+        make_train_run(mock_task, data_source, f"item-{i}")
+
+    result = await run_job(job, eval_config, lambda tr: {"accuracy": 1.0})
+
+    assert result.train_set_size == 8
+    assert result.num_judged == 3
+    assert result.hit_cap is True
+    assert len(result.judged_runs) == 3
+
+    # Deterministic (sorted-by-id) capping: a second identical run covers the SAME task_run_ids.
+    job2 = make_judge_feedback_batch(
+        mock_task, eval_config, stop_after_failures=None, max_samples=3
+    )
+    result2 = await run_job(job2, eval_config, lambda tr: {"accuracy": 1.0}, seed=999)
+    assert {r.task_run_id for r in result.judged_runs} == {
+        r.task_run_id for r in result2.judged_runs
+    }
+
+
+@pytest.mark.asyncio
+async def test_empty_candidate_set(mock_task, data_source):
+    # No dataset item carries the target tags: the chunk loop never runs, so counts are zero, all
+    # aggregate signals are None/empty, hit_cap is False, and no callback fires.
+    eval = make_eval(mock_task)
+    eval_config = make_eval_config(eval)
+    job = make_judge_feedback_batch(
+        mock_task, eval_config, target_tags=["nonexistent"], stop_after_failures=None
+    )
+    make_train_run(mock_task, data_source, "item-0", tags=["other"])
+
+    ticks: list[tuple[int, int, int]] = []
+
+    async def on_progress(*args):
+        ticks.append(args)
+
+    result = await run_job(
+        job, eval_config, lambda tr: {"accuracy": 1.0}, progress_callback=on_progress
+    )
+
+    assert result.train_set_size == 0
+    assert result.num_judged == 0
+    assert result.failing_count == 0
+    assert result.hit_cap is False
+    assert result.judged_runs == []
+    assert result.failing_runs == []
+    assert result.errors == []
+    assert result.mean_normalized_scores == {}
+    assert result.mean_normalized_score is None
+    assert result.total_usage is None
+    assert ticks == []
+
+
+@pytest.mark.asyncio
 async def test_exhausted_train_set_is_not_hit_cap(mock_task, data_source):
     eval = make_eval(mock_task)
     eval_config = make_eval_config(eval)

--- a/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
@@ -182,6 +182,7 @@ async def run_job(
     retry_delay=0,
     fresh_usage=None,
     progress_callback=None,
+    error_callback=None,
 ):
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(
@@ -200,7 +201,9 @@ async def run_job(
             retry_delay=retry_delay,
         )
         return await runner.run(
-            concurrency=concurrency, progress_callback=progress_callback
+            concurrency=concurrency,
+            progress_callback=progress_callback,
+            error_callback=error_callback,
         )
 
 
@@ -580,6 +583,53 @@ async def test_threshold_override_five_star(mock_task, data_source):
     )
     result_fail = await run_job(job_fail, eval_config, score_fn)
     assert result_fail.failing_count == 1
+
+
+@pytest.mark.asyncio
+async def test_error_callback_fires_live_not_batched(mock_task, data_source):
+    # Regression: errors must be delivered to error_callback as they happen (interleaved with
+    # progress), not all at the end — otherwise a job's "View Errors" shows nothing mid-run.
+    eval = make_eval(mock_task)
+    eval_config = make_eval_config(eval)
+    # Gate mode, one item per chunk, so the error in chunk 1 must be reported before chunk 2's
+    # progress tick.
+    job = make_judge_feedback_batch(
+        mock_task, eval_config, stop_after_failures=None, max_samples=10
+    )
+    make_train_run(mock_task, data_source, "error-item")
+    make_train_run(mock_task, data_source, "ok-item")
+
+    def score_fn(task_run):
+        if task_run.input == "error-item":
+            raise RuntimeError("boom")
+        return {"accuracy": 1.0}
+
+    events: list[str] = []
+
+    async def on_progress(num_judged, error_count, planned_total):
+        events.append(f"progress:{num_judged}")
+
+    async def on_error(item_error):
+        events.append(f"error:{item_error.task_run_id}")
+
+    result = await run_job(
+        job,
+        eval_config,
+        score_fn,
+        concurrency=1,
+        progress_callback=on_progress,
+        error_callback=on_error,
+    )
+
+    # The error is collected once and surfaced through the callback.
+    assert len(result.errors) == 1
+    error_events = [e for e in events if e.startswith("error:")]
+    assert len(error_events) == 1
+    assert "boom" in result.errors[0].error
+    # Live delivery: the error event lands before the LAST progress tick (both items examined),
+    # i.e. it was not deferred until after the run completed.
+    assert events.index(error_events[0]) < len(events) - 1
+    assert events[-1] == "progress:2"
 
 
 @pytest.mark.asyncio

--- a/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
@@ -181,6 +181,7 @@ async def run_job(
     concurrency=25,
     retry_delay=0,
     fresh_usage=None,
+    progress_callback=None,
 ):
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(
@@ -198,7 +199,9 @@ async def run_job(
             rng=random.Random(seed),
             retry_delay=retry_delay,
         )
-        return await runner.run(concurrency=concurrency)
+        return await runner.run(
+            concurrency=concurrency, progress_callback=progress_callback
+        )
 
 
 # ---- Pure helper tests ----
@@ -312,6 +315,39 @@ async def test_full_coverage_returns_all_judged_runs(mock_task, data_source):
 
     # All judged items persisted as children (pass and fail)
     assert len(job.runs()) == 6
+
+
+@pytest.mark.asyncio
+async def test_progress_callback_streams_per_chunk(mock_task, data_source):
+    # The callback fires once per chunk with (num_judged, error_count, planned_total),
+    # where planned_total is the capped matching-set size, so a job can stream progress.
+    eval = make_eval(mock_task)
+    eval_config = make_eval_config(eval)
+    job = make_judge_feedback_batch(
+        mock_task, eval_config, stop_after_failures=None, max_samples=10
+    )
+    for i in range(5):
+        make_train_run(mock_task, data_source, f"item-{i}")
+
+    ticks: list[tuple[int, int, int]] = []
+
+    async def on_progress(num_judged, error_count, planned_total):
+        ticks.append((num_judged, error_count, planned_total))
+
+    # concurrency=2 over 5 items -> chunks of 2,2,1 -> 3 ticks, num_judged monotone.
+    result = await run_job(
+        job,
+        eval_config,
+        lambda tr: {"accuracy": 1.0},
+        concurrency=2,
+        progress_callback=on_progress,
+    )
+
+    assert result.num_judged == 5
+    assert [t[0] for t in ticks] == [2, 4, 5]
+    assert all(t[1] == 0 for t in ticks)
+    # planned_total is the capped set (min(train_set_size, max_samples) = 5).
+    assert all(t[2] == 5 for t in ticks)
 
 
 @pytest.mark.asyncio

--- a/libs/core/kiln_ai/datamodel/judge_feedback_batch.py
+++ b/libs/core/kiln_ai/datamodel/judge_feedback_batch.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, List, Union
 
-from pydantic import Field
+from pydantic import Field, model_validator
+from typing_extensions import Self
 
 from kiln_ai.datamodel.basemodel import (
     ID_TYPE,
@@ -108,6 +109,18 @@ class JudgeFeedbackBatch(
         le=1.0,
         description="The normalized (0-1) pass bar. A score below this counts as failing.",
     )
+
+    @model_validator(mode="after")
+    def validate_config(self) -> Self:
+        # generate_outputs runs run_config_id on each item, so it must be set (defense in depth: the
+        # API request model validates this too, but the datamodel can be built directly).
+        if self.generate_outputs and not self.run_config_id:
+            raise ValueError("run_config_id is required when generate_outputs is true")
+        # Empty target_tags matches every item (empty subset), which is an ambiguous footgun for a
+        # "sample by tag" config — require at least one, mirroring the field description.
+        if not self.target_tags:
+            raise ValueError("target_tags must contain at least one tag")
+        return self
 
     def parent_task(self) -> Union["Task", None]:
         if self.parent is not None and self.parent.__class__.__name__ != "Task":

--- a/libs/core/kiln_ai/datamodel/test_judge_feedback_batch.py
+++ b/libs/core/kiln_ai/datamodel/test_judge_feedback_batch.py
@@ -85,3 +85,31 @@ def test_run_parent_typing(task):
         parent=job, task_run_id="d1", scores={"accuracy": 1.0}, passed=True
     )
     assert run.parent_judge_feedback_batch().id == job.id
+
+
+def test_generate_outputs_requires_run_config_id(task):
+    with pytest.raises(ValueError, match="run_config_id is required"):
+        JudgeFeedbackBatch(
+            name="scan",
+            target_tags=["t"],
+            eval_config_id="ec1",
+            generate_outputs=True,
+            parent=task,
+        )
+    # generate_outputs=True with a run_config_id is valid.
+    job = JudgeFeedbackBatch(
+        name="scan",
+        target_tags=["t"],
+        eval_config_id="ec1",
+        generate_outputs=True,
+        run_config_id="rc1",
+        parent=task,
+    )
+    assert job.generate_outputs is True
+
+
+def test_empty_target_tags_rejected(task):
+    with pytest.raises(ValueError, match="at least one tag"):
+        JudgeFeedbackBatch(
+            name="scan", target_tags=[], eval_config_id="ec1", parent=task
+        )

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_judge_feedback_batches_judge_feedback_batch_id_run.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_judge_feedback_batches_judge_feedback_batch_id_run.json
@@ -2,8 +2,7 @@
   "method": "post",
   "path": "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches/{judge_feedback_batch_id}/run",
   "agent_policy": {
-    "permission": "allow",
-    "requires_approval": true,
-    "approval_description": "Run judge feedback batch? It makes model calls over the sampled dataset items."
+    "permission": "deny",
+    "requires_approval": false
   }
 }

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_judge_feedback_batches_run.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_judge_feedback_batches_run.json
@@ -2,8 +2,7 @@
   "method": "post",
   "path": "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches/run",
   "agent_policy": {
-    "permission": "allow",
-    "requires_approval": true,
-    "approval_description": "Create and run judge feedback batch? It makes model calls over the sampled dataset items."
+    "permission": "deny",
+    "requires_approval": false
   }
 }


### PR DESCRIPTION
Brings the `judge_feedback_batch` background-job worker to parity with the eval job worker, reshapes it to run a **pre-existing** batch (eval parity), and applies fixes from a deep multi-phase code review of the whole `judge_feedback_batch` feature. Targets `integration/auto-mode-e2e` (the auto-mode e2e integration branch). Includes the work merged from #1543.

## Job shape: run a pre-existing batch (eval parity)
The job was reshaped from "create-and-run" to "run an existing batch", mirroring `EvalJobWorker`:
- The batch config is created first via the synchronous `POST .../judge_feedback_batches` (persisted under the git-sync write lock); the job then just runs it by id.
- `JudgeFeedbackBatchJobParams` is now `{project_id, task_id, judge_feedback_batch_id}` (was a full `CreateJudgeFeedbackBatchRequest`). `run()`/`describe()` load the batch by id and read its config off disk.
- Because the id is caller-supplied and lives in `job.params`, it's retrievable via `GET /api/jobs/{id}` even if the run fails (the old create-and-run job only surfaced the minted id in its success result). The job result now echoes `judge_feedback_batch_id` from params.
- The worker no longer writes the config, so the earlier "wrap the batch save in the git-sync context" worker workaround is gone — the create endpoint owns that write.

## Worker parity
- **Progress**: the worker previously reported progress once at the end and used `train_set_size` as the denominator, so the bar stalled below 100% when the matching set exceeded `max_samples`. The runner now takes an optional `progress_callback` and streams `(num_judged, error_count, planned_total)` per judged chunk; live + final progress use the capped denominator `min(train_set_size, max_samples)`, reaching 100% on full coverage (mirrors the eval worker). `success` excludes errors (`num_judged - error_count`) so `processed = success + error` holds and the bar can't overshoot.
- **Metadata / jobs UI**: added `JudgeFeedbackBatchJobProperties` + `describe()` (mirrors `EvalJobProperties`) — judge/eval names, algorithm, model, run config (only when generating outputs), tags, max_samples, stop_after_failures — and render them in the jobs table (was a raw `Judge_feedback_batch` label).
- **Errors**: per-item errors reach the View Errors UI, and are now logged **live** via an `error_callback` the moment each is collected — previously the button appeared mid-run (gated by the streamed error count) but the messages only landed in a post-run loop, so the log read "No error messages recorded" until completion. Message quality improved by unwrapping `KilnRunError.original` like the eval worker.
- **Field descriptions**: added to `JudgeFeedbackBatchJobResult`, `JudgeFeedbackBatchJobParams`, and the `project_id`/`task_id` params.

## Deep code review fixes
Multi-phase review (runner / worker / data model / REST API / UI / tests). **0 critical, 6 moderate (all fixed), 24 mild (12 fixed, rest documented).** Highlights:
- **Progress double-counting**: `num_judged` already includes errored items, so reporting `success = num_judged` alongside a separate error count breached the `processed = success + error` contract — now `success = num_judged - error_count` in both the streamed callback and the final snapshot.
- **Gate-mode determinism**: gate mode now samples deterministically (sorted by id) before capping, so two runs cover the same `task_run_id`s — the pairing the gate exists for (a random shuffle previously picked disjoint subsets past `max_samples`). Train-signal mode keeps the random minibatch.
- **Data model**: added a `JudgeFeedbackBatch` model_validator (`generate_outputs` ⇒ `run_config_id`, non-empty `target_tags`) as defense-in-depth (mirrors `EvalRun`).
- Runner tests for the empty candidate set and gate-mode `hit_cap=True` (incl. proof that two gate runs cover the same ids), plus a test asserting errors are delivered live (interleaved with progress).
- Polish: `_error_detail` on save errors, `concurrency = max(1, concurrency)` guard, 404 message/wording (`Judge feedback batch not found`), `judge_feedback_batch_from_id` accepts a preloaded task (removes the run endpoint's double task load), docstrings covering generate-outputs mode.

## Agent policy
The synchronous run / create-and-run endpoints are superseded by the create + job flow, so the agent goes through `POST /api/jobs/judge_feedback_batch/run` for dashboard visibility:
- `create` → allow (cheap, no model calls — the agent creates the batch, then runs it as a job)
- `run` (existing, sync) → deny
- `create-and-run` (sync) → deny
- run as job (`/api/jobs/...`) → allow + approval
- list / get / runs (GET) → allow

Regenerated the agent-check annotation JSONs so the policy is actually enforced (the chat backend reads the dumped JSONs, not the live spec) — fixes the `check_api_bindings` CI job. The synchronous create-and-run / run endpoints are left in place for callers not yet migrated.

## UI hardening
- Render judge-batch properties in the jobs table (`eval_name`, `stop_after_failures`, tags, etc.).
- Guard the `target_tags` render with optional chaining so a job record with incomplete properties can't throw and crash the whole jobs table (per gemini-code-assist review).

## Verification
Full `uv run ./checks.sh --agent-mode` green (lint, format, typecheck, py + web tests, schema, build). `api_schema.d.ts` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
