### PR TITLE
fix: retries are never happening in eval runner

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -274,7 +274,9 @@ class EvalRunner:
                     f"Transient error running eval job for dataset item {job.item.id}: {e}",
                     exc_info=True,
                 )
-                raise RetryableError(str(e)) from e
+                # KilnRunError's own message is genericized user-facing text; keep
+                # the underlying provider detail for the developer-facing error log.
+                raise RetryableError(str(_unwrap_kiln_run_error(e))) from e
             logger.error(
                 f"Error running eval job for dataset item {job.item.id}: {e}",
                 exc_info=True,

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -6,6 +6,7 @@ from typing import AsyncGenerator, Dict, List, Literal, Set
 import litellm
 
 from kiln_ai.adapters.adapter_registry import load_skills_for_task
+from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.eval.base_eval import BaseEval
 from kiln_ai.adapters.eval.registry import eval_adapter_from_type
 from kiln_ai.adapters.model_adapters.base_adapter import SkillsDict
@@ -281,7 +282,22 @@ class EvalRunner:
             raise
 
 
+def _unwrap_kiln_run_error(e: BaseException) -> BaseException:
+    """The innermost non-wrapper error.
+
+    The model adapter wraps provider exceptions in KilnRunError (to carry the
+    partial trace), whose own message is genericized user-facing text — so both
+    retry classification and error detail must use the underlying error. The
+    isinstance guard on `original` keeps a (contract-violating) None from
+    escaping as the result."""
+    while isinstance(e, KilnRunError) and isinstance(e.original, BaseException):
+        e = e.original
+    return e
+
+
 def _is_retryable_error(e: BaseException) -> bool:
+    e = _unwrap_kiln_run_error(e)
+
     if isinstance(
         e,
         (

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import litellm
 import pytest
 
+from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.eval.base_eval import BaseEval
 from kiln_ai.adapters.eval.eval_runner import EvalJob, EvalRunner, _is_retryable_error
 from kiln_ai.adapters.ml_model_list import ModelProviderName
@@ -866,6 +867,43 @@ def test_is_retryable_error_returns_true(error):
 )
 def test_is_retryable_error_returns_false(error):
     assert _is_retryable_error(error) is False
+
+
+def test_is_retryable_error_unwraps_kiln_run_error():
+    # The model adapter wraps provider exceptions in KilnRunError (to carry the
+    # partial trace), so the classifier must look through the wrapper — otherwise
+    # rate limits from a real adapter run would never be retried.
+    wrapped = KilnRunError(
+        message="Rate limit exceeded. Wait a moment and try again.",
+        partial_trace=None,
+        original=litellm.RateLimitError("rate limited", "provider", "model", None),
+    )
+    assert _is_retryable_error(wrapped) is True
+
+
+def test_is_retryable_error_wrapped_non_transient_returns_false():
+    wrapped = KilnRunError(
+        message="An unexpected error occurred.",
+        partial_trace=None,
+        original=RuntimeError("boom"),
+    )
+    assert _is_retryable_error(wrapped) is False
+
+
+def test_is_retryable_error_unwraps_nested_kiln_run_error():
+    # Not produced by the current adapter chain (it passes through already-wrapped
+    # errors), but the unwrap walks nested wrappers so classification can't
+    # silently break if that ever changes.
+    nested = KilnRunError(
+        message="Rate limit exceeded. Wait a moment and try again.",
+        partial_trace=None,
+        original=KilnRunError(
+            message="Rate limit exceeded. Wait a moment and try again.",
+            partial_trace=None,
+            original=litellm.RateLimitError("rate limited", "provider", "model", None),
+        ),
+    )
+    assert _is_retryable_error(nested) is True
 
 
 # --- save_context tests ---

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -28,6 +28,7 @@ from kiln_ai.datamodel.eval import (
 )
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.task import StructuredOutputMode, TaskRunConfig
+from kiln_ai.utils.async_job_runner import RetryableError
 from kiln_ai.utils.git_sync_protocols import default_save_context
 from kiln_ai.utils.open_ai_types import ChatCompletionMessageParam
 
@@ -888,6 +889,53 @@ def test_is_retryable_error_wrapped_non_transient_returns_false():
         original=RuntimeError("boom"),
     )
     assert _is_retryable_error(wrapped) is False
+
+
+@pytest.mark.asyncio
+async def test_run_job_wrapped_rate_limit_raises_retryable_with_detail(
+    mock_eval_runner, mock_task, data_source, mock_run_config, mock_eval_config
+):
+    # Real adapter failures arrive wrapped in KilnRunError whose own message is the
+    # genericized user-facing text. run_job must still classify the failure as
+    # transient (RetryableError) and keep the underlying provider message for the
+    # developer-facing logs.
+    task_run = TaskRun(
+        parent=mock_task,
+        input="test input",
+        input_source=data_source,
+        output=TaskOutput(output="test output"),
+    )
+    task_run.save_to_file()
+    job = EvalJob(
+        item=task_run,
+        task_run_config=mock_run_config,
+        type="task_run_eval",
+        eval_config=mock_eval_config,
+    )
+
+    class RateLimitedEvaluator(BaseEval):
+        async def run_task_and_eval(self, eval_job_item: TaskRun):
+            raise KilnRunError(
+                message="Rate limit exceeded. Wait a moment and try again.",
+                partial_trace=None,
+                original=litellm.RateLimitError(
+                    "rate limit exceeded, please try again later",
+                    "fireworks_ai",
+                    "model",
+                    None,
+                ),
+            )
+
+    with patch(
+        "kiln_ai.adapters.eval.eval_runner.eval_adapter_from_type",
+        return_value=lambda *args, **kwargs: RateLimitedEvaluator(*args, **kwargs),
+    ):
+        with pytest.raises(RetryableError) as exc_info:
+            await mock_eval_runner.run_job(job)
+
+    assert "rate limit exceeded, please try again later" in str(exc_info.value)
+    assert "An unexpected error occurred" not in str(exc_info.value)
+    assert len(mock_eval_config.runs()) == 0
 
 
 def test_is_retryable_error_unwraps_nested_kiln_run_error():


### PR DESCRIPTION
## What

Extracted root-cause fix from #1547 (as discussed there), targeting `main` directly since evals on main are affected today.

`EvalRunner.run_job` classifies transient failures with `_is_retryable_error` and re-raises them as `RetryableError` so `AsyncJobRunner` retries them (`max_retries=2`). But the classifier checks `isinstance(e, litellm.RateLimitError)` etc., while the model adapter wraps every provider exception in `KilnRunError` (`base_adapter.py`) before it reaches the retry loop. The wrapper never matched, so **no transient eval error was ever retried on a real run** — rate-limited items failed on their first attempt. Tests didn't catch it because they raise bare litellm errors instead of wrapped ones.

## Fix

`_is_retryable_error` now unwraps `KilnRunError` via a small `_unwrap_kiln_run_error` helper and classifies the underlying error. The helper walks nested wrappers (not currently possible, defense-in-depth) and guards a contract-violating `None` original.

That's the whole change — no new retry knobs or backoff behavior; the runner's existing `max_retries=2` / 1s delay simply works now. The fuller retry work (configurable schedule for background jobs, jittered exponential backoff) stays in #1547.

## Tests

- Wrapped rate limit → retryable; wrapped non-transient → not; nested wrap → retryable.
- Full suite green (6219 passed); ruff / format / ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNMsZVT2b9PuANGAHkPyb1