### PR TITLE
feat(eval-job): expose concurrency in job params

### DIFF
--- a/app/desktop/studio_server/jobs/test_api.py
+++ b/app/desktop/studio_server/jobs/test_api.py
@@ -170,6 +170,7 @@ _EVAL_PARAMS = {
     "eval_id": "e1",
     "eval_config_id": "ec1",
     "run_config_id": "rc1",
+    "concurrency": None,
 }
 
 

--- a/app/desktop/studio_server/jobs/workers/eval.py
+++ b/app/desktop/studio_server/jobs/workers/eval.py
@@ -4,7 +4,11 @@ import asyncio
 
 from app.desktop.git_sync.save_context import save_context_for_project
 from kiln_ai.adapters.errors import KilnRunError
-from kiln_ai.adapters.eval.eval_runner import EvalJob, EvalRunner
+from kiln_ai.adapters.eval.eval_runner import (
+    DEFAULT_EVAL_CONCURRENCY,
+    EvalJob,
+    EvalRunner,
+)
 from kiln_ai.datamodel.dataset_filters import dataset_filter_from_id
 from kiln_ai.datamodel.eval import Eval, EvalConfig
 from kiln_ai.datamodel.prompt_type import generator_label
@@ -81,7 +85,7 @@ class EvalJobParams(BaseModel):
         default=None,
         ge=1,
         description="Max dataset items evaluated in parallel by the runner. Leave null to use the "
-        "runner's default (25).",
+        f"runner's default ({DEFAULT_EVAL_CONCURRENCY}).",
     )
 
 

--- a/app/desktop/studio_server/jobs/workers/eval.py
+++ b/app/desktop/studio_server/jobs/workers/eval.py
@@ -77,6 +77,12 @@ class EvalJobParams(BaseModel):
     run_config_id: str = Field(
         description="Id of the task run config whose outputs are being evaluated."
     )
+    concurrency: int | None = Field(
+        default=None,
+        ge=1,
+        description="Max dataset items evaluated in parallel by the runner. Leave null to use the "
+        "runner's default (25).",
+    )
 
 
 class EvalJobResult(BaseModel):
@@ -302,7 +308,9 @@ class EvalJobWorker(JobWorker[EvalJobParams, EvalJobResult]):
         success = baseline_success
         total = baseline.total if baseline.total is not None else baseline_success
         error = 0
-        async for progress in eval_runner.run(observers=[_EvalErrorLogObserver(ctx)]):
+        async for progress in eval_runner.run(
+            concurrency=params.concurrency, observers=[_EvalErrorLogObserver(ctx)]
+        ):
             # progress.total = full - baseline_success (the unfinished remainder),
             # so baseline_success + progress.total = the full eval-set size.
             success = baseline_success + progress.complete

