### PR TITLE
Fix dead transient-error retries; patient backoff for background jobs

### DIFF
--- a/app/desktop/studio_server/jobs/models.py
+++ b/app/desktop/studio_server/jobs/models.py
@@ -39,6 +39,14 @@ TERMINAL_STATUSES = frozenset(
     }
 )
 
+# Background jobs retry items that fail with a transient provider error (rate limit,
+# connection blip) with exponential backoff, and only surface the error to the job's
+# error log once every attempt fails. This is a more patient schedule than the
+# runners' own defaults (which interactive endpoints keep): with a 5s base delay the
+# waits are ~5/10/20/40s (jittered), giving a throttled provider room to recover.
+JOB_TRANSIENT_ERROR_MAX_RETRIES = 4
+JOB_TRANSIENT_ERROR_RETRY_DELAY_SECONDS = 5.0
+
 
 class JobProgress(BaseModel):
     """Count-based progress for a job.

--- a/app/desktop/studio_server/jobs/workers/eval.py
+++ b/app/desktop/studio_server/jobs/workers/eval.py
@@ -19,7 +19,13 @@ from kiln_ai.utils.async_job_runner import AsyncJobRunnerObserver
 from pydantic import BaseModel, Field
 
 from ...eval_api import eval_config_from_id, task_run_config_from_id
-from ..models import JobContext, JobDerivedState, JobWorker
+from ..models import (
+    JOB_TRANSIENT_ERROR_MAX_RETRIES,
+    JOB_TRANSIENT_ERROR_RETRY_DELAY_SECONDS,
+    JobContext,
+    JobDerivedState,
+    JobWorker,
+)
 
 
 def _safe_str(exc: Exception) -> str:
@@ -313,7 +319,10 @@ class EvalJobWorker(JobWorker[EvalJobParams, EvalJobResult]):
         total = baseline.total if baseline.total is not None else baseline_success
         error = 0
         async for progress in eval_runner.run(
-            concurrency=params.concurrency, observers=[_EvalErrorLogObserver(ctx)]
+            concurrency=params.concurrency,
+            observers=[_EvalErrorLogObserver(ctx)],
+            max_retries=JOB_TRANSIENT_ERROR_MAX_RETRIES,
+            retry_delay=JOB_TRANSIENT_ERROR_RETRY_DELAY_SECONDS,
         ):
             # progress.total = full - baseline_success (the unfinished remainder),
             # so baseline_success + progress.total = the full eval-set size.

--- a/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/judge_feedback_batch.py
@@ -18,7 +18,12 @@ from ...judge_feedback_batch_api import (
     validate_judge_eval,
     validate_run_config_id,
 )
-from ..models import JobContext, JobWorker
+from ..models import (
+    JOB_TRANSIENT_ERROR_MAX_RETRIES,
+    JOB_TRANSIENT_ERROR_RETRY_DELAY_SECONDS,
+    JobContext,
+    JobWorker,
+)
 
 
 class JudgeFeedbackBatchJobParams(BaseModel):
@@ -225,6 +230,8 @@ class JudgeFeedbackBatchJobWorker(
                 params.project_id,
                 context=f"judge feedback batch {params.judge_feedback_batch_id}",
             ),
+            max_retries=JOB_TRANSIENT_ERROR_MAX_RETRIES,
+            retry_delay=JOB_TRANSIENT_ERROR_RETRY_DELAY_SECONDS,
         )
 
         async def report_progress(

--- a/app/desktop/studio_server/jobs/workers/test_eval.py
+++ b/app/desktop/studio_server/jobs/workers/test_eval.py
@@ -5,7 +5,11 @@ from typing import AsyncIterator
 from unittest.mock import patch
 
 import pytest
-from app.desktop.studio_server.jobs.models import BackgroundJobStatus
+from app.desktop.studio_server.jobs.models import (
+    JOB_TRANSIENT_ERROR_MAX_RETRIES,
+    JOB_TRANSIENT_ERROR_RETRY_DELAY_SECONDS,
+    BackgroundJobStatus,
+)
 from app.desktop.studio_server.jobs.registry import JobRegistry
 from app.desktop.studio_server.jobs.workers.eval import (
     EvalJobParams,
@@ -174,7 +178,7 @@ def _make_eval_run(eval_config, dataset_id, run_config_id) -> EvalRun:
 @contextmanager
 def _stub_eval_runner_run(progresses: list[Progress]):
     async def fake_run(
-        self, concurrency: int = 25, observers=None
+        self, concurrency: int = 25, observers=None, max_retries=0, retry_delay=1.0
     ) -> AsyncIterator[Progress]:
         for progress in progresses:
             yield progress
@@ -636,13 +640,17 @@ async def test_registry_create_guards_describe_failure(
 async def test_run_forwards_concurrency_to_runner(
     resolve_project, task, eval_config, run_config, data_source, concurrency
 ):
-    # The job's concurrency param (None -> runner default) flows straight to EvalRunner.run.
-    received: dict[str, int | None] = {}
+    # The job's concurrency param (None -> runner default) flows straight to
+    # EvalRunner.run, and the job overrides the runner's default retry schedule
+    # with the more patient job one (non-job endpoints keep the defaults).
+    received: dict[str, int | float | None] = {}
 
     async def fake_run(
-        self, concurrency=None, observers=None
+        self, concurrency=None, observers=None, max_retries=0, retry_delay=1.0
     ) -> AsyncIterator[Progress]:
         received["concurrency"] = concurrency
+        received["max_retries"] = max_retries
+        received["retry_delay"] = retry_delay
         for _ in ():
             yield  # pragma: no cover — never yields; typed as a generator
 
@@ -669,6 +677,8 @@ async def test_run_forwards_concurrency_to_runner(
         await EvalJobWorker().run(params, FakeCtx())
 
     assert received["concurrency"] == concurrency
+    assert received["max_retries"] == JOB_TRANSIENT_ERROR_MAX_RETRIES
+    assert received["retry_delay"] == JOB_TRANSIENT_ERROR_RETRY_DELAY_SECONDS
 
 
 @pytest.mark.parametrize("bad_value", [0, -1])

--- a/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
+++ b/app/desktop/studio_server/jobs/workers/test_judge_feedback_batch.py
@@ -6,6 +6,10 @@ from unittest.mock import patch
 import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
+from app.desktop.studio_server.jobs.models import (
+    JOB_TRANSIENT_ERROR_MAX_RETRIES,
+    JOB_TRANSIENT_ERROR_RETRY_DELAY_SECONDS,
+)
 from app.desktop.studio_server.jobs.workers.judge_feedback_batch import (
     JudgeFeedbackBatchJobParams,
     JudgeFeedbackBatchJobResult,
@@ -251,6 +255,37 @@ async def test_run_forwards_concurrency_to_runner(
         await JudgeFeedbackBatchJobWorker().run(params, ctx)
 
     assert received["concurrency"] == concurrency
+
+
+async def test_run_enables_transient_retries_on_runner(
+    resolve_project, task, eval_config, run_config, batch, params
+):
+    # Background jobs override the runner's default retry schedule with the more
+    # patient job one; the synchronous endpoint keeps the runner defaults.
+    received: dict[str, float] = {}
+
+    async def fake_run(
+        self, concurrency=None, progress_callback=None, error_callback=None
+    ) -> JudgeFeedbackBatchRunResult:
+        received["max_retries"] = self._max_retries
+        received["retry_delay"] = self._retry_delay
+        return _fake_result()
+
+    ctx = _FakeCtx()
+    with (
+        patch(
+            "kiln_ai.adapters.eval.judge_feedback_batch_runner.JudgeFeedbackBatchRunner.run",
+            new=fake_run,
+        ),
+        patch(
+            "app.desktop.studio_server.jobs.workers.judge_feedback_batch.save_context_for_project",
+            return_value=None,
+        ),
+    ):
+        await JudgeFeedbackBatchJobWorker().run(params, ctx)
+
+    assert received["max_retries"] == JOB_TRANSIENT_ERROR_MAX_RETRIES
+    assert received["retry_delay"] == JOB_TRANSIENT_ERROR_RETRY_DELAY_SECONDS
 
 
 @pytest.mark.parametrize("concurrency", [0, -1])

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -6,6 +6,7 @@ from typing import AsyncGenerator, Dict, List, Literal, Set
 import litellm
 
 from kiln_ai.adapters.adapter_registry import load_skills_for_task
+from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.eval.base_eval import BaseEval
 from kiln_ai.adapters.eval.registry import eval_adapter_from_type
 from kiln_ai.adapters.model_adapters.base_adapter import SkillsDict
@@ -195,6 +196,8 @@ class EvalRunner:
         self,
         concurrency: int | None = None,
         observers: list[AsyncJobRunnerObserver[EvalJob]] | None = None,
+        max_retries: int = 2,
+        retry_delay: float = 1.0,
     ) -> AsyncGenerator[Progress, None]:
         """
         Runs the configured eval run with parallel workers and yields progress updates.
