### PR TITLE
Test Failure: Strip unsupported integer bounds from json_schema output (fixes Claude-via-OpenRouter llm_as_judge 400)

### DIFF
--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -39,6 +39,7 @@ from kiln_ai.adapters.model_adapters.litellm_config import LiteLlmConfig
 from kiln_ai.datamodel.datamodel_enums import InputType
 from kiln_ai.datamodel.json_schema import (
     close_object_schemas,
+    strip_numeric_bounds,
     validate_schema_with_value_error,
 )
 from kiln_ai.datamodel.run_config import (
@@ -482,6 +483,13 @@ class LiteLlmAdapter(BaseAdapter):
                 "Invalid output schema for this task. Cannot use JSON schema response format."
             )
         output_schema = close_object_schemas(output_schema, strict=True)
+        # Strip numeric bounds (min/max/etc.) from integer/number nodes for the
+        # json_schema wire format. Some providers (e.g. Claude via OpenRouter,
+        # which maps onto Anthropic's newer output_config.format.schema API)
+        # reject numeric bounds on integer/number types and return HTTP 400.
+        # The valid ranges are still enforced by the prompt + post-hoc
+        # validation, so this only affects the schema sent over the wire.
+        output_schema = strip_numeric_bounds(output_schema)
         return {
             "response_format": {
                 "type": "json_schema",

--- a/libs/core/kiln_ai/datamodel/json_schema.py
+++ b/libs/core/kiln_ai/datamodel/json_schema.py
@@ -157,6 +157,69 @@ def single_string_field_name(schema: Dict) -> str | None:
     return None
 
 
+def strip_numeric_bounds(schema: Dict) -> Dict:
+    """Return a deep-copied schema with numeric-constraint keywords removed.
+
+    Any schema node whose 'type' is 'integer' or 'number' has the keywords
+    'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', and
+    'multipleOf' removed. This normalization is recursive and walks nested
+    schema structures such as 'properties', 'items', '$defs'/'definitions', and
+    composed schemas like 'anyOf'/'oneOf'/'allOf'.
+
+    This is used only for the json_schema wire format sent to some providers
+    (e.g. Claude via OpenRouter, which maps onto Anthropic's newer
+    output_config.format.schema API that rejects numeric bounds on
+    integer/number types). It does NOT change how Kiln validates model outputs:
+    the valid ranges are still enforced by the prompt and post-hoc validation.
+    """
+
+    numeric_bound_keys = (
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+    )
+
+    def _normalize(node: Any) -> Any:
+        if isinstance(node, list):
+            return [_normalize(item) for item in node]
+
+        if not isinstance(node, dict):
+            return node
+
+        normalized = deepcopy(node)
+
+        for key in (
+            "properties",
+            "$defs",
+            "definitions",
+            "patternProperties",
+            "dependentSchemas",
+        ):
+            if key in normalized and isinstance(normalized[key], dict):
+                normalized[key] = {
+                    child_key: _normalize(child_value)
+                    for child_key, child_value in normalized[key].items()
+                }
+
+        for key in ("items", "additionalProperties", "not", "if", "then", "else"):
+            if key in normalized:
+                normalized[key] = _normalize(normalized[key])
+
+        for key in ("prefixItems", "allOf", "anyOf", "oneOf"):
+            if key in normalized and isinstance(normalized[key], list):
+                normalized[key] = [_normalize(item) for item in normalized[key]]
+
+        if normalized.get("type") in ("integer", "number"):
+            for key in numeric_bound_keys:
+                normalized.pop(key, None)
+
+        return normalized
+
+    return _normalize(schema)
+
+
 def close_object_schemas(schema: Dict, strict: bool = False) -> Dict:
     """Return a deep-copied schema with object nodes closed by default.
 

--- a/libs/core/kiln_ai/datamodel/json_schema.py
+++ b/libs/core/kiln_ai/datamodel/json_schema.py
@@ -160,9 +160,11 @@ def single_string_field_name(schema: Dict) -> str | None:
 def strip_numeric_bounds(schema: Dict) -> Dict:
     """Return a deep-copied schema with numeric-constraint keywords removed.
 
-    Any schema node whose 'type' is 'integer' or 'number' has the keywords
-    'minimum', 'maximum', 'exclusiveMinimum', 'exclusiveMaximum', and
-    'multipleOf' removed. This normalization is recursive and walks nested
+    Any schema node whose 'type' is 'integer' or 'number' (either as a string
+    or as a list that contains 'integer' or 'number', e.g. ['integer', 'null']
+    for nullable fields) has the keywords 'minimum', 'maximum',
+    'exclusiveMinimum', 'exclusiveMaximum', and 'multipleOf' removed. This
+    normalization is recursive and walks nested
     schema structures such as 'properties', 'items', '$defs'/'definitions', and
     composed schemas like 'anyOf'/'oneOf'/'allOf'.
 
@@ -211,7 +213,12 @@ def strip_numeric_bounds(schema: Dict) -> Dict:
             if key in normalized and isinstance(normalized[key], list):
                 normalized[key] = [_normalize(item) for item in normalized[key]]
 
-        if normalized.get("type") in ("integer", "number"):
+        node_type = normalized.get("type")
+        is_numeric = node_type in ("integer", "number") or (
+            isinstance(node_type, list)
+            and any(x in ("integer", "number") for x in node_type)
+        )
+        if is_numeric:
             for key in numeric_bound_keys:
                 normalized.pop(key, None)
 

--- a/libs/core/kiln_ai/datamodel/test_json_schema.py
+++ b/libs/core/kiln_ai/datamodel/test_json_schema.py
@@ -423,6 +423,54 @@ def test_strip_numeric_bounds_nested_structures():
     assert result["$defs"]["Rating"] == {"type": "integer"}
 
 
+def test_strip_numeric_bounds_nullable_types():
+    schema = {
+        "type": "object",
+        "properties": {
+            "five_star": {
+                "type": ["integer", "null"],
+                "minimum": 1,
+                "maximum": 5,
+                "description": "A rating",
+            },
+            "score": {
+                "type": ["number", "null"],
+                "minimum": 0,
+                "maximum": 1,
+                "exclusiveMinimum": 0,
+                "exclusiveMaximum": 1,
+                "multipleOf": 0.1,
+                "title": "Score",
+            },
+            "name": {
+                "type": ["string", "null"],
+                "minLength": 1,
+                "maxLength": 10,
+            },
+        },
+    }
+    result = strip_numeric_bounds(schema)
+
+    # nullable integer node: numeric bounds stripped, other fields intact
+    assert result["properties"]["five_star"] == {
+        "type": ["integer", "null"],
+        "description": "A rating",
+    }
+    # nullable number node: all numeric bound keywords stripped, other fields intact
+    assert result["properties"]["score"] == {
+        "type": ["number", "null"],
+        "title": "Score",
+    }
+    # nullable string node: length keywords are NOT numeric bounds, left intact
+    assert result["properties"]["name"] == {
+        "type": ["string", "null"],
+        "minLength": 1,
+        "maxLength": 10,
+    }
+    # original schema is not mutated
+    assert schema["properties"]["five_star"]["minimum"] == 1
+
+
 def test_close_object_schemas_strict_no_properties():
     schema = {
         "type": "object",

--- a/libs/core/kiln_ai/datamodel/test_json_schema.py
+++ b/libs/core/kiln_ai/datamodel/test_json_schema.py
@@ -10,6 +10,7 @@ from kiln_ai.datamodel.json_schema import (
     schema_from_json_str,
     single_string_field_name,
     string_to_json_key,
+    strip_numeric_bounds,
     validate_schema,
     validate_schema_with_value_error,
 )
@@ -327,6 +328,99 @@ def test_close_object_schemas_non_strict_no_required():
 
     result_explicit = close_object_schemas(schema, strict=False)
     assert "required" not in result_explicit
+
+
+def test_strip_numeric_bounds_integer_and_number():
+    schema = {
+        "type": "object",
+        "properties": {
+            "five_star": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+                "description": "A rating",
+            },
+            "score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "exclusiveMinimum": 0,
+                "exclusiveMaximum": 1,
+                "multipleOf": 0.1,
+                "title": "Score",
+            },
+            "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 10,
+            },
+        },
+    }
+    result = strip_numeric_bounds(schema)
+
+    # integer node: numeric bounds stripped, other fields intact
+    assert result["properties"]["five_star"] == {
+        "type": "integer",
+        "description": "A rating",
+    }
+    # number node: all numeric bound keywords stripped, other fields intact
+    assert result["properties"]["score"] == {
+        "type": "number",
+        "title": "Score",
+    }
+    # string node: length keywords are NOT numeric bounds, left intact
+    assert result["properties"]["name"] == {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 10,
+    }
+    # original schema is not mutated
+    assert schema["properties"]["five_star"]["minimum"] == 1
+
+
+def test_strip_numeric_bounds_nested_structures():
+    schema = {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 10,
+                },
+            },
+            "nested": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "minimum": 0,
+                    },
+                },
+            },
+            "choice": {
+                "anyOf": [
+                    {"type": "integer", "minimum": 1, "maximum": 3},
+                    {"type": "string"},
+                ],
+            },
+        },
+        "$defs": {
+            "Rating": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+            },
+        },
+    }
+    result = strip_numeric_bounds(schema)
+
+    assert result["properties"]["items"]["items"] == {"type": "integer"}
+    assert result["properties"]["nested"]["properties"]["count"] == {"type": "integer"}
+    assert result["properties"]["choice"]["anyOf"][0] == {"type": "integer"}
+    assert result["properties"]["choice"]["anyOf"][1] == {"type": "string"}
+    assert result["$defs"]["Rating"] == {"type": "integer"}
 
 
 def test_close_object_schemas_strict_no_properties():