--- a/app/desktop/studio_server/jobs/workers/test_eval.py
+++ b/app/desktop/studio_server/jobs/workers/test_eval.py
@@ -34,6 +34,7 @@ from kiln_ai.datamodel.eval import (
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.task import StructuredOutputMode, TaskRunConfig
 from kiln_ai.utils.async_job_runner import Progress, RetryableError
+from pydantic import ValidationError
 
 
 @pytest.fixture
@@ -629,6 +630,60 @@ async def test_registry_create_guards_describe_failure(
 
 
 # -- run ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("concurrency", [None, 3, 25])
+async def test_run_forwards_concurrency_to_runner(
+    resolve_project, task, eval_config, run_config, data_source, concurrency
+):
+    # The job's concurrency param (None -> runner default) flows straight to EvalRunner.run.
+    received: dict[str, int | None] = {}
+
+    async def fake_run(
+        self, concurrency=None, observers=None
+    ) -> AsyncIterator[Progress]:
+        received["concurrency"] = concurrency
+        for _ in ():
+            yield  # pragma: no cover — never yields; typed as a generator
+
+    params = EvalJobParams(
+        project_id="project1",
+        task_id="task1",
+        eval_id="eval1",
+        eval_config_id="eval_config1",
+        run_config_id="run_config1",
+        concurrency=concurrency,
+    )
+
+    class FakeCtx:
+        job_id = "j_test"
+        run_id = "run_test"
+
+        async def report_progress(self, success, error=0, total=None, message=None):
+            pass
+
+        async def report_error(self, error_message, **extra):
+            pass
+
+    with patch("kiln_ai.adapters.eval.eval_runner.EvalRunner.run", new=fake_run):
+        await EvalJobWorker().run(params, FakeCtx())
+
+    assert received["concurrency"] == concurrency
+
+
+@pytest.mark.parametrize("bad_value", [0, -1])
+def test_concurrency_below_one_rejected(bad_value):
+    # ge=1 surfaces invalid concurrency as a 422 at the API boundary rather than a
+    # runner-side ValueError (mirrors max_samples / stop_after_failures validation).
+    with pytest.raises(ValidationError):
+        EvalJobParams(
+            project_id="project1",
+            task_id="task1",
+            eval_id="eval1",
+            eval_config_id="eval_config1",
+            run_config_id="run_config1",
+            concurrency=bad_value,
+        )
 
 
 async def test_run_maps_progress_and_returns_result(

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -6158,6 +6158,11 @@ export interface components {
              * @description Id of the task run config whose outputs are being evaluated.
              */
             run_config_id: string;
+            /**
+             * Concurrency
+             * @description Max dataset items evaluated in parallel by the runner. Leave null to use the runner's default (25).
+             */
+            concurrency?: number | null;
         };
         /**
          * EvalOutputScore

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -190,7 +190,7 @@ class EvalRunner:
 
     async def run(
         self,
-        concurrency: int = 25,
+        concurrency: int | None = None,
         observers: list[AsyncJobRunnerObserver[EvalJob]] | None = None,
     ) -> AsyncGenerator[Progress, None]:
         """
@@ -199,7 +199,11 @@ class EvalRunner:
         Pass `observers` to be notified per-item (e.g. to surface the exception of
         a failed dataset item — `Progress.errors` is only a count). Optional so the
         streaming UI paths can keep calling `run()` with no observer.
+
+        `concurrency` bounds how many items run in parallel; None uses the default.
         """
+        if concurrency is None:
+            concurrency = 25
         jobs = self.collect_tasks()
 
         runner = AsyncJobRunner(

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -24,6 +24,9 @@ from kiln_ai.utils.git_sync_protocols import SaveContext, default_save_context
 
 logger = logging.getLogger(__name__)
 
+# Default number of dataset items evaluated in parallel when a caller doesn't specify one.
+DEFAULT_EVAL_CONCURRENCY = 25
+
 
 @dataclass
 class EvalJob:
@@ -203,7 +206,7 @@ class EvalRunner:
         `concurrency` bounds how many items run in parallel; None uses the default.
         """
         if concurrency is None:
-            concurrency = 25
+            concurrency = DEFAULT_EVAL_CONCURRENCY
         jobs = self.collect_tasks()
 
         runner = AsyncJobRunner(


### PR DESCRIPTION
## What

Add an optional `concurrency` field to `EvalJobParams` and forward it to `EvalRunner.run()` inside the eval job worker. Mirrors the judge-feedback-batch job param (#1544).

## Why

`EvalRunner.run()` already bounds how many dataset items are evaluated in parallel, but the background eval job worker called `eval_runner.run(observers=...)` without a concurrency argument — so job-API callers were always stuck on the runner's default (25) and couldn't tune parallelism.

## Details

- `concurrency: int | None = None` on `EvalJobParams`, with `ge=1` and a field description. Null uses the runner's default (**25**); `ge=1` surfaces invalid values as a **422** at the API boundary (consistent with `max_samples`-style validation) instead of a runner-side `ValueError`.
- Worker forwards `concurrency=params.concurrency` to `eval_runner.run(...)`.
- `EvalRunner.run()` signature changed from `concurrency: int = 25` to `concurrency: int | None = None`, resolving the `25` default internally — keeping it a single source of truth rather than duplicating the literal in the param. Existing callers (streaming eval API, tests) are unaffected.
- Regenerated `api_schema.d.ts`.
- Added a parametrized forwarding test (`None`, 3, 25) and a validation test rejecting `0`/`-1`.

## Checks

- `pytest` on `test_eval.py` + `test_eval_runner.py`: 70 passed
- ruff check/format, project-level `ty check`, and `check_schema.sh`: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)