### PR TITLE
Raise a clear error on content-filter / refusal responses instead of a generic empty-content error

### DIFF
--- a/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
@@ -5,7 +5,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncIterator
+from typing import TYPE_CHECKING, Any, AsyncIterator, NoReturn
 
 from litellm.types.utils import ChatCompletionMessageToolCall, Choices, ModelResponse
 
@@ -36,7 +36,7 @@ EMPTY_RESPONSE_ERROR_MESSAGE = (
 
 CONTENT_FILTER_ERROR_MESSAGE = (
     "The model declined to respond to this request (the provider's safety "
-    "classifier returned a content-filter/refusal, finish_reason='content_filter'). "
+    "classifier returned a content-filter/refusal, finish_reason={finish_reason!r}). "
     "This can be a false positive on some models; try rephrasing the prompt or using "
     "a different model."
 )
@@ -50,20 +50,39 @@ def _is_content_filter_finish_reason(finish_reason: Any) -> bool:
     return "content_filter" in normalized or "refusal" in normalized
 
 
-def raise_for_empty_model_response(response_choice: Choices) -> None:
+def raise_for_empty_model_response(response_choice: Any) -> NoReturn:
     """
     Raise a clear error when a model returns an assistant message with no content
     and no tool calls.
 
-    When the empty response is due to a provider content-filter/refusal (e.g.
-    Anthropic's stop_reason "refusal", which LiteLLM maps to
-    finish_reason='content_filter'), raise a specific, actionable error rather than
-    the generic "no content or tool calls" message.
+    When the empty response is due to a provider content-filter/refusal, raise a
+    specific, actionable error rather than the generic "no content or tool calls"
+    message. This covers two provider signals:
+
+    - a content-filter/refusal ``finish_reason`` (e.g. Anthropic's stop_reason
+      "refusal", which LiteLLM maps to finish_reason='content_filter'), and
+    - OpenAI's ``message.refusal`` field, which can be populated while
+      ``finish_reason`` remains 'stop'.
+
+    Accepts either a dict-shaped or object-shaped choice.
     """
-    if _is_content_filter_finish_reason(
-        getattr(response_choice, "finish_reason", None)
-    ):
-        raise ValueError(CONTENT_FILTER_ERROR_MESSAGE)
+    if isinstance(response_choice, dict):
+        finish_reason = response_choice.get("finish_reason")
+        message = response_choice.get("message")
+        refusal = (
+            message.get("refusal")
+            if isinstance(message, dict)
+            else getattr(message, "refusal", None)
+        )
+    else:
+        finish_reason = getattr(response_choice, "finish_reason", None)
+        message = getattr(response_choice, "message", None)
+        refusal = getattr(message, "refusal", None) if message is not None else None
+
+    if refusal or _is_content_filter_finish_reason(finish_reason):
+        raise ValueError(
+            CONTENT_FILTER_ERROR_MESSAGE.format(finish_reason=finish_reason)
+        )
     raise ValueError(EMPTY_RESPONSE_ERROR_MESSAGE)
 
 

--- a/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
@@ -29,6 +29,43 @@ MAX_TOOL_CALLS_PER_TURN = 30
 
 logger = logging.getLogger(__name__)
 
+EMPTY_RESPONSE_ERROR_MESSAGE = (
+    "Model returned an assistant message, but no content or tool calls. "
+    "This is not supported."
+)
+
+CONTENT_FILTER_ERROR_MESSAGE = (
+    "The model declined to respond to this request (the provider's safety "
+    "classifier returned a content-filter/refusal, finish_reason='content_filter'). "
+    "This can be a false positive on some models; try rephrasing the prompt or using "
+    "a different model."
+)
+
+
+def _is_content_filter_finish_reason(finish_reason: Any) -> bool:
+    """Return True if the finish/stop reason indicates a content-filter/refusal."""
+    if not finish_reason:
+        return False
+    normalized = str(finish_reason).lower()
+    return "content_filter" in normalized or "refusal" in normalized
+
+
+def raise_for_empty_model_response(response_choice: Choices) -> None:
+    """
+    Raise a clear error when a model returns an assistant message with no content
+    and no tool calls.
+
+    When the empty response is due to a provider content-filter/refusal (e.g.
+    Anthropic's stop_reason "refusal", which LiteLLM maps to
+    finish_reason='content_filter'), raise a specific, actionable error rather than
+    the generic "no content or tool calls" message.
+    """
+    if _is_content_filter_finish_reason(
+        getattr(response_choice, "finish_reason", None)
+    ):
+        raise ValueError(CONTENT_FILTER_ERROR_MESSAGE)
+    raise ValueError(EMPTY_RESPONSE_ERROR_MESSAGE)
+
 
 @dataclass
 class AdapterStreamResult:
@@ -184,9 +221,7 @@ class AdapterStream:
             content = response_choice.message.content
             tool_calls = response_choice.message.tool_calls
             if not content and not tool_calls:
-                raise ValueError(
-                    "Model returned an assistant message, but no content or tool calls. This is not supported."
-                )
+                raise_for_empty_model_response(response_choice)
 
             self._messages.append(response_choice.message)
             self._message_latency[len(self._messages) - 1] = call_latency_ms

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -28,6 +28,7 @@ from kiln_ai.adapters.ml_model_list import (
     StructuredOutputMode,
 )
 from kiln_ai.adapters.model_adapters.adapter_stream import (
+    EMPTY_RESPONSE_ERROR_MESSAGE,
     AdapterStream,
     raise_for_empty_model_response,
 )
@@ -974,9 +975,7 @@ class LiteLlmAdapter(BaseAdapter):
             message["usage"] = usage
 
         if not message.get("content") and not message.get("tool_calls"):
-            raise ValueError(
-                "Model returned an assistant message, but no content or tool calls. This is not supported."
-            )
+            raise ValueError(EMPTY_RESPONSE_ERROR_MESSAGE)
 
         return message
 

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -27,7 +27,10 @@ from kiln_ai.adapters.ml_model_list import (
     ModelProviderName,
     StructuredOutputMode,
 )
-from kiln_ai.adapters.model_adapters.adapter_stream import AdapterStream
+from kiln_ai.adapters.model_adapters.adapter_stream import (
+    AdapterStream,
+    raise_for_empty_model_response,
+)
 from kiln_ai.adapters.model_adapters.base_adapter import (
     AdapterConfig,
     BaseAdapter,
@@ -166,9 +169,7 @@ class LiteLlmAdapter(BaseAdapter):
             content = response_choice.message.content
             tool_calls = response_choice.message.tool_calls
             if not content and not tool_calls:
-                raise ValueError(
-                    "Model returned an assistant message, but no content or tool calls. This is not supported."
-                )
+                raise_for_empty_model_response(response_choice)
 
             # Add message to messages, so it can be used in the next turn
             messages.append(response_choice.message)

--- a/libs/core/kiln_ai/adapters/model_adapters/test_adapter_stream.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_adapter_stream.py
@@ -565,6 +565,33 @@ class TestAdapterStreamEdgeCases:
                 async for _ in stream:
                     pass
 
+    @pytest.mark.asyncio
+    async def test_content_filter_raises_specific_error(
+        self, mock_adapter, mock_provider
+    ):
+        response = _make_model_response(content=None, tool_calls=None)
+        response.choices[0].message.content = None
+        response.choices[0].finish_reason = "content_filter"
+        fake_stream = FakeStreamingCompletion(
+            response, [_make_streaming_chunk(finish_reason="content_filter")]
+        )
+
+        with patch(
+            "kiln_ai.adapters.model_adapters.adapter_stream.StreamingCompletion",
+            return_value=fake_stream,
+        ):
+            stream = AdapterStream(
+                adapter=mock_adapter,
+                provider=mock_provider,
+                chat_formatter=FakeChatFormatter(),
+                initial_messages=[],
+                top_logprobs=None,
+            )
+            with pytest.raises(ValueError, match="content-filter/refusal") as exc_info:
+                async for _ in stream:
+                    pass
+        assert "no content or tool calls" not in str(exc_info.value)
+
 
 class TestAdapterStreamPerMessageUsage:
     """Per-message usage capture mirroring the non-streaming adapter."""

--- a/libs/core/kiln_ai/adapters/model_adapters/test_adapter_stream.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_adapter_stream.py
@@ -15,7 +15,10 @@ from litellm.types.utils import (
 from litellm.types.utils import Message as LiteLLMMessage
 
 from kiln_ai.adapters.chat import ChatFormatter
-from kiln_ai.adapters.model_adapters.adapter_stream import AdapterStream
+from kiln_ai.adapters.model_adapters.adapter_stream import (
+    AdapterStream,
+    raise_for_empty_model_response,
+)
 from kiln_ai.adapters.model_adapters.stream_events import (
     ToolCallEvent,
     ToolCallEventType,
@@ -591,6 +594,66 @@ class TestAdapterStreamEdgeCases:
                 async for _ in stream:
                     pass
         assert "no content or tool calls" not in str(exc_info.value)
+        # The actual finish_reason is interpolated (repr renders as 'content_filter').
+        assert "finish_reason='content_filter'" in str(exc_info.value)
+
+
+class TestRaiseForEmptyModelResponse:
+    """Direct unit tests for raise_for_empty_model_response."""
+
+    def test_content_filter_finish_reason_object(self):
+        choice = MagicMock()
+        choice.finish_reason = "content_filter"
+        choice.message = MagicMock(refusal=None)
+        with pytest.raises(ValueError, match="content-filter/refusal") as exc_info:
+            raise_for_empty_model_response(choice)
+        assert "finish_reason='content_filter'" in str(exc_info.value)
+
+    def test_refusal_finish_reason_interpolated(self):
+        choice = MagicMock()
+        choice.finish_reason = "refusal"
+        choice.message = MagicMock(refusal=None)
+        with pytest.raises(ValueError, match="content-filter/refusal") as exc_info:
+            raise_for_empty_model_response(choice)
+        assert "finish_reason='refusal'" in str(exc_info.value)
+
+    def test_message_refusal_field_object_style(self):
+        # message.refusal set while finish_reason stays 'stop' (OpenAI behavior).
+        choice = MagicMock()
+        choice.finish_reason = "stop"
+        choice.message = MagicMock(refusal="I cannot help with that request.")
+        with pytest.raises(ValueError, match="content-filter/refusal") as exc_info:
+            raise_for_empty_model_response(choice)
+        assert "no content or tool calls" not in str(exc_info.value)
+
+    def test_message_refusal_field_dict_style(self):
+        choice = {
+            "finish_reason": "stop",
+            "message": {
+                "content": None,
+                "tool_calls": None,
+                "refusal": "I cannot help with that request.",
+            },
+        }
+        with pytest.raises(ValueError, match="content-filter/refusal") as exc_info:
+            raise_for_empty_model_response(choice)
+        assert "no content or tool calls" not in str(exc_info.value)
+
+    def test_normal_empty_stop_raises_generic(self):
+        choice = MagicMock()
+        choice.finish_reason = "stop"
+        choice.message = MagicMock(refusal=None)
+        with pytest.raises(ValueError, match="no content or tool calls"):
+            raise_for_empty_model_response(choice)
+
+    def test_non_matching_finish_reason_raises_generic(self):
+        # Exercises the _is_content_filter_finish_reason `return False` branch.
+        choice = MagicMock()
+        choice.finish_reason = "length"
+        choice.message = MagicMock(refusal=None)
+        with pytest.raises(ValueError, match="no content or tool calls") as exc_info:
+            raise_for_empty_model_response(choice)
+        assert "content-filter/refusal" not in str(exc_info.value)
 
 
 class TestAdapterStreamPerMessageUsage:

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -3292,10 +3292,46 @@ class TestEmptyResponseErrors:
                 "acompletion_checking_response",
                 return_value=(response, response.choices[0]),
             ):
-                with pytest.raises(ValueError, match="content-filter/refusal"):
+                with pytest.raises(
+                    ValueError, match="content-filter/refusal"
+                ) as exc_info:
                     await adapter._run_model_turn(
                         provider, [{"role": "user", "content": "Hi"}], None, False
                     )
+        # LiteLLM normalizes a "refusal" stop reason to finish_reason='content_filter'
+        # on a real ModelResponse; the actual (normalized) value is interpolated.
+        assert "finish_reason='content_filter'" in str(exc_info.value)
+        assert "no content or tool calls" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_message_refusal_field_raises_specific_error(self, adapter, provider):
+        # OpenAI can signal a refusal via message.refusal while finish_reason='stop'.
+        response = ModelResponse(
+            model="test-model",
+            choices=[
+                {
+                    "message": {
+                        "content": None,
+                        "tool_calls": None,
+                        "refusal": "I cannot help with that request.",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+        )
+        with patch.object(adapter, "build_completion_kwargs", return_value={}):
+            with patch.object(
+                adapter,
+                "acompletion_checking_response",
+                return_value=(response, response.choices[0]),
+            ):
+                with pytest.raises(
+                    ValueError, match="content-filter/refusal"
+                ) as exc_info:
+                    await adapter._run_model_turn(
+                        provider, [{"role": "user", "content": "Hi"}], None, False
+                    )
+        assert "no content or tool calls" not in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_normal_finish_reason_raises_generic_error(self, adapter, provider):

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -12,6 +12,7 @@ from litellm.types.utils import (
 )
 
 from kiln_ai.adapters.ml_model_list import (
+    KilnModelProvider,
     ModelName,
     ModelProviderName,
     StructuredOutputMode,
@@ -3237,3 +3238,92 @@ class TestUsageTracking:
         assert new_usage.input_tokens == 3
         assert new_usage.output_tokens == 4
         assert new_usage.cost == 0.05
+
+
+class TestEmptyResponseErrors:
+    """Empty-content responses should raise a clear, finish_reason-aware error."""
+
+    @pytest.fixture
+    def adapter(self, config, mock_task):
+        return LiteLlmAdapter(config=config, kiln_task=mock_task)
+
+    @pytest.fixture
+    def provider(self):
+        return KilnModelProvider(
+            name=ModelProviderName.openrouter, model_id="test-model"
+        )
+
+    def _empty_response(self, finish_reason):
+        return ModelResponse(
+            model="test-model",
+            choices=[
+                {
+                    "message": {"content": None, "tool_calls": None},
+                    "finish_reason": finish_reason,
+                }
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_content_filter_raises_specific_error(self, adapter, provider):
+        response = self._empty_response("content_filter")
+        with patch.object(adapter, "build_completion_kwargs", return_value={}):
+            with patch.object(
+                adapter,
+                "acompletion_checking_response",
+                return_value=(response, response.choices[0]),
+            ):
+                with pytest.raises(
+                    ValueError, match="content-filter/refusal"
+                ) as exc_info:
+                    await adapter._run_model_turn(
+                        provider, [{"role": "user", "content": "Hi"}], None, False
+                    )
+        # It must NOT be the generic message.
+        assert "no content or tool calls" not in str(exc_info.value)
+        assert "finish_reason='content_filter'" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_refusal_finish_reason_raises_specific_error(self, adapter, provider):
+        response = self._empty_response("refusal")
+        with patch.object(adapter, "build_completion_kwargs", return_value={}):
+            with patch.object(
+                adapter,
+                "acompletion_checking_response",
+                return_value=(response, response.choices[0]),
+            ):
+                with pytest.raises(ValueError, match="content-filter/refusal"):
+                    await adapter._run_model_turn(
+                        provider, [{"role": "user", "content": "Hi"}], None, False
+                    )
+
+    @pytest.mark.asyncio
+    async def test_normal_finish_reason_raises_generic_error(self, adapter, provider):
+        response = self._empty_response("stop")
+        with patch.object(adapter, "build_completion_kwargs", return_value={}):
+            with patch.object(
+                adapter,
+                "acompletion_checking_response",
+                return_value=(response, response.choices[0]),
+            ):
+                with pytest.raises(
+                    ValueError, match="no content or tool calls"
+                ) as exc_info:
+                    await adapter._run_model_turn(
+                        provider, [{"role": "user", "content": "Hi"}], None, False
+                    )
+        assert "content-filter/refusal" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_missing_finish_reason_raises_generic_error(self, adapter, provider):
+        response = self._empty_response(None)
+        with patch.object(adapter, "build_completion_kwargs", return_value={}):
+            with patch.object(
+                adapter,
+                "acompletion_checking_response",
+                return_value=(response, response.choices[0]),
+            ):
+                with pytest.raises(ValueError, match="no content or tool calls"):
+                    await adapter._run_model_turn(
+                        provider, [{"role": "user", "content": "Hi"}], None, False
+                    )


### PR DESCRIPTION
## What does this PR do?

Improves the error Kiln surfaces when a provider returns an assistant message with **empty content, no tool calls, and `finish_reason='content_filter'`** (Anthropic maps its `stop_reason:"refusal"` to LiteLLM's `finish_reason='content_filter'`).

Previously Kiln raised the generic, misleading `"Model returned an assistant message, but no content or tool calls. This is not supported."`, which hid the real reason (the provider's safety classifier declined the request). Now it raises a specific, actionable error.

**Background:** while validating Claude Fable 5, its plaintext/CoT generations deterministically failed. A probe showed the model wasn't truncated (LiteLLM sent the full `max_tokens: 128000`) — it returned `finish_reason='content_filter'` with empty content (`completion_tokens=2`). Isolating tests showed this is a **benign false-positive safety-classifier refusal** triggered by a specific eval prompt's phrasing; the model answers fine on clean prompts. This PR does **not** change model behavior — it just reports the refusal honestly instead of a confusing empty-content error.

**Change:** added a shared helper `raise_for_empty_model_response(response_choice)` in `adapter_stream.py` that inspects `finish_reason`; if it indicates content-filter/refusal (tolerant match on `content_filter`/`refusal`) it raises a clear message, otherwise the unchanged generic error. Wired into both the run path (`litellm_adapter._run_model_turn`) and the streaming path (`adapter_stream._stream_model_turn`). Same `ValueError` type as before.

New message:
> The model declined to respond to this request (the provider's safety classifier returned a content-filter/refusal, finish_reason='content_filter'). This can be a false positive on some models; try rephrasing the prompt or using a different model.

### Test Results

- **Unit tests:** 172 passed across `test_litellm_adapter.py` + `test_adapter_stream.py`, including new tests covering `finish_reason` = `content_filter`, `refusal`, `stop`, and `None` (assert the specific message for filter/refusal, and the unchanged generic message otherwise).
- **Paid confirmation:** a real Fable 5 refusal now surfaces the new clear message (the call still fails because the model refuses — expected). Regression: `test_all_models_providers_plaintext[gpt_4_1_nano-openai]` passes (normal empty-content/non-filter behavior unchanged).

## Related Issues

N/A

## Contributor License Agreement

I, @tawnymanticore, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aykiqr3HuYmqhWWMw2vZf3)_