### PR DESCRIPTION
## What does this PR do?

Fixes an HTTP 400 when running LLM-as-judge (g-eval) evaluations on Claude models routed through **OpenRouter**.

**Root cause:** the g-eval score schema's `five_star` rating field is an `integer` with `minimum: 1, maximum: 5` (`libs/core/kiln_ai/adapters/eval/base_eval.py`). When a Claude model is used via OpenRouter with `structured_output_mode=json_schema`, LiteLLM maps the request onto Anthropic's newer `output_config.format.schema` structured-outputs API, which **rejects `minimum`/`maximum` on integer types** (`output_config.format.schema: For 'integer' type, properties maximum, minimum are not supported`). Anthropic-direct uses a tolerant path, so the failure only appeared on the OpenRouter route.

**Fix:** added a recursive `strip_numeric_bounds()` helper in `libs/core/kiln_ai/datamodel/json_schema.py` that removes numeric-constraint keywords (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`) from every `integer`/`number` node (recursing through `properties`, `items`, `$defs`/`definitions`, `anyOf`/`oneOf`/`allOf`, etc.). It is applied **only** to the `json_schema` wire format in `litellm_adapter.json_schema_response_format()`, right after `close_object_schemas()`. Stored task schemas and post-hoc output validation are untouched — the 1–5 range is still enforced by the prompt and validation, so model outputs remain bounded.

### Test Results

Paid tests (`--runpaid --ollama`). The previously-failing judge tests now pass, and no regressions were observed:

- **Target (was 400):** `test_all_built_in_models_llm_as_judge[claude_sonnet_4_6-openrouter]` ✅ and `[claude_fable_5-openrouter]` ✅.
- **Regression — llm_as_judge:** ✅ gpt_4_1 / gpt_4_1_mini / gpt_4_1_nano (openai + openrouter), gemini_2_5_flash / flash_lite (openrouter), claude_fable_5 and claude_sonnet_4_6 (anthropic + openrouter). (Unrelated failures only from providers with no API key in the test env — azure_openai/vertex/gemini_api — and the delisted `claude_3_5_sonnet`, which uses function_calling mode this change never touches.)
- **Regression — structured output:** ✅ gpt_4_1/mini/nano (openai + openrouter), claude_fable_5 (anthropic + openrouter).
- **Unit tests:** 181 passed in `test_json_schema.py` + `test_litellm_adapter.py`, including new tests asserting `strip_numeric_bounds()` strips integer/number bounds (incl. nested) and leaves other fields intact.

Note: a separate latent issue exists (the Claude OpenRouter provider blocks omit `temp_top_p_exclusive`, so both `temperature` and `top_p` are sent) — it did NOT surface after this fix, so it's left for a possible future follow-up.

## Related Issues

N/A

## Contributor License Agreement

I, @tawnymanticore, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aykiqr3HuYmqhWWMw2vZf3)_