@@ -204,6 +207,11 @@ class EvalRunner:
         streaming UI paths can keep calling `run()` with no observer.
 
         `concurrency` bounds how many items run in parallel; None uses the default.
+
+        `max_retries` re-attempts items that fail with a transient error (rate limit,
+        connection blip) with exponential backoff starting at `retry_delay` seconds,
+        only surfacing the error if every attempt fails. Background jobs override the
+        defaults with a more patient schedule.
         """
         if concurrency is None:
             concurrency = DEFAULT_EVAL_CONCURRENCY
@@ -213,7 +221,8 @@ class EvalRunner:
             concurrency=concurrency,
             jobs=jobs,
             run_job_fn=self.run_job,
-            max_retries=2,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
             observers=observers,
         )
         async for progress in runner.run():
@@ -290,11 +299,16 @@ class EvalRunner:
             return True
         except Exception as e:
             if _is_retryable_error(e):
-                logger.error(
+                # Warning, not error: this fires per attempt, and the runner may
+                # still retry. A final failure is reported via the runner's observers.
+                logger.warning(
                     f"Transient error running eval job for dataset item {job.item.id}: {e}",
                     exc_info=True,
                 )
-                raise RetryableError(str(e)) from e
+                # KilnRunError's own message is genericized user-facing text; keep
+                # the underlying provider detail for the developer-facing error log.
+                detail = str(e.original) if isinstance(e, KilnRunError) else str(e)
+                raise RetryableError(detail) from e
             logger.error(
                 f"Error running eval job for dataset item {job.item.id}: {e}",
                 exc_info=True,
@@ -303,6 +317,11 @@ class EvalRunner:
 
 
 def _is_retryable_error(e: BaseException) -> bool:
+    # The model adapter wraps provider exceptions in KilnRunError (to carry the
+    # partial trace), so classify by the underlying error it wraps.
+    if isinstance(e, KilnRunError):
+        return _is_retryable_error(e.original)
+
     if isinstance(
         e,
         (

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -307,8 +307,7 @@ class EvalRunner:
                 )
                 # KilnRunError's own message is genericized user-facing text; keep
                 # the underlying provider detail for the developer-facing error log.
-                detail = str(e.original) if isinstance(e, KilnRunError) else str(e)
-                raise RetryableError(detail) from e
+                raise RetryableError(str(_unwrap_kiln_run_error(e))) from e
             logger.error(
                 f"Error running eval job for dataset item {job.item.id}: {e}",
                 exc_info=True,
@@ -316,11 +315,21 @@ class EvalRunner:
             raise
 
 
+def _unwrap_kiln_run_error(e: BaseException) -> BaseException:
+    """The innermost non-wrapper error.
+
+    The model adapter wraps provider exceptions in KilnRunError (to carry the
+    partial trace), whose own message is genericized user-facing text — so both
+    retry classification and error detail must use the underlying error. The
+    isinstance guard on `original` keeps a (contract-violating) None from
+    escaping as the result."""
+    while isinstance(e, KilnRunError) and isinstance(e.original, BaseException):
+        e = e.original
+    return e
+
+
 def _is_retryable_error(e: BaseException) -> bool:
-    # The model adapter wraps provider exceptions in KilnRunError (to carry the
-    # partial trace), so classify by the underlying error it wraps.
-    if isinstance(e, KilnRunError):
-        return _is_retryable_error(e.original)
+    e = _unwrap_kiln_run_error(e)
 
     if isinstance(
         e,

--- a/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
@@ -41,6 +41,7 @@ from kiln_ai.datamodel.task import RunConfigProperties
 from kiln_ai.datamodel.task_output import normalize_rating
 from kiln_ai.datamodel.task_run import TaskRun
 from kiln_ai.datamodel.usage import Usage
+from kiln_ai.utils.async_job_runner import jittered_backoff_delay
 from kiln_ai.utils.git_sync_protocols import SaveContext, default_save_context
 
 logger = logging.getLogger(__name__)
@@ -513,6 +514,7 @@ class JudgeFeedbackBatchRunner:
         they'd be collected as per-item errors and silently shrink coverage (skewing a gate). Reuses
         the eval runner's transient-error classification. Raises on a non-transient error or once
         retries are exhausted — the caller turns that into a collected JudgeFeedbackBatchItemError.
+        Background jobs override the constructor's retry defaults with a more patient schedule.
 
         Returns the judge's scores, its intermediate outputs, and — in generate_outputs mode — the
         generation's token/cost/latency Usage (None when an existing output was judged, since nothing
@@ -538,9 +540,6 @@ class JudgeFeedbackBatchRunner:
                 last_error = e
                 if not (_is_retryable_error(e) and attempt < self._max_retries):
                     break
-                # Exponential backoff: rate limits don't clear on a fixed 1s gap, and several
-                # generate+judge calls retrying in lockstep just re-floods a throttled provider.
-                # Back off progressively (delay, 2x, 4x, ...) so a 429 gets room to recover.
-                await asyncio.sleep(self._retry_delay * (2**attempt))
+                await asyncio.sleep(jittered_backoff_delay(self._retry_delay, attempt))
         assert last_error is not None  # the loop runs at least once
         raise last_error

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import litellm
 import pytest
 
+from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.eval.base_eval import BaseEval
 from kiln_ai.adapters.eval.eval_runner import EvalJob, EvalRunner, _is_retryable_error
 from kiln_ai.adapters.ml_model_list import ModelProviderName
@@ -27,6 +28,7 @@ from kiln_ai.datamodel.eval import (
 )
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.task import StructuredOutputMode, TaskRunConfig
+from kiln_ai.utils.async_job_runner import RetryableError
 from kiln_ai.utils.git_sync_protocols import default_save_context
 from kiln_ai.utils.open_ai_types import ChatCompletionMessageParam
 
@@ -651,6 +653,53 @@ async def test_run_job_evaluator_error(
 
 
 @pytest.mark.asyncio
+async def test_run_job_wrapped_rate_limit_raises_retryable_with_detail(
+    mock_eval_runner, mock_task, data_source, mock_run_config, mock_eval_config
+):
+    # Real adapter failures arrive wrapped in KilnRunError whose own message is the
+    # genericized user-facing text. run_job must still classify the failure as
+    # transient (RetryableError) and keep the underlying provider detail for the
+    # developer-facing job error log.
+    task_run = TaskRun(
+        parent=mock_task,
+        input="test input",
+        input_source=data_source,
+        output=TaskOutput(output="test output"),
+    )
+    task_run.save_to_file()
+    job = EvalJob(
+        item=task_run,
+        task_run_config=mock_run_config,
+        type="task_run_eval",
+        eval_config=mock_eval_config,
+    )
+
+    class RateLimitedEvaluator(BaseEval):
+        async def run_task_and_eval(self, eval_job_item: TaskRun):
+            raise KilnRunError(
+                message="Rate limit exceeded. Wait a moment and try again.",
+                partial_trace=None,
+                original=litellm.RateLimitError(
+                    "rate limit exceeded, please try again later",
+                    "fireworks_ai",
+                    "model",
+                    None,
+                ),
+            )
+
+    with patch(
+        "kiln_ai.adapters.eval.eval_runner.eval_adapter_from_type",
+        return_value=lambda *args, **kwargs: RateLimitedEvaluator(*args, **kwargs),
+    ):
+        with pytest.raises(RetryableError) as exc_info:
+            await mock_eval_runner.run_job(job)
+
+    assert "rate limit exceeded, please try again later" in str(exc_info.value)
+    assert "An unexpected error occurred" not in str(exc_info.value)
+    assert len(mock_eval_config.runs()) == 0
+
+
+@pytest.mark.asyncio
 async def test_run_job_with_full_trace_evaluation_data_type(
     mock_eval_runner, mock_task, data_source, mock_run_config, mock_eval_config
 ):
@@ -866,6 +915,59 @@ def test_is_retryable_error_returns_true(error):
 )
 def test_is_retryable_error_returns_false(error):
     assert _is_retryable_error(error) is False
+
+
+def test_is_retryable_error_unwraps_kiln_run_error():
+    # The model adapter wraps provider exceptions in KilnRunError (to carry the
+    # partial trace), so the classifier must look through the wrapper — otherwise
+    # rate limits from a real adapter run would never be retried.
+    wrapped = KilnRunError(
+        message="Rate limit exceeded. Wait a moment and try again.",
+        partial_trace=None,
+        original=litellm.RateLimitError("rate limited", "provider", "model", None),
+    )
+    assert _is_retryable_error(wrapped) is True
+
+
+def test_is_retryable_error_wrapped_non_transient_returns_false():
+    wrapped = KilnRunError(
+        message="An unexpected error occurred.",
+        partial_trace=None,
+        original=RuntimeError("boom"),
+    )
+    assert _is_retryable_error(wrapped) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "run_kwargs,expected_max_retries,expected_retry_delay",
+    [
+        ({}, 2, 1.0),
+        ({"max_retries": 4, "retry_delay": 5.0}, 4, 5.0),
+    ],
+)
+async def test_run_threads_retry_config_to_async_job_runner(
+    mock_eval_runner, run_kwargs, expected_max_retries, expected_retry_delay
+):
+    # The historical default (2 retries) is kept for existing callers; background
+    # jobs override it, and the values must reach the AsyncJobRunner doing the
+    # retrying.
+    captured: dict = {}
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def run(self):
+            for _ in ():
+                yield  # pragma: no cover — typed as a generator, never yields
+
+    with patch("kiln_ai.adapters.eval.eval_runner.AsyncJobRunner", FakeRunner):
+        async for _ in mock_eval_runner.run(**run_kwargs):
+            pass
+
+    assert captured["max_retries"] == expected_max_retries
+    assert captured["retry_delay"] == expected_retry_delay
 
 
 # --- save_context tests ---

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -938,6 +938,22 @@ def test_is_retryable_error_wrapped_non_transient_returns_false():
     assert _is_retryable_error(wrapped) is False
 
 
+def test_is_retryable_error_unwraps_nested_kiln_run_error():
+    # Not produced by the current adapter chain (it passes through already-wrapped
+    # errors), but the unwrap walks nested wrappers so classification and error
+    # detail can't silently diverge if that ever changes.
+    nested = KilnRunError(
+        message="Rate limit exceeded. Wait a moment and try again.",
+        partial_trace=None,
+        original=KilnRunError(
+            message="Rate limit exceeded. Wait a moment and try again.",
+            partial_trace=None,
+            original=litellm.RateLimitError("rate limited", "provider", "model", None),
+        ),
+    )
+    assert _is_retryable_error(nested) is True
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "run_kwargs,expected_max_retries,expected_retry_delay",

--- a/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
@@ -179,6 +179,7 @@ async def run_job(
     calls=None,
     seed=1,
     concurrency=25,
+    max_retries=0,
     retry_delay=0,
     fresh_usage=None,
     progress_callback=None,
@@ -198,6 +199,7 @@ async def run_job(
             judge_feedback_batch,
             eval_config,
             rng=random.Random(seed),
+            max_retries=max_retries,
             retry_delay=retry_delay,
         )
         return await runner.run(
@@ -710,7 +712,7 @@ async def test_transient_error_retries_then_succeeds(mock_task, data_source):
             raise ValueError("This task requires a specific output schema")
         return {"accuracy": 0.0}
 
-    result = await run_job(job, eval_config, score_fn)
+    result = await run_job(job, eval_config, score_fn, max_retries=2)
 
     # Retried once then succeeded — the item is judged, no error surfaced.
     assert attempts["n"] == 2
@@ -734,13 +736,29 @@ async def test_non_transient_error_not_retried(mock_task, data_source):
         attempts["n"] += 1
         raise RuntimeError("hard failure")
 
-    result = await run_job(job, eval_config, score_fn)
+    result = await run_job(job, eval_config, score_fn, max_retries=2)
 
-    # A non-transient error is collected once, not retried.
+    # A non-transient error is collected once, not retried (even with retries enabled).
     assert attempts["n"] == 1
     assert len(result.judged_runs) == 0
     assert len(result.errors) == 1
     assert "hard failure" in result.errors[0].error
+
+
+def test_default_retry_config(mock_task, data_source):
+    # The constructor keeps the historical default (2 retries, 2s base delay) so
+    # existing callers are unaffected; background jobs override with a more
+    # patient schedule.
+    eval = make_eval(mock_task)
+    eval_config = make_eval_config(eval)
+    job = make_judge_feedback_batch(
+        mock_task, eval_config, stop_after_failures=1, max_samples=1
+    )
+
+    runner = JudgeFeedbackBatchRunner(job, eval_config)
+
+    assert runner._max_retries == 2
+    assert runner._retry_delay == 2.0
 
 
 @pytest.mark.asyncio
@@ -777,8 +795,13 @@ async def test_transient_retries_back_off_exponentially(mock_task, data_source):
             "kiln_ai.adapters.eval.judge_feedback_batch_runner.asyncio.sleep",
             fake_sleep,
         )
+        # Pin the jitter factor so the exponential progression is exact.
+        mp.setattr(
+            "kiln_ai.utils.async_job_runner.random.uniform",
+            lambda a, b: 1.0,
+        )
         runner = JudgeFeedbackBatchRunner(
-            job, eval_config, rng=random.Random(1), retry_delay=1.0
+            job, eval_config, rng=random.Random(1), max_retries=2, retry_delay=1.0
         )
         result = await runner.run(concurrency=1)
 

--- a/libs/core/kiln_ai/utils/async_job_runner.py
+++ b/libs/core/kiln_ai/utils/async_job_runner.py
@@ -1,11 +1,20 @@
 import asyncio
 import logging
+import random
 from dataclasses import dataclass
 from typing import AsyncGenerator, Awaitable, Callable, Generic, List, TypeVar
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+def jittered_backoff_delay(retry_delay: float, attempt: int) -> float:
+    """Delay before retrying a transient failure: exponential (delay, 2x, 4x, ...)
+    with ±50% jitter. Rate limits rarely clear on a fixed short gap, and concurrent
+    workers throttled at the same moment would otherwise retry in lockstep and
+    re-flood the provider."""
+    return retry_delay * (2**attempt) * random.uniform(0.5, 1.5)
 
 
 @dataclass
@@ -161,7 +170,9 @@ class AsyncJobRunner(Generic[T]):
                     if is_last_attempt:
                         logger.error("Job failed to complete", exc_info=e)
                         break
-                    await asyncio.sleep(self.retry_delay)
+                    await asyncio.sleep(
+                        jittered_backoff_delay(self.retry_delay, attempt)
+                    )
                 except Exception as e:
                     result = False
                     last_error = e

--- a/libs/core/kiln_ai/utils/test_async_job_runner.py
+++ b/libs/core/kiln_ai/utils/test_async_job_runner.py
@@ -8,6 +8,7 @@ from kiln_ai.utils.async_job_runner import (
     AsyncJobRunnerObserver,
     Progress,
     RetryableError,
+    jittered_backoff_delay,
 )
 
 
@@ -358,15 +359,29 @@ async def test_async_job_runner_retry_delay():
         retry_delay=0.5,
     )
 
-    with patch(
-        "kiln_ai.utils.async_job_runner.asyncio.sleep", new_callable=AsyncMock
-    ) as mock_sleep:
+    with (
+        patch(
+            "kiln_ai.utils.async_job_runner.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep,
+        patch("kiln_ai.utils.async_job_runner.random.uniform", return_value=1.0),
+    ):
         updates = [progress async for progress in runner.run()]
         assert updates[-1].complete == 1
         assert updates[-1].errors == 0
         assert call_count == 3
         assert mock_sleep.await_count == 2
-        mock_sleep.assert_awaited_with(0.5)
+        # Exponential backoff: base delay, then 2x (jitter factor patched to 1.0).
+        assert [c.args[0] for c in mock_sleep.await_args_list] == [0.5, 1.0]
+
+
+def test_jittered_backoff_delay_exponential_with_jitter_bounds():
+    # delay * 2^attempt scaled by a jitter factor in [0.5, 1.5), so concurrent
+    # workers throttled at the same moment don't retry in lockstep.
+    for attempt in range(4):
+        base = 2.0 * (2**attempt)
+        for _ in range(25):
+            delay = jittered_backoff_delay(2.0, attempt)
+            assert base * 0.5 <= delay < base * 1.5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Eval jobs and judge feedback batch jobs were surfacing raw rate-limit errors (e.g. Fireworks 429s) in View Errors after a single attempt, despite both runners having retry logic.

### Root cause: the retry machinery was dead code in production

`_is_retryable_error` checks `isinstance(e, litellm.RateLimitError)` etc., but the model adapter wraps every provider exception in `KilnRunError` (`base_adapter.py`) before it reaches the retry loops. The wrapper never matched, so no transient error was ever retried on a real run. Tests didn't catch it because they raise bare litellm errors instead of wrapped ones.

## Changes

- **`_is_retryable_error` unwraps `KilnRunError`** and classifies the underlying error — the root-cause fix, shared by both runners.
- **Jittered exponential backoff** (`jittered_backoff_delay`, shared): `retry_delay * 2^attempt * uniform(0.5, 1.5)` replaces the fixed sleep in `AsyncJobRunner` and the plain exponential in the judge runner, so 25 concurrent workers throttled at the same moment don't retry in lockstep and re-flood the provider.
- **`EvalRunner.run()` exposes `max_retries` / `retry_delay`** (defaults unchanged: 2 retries, 1s base — the SSE endpoints keep them). `JudgeFeedbackBatchRunner` keeps its 2 / 2.0s defaults for the synchronous endpoint.
- **Both job workers override with a patient schedule**: `JOB_TRANSIENT_ERROR_MAX_RETRIES = 4`, 5s base → ~5/10/20/40s jittered waits (~75s of headroom for a 429 to clear) before an error surfaces to the job error log.
- **Error detail preserved**: the `RetryableError` raised from `run_job` now carries the underlying provider message rather than `KilnRunError`'s genericized user-facing text, so View Errors keeps showing the real provider error.

Transient = rate limit, connection error, 5xx-class provider errors, schema-mismatch output (the existing classifier). Intermediate failures are swallowed; only the final exhausted failure reaches the error log.

Note: since the classifier fix revives the runners' built-in retries, non-job endpoints now genuinely retry twice (short backoff) where their effective behavior was zero retries — the intended behavior coming back, not a new policy.

## Tests

- Classifier unwrap cases (wrapped rate limit → retryable; wrapped non-transient → not).
- `run_job` raises `RetryableError` with the underlying provider detail for wrapped rate limits.
- Retry config threading: `EvalRunner.run` → `AsyncJobRunner`, and both workers → runners (asserted against the job constants).
- Backoff shape: exponential progression with pinned jitter; jitter bounds test.
- Judge runner default retry config test; existing retry tests updated to opt in explicitly where they relied on constructor defaults.

Full suite green: 6440 passed; ruff / format / ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNMsZVT2b9PuANGAHkPyb1