### PR TITLE
Judge feedback batch: job runs a pre-existing batch (eval parity)

### DIFF
--- a/app/desktop/studio_server/jobs/api.py
+++ b/app/desktop/studio_server/jobs/api.py
@@ -196,13 +196,15 @@ def connect_jobs_api(app: FastAPI) -> None:
     async def run_judge_feedback_batch_job(
         params: JudgeFeedbackBatchJobParams,
     ) -> CreateJobResponse:
-        """Create and run a judge feedback batch as a background job, returning immediately.
+        """Run a pre-existing judge feedback batch as a background job, returning immediately.
 
-        The job-backed counterpart to `POST /judge_feedback_batches/run`: lets an agent
-        fire many gates and `POST /api/jobs/wait` on all of them at once instead of
-        blocking on each synchronous call. The aggregate scores/usage/latency are on the
-        job result; the per-item runs (with the judge's feedback) are persisted — fetch
-        them via `GET /judge_feedback_batches/{id}/runs` (the result carries the batch id).
+        Create the batch first via `POST /judge_feedback_batches` (returns its id), then run
+        it here — mirroring how eval jobs run a pre-existing eval, so the batch id lives in the
+        job's params and is retrievable via `GET /api/jobs/{id}` even if the run fails. Lets an
+        agent fire many gates and `POST /api/jobs/wait` on all of them at once instead of
+        blocking on each synchronous call. The aggregate scores/usage/latency are on the job
+        result; the per-item runs (with the judge's feedback) are persisted — fetch them via
+        `GET /judge_feedback_batches/{id}/runs`.
         """
         job = await job_registry.create(
             type_name=JudgeFeedbackBatchJobWorker.type_name,

--- a/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
@@ -9,31 +9,32 @@ from kiln_ai.adapters.eval.judge_feedback_batch_runner import (
 )
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.usage import Usage
-from kiln_ai.utils.git_sync_protocols import default_save_context
 from kiln_server.task_api import task_from_id
 from pydantic import BaseModel, Field
 
 from ...judge_feedback_batch_api import (
-    CreateJudgeFeedbackBatchRequest,
-    _build_judge_feedback_batch,
     eval_config_from_id,
+    judge_feedback_batch_from_id,
     validate_judge_eval,
     validate_run_config_id,
 )
 from ..models import JobContext, JobWorker
 
 
-class JudgeFeedbackBatchJobParams(CreateJudgeFeedbackBatchRequest):
-    """Create-and-run a judge feedback batch as a background job.
+class JudgeFeedbackBatchJobParams(BaseModel):
+    """Run an existing judge feedback batch as a background job.
 
-    Inherits every CreateJudgeFeedbackBatchRequest field (and its validation) and
-    adds the project/task scope, so the body is the same as the synchronous
-    create-and-run endpoint plus project_id/task_id.
+    The batch config is created first via `POST .../judge_feedback_batches` (which
+    returns its id); the job just runs it — mirroring how `EvalJobParams` runs a
+    pre-existing eval. Because the id is carried in params (not minted inside
+    run()), it's retrievable via `GET /api/jobs/{id}` even if the run fails.
     """
 
     project_id: str = Field(description="The ID of the project the task belongs to.")
-    task_id: str = Field(
-        description="The ID of the task to run the judge feedback batch under."
+    task_id: str = Field(description="The ID of the task the batch belongs to.")
+    judge_feedback_batch_id: str = Field(
+        description="The ID of the judge feedback batch to run. Create it first via "
+        "POST /api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches."
     )
 
 
@@ -49,7 +50,7 @@ class JudgeFeedbackBatchJobResult(BaseModel):
     """
 
     judge_feedback_batch_id: str = Field(
-        description="The ID of the persisted judge feedback batch this job created and ran. "
+        description="The ID of the judge feedback batch this job ran (echoes the id from params). "
         "Fetch its per-item runs (with feedback) via GET /judge_feedback_batches/{id}/runs."
     )
     num_judged: int = Field(
@@ -121,15 +122,17 @@ class JudgeFeedbackBatchJobProperties(BaseModel):
 class JudgeFeedbackBatchJobWorker(
     JobWorker[JudgeFeedbackBatchJobParams, JudgeFeedbackBatchJobResult]
 ):
-    """Background worker that creates and runs a judge feedback batch.
+    """Background worker that runs a pre-existing judge feedback batch.
 
     Wraps `JudgeFeedbackBatchRunner` unchanged (mirrors `EvalJobWorker` wrapping
-    `EvalRunner`). Making the judge run job-backed lets an agent fire many gates
-    at once and `POST /api/jobs/wait` on all of them together, instead of blocking
-    on each synchronous call serially. The runner streams progress per judged
-    chunk. `supports_pause` stays False — re-running creates a fresh batch, so
-    there's nothing to resume, and `compute_state` keeps its default (None): the
-    batch id is minted inside run(), so params alone can't locate it to reconcile.
+    `EvalRunner`). The batch config is created first via the synchronous create
+    endpoint; this job only runs it (the id is in params). Making the judge run
+    job-backed lets an agent fire many gates at once and `POST /api/jobs/wait` on
+    all of them together, instead of blocking on each synchronous call serially.
+    The runner streams progress per judged chunk. `supports_pause` stays False and
+    `compute_state` keeps its default (None) for now — the runner already reuses
+    cached child runs, so a re-run is idempotent, but deriving progress from disk
+    is left as a follow-up.
     """
 
     type_name = "judge_feedback_batch"
@@ -149,7 +152,10 @@ class JudgeFeedbackBatchJobWorker(
         self, params: JudgeFeedbackBatchJobParams
     ) -> JudgeFeedbackBatchJobProperties:
         task = task_from_id(params.project_id, params.task_id)
-        eval_config = eval_config_from_id(task, params.eval_config_id)
+        batch = judge_feedback_batch_from_id(
+            params.project_id, params.task_id, params.judge_feedback_batch_id, task=task
+        )
+        eval_config = eval_config_from_id(task, batch.eval_config_id)
         eval = eval_config.parent_eval()
 
         # The run config only matters when generating fresh outputs; and only the
@@ -158,12 +164,12 @@ class JudgeFeedbackBatchJobWorker(
         run_config_name = ""
         run_config_model_name = ""
         run_config_model_provider = ""
-        if params.run_config_id is not None:
+        if batch.run_config_id is not None:
             run_config = next(
                 (
                     rc
                     for rc in task.run_configs(readonly=True)
-                    if rc.id == params.run_config_id
+                    if rc.id == batch.run_config_id
                 ),
                 None,
             )
@@ -177,55 +183,42 @@ class JudgeFeedbackBatchJobWorker(
                     )
 
         return JudgeFeedbackBatchJobProperties(
-            batch_name=params.name or "Judge Feedback Batch",
+            batch_name=batch.name,
             eval_name=eval.name if eval is not None else "",
             judge_name=eval_config.name,
             judge_algorithm=eval_config.config_type.value,
             judge_model_name=eval_config.model_name,
             judge_model_provider=eval_config.model_provider,
-            generate_outputs=params.generate_outputs,
+            generate_outputs=batch.generate_outputs,
             run_config_name=run_config_name,
             run_config_model_name=run_config_model_name,
             run_config_model_provider=run_config_model_provider,
-            target_tags=list(params.target_tags),
-            max_samples=params.max_samples,
-            stop_after_failures=params.stop_after_failures,
+            target_tags=list(batch.target_tags or []),
+            max_samples=batch.max_samples,
+            stop_after_failures=batch.stop_after_failures,
         )
 
     async def run(
         self, params: JudgeFeedbackBatchJobParams, ctx: JobContext
     ) -> JudgeFeedbackBatchJobResult:
-        # params IS a CreateJudgeFeedbackBatchRequest (plus project/task scope), so
-        # the existing validators + builder accept it directly.
+        # Load the pre-created batch config (the create endpoint already persisted it under the
+        # git-sync write lock), then run it. Nothing is created here, so there is no config write to
+        # wrap — only the runner's per-item child writes, which it wraps in its own save_context.
         task = task_from_id(params.project_id, params.task_id)
-        eval_config = eval_config_from_id(task, params.eval_config_id)
-        validate_judge_eval(eval_config, params.generate_outputs)
-        validate_run_config_id(task, params.run_config_id)
-
-        judge_feedback_batch = _build_judge_feedback_batch(task, params)
-        batch_id = judge_feedback_batch.id
-        if batch_id is None:
-            raise ValueError("Judge feedback batch was not assigned an id")
-
-        # Wrap the batch-config write in the git-sync context too — not just the runner's per-item
-        # child writes. A raw save_to_file would leave the new config as dirty working-tree state,
-        # which the first child write's atomic_write ensure_clean() stashes away — losing the config
-        # and orphaning its children under auto git-sync. None coalesces to a no-op context. The
-        # same context is reused for the child writes; each save is a separate (non-nested) block.
-        save_context = (
-            save_context_for_project(
-                params.project_id,
-                context=f"judge feedback batch {batch_id}",
-            )
-            or default_save_context
+        judge_feedback_batch = judge_feedback_batch_from_id(
+            params.project_id, params.task_id, params.judge_feedback_batch_id, task=task
         )
-        async with save_context():
-            judge_feedback_batch.save_to_file()
+        eval_config = eval_config_from_id(task, judge_feedback_batch.eval_config_id)
+        validate_judge_eval(eval_config, judge_feedback_batch.generate_outputs)
+        validate_run_config_id(task, judge_feedback_batch.run_config_id)
 
         runner = JudgeFeedbackBatchRunner(
             judge_feedback_batch,
             eval_config,
-            save_context=save_context,
+            save_context=save_context_for_project(
+                params.project_id,
+                context=f"judge feedback batch {params.judge_feedback_batch_id}",
+            ),
         )
 
         async def report_progress(
@@ -247,7 +240,7 @@ class JudgeFeedbackBatchJobWorker(
             await ctx.report_error(
                 item_error.error,
                 dataset_id=item_error.task_run_id,
-                run_config_id=params.run_config_id,
+                run_config_id=judge_feedback_batch.run_config_id,
             )
 
         result = await runner.run(
@@ -260,7 +253,7 @@ class JudgeFeedbackBatchJobWorker(
         # bar can legitimately end below total — the job still succeeds. success excludes errors to
         # keep success + error <= total (see report_progress above).
         error_count = len(result.errors)
-        planned_total = min(result.train_set_size, params.max_samples)
+        planned_total = min(result.train_set_size, judge_feedback_batch.max_samples)
         await ctx.report_progress(
             success=result.num_judged - error_count,
             error=error_count,
@@ -268,12 +261,12 @@ class JudgeFeedbackBatchJobWorker(
         )
 
         return JudgeFeedbackBatchJobResult(
-            judge_feedback_batch_id=batch_id,
+            judge_feedback_batch_id=params.judge_feedback_batch_id,
             num_judged=result.num_judged,
             failing_count=result.failing_count,
             train_set_size=result.train_set_size,
             hit_cap=result.hit_cap,
-            error_count=len(result.errors),
+            error_count=error_count,
             mean_normalized_scores=result.mean_normalized_scores,
             mean_normalized_score=result.mean_normalized_score,
             total_usage=result.total_usage,

--- a/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
+from fastapi import HTTPException
 from app.desktop.studio_server.jobs.workers.judge_feedback_batch import (
     JudgeFeedbackBatchJobParams,
     JudgeFeedbackBatchJobResult,
@@ -101,15 +102,28 @@ def run_config(task):
 
 
 @pytest.fixture
-def params():
-    return JudgeFeedbackBatchJobParams(
-        project_id="project1",
-        task_id="task1",
+def batch(task, eval_config, run_config):
+    """A pre-created judge feedback batch on disk — the job runs an existing one."""
+    batch = JudgeFeedbackBatch(
+        id="batch1",
+        name="Test Batch",
         target_tags=["train_set"],
         eval_config_id="eval_config1",
         run_config_id="run_config1",
         generate_outputs=True,
         max_samples=50,
+        parent=task,
+    )
+    batch.save_to_file()
+    return batch
+
+
+@pytest.fixture
+def params(batch):
+    return JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        judge_feedback_batch_id=batch.id,
     )
 
 
@@ -182,14 +196,16 @@ def _stub_runner(result: JudgeFeedbackBatchRunResult):
         yield
 
 
-async def test_run_creates_batch_and_maps_result(
-    resolve_project, task, eval_config, run_config, params
+async def test_run_loads_existing_batch_and_maps_result(
+    resolve_project, task, eval_config, run_config, batch, params
 ):
     ctx = _FakeCtx()
     with _stub_runner(_fake_result()):
         result = await JudgeFeedbackBatchJobWorker().run(params, ctx)
 
     assert isinstance(result, JudgeFeedbackBatchJobResult)
+    # The job runs the PRE-EXISTING batch named in params; the id round-trips into the result.
+    assert result.judge_feedback_batch_id == batch.id
     assert result.num_judged == 5
     assert result.failing_count == 2
     assert result.train_set_size == 10
@@ -200,70 +216,18 @@ async def test_run_creates_batch_and_maps_result(
     assert result.mean_cost == 0.01
     assert result.mean_latency_ms == 120.0
 
-    # The job created + persisted a batch under the task; its id round-trips.
-    batch = JudgeFeedbackBatch.from_id_and_parent_path(
-        result.judge_feedback_batch_id, task.path
-    )
-    assert batch is not None
-    assert batch.target_tags == ["train_set"]
-    assert batch.eval_config_id == "eval_config1"
-    assert batch.generate_outputs is True
 
-
-async def test_run_wraps_batch_config_save_in_git_context(
-    resolve_project, task, eval_config, run_config, params
-):
-    """The batch-config write must go through the git-sync save_context (not a raw save), fully
-    committed before the runner starts — otherwise auto git-sync's ensure_clean() stashes the
-    untracked config away on the first child write, losing it and orphaning the children."""
-    events: list[str] = []
-
-    @asynccontextmanager
-    async def recording_cm():
-        events.append("enter")
-        try:
-            yield
-        finally:
-            events.append("exit")
-
-    def recording_factory():
-        return recording_cm()
-
-    async def fake_run(
-        self, concurrency=None, progress_callback=None, error_callback=None
-    ) -> JudgeFeedbackBatchRunResult:
-        events.append("run")
-        # The batch config must already be persisted (and its save context closed) by run time.
-        assert (
-            JudgeFeedbackBatch.from_id_and_parent_path(
-                self.judge_feedback_batch.id, task.path
-            )
-            is not None
-        )
-        return _fake_result()
-
+async def test_run_missing_batch_raises(resolve_project, task, eval_config):
+    # No batch persisted for this id -> the run fails cleanly (the registry marks the job failed).
     ctx = _FakeCtx()
-    with (
-        patch(
-            "app.desktop.studio_server.jobs.workers.judge_feedback_batch.save_context_for_project",
-            return_value=recording_factory,
-        ),
-        patch(
-            "kiln_ai.adapters.eval.judge_feedback_batch_runner.JudgeFeedbackBatchRunner.run",
-            new=fake_run,
-        ),
-    ):
-        result = await JudgeFeedbackBatchJobWorker().run(params, ctx)
-
-    # The batch save was wrapped in the git context and its atomic write closed BEFORE the runner
-    # ran (separate, non-nested blocks): enter -> exit -> run.
-    assert events == ["enter", "exit", "run"]
-    assert (
-        JudgeFeedbackBatch.from_id_and_parent_path(
-            result.judge_feedback_batch_id, task.path
-        )
-        is not None
+    params = JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        judge_feedback_batch_id="does_not_exist",
     )
+    with pytest.raises(HTTPException) as exc_info:
+        await JudgeFeedbackBatchJobWorker().run(params, ctx)
+    assert exc_info.value.status_code == 404
 
 
 async def test_run_reports_progress_and_per_item_errors(
@@ -294,14 +258,21 @@ async def test_run_progress_total_is_capped_at_max_samples(
     """When train_set_size exceeds max_samples, progress totals against the capped
     count (max_samples), not the full matching set — so a fully-judged run reads
     as 100% rather than stalling at max_samples/train_set_size."""
-    params = JudgeFeedbackBatchJobParams(
-        project_id="project1",
-        task_id="task1",
+    capped_batch = JudgeFeedbackBatch(
+        id="batch_capped",
+        name="Capped Batch",
         target_tags=["train_set"],
         eval_config_id="eval_config1",
         run_config_id="run_config1",
         generate_outputs=True,
         max_samples=20,
+        parent=task,
+    )
+    capped_batch.save_to_file()
+    params = JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        judge_feedback_batch_id=capped_batch.id,
     )
     result = JudgeFeedbackBatchRunResult(
         failing_runs=[],
@@ -322,11 +293,12 @@ async def test_run_progress_total_is_capped_at_max_samples(
 
 
 async def test_describe_publishes_properties(
-    resolve_project, task, eval_config, run_config, params
+    resolve_project, task, eval_config, run_config, batch, params
 ):
     props = await JudgeFeedbackBatchJobWorker().describe(params)
 
-    assert props.batch_name  # generated or provided, never empty
+    # Derived from the persisted batch, not from params.
+    assert props.batch_name == "Test Batch"
     assert props.eval_name == "Test Eval"
     assert props.judge_name == "Test Eval Config"
     assert props.judge_model_name == "gpt-4"
@@ -344,12 +316,19 @@ async def test_describe_judge_only_mode_leaves_run_config_blank(
 ):
     # Judge-only mode (generate_outputs=False, no run_config_id): the run-config display fields are
     # left blank, but the judge/eval/batch info still resolves.
-    params = JudgeFeedbackBatchJobParams(
-        project_id="project1",
-        task_id="task1",
+    judge_only_batch = JudgeFeedbackBatch(
+        id="batch_judge_only",
+        name="Judge Only Batch",
         target_tags=["train_set"],
         eval_config_id="eval_config1",
         generate_outputs=False,
+        parent=task,
+    )
+    judge_only_batch.save_to_file()
+    params = JudgeFeedbackBatchJobParams(
+        project_id="project1",
+        task_id="task1",
+        judge_feedback_batch_id=judge_only_batch.id,
     )
     props = await JudgeFeedbackBatchJobWorker().describe(params)
 

--- a/app/desktop/studio_server/judge_feedback_batch_api.py
+++ b/app/desktop/studio_server/judge_feedback_batch_api.py
@@ -245,7 +245,9 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches",
         summary="Create Judge Feedback Batch",
         tags=["Judge Feedback Batches"],
-        openapi_extra=DENY_AGENT,
+        # Agent-callable: the agent creates the batch here, then runs it via the job endpoint
+        # (POST /api/jobs/judge_feedback_batch/run). Creating is cheap and makes no model calls.
+        openapi_extra=ALLOW_AGENT,
     )
     async def create_judge_feedback_batch(
         project_id: Annotated[

--- a/app/desktop/studio_server/judge_feedback_batch_api.py
+++ b/app/desktop/studio_server/judge_feedback_batch_api.py
@@ -19,7 +19,7 @@ from kiln_server.git_sync_decorators import build_save_context, no_write_lock
 from kiln_server.task_api import task_from_id
 from kiln_server.utils.agent_checks.policy import (
     ALLOW_AGENT,
-    agent_policy_require_approval,
+    DENY_AGENT,
 )
 from pydantic import BaseModel, Field, model_validator
 
@@ -245,7 +245,7 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches",
         summary="Create Judge Feedback Batch",
         tags=["Judge Feedback Batches"],
-        openapi_extra=ALLOW_AGENT,
+        openapi_extra=DENY_AGENT,
     )
     async def create_judge_feedback_batch(
         project_id: Annotated[
@@ -271,9 +271,7 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches/{judge_feedback_batch_id}/run",
         summary="Run Judge Feedback Batch",
         tags=["Judge Feedback Batches"],
-        openapi_extra=agent_policy_require_approval(
-            "Run judge feedback batch? It makes model calls over the sampled dataset items."
-        ),
+        openapi_extra=DENY_AGENT,
     )
     @no_write_lock
     async def run_judge_feedback_batch(
@@ -313,9 +311,7 @@ def connect_judge_feedback_batch_api(app: FastAPI):
         "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches/run",
         summary="Create And Run Judge Feedback Batch",
         tags=["Judge Feedback Batches"],
-        openapi_extra=agent_policy_require_approval(
-            "Create and run judge feedback batch? It makes model calls over the sampled dataset items."
-        ),
+        openapi_extra=DENY_AGENT,
     )
     @no_write_lock
     async def create_and_run_judge_feedback_batch(

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -3490,13 +3490,15 @@ export interface paths {
         put?: never;
         /**
          * Run Judge Feedback Batch Job
-         * @description Create and run a judge feedback batch as a background job, returning immediately.
+         * @description Run a pre-existing judge feedback batch as a background job, returning immediately.
          *
-         *     The job-backed counterpart to `POST /judge_feedback_batches/run`: lets an agent
-         *     fire many gates and `POST /api/jobs/wait` on all of them at once instead of
-         *     blocking on each synchronous call. The aggregate scores/usage/latency are on the
-         *     job result; the per-item runs (with the judge's feedback) are persisted — fetch
-         *     them via `GET /judge_feedback_batches/{id}/runs` (the result carries the batch id).
+         *     Create the batch first via `POST /judge_feedback_batches` (returns its id), then run
+         *     it here — mirroring how eval jobs run a pre-existing eval, so the batch id lives in the
+         *     job's params and is retrievable via `GET /api/jobs/{id}` even if the run fails. Lets an
+         *     agent fire many gates and `POST /api/jobs/wait` on all of them at once instead of
+         *     blocking on each synchronous call. The aggregate scores/usage/latency are on the job
+         *     result; the per-item runs (with the judge's feedback) are persisted — fetch them via
+         *     `GET /judge_feedback_batches/{id}/runs`.
          */
         post: operations["run_judge_feedback_batch_job_api_jobs_judge_feedback_batch_run_post"];
         delete?: never;
@@ -7745,61 +7747,14 @@ export interface components {
         };
         /**
          * JudgeFeedbackBatchJobParams
-         * @description Create-and-run a judge feedback batch as a background job.
+         * @description Run an existing judge feedback batch as a background job.
          *
-         *     Inherits every CreateJudgeFeedbackBatchRequest field (and its validation) and
-         *     adds the project/task scope, so the body is the same as the synchronous
-         *     create-and-run endpoint plus project_id/task_id.
+         *     The batch config is created first via `POST .../judge_feedback_batches` (which
+         *     returns its id); the job just runs it — mirroring how `EvalJobParams` runs a
+         *     pre-existing eval. Because the id is carried in params (not minted inside
+         *     run()), it's retrievable via `GET /api/jobs/{id}` even if the run fails.
          */
         JudgeFeedbackBatchJobParams: {
-            /**
-             * Name
-             * @description The name of the judge feedback batch. A memorable name is generated if omitted.
-             */
-            name?: string | null;
-            /**
-             * Description
-             * @description A description of the judge feedback batch.
-             */
-            description?: string | null;
-            /**
-             * Target Tags
-             * @description Dataset items must carry all of these tags to be sampled. At least one required.
-             */
-            target_tags: string[];
-            /**
-             * Eval Config Id
-             * @description The ID of the eval config (the judge) used to score sampled items.
-             */
-            eval_config_id: string;
-            /**
-             * Run Config Id
-             * @description The ID of the run config. Metadata when judging existing outputs; required and run on each item when generate_outputs=true.
-             */
-            run_config_id?: string | null;
-            /**
-             * Generate Outputs
-             * @description If true, run run_config_id on each sampled item to generate a fresh output and judge that (gate a candidate, scoped to the tagged items). If false, judge existing outputs.
-             * @default false
-             */
-            generate_outputs: boolean;
-            /**
-             * Stop After Failures
-             * @description If set, stop once this many failing examples are found (a cheap minibatch for the train signal). If null (default), judge the whole matching set up to max_samples (full coverage — required for a val gate paired by task_run_id).
-             */
-            stop_after_failures?: number | null;
-            /**
-             * Max Samples
-             * @description The maximum number of items to judge.
-             * @default 50
-             */
-            max_samples: number;
-            /**
-             * Threshold
-             * @description The normalized (0-1) pass bar. A score below this counts as failing.
-             * @default 0.75
-             */
-            threshold: number;
             /**
              * Project Id
              * @description The ID of the project the task belongs to.
@@ -7807,9 +7762,14 @@ export interface components {
             project_id: string;
             /**
              * Task Id
-             * @description The ID of the task to run the judge feedback batch under.
+             * @description The ID of the task the batch belongs to.
              */
             task_id: string;
+            /**
+             * Judge Feedback Batch Id
+             * @description The ID of the judge feedback batch to run. Create it first via POST /api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches.
+             */
+            judge_feedback_batch_id: string;
         };
         /**
          * JudgeFeedbackBatchRun

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_judge_feedback_batches_judge_feedback_batch_id_run.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_judge_feedback_batches_judge_feedback_batch_id_run.json
@@ -2,8 +2,7 @@
   "method": "post",
   "path": "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches/{judge_feedback_batch_id}/run",
   "agent_policy": {
-    "permission": "allow",
-    "requires_approval": true,
-    "approval_description": "Run judge feedback batch? It makes model calls over the sampled dataset items."
+    "permission": "deny",
+    "requires_approval": false
   }
 }

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_judge_feedback_batches_run.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_tasks_task_id_judge_feedback_batches_run.json
@@ -2,8 +2,7 @@
   "method": "post",
   "path": "/api/projects/{project_id}/tasks/{task_id}/judge_feedback_batches/run",
   "agent_policy": {
-    "permission": "allow",
-    "requires_approval": true,
-    "approval_description": "Create and run judge feedback batch? It makes model calls over the sampled dataset items."
+    "permission": "deny",
+    "requires_approval": false
   }
 }


### PR DESCRIPTION
Reshapes the `judge_feedback_batch` job from **create-and-run** to **run an existing batch**, mirroring `EvalJobWorker`. Targets `leonard/judge-feedback-batch-job-polish`.

## What changes
- **`JudgeFeedbackBatchJobParams`** is now `{ project_id, task_id, judge_feedback_batch_id }` (was a full create request). `run()` / `describe()` load the batch by id and read its config off disk.
- The batch config is created up front via the existing sync `POST .../judge_feedback_batches` (persisted under the git-sync write lock); **the job no longer writes the config at all** — so the earlier "wrap the batch save in git-sync" workaround is removed (the create endpoint owns that write).
- Job result echoes `judge_feedback_batch_id` from params.
- Route docstring + regenerated `api_schema.d.ts`. Tests reworked (run-existing, missing-batch 404, describe from persisted batch); dropped the obsolete config-save-wrap test.

## Why
- **Handle problem solved:** the batch id is caller-supplied → in `job.params` → retrievable via `GET /api/jobs/{id}` **even on failure**. (Create-and-run only surfaced the minted id in the success result.)
- **Eval parity:** same params shape (entity id in params), results on disk. Sets up a disk-derived summary GET + a real `compute_state` later.

## Bot flow after this
```
POST .../judge_feedback_batches            -> { id }
POST /api/jobs/judge_feedback_batch/run { judge_feedback_batch_id: id } -> { job_id }
GET  /api/jobs/{id}  (params has the id, even on failure) ; POST /api/jobs/wait
GET  .../judge_feedback_batches/{id}/runs  -> per-item results from disk
```

## Verification
Full `uv run ./checks.sh --agent-mode` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)