### PR TITLE
Per-conversation spend budget for the Kiln Assistant

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,5 +38,13 @@
   },
   "eslint.validate": ["javascript", "javascriptreact", "typescript", "svelte"],
   "typescript.preferences.importModuleSpecifier": "shortest",
-  "typescript.suggest.autoImports": true
+  "typescript.suggest.autoImports": true,
+  "cursorpyright.analysis.autoImportCompletions": true,
+  "cursorpyright.analysis.extraPaths": [
+    "./"
+  ],
+  "cursorpyright.analysis.ignore": [
+    "**/test_*.py"
+  ],
+  "cursorpyright.analysis.typeCheckingMode": "basic"
 }

--- a/app/desktop/desktop_server.py
+++ b/app/desktop/desktop_server.py
@@ -23,6 +23,7 @@ from app.desktop.git_sync.background_sync import BackgroundSync
 from app.desktop.git_sync.config import get_git_sync_config
 from app.desktop.git_sync.git_sync_api import connect_git_sync_api
 from app.desktop.git_sync.middleware import GitSyncMiddleware
+from app.desktop.studio_server.budget_middleware import BudgetContextMiddleware
 from app.desktop.git_sync.registry import GitSyncRegistry
 from app.desktop.log_config import log_config
 from app.desktop.studio_server.agent_api import connect_agent_api
@@ -139,7 +140,12 @@ def make_app(tk_root: tk.Tk | None = None):
     # CORSMiddleware and receive CORS headers. Adding it here with
     # app.add_middleware() would make it outermost, bypassing CORS and causing
     # the browser to block git-sync error responses ("origin not allowed").
-    app = kiln_server.make_app(lifespan=lifespan, extra_middleware=[GitSyncMiddleware])
+    # BudgetContextMiddleware attributes assistant-triggered requests (via the
+    # X-Kiln-Conversation-Id header) to a conversation's spend ledger.
+    app = kiln_server.make_app(
+        lifespan=lifespan,
+        extra_middleware=[GitSyncMiddleware, BudgetContextMiddleware],
+    )
     connect_provider_api(app)
     connect_prompt_api(app)
     connect_repair_api(app)

--- a/app/desktop/studio_server/budget_middleware.py
+++ b/app/desktop/studio_server/budget_middleware.py
@@ -1,0 +1,32 @@
+"""Middleware attributing local API requests to an assistant conversation.
+
+The assistant's ``call_kiln_api`` tool stamps ``X-Kiln-Conversation-Id`` on the
+requests it makes to this server. This middleware reads that header into the
+``spend_ledger.current_conversation_id`` contextvar for the duration of the
+request, so model runs executed while handling it (task runs, evals, judges,
+data gen) credit the conversation's spend ledger — see
+``spend_ledger.record_spend_for_current_conversation``, called from the LiteLLM
+adapter per LLM call.
+
+Requests without the header (everything user-initiated) leave the contextvar
+unset and are never budget-tracked.
+"""
+
+from kiln_ai.utils import spend_ledger
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+
+class BudgetContextMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        conversation_id = request.headers.get(spend_ledger.CONVERSATION_ID_HEADER)
+        if conversation_id is None or not spend_ledger.is_valid_conversation_id(
+            conversation_id
+        ):
+            return await call_next(request)
+
+        token = spend_ledger.current_conversation_id.set(conversation_id)
+        try:
+            return await call_next(request)
+        finally:
+            spend_ledger.current_conversation_id.reset(token)

--- a/app/desktop/studio_server/chat/auto/api.py
+++ b/app/desktop/studio_server/chat/auto/api.py
@@ -44,6 +44,11 @@ class DeclineAutoRequest(BaseModel):
     # for. Normally empty (the model is instructed to call enable_auto_mode alone);
     # each is resolved as denied so the conversation can continue interactively.
     siblings: list[ToolCallInfo] = Field(default_factory=list)
+    # Stable conversation identity (uuid4) for spend budgeting. No auto run exists
+    # on the decline path (the user declined at the consent gate), so the id must
+    # come from the client rather than run state — without it the post-decline
+    # interactive continuation would bypass the budget gate.
+    conversation_id: str | None = None
 
 
 class SendMessageRequest(BaseModel):
@@ -147,10 +152,16 @@ def connect_chat_auto_api(app: FastAPI) -> None:
                     "content": DENIED_TOOL_OUTPUT,
                 }
             )
+        initial_body: dict[str, Any] = {
+            "trace_id": body.trace_id,
+            "messages": messages,
+        }
+        if body.conversation_id is not None:
+            initial_body["conversation_id"] = body.conversation_id
         session = ChatStreamSession(
             upstream_url=_upstream_chat_url(),
             headers=_build_upstream_headers(api_key),
-            initial_body={"trace_id": body.trace_id, "messages": messages},
+            initial_body=initial_body,
         )
         return CancellableStreamingResponse(
             content=session.stream(),

--- a/app/desktop/studio_server/chat/auto/models.py
+++ b/app/desktop/studio_server/chat/auto/models.py
@@ -103,6 +103,12 @@ class AutoRunRecord(BaseModel):
 
     run_id: str
     status: AutoRunStatus
+    # Stable conversation identity (uuid4) for spend budgeting. Persisted on the
+    # run so it survives seed reconstruction: an idle→running resume (send_message)
+    # builds a FRESH seed, so the id must be recovered from run state rather than
+    # re-supplied by the client — otherwise the resumed burst runs unattributed
+    # and the budget gate never fires.
+    conversation_id: str | None = None
     # Latest persisted leaf the runner has seen. Optional (Revision R2): a
     # no-trace seed (brand-new conversation) has no leaf until the backend emits
     # the first kiln_chat_trace, at which point _on_trace populates it.

--- a/app/desktop/studio_server/chat/auto/models.py
+++ b/app/desktop/studio_server/chat/auto/models.py
@@ -93,6 +93,9 @@ class AutoChatSeed(BaseModel):
     pending_tool_calls: list[ToolCallInfo] = Field(default_factory=list)
     # Extra messages to prepend (e.g. a new user message on the manual idle path).
     extra_messages: list[dict[str, Any]] = Field(default_factory=list)
+    # Stable conversation identity (uuid4) for spend budgeting; forwarded on
+    # every upstream request the runner makes and threaded into tool execution.
+    conversation_id: str | None = None
 
 
 class AutoRunRecord(BaseModel):

--- a/app/desktop/studio_server/chat/auto/registry.py
+++ b/app/desktop/studio_server/chat/auto/registry.py
@@ -295,6 +295,9 @@ class AutoChatRegistry:
         record = AutoRunRecord(
             run_id=run_id,
             status=AutoRunStatus.IDLE if is_armed_only else AutoRunStatus.RUNNING,
+            # Stable for the life of the run; recovered into the resume seed so
+            # an idle→running resume keeps crediting/gating the conversation.
+            conversation_id=seed.conversation_id,
             # Revision R2: a no-trace seed (brand-new conversation) has no leaf
             # until the backend emits the first kiln_chat_trace; _on_trace then
             # populates current_trace_id / seen_trace_ids / the trace index.
@@ -358,10 +361,13 @@ class AutoChatRegistry:
             run.enqueue(message)
             return True
 
-        # IDLE → start a new burst seeded with the queued message(s).
+        # IDLE → start a new burst seeded with the queued message(s). Carry the
+        # conversation_id forward from run state (the client doesn't re-send it
+        # on /message) so the resumed burst still credits + gates spend.
         seed = AutoChatSeed(
             trace_id=message.trace_id or run.record.current_trace_id,
             extra_messages=[message.as_chat_message()],
+            conversation_id=run.record.conversation_id,
         )
         run.record.status = AutoRunStatus.RUNNING
         run.start_burst(seed)

--- a/app/desktop/studio_server/chat/auto/runner.py
+++ b/app/desktop/studio_server/chat/auto/runner.py
@@ -276,7 +276,9 @@ class AutoChatRunner:
                 ]
 
                 self._emit(format_tool_exec_start(len(client_events)))
-                results = await execute_tool_batch(tool_calls, {})
+                results = await execute_tool_batch(
+                    tool_calls, {}, conversation_id=self._seed.conversation_id
+                )
                 for e in enable_events:
                     results[e.toolCallId] = ENABLE_AUTO_MODE_RESULT
                 for tc_id, output in results.items():
@@ -395,6 +397,7 @@ class AutoChatRunner:
                     for e in siblings
                 ],
                 {},
+                conversation_id=self._seed.conversation_id,
             )
             if siblings
             else {}
@@ -495,7 +498,9 @@ class AutoChatRunner:
                 )
                 for tc in self._seed.pending_tool_calls
             ]
-            results = await execute_tool_batch(siblings, {})
+            results = await execute_tool_batch(
+                siblings, {}, conversation_id=self._seed.conversation_id
+            )
             for tc_id, output in results.items():
                 messages.append(
                     {
@@ -508,11 +513,12 @@ class AutoChatRunner:
         # auto_mode rides every continuation: each builder below does {**body, ...},
         # so seeding it once here propagates it through the whole burst. The
         # upstream orchestrator reads it to phrase the auto-round-cap reminder for
-        # an absent user (act or report stuck, don't ask a question).
-        if self._seed.trace_id is None:
-            return {"messages": messages, "auto_mode": True}
-        return {
-            "trace_id": self._seed.trace_id,
-            "messages": messages,
-            "auto_mode": True,
-        }
+        # an absent user (act or report stuck, don't ask a question). The same
+        # propagation carries conversation_id so the backend persists it on
+        # every snapshot in the burst.
+        body: dict[str, Any] = {"messages": messages, "auto_mode": True}
+        if self._seed.trace_id is not None:
+            body["trace_id"] = self._seed.trace_id
+        if self._seed.conversation_id is not None:
+            body["conversation_id"] = self._seed.conversation_id
+        return body

--- a/app/desktop/studio_server/chat/auto/test_api.py
+++ b/app/desktop/studio_server/chat/auto/test_api.py
@@ -305,6 +305,40 @@ async def test_decline_resumes_interactive_stream(client, registry, mock_api_key
     }
 
 
+@pytest.mark.asyncio
+async def test_decline_threads_conversation_id(client, registry, mock_api_key):
+    # No auto run exists on the decline path, so the conversation_id must come
+    # from the client and be forwarded into the interactive continuation so its
+    # call_kiln_api calls stay budget-gated.
+    conversation_id = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+    continuation = [sse_text_delta("continuing"), finish("stop")]
+    fake = FakeUpstreamClient([FakeUpstreamResponse(chunks=continuation)])
+    with patch.object(httpx, "AsyncClient", return_value=fake):
+        r = await client.post(
+            "/api/chat/auto/decline",
+            json={
+                "trace_id": "t1",
+                "enable_tool_call_id": "tc_enable",
+                "conversation_id": conversation_id,
+            },
+        )
+    assert r.status_code == 200
+    assert fake.bodies[0]["conversation_id"] == conversation_id
+
+
+@pytest.mark.asyncio
+async def test_decline_without_conversation_id_omits_it(client, registry, mock_api_key):
+    continuation = [sse_text_delta("continuing"), finish("stop")]
+    fake = FakeUpstreamClient([FakeUpstreamResponse(chunks=continuation)])
+    with patch.object(httpx, "AsyncClient", return_value=fake):
+        r = await client.post(
+            "/api/chat/auto/decline",
+            json={"trace_id": "t1", "enable_tool_call_id": "tc_enable"},
+        )
+    assert r.status_code == 200
+    assert "conversation_id" not in fake.bodies[0]
+
+
 # ── stop ─────────────────────────────────────────────────────────────────────
 
 

--- a/app/desktop/studio_server/chat/auto/test_registry.py
+++ b/app/desktop/studio_server/chat/auto/test_registry.py
@@ -487,6 +487,48 @@ async def test_send_message_while_idle_starts_new_burst():
 
 
 @pytest.mark.asyncio
+async def test_idle_resume_carries_conversation_id_from_run_state():
+    # Regression: an idle→running resume rebuilds a fresh AutoChatSeed. The
+    # conversation_id must be recovered from run state (the client does not
+    # re-send it on /message), otherwise the resumed burst runs with
+    # conversation_id=None — silently disabling the budget gate and spend
+    # tracking for exactly the "budget exhausted → extend → continue" flow.
+    conversation_id = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+    reg = AutoChatRegistry()
+    burst1 = [trace("tr-1"), text_delta("hi"), finish("stop")]
+    burst2 = [trace("tr-2"), text_delta("resumed"), finish("stop")]
+    client = FakeUpstreamClient(
+        [FakeUpstreamResponse(chunks=burst1), FakeUpstreamResponse(chunks=burst2)]
+    )
+    seed = AutoChatSeed(
+        trace_id="tr-0",
+        enable_tool_call_id="enable-1",
+        conversation_id=conversation_id,
+    )
+    with patch.object(httpx, "AsyncClient", return_value=client):
+        rec = reg.start(seed, reason=None, upstream_url=URL, headers={})
+        # The run persists the identity so it survives seed reconstruction.
+        run = reg.get(rec.run_id)
+        assert run is not None
+        assert run.record.conversation_id == conversation_id
+
+        await _wait_settled(reg, rec.run_id)
+        assert run.record.status == AutoRunStatus.IDLE
+
+        # Resume via /message WITHOUT re-supplying conversation_id.
+        accepted = reg.send_message(
+            rec.run_id, InboundMessage(content="resume please", trace_id="tr-1")
+        )
+        assert accepted is True
+        await _wait_settled(reg, rec.run_id)
+
+    # The resumed burst's upstream continuation carries the conversation_id,
+    # so the backend keeps persisting it and the gate/credit stay active.
+    second_body = client.bodies[1]
+    assert second_body["conversation_id"] == conversation_id
+
+
+@pytest.mark.asyncio
 async def test_send_message_unknown_or_off_returns_false():
     reg = AutoChatRegistry()
     assert reg.send_message("ar_nope", InboundMessage(content="x")) is False

--- a/app/desktop/studio_server/chat/auto/test_runner.py
+++ b/app/desktop/studio_server/chat/auto/test_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -835,3 +836,56 @@ async def test_graceful_stop_drops_queued_inbound_on_plain_text():
     assert runner.status == AutoRunStatus.USER_STOPPED
     # No second round despite the queued message.
     assert len(client.bodies) == 1
+
+
+CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+
+
+class TestSeedConversationId:
+    @pytest.mark.asyncio
+    async def test_seed_body_carries_conversation_id(self):
+        seed = AutoChatSeed(
+            trace_id="tr-0",
+            enable_tool_call_id="enable-1",
+            conversation_id=CONVERSATION_ID,
+        )
+        runner, _, _ = _runner(FakeUpstreamClient([]), seed)
+        body = await runner._build_seed_body()
+        assert body["conversation_id"] == CONVERSATION_ID
+
+    @pytest.mark.asyncio
+    async def test_seed_body_omits_conversation_id_when_absent(self):
+        seed = AutoChatSeed(trace_id="tr-0", enable_tool_call_id="enable-1")
+        runner, _, _ = _runner(FakeUpstreamClient([]), seed)
+        body = await runner._build_seed_body()
+        assert "conversation_id" not in body
+
+    @pytest.mark.asyncio
+    async def test_auto_executed_tools_receive_conversation_id(self):
+        seed = AutoChatSeed(trace_id="tr-0", conversation_id=CONVERSATION_ID)
+        round1 = [
+            tool_input_available("tc-1", "multiply", {"a": 2, "b": 3}),
+            trace("tr-1"),
+            finish_tool_calls(),
+        ]
+        round2 = [text_delta("done"), trace("tr-2"), finish("stop")]
+        client = FakeUpstreamClient(
+            [FakeUpstreamResponse(chunks=round1), FakeUpstreamResponse(chunks=round2)]
+        )
+        runner, _, _ = _runner(client, seed)
+        # Patch via the runner class's own module object: under pytest-xdist the
+        # package can be imported under an aliased name, so a string target can
+        # hit a different module object than the one the runner actually uses.
+        runner_module = sys.modules[AutoChatRunner.__module__]
+        with (
+            patch.object(httpx, "AsyncClient", return_value=client),
+            patch.object(
+                runner_module,
+                "execute_tool_batch",
+                new=AsyncMock(return_value={"tc-1": "6"}),
+            ) as batch_mock,
+        ):
+            await runner.run()
+        assert batch_mock.call_args.kwargs["conversation_id"] == CONVERSATION_ID
+        # The continuation body keeps carrying it upstream.
+        assert client.bodies[1]["conversation_id"] == CONVERSATION_ID

--- a/app/desktop/studio_server/chat/constants.py
+++ b/app/desktop/studio_server/chat/constants.py
@@ -28,8 +28,21 @@ SSE_TYPE_AUTO_MODE_STATE = "auto-mode-state"
 DENIED_TOOL_OUTPUT = json.dumps(
     {"error": "The user did not accept the toolcall"}, ensure_ascii=False
 )
+# Returned instead of dispatching call_kiln_api when the conversation's spend
+# budget is exhausted. Reads as a normal tool error so the model relays it and
+# stops triggering operations; only the user can extend the budget (the
+# budget-set endpoint is DENY_AGENT).
+BUDGET_EXCEEDED_TOOL_OUTPUT = json.dumps(
+    {
+        "error": "The conversation's spend budget is exhausted. This operation was "
+        "not run. Do not retry. Tell the user they can extend the budget from the "
+        "budget control in the chat UI if they want you to continue."
+    },
+    ensure_ascii=False,
+)
+CALL_KILN_API_TOOL_NAME = "call_kiln_api"
 FUNCTION_NAME_TO_TOOL_ID: dict[str, str] = {
-    "call_kiln_api": KilnBuiltInToolId.CALL_KILN_API,
+    CALL_KILN_API_TOOL_NAME: KilnBuiltInToolId.CALL_KILN_API,
     "add": KilnBuiltInToolId.ADD_NUMBERS,
     "subtract": KilnBuiltInToolId.SUBTRACT_NUMBERS,
     "multiply": KilnBuiltInToolId.MULTIPLY_NUMBERS,

--- a/app/desktop/studio_server/chat/routes.py
+++ b/app/desktop/studio_server/chat/routes.py
@@ -32,7 +32,8 @@ from fastapi import FastAPI, HTTPException, Path, Query
 from fastapi.responses import StreamingResponse
 from kiln_server.cancellable_streaming_response import CancellableStreamingResponse
 from kiln_server.git_sync_decorators import no_write_lock
-from kiln_server.utils.agent_checks.policy import DENY_AGENT
+from kiln_ai.utils import spend_ledger
+from kiln_server.utils.agent_checks.policy import ALLOW_AGENT, DENY_AGENT
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
@@ -141,6 +142,10 @@ class ChatSessionSnapshot(BaseModel):
     id: str
     task_run: TaskRunSnapshot
     context_usage: ContextUsage | None = None
+    # Stable conversation identity persisted upstream; lets a client that lost
+    # local state (new tab, history restore) re-learn it and re-bind the
+    # conversation's spend budget.
+    conversation_id: str | None = None
 
 
 class ChatRequestMessage(BaseModel):
@@ -155,6 +160,10 @@ class ChatRequest(BaseModel):
 
     messages: list[ChatRequestMessage]
     trace_id: str | None = None
+    # Client-minted stable conversation identity (uuid4). Forwarded upstream
+    # (the copilot backend persists it on snapshots) and used locally to key
+    # the conversation's spend budget.
+    conversation_id: str | None = None
 
 
 class ExecuteToolsRequest(BaseModel):
@@ -163,6 +172,38 @@ class ExecuteToolsRequest(BaseModel):
     trace_id: str
     tool_calls: list[ToolCallInfo]
     decisions: dict[str, bool]
+    conversation_id: str | None = None
+
+
+class BudgetStatusResponse(BaseModel):
+    """A conversation's spend-budget state, from the local spend ledger."""
+
+    conversation_id: str
+    budget_usd: float | None = None
+    spent_usd: float = 0.0
+    remaining_usd: float | None = None
+    exhausted: bool = False
+    # Model calls LiteLLM couldn't price (local/custom models); they debit
+    # nothing, so when > 0 the budget is only partially tracked.
+    unpriced_runs: int = 0
+    unpriced_tokens: int = 0
+
+    @classmethod
+    def from_status(cls, status: spend_ledger.BudgetStatus) -> "BudgetStatusResponse":
+        return cls(
+            conversation_id=status.conversation_id,
+            budget_usd=status.budget_usd,
+            spent_usd=status.spent_usd,
+            remaining_usd=status.remaining_usd,
+            exhausted=status.exhausted,
+            unpriced_runs=status.unpriced_runs,
+            unpriced_tokens=status.unpriced_tokens,
+        )
+
+
+class SetBudgetRequest(BaseModel):
+    # None clears the budget (spend tracking continues).
+    budget_usd: float | None = None
 
 
 def connect_chat_api(app: FastAPI) -> None:
@@ -181,7 +222,9 @@ def connect_chat_api(app: FastAPI) -> None:
         the toolcalls and continue the chat stream.
         """
         api_key = get_copilot_api_key()
-        tool_results = await execute_tool_batch(body.tool_calls, body.decisions)
+        tool_results = await execute_tool_batch(
+            body.tool_calls, body.decisions, conversation_id=body.conversation_id
+        )
         continuation_body: dict[str, Any] = {
             "trace_id": body.trace_id,
             "messages": [
@@ -193,6 +236,8 @@ def connect_chat_api(app: FastAPI) -> None:
                 for tc_id, output in tool_results.items()
             ],
         }
+        if body.conversation_id is not None:
+            continuation_body["conversation_id"] = body.conversation_id
         session = ChatStreamSession(
             upstream_url=_upstream_chat_url(),
             headers=_build_upstream_headers(api_key),
@@ -334,6 +379,48 @@ def connect_chat_api(app: FastAPI) -> None:
         )
         if detailed.status_code != HTTPStatus.NO_CONTENT:
             _raise_upstream_error(detailed)
+
+    @app.get(
+        "/api/chat/budget/{conversation_id}",
+        summary="Get conversation spend budget",
+        tags=["Copilot"],
+        # Readable by the assistant so the model can check its remaining budget.
+        openapi_extra=ALLOW_AGENT,
+    )
+    async def get_chat_budget(
+        conversation_id: Annotated[
+            str, Path(description="Stable conversation id (uuid4).")
+        ],
+    ) -> BudgetStatusResponse | None:
+        """The conversation's spend-budget status; null when nothing recorded."""
+        if not spend_ledger.is_valid_conversation_id(conversation_id):
+            raise HTTPException(status_code=400, detail="Invalid conversation id")
+        status = spend_ledger.get_status(conversation_id)
+        if status is None:
+            return None
+        return BudgetStatusResponse.from_status(status)
+
+    @app.post(
+        "/api/chat/budget/{conversation_id}",
+        summary="Set conversation spend budget",
+        tags=["Copilot"],
+        # The assistant must never raise its own budget — user-only endpoint.
+        openapi_extra=DENY_AGENT,
+    )
+    async def set_chat_budget(
+        conversation_id: Annotated[
+            str, Path(description="Stable conversation id (uuid4).")
+        ],
+        body: SetBudgetRequest,
+    ) -> BudgetStatusResponse:
+        """Set or extend (absolute value) the conversation's USD spend budget."""
+        if not spend_ledger.is_valid_conversation_id(conversation_id):
+            raise HTTPException(status_code=400, detail="Invalid conversation id")
+        try:
+            status = spend_ledger.set_budget(conversation_id, body.budget_usd)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        return BudgetStatusResponse.from_status(status)
 
     @app.post(
         "/api/chat",

--- a/app/desktop/studio_server/chat/routes.py
+++ b/app/desktop/studio_server/chat/routes.py
@@ -408,8 +408,7 @@ def connect_chat_api(app: FastAPI) -> None:
         ],
     ) -> BudgetStatusResponse | None:
         """The conversation's spend-budget status; null when nothing recorded."""
-        if not spend_ledger.is_valid_conversation_id(conversation_id):
-            raise HTTPException(status_code=400, detail="Invalid conversation id")
+        _require_valid_conversation_id(conversation_id)
         # ALLOW_AGENT: the assistant can call this. Scope its reads to its own
         # conversation — when this request carries the conversation contextvar
         # (set by the budget middleware from the X-Kiln-Conversation-Id header an
@@ -442,8 +441,7 @@ def connect_chat_api(app: FastAPI) -> None:
         body: SetBudgetRequest,
     ) -> BudgetStatusResponse:
         """Set or extend (absolute value) the conversation's USD spend budget."""
-        if not spend_ledger.is_valid_conversation_id(conversation_id):
-            raise HTTPException(status_code=400, detail="Invalid conversation id")
+        _require_valid_conversation_id(conversation_id)
         try:
             status = spend_ledger.set_budget(conversation_id, body.budget_usd)
         except ValueError as e:

--- a/app/desktop/studio_server/chat/routes.py
+++ b/app/desktop/studio_server/chat/routes.py
@@ -37,6 +37,16 @@ from kiln_server.utils.agent_checks.policy import ALLOW_AGENT, DENY_AGENT
 from pydantic import BaseModel, ConfigDict, ValidationError
 
 
+def _require_valid_conversation_id(conversation_id: str | None) -> None:
+    """400 on a malformed client-supplied conversation_id before it is forwarded
+    upstream / used to key the spend ledger — matching the budget endpoints, so a
+    buggy client gets a clear error instead of silently untracked spend."""
+    if conversation_id is not None and not spend_ledger.is_valid_conversation_id(
+        conversation_id
+    ):
+        raise HTTPException(status_code=400, detail="Invalid conversation id")
+
+
 def _build_upstream_headers(api_key: str) -> dict[str, str]:
     return {
         **_get_common_headers(),
@@ -221,6 +231,7 @@ def connect_chat_api(app: FastAPI) -> None:
         toolcalls in the UI, then send back the decisions through this endpoint, which will execute
         the toolcalls and continue the chat stream.
         """
+        _require_valid_conversation_id(body.conversation_id)
         api_key = get_copilot_api_key()
         tool_results = await execute_tool_batch(
             body.tool_calls, body.decisions, conversation_id=body.conversation_id
@@ -387,7 +398,11 @@ def connect_chat_api(app: FastAPI) -> None:
         # Readable by the assistant so the model can check its remaining budget.
         openapi_extra=ALLOW_AGENT,
     )
-    async def get_chat_budget(
+    # Sync def (not async): the body does blocking ledger disk I/O and awaits
+    # nothing, so FastAPI runs it in a threadpool instead of on the event loop.
+    # (The conversation contextvar set by the middleware propagates into the
+    # threadpool via contextvars context copy.)
+    def get_chat_budget(
         conversation_id: Annotated[
             str, Path(description="Stable conversation id (uuid4).")
         ],
@@ -395,6 +410,18 @@ def connect_chat_api(app: FastAPI) -> None:
         """The conversation's spend-budget status; null when nothing recorded."""
         if not spend_ledger.is_valid_conversation_id(conversation_id):
             raise HTTPException(status_code=400, detail="Invalid conversation id")
+        # ALLOW_AGENT: the assistant can call this. Scope its reads to its own
+        # conversation — when this request carries the conversation contextvar
+        # (set by the budget middleware from the X-Kiln-Conversation-Id header an
+        # assistant call_kiln_api stamps), reject a mismatched id so the model
+        # can't read another conversation's spend. UI requests carry no header,
+        # so the contextvar is unset and any conversation is readable.
+        bound = spend_ledger.current_conversation_id.get()
+        if bound is not None and bound != conversation_id:
+            raise HTTPException(
+                status_code=403,
+                detail="conversation_id does not match the active conversation",
+            )
         status = spend_ledger.get_status(conversation_id)
         if status is None:
             return None
@@ -407,7 +434,8 @@ def connect_chat_api(app: FastAPI) -> None:
         # The assistant must never raise its own budget — user-only endpoint.
         openapi_extra=DENY_AGENT,
     )
-    async def set_chat_budget(
+    # Sync def: blocking ledger disk I/O, no awaits — runs in FastAPI's threadpool.
+    def set_chat_budget(
         conversation_id: Annotated[
             str, Path(description="Stable conversation id (uuid4).")
         ],
@@ -431,6 +459,7 @@ def connect_chat_api(app: FastAPI) -> None:
     @no_write_lock
     async def chat(body: ChatRequest) -> StreamingResponse:
         """Forward chat to Kiln Copilot and stream AI SDK events as Server-Sent Events."""
+        _require_valid_conversation_id(body.conversation_id)
         api_key = get_copilot_api_key()
 
         session = ChatStreamSession(

--- a/app/desktop/studio_server/chat/stream_session.py
+++ b/app/desktop/studio_server/chat/stream_session.py
@@ -8,6 +8,8 @@ from typing import Any, AsyncIterator, Callable, Literal
 
 import httpx
 from app.desktop.studio_server.chat.constants import (
+    BUDGET_EXCEEDED_TOOL_OUTPUT,
+    CALL_KILN_API_TOOL_NAME,
     CHAT_TIMEOUT,
     DENIED_TOOL_OUTPUT,
     FUNCTION_NAME_TO_TOOL_ID,
@@ -32,6 +34,7 @@ from kiln_ai.tools.built_in_tools.enable_auto_mode_tool import (
     ENABLE_AUTO_MODE_TOOL_NAME,
 )
 from kiln_ai.tools.tool_registry import tool_from_id
+from kiln_ai.utils import spend_ledger
 from pydantic import BaseModel, ConfigDict, Field
 
 # The tool result the app server resolves an intercepted disable_auto_mode call
@@ -449,6 +452,7 @@ async def iter_round_with_retries(
 async def execute_tool_batch(
     tool_calls: list[ToolCallInfo],
     decisions: dict[str, bool],
+    conversation_id: str | None = None,
 ) -> dict[str, str]:
     results: dict[str, str] = {}
     for tc in tool_calls:
@@ -457,7 +461,20 @@ async def execute_tool_batch(
             if approved is not True:
                 results[tc.tool_call_id] = DENIED_TOOL_OUTPUT
                 continue
-        tool_result = await execute_tool(tc.tool_name, tc.input)
+        # Budget gate: block operation-triggering tool calls once the
+        # conversation's spend budget is exhausted. Checked per call (not once
+        # per batch) so an earlier call in the batch exhausting the budget
+        # blocks the later ones. Applies to interactive and auto mode alike.
+        if (
+            tc.tool_name == CALL_KILN_API_TOOL_NAME
+            and conversation_id is not None
+            and spend_ledger.is_exhausted(conversation_id)
+        ):
+            results[tc.tool_call_id] = BUDGET_EXCEEDED_TOOL_OUTPUT
+            continue
+        tool_result = await execute_tool(
+            tc.tool_name, tc.input, conversation_id=conversation_id
+        )
         results[tc.tool_call_id] = tool_result
     return results
 
@@ -475,6 +492,9 @@ class ChatStreamSession:
         self._headers = headers
         self._body = initial_body
         self._initial_trace_id: str | None = initial_body.get("trace_id")
+        # Stable conversation identity for spend tracking; rides the request
+        # body (and is persisted by the copilot backend). Survives all rounds.
+        self._conversation_id: str | None = initial_body.get("conversation_id")
 
     async def stream(self):
         """AsyncGenerator yielding SSE bytes to the client."""
@@ -580,6 +600,7 @@ class ChatStreamSession:
                                 for e in non_disable
                             ],
                             {},
+                            conversation_id=self._conversation_id,
                         )
                         tool_results = {
                             disable_evt.toolCallId: DISABLE_AUTO_MODE_RESULT,
@@ -655,7 +676,11 @@ class ChatStreamSession:
                     requiresApproval=tool_requires_user_approval(event),
                 )
             )
-        return await execute_tool_batch(tool_calls, approval_decisions or {})
+        return await execute_tool_batch(
+            tool_calls,
+            approval_decisions or {},
+            conversation_id=self._conversation_id,
+        )
 
     @staticmethod
     async def _clear_auto_mode_flag(trace_id: str | None) -> None:
@@ -683,7 +708,9 @@ class ChatStreamSession:
         return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n".encode()
 
 
-async def execute_tool(tool_name: str, args: dict[str, Any]) -> str:
+async def execute_tool(
+    tool_name: str, args: dict[str, Any], conversation_id: str | None = None
+) -> str:
     """Run a Kiln built-in tool by OpenAI function name; return its output string."""
     logger.info("Executing server tool %s", tool_name)
     args_str = json.dumps(args, default=str, ensure_ascii=False)
@@ -693,6 +720,10 @@ async def execute_tool(tool_name: str, args: dict[str, Any]) -> str:
         return json.dumps(
             {"error": f"Unknown tool name: {tool_name}"}, ensure_ascii=False
         )
+    # Attribute the tool's work to the assistant conversation for spend
+    # tracking: KilnApiCallTool reads this contextvar to stamp the
+    # X-Kiln-Conversation-Id header on the local API request it makes.
+    token = spend_ledger.current_conversation_id.set(conversation_id)
     try:
         tool = tool_from_id(tool_id)
         result = await tool.run(**args)
@@ -700,6 +731,8 @@ async def execute_tool(tool_name: str, args: dict[str, Any]) -> str:
     except Exception as e:
         logger.exception("Built-in tool %s failed", tool_name)
         return json.dumps({"error": str(e)}, ensure_ascii=False)
+    finally:
+        spend_ledger.current_conversation_id.reset(token)
 
 
 def _build_openai_tool_continuation(

--- a/app/desktop/studio_server/chat/test_routes.py
+++ b/app/desktop/studio_server/chat/test_routes.py
@@ -1354,6 +1354,28 @@ class TestConversationIdThreading:
         )
         assert body["conversation_id"] == CONVERSATION_ID
 
+    def test_chat_rejects_invalid_conversation_id(self, client, mock_api_key):
+        response = client.post(
+            "/api/chat",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "conversation_id": "not-a-uuid",
+            },
+        )
+        assert response.status_code == 400
+
+    def test_execute_tools_rejects_invalid_conversation_id(self, client, mock_api_key):
+        response = client.post(
+            "/api/chat/execute-tools",
+            json={
+                "trace_id": "t1",
+                "tool_calls": [],
+                "decisions": {},
+                "conversation_id": "bad-id",
+            },
+        )
+        assert response.status_code == 400
+
     def test_execute_tools_passes_conversation_id_to_batch(self, client, mock_api_key):
         mock_class, mock_client, _ = make_httpx_mock()
         batch_mock = AsyncMock(return_value={"tc1": "ok"})
@@ -1450,3 +1472,32 @@ class TestBudgetEndpoints:
         budget_path = openapi["paths"]["/api/chat/budget/{conversation_id}"]
         assert budget_path["post"]["x-agent-policy"]["permission"] == "deny"
         assert budget_path["get"]["x-agent-policy"]["permission"] == "allow"
+
+    def test_get_budget_rejects_mismatched_bound_conversation(self, client):
+        """When the agent's conversation is bound (contextvar set), it may only
+        read its own budget — a mismatched id is 403 (can't read another's spend)."""
+        other = "9e8d7c6b-5a49-4321-9fed-cba987654321"
+        mock_cv = MagicMock()
+        mock_cv.get.return_value = other
+        with patch(
+            "app.desktop.studio_server.chat.routes.spend_ledger.current_conversation_id",
+            mock_cv,
+        ):
+            response = client.get(f"/api/chat/budget/{CONVERSATION_ID}")
+        assert response.status_code == 403
+
+    def test_get_budget_allows_matching_bound_conversation(self, client):
+        mock_cv = MagicMock()
+        mock_cv.get.return_value = CONVERSATION_ID
+        with (
+            patch(
+                "app.desktop.studio_server.chat.routes.spend_ledger.current_conversation_id",
+                mock_cv,
+            ),
+            patch(
+                "app.desktop.studio_server.chat.routes.spend_ledger.get_status",
+                return_value=None,
+            ),
+        ):
+            response = client.get(f"/api/chat/budget/{CONVERSATION_ID}")
+        assert response.status_code == 200

--- a/app/desktop/studio_server/chat/test_routes.py
+++ b/app/desktop/studio_server/chat/test_routes.py
@@ -584,7 +584,7 @@ class TestRemoteToolRoundTrip:
         with patch(PATCH_ASYNC_CLIENT, mock_class):
             with patch(
                 PATCH_EXECUTE_TOOL,
-                AsyncMock(side_effect=lambda *_: next(execute_results)),
+                AsyncMock(side_effect=lambda *_, **__: next(execute_results)),
             ):
                 response = client.post(
                     "/api/chat",
@@ -1088,7 +1088,7 @@ class TestMockedFlows:
             "kiln_tool::multiply_numbers": "12",
         }
 
-        async def mock_execute(tool_name, args):
+        async def mock_execute(tool_name, args, conversation_id=None):
             execute_calls.append((tool_name, args))
             return original_results.get(tool_name, "unknown")
 
@@ -1329,3 +1329,124 @@ def test_version_policy_degrades_on_transport_error(client, mock_api_key):
         r = client.get("/api/chat/version_policy")
     assert r.status_code == 200
     assert r.json() == {"required": False, "upgrade_nudge_version": None}
+
+
+CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+
+
+class TestConversationIdThreading:
+    def test_chat_forwards_conversation_id_upstream(self, client, mock_api_key):
+        mock_class, mock_client, _ = make_httpx_mock()
+
+        with patch(PATCH_ASYNC_CLIENT, mock_class):
+            response = client.post(
+                "/api/chat",
+                json={
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "conversation_id": CONVERSATION_ID,
+                },
+            )
+            _ = response.content
+
+        call_kwargs = mock_client.stream.call_args
+        body = call_kwargs.kwargs.get("json") or json.loads(
+            call_kwargs.kwargs.get("content", "{}")
+        )
+        assert body["conversation_id"] == CONVERSATION_ID
+
+    def test_execute_tools_passes_conversation_id_to_batch(self, client, mock_api_key):
+        mock_class, mock_client, _ = make_httpx_mock()
+        batch_mock = AsyncMock(return_value={"tc1": "ok"})
+
+        with (
+            patch(PATCH_ASYNC_CLIENT, mock_class),
+            patch(
+                "app.desktop.studio_server.chat.routes.execute_tool_batch",
+                batch_mock,
+            ),
+        ):
+            response = client.post(
+                "/api/chat/execute-tools",
+                json={
+                    "trace_id": "trace-1",
+                    "tool_calls": [
+                        {
+                            "toolCallId": "tc1",
+                            "toolName": "call_kiln_api",
+                            "input": {},
+                            "requiresApproval": True,
+                        }
+                    ],
+                    "decisions": {"tc1": True},
+                    "conversation_id": CONVERSATION_ID,
+                },
+            )
+            _ = response.content
+
+        assert batch_mock.call_args.kwargs["conversation_id"] == CONVERSATION_ID
+        # The continuation body keeps the conversation id so the backend
+        # persists it on the next snapshot too.
+        call_kwargs = mock_client.stream.call_args
+        body = call_kwargs.kwargs.get("json") or json.loads(
+            call_kwargs.kwargs.get("content", "{}")
+        )
+        assert body["conversation_id"] == CONVERSATION_ID
+
+
+class TestBudgetEndpoints:
+    def test_get_budget_invalid_id_returns_400(self, client):
+        response = client.get("/api/chat/budget/not-a-uuid")
+        assert response.status_code == 400
+
+    def test_get_budget_unknown_returns_null(self, client):
+        with patch(
+            "app.desktop.studio_server.chat.routes.spend_ledger.get_status",
+            return_value=None,
+        ):
+            response = client.get(f"/api/chat/budget/{CONVERSATION_ID}")
+        assert response.status_code == 200
+        assert response.json() is None
+
+    def test_set_and_get_budget_roundtrip(self, client, tmp_path):
+        from kiln_ai.utils import spend_ledger as ledger
+
+        with patch.object(
+            ledger.Config,
+            "settings_dir",
+            classmethod(lambda cls, create=True: str(tmp_path)),
+        ):
+            response = client.post(
+                f"/api/chat/budget/{CONVERSATION_ID}", json={"budget_usd": 2.5}
+            )
+            assert response.status_code == 200
+            body = response.json()
+            assert body["budget_usd"] == 2.5
+            assert body["spent_usd"] == 0.0
+            assert body["remaining_usd"] == 2.5
+            assert body["exhausted"] is False
+
+            ledger.record_spend(CONVERSATION_ID, 2.5, 100)
+            response = client.get(f"/api/chat/budget/{CONVERSATION_ID}")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["exhausted"] is True
+            assert body["remaining_usd"] == 0.0
+
+    def test_set_budget_invalid_amount_returns_400(self, client):
+        response = client.post(
+            f"/api/chat/budget/{CONVERSATION_ID}", json={"budget_usd": -1}
+        )
+        assert response.status_code == 400
+
+    def test_set_budget_denied_for_agent(self, client):
+        """The assistant must never raise its own budget: POST is DENY_AGENT,
+        GET is allowed (the model may check remaining budget)."""
+        from app.desktop.studio_server.chat.routes import connect_chat_api
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        connect_chat_api(app)
+        openapi = app.openapi()
+        budget_path = openapi["paths"]["/api/chat/budget/{conversation_id}"]
+        assert budget_path["post"]["x-agent-policy"]["permission"] == "deny"
+        assert budget_path["get"]["x-agent-policy"]["permission"] == "allow"

--- a/app/desktop/studio_server/chat/test_stream_session.py
+++ b/app/desktop/studio_server/chat/test_stream_session.py
@@ -471,3 +471,141 @@ class TestExecuteToolBatch:
             out = await execute_tool_batch(calls, {})
         assert "error" in json.loads(out["b"])
         m.assert_not_called()
+
+
+CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+
+
+class TestBudgetGate:
+    """execute_tool_batch blocks call_kiln_api once the conversation's spend
+    budget is exhausted; other tools and untracked conversations pass through."""
+
+    def _call_kiln_api_tc(self, tc_id: str = "c1") -> ToolCallInfo:
+        return ToolCallInfo(
+            toolCallId=tc_id,
+            toolName="call_kiln_api",
+            input={"method": "GET", "url_path": "/api/projects"},
+            requiresApproval=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_blocks_call_kiln_api_when_exhausted(self):
+        from app.desktop.studio_server.chat.constants import (
+            BUDGET_EXCEEDED_TOOL_OUTPUT,
+        )
+
+        with (
+            patch(
+                "app.desktop.studio_server.chat.stream_session.spend_ledger.is_exhausted",
+                return_value=True,
+            ),
+            patch(
+                "app.desktop.studio_server.chat.stream_session.execute_tool",
+                new=AsyncMock(return_value="should-not-run"),
+            ) as mock_execute,
+        ):
+            out = await execute_tool_batch(
+                [self._call_kiln_api_tc()], {}, conversation_id=CONVERSATION_ID
+            )
+        assert out == {"c1": BUDGET_EXCEEDED_TOOL_OUTPUT}
+        mock_execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_math_tools_not_gated_when_exhausted(self):
+        with patch(
+            "app.desktop.studio_server.chat.stream_session.spend_ledger.is_exhausted",
+            return_value=True,
+        ):
+            out = await execute_tool_batch(
+                [
+                    ToolCallInfo(
+                        toolCallId="m1",
+                        toolName="multiply",
+                        input={"a": 3, "b": 4},
+                        requiresApproval=False,
+                    )
+                ],
+                {},
+                conversation_id=CONVERSATION_ID,
+            )
+        assert out == {"m1": "12"}
+
+    @pytest.mark.asyncio
+    async def test_not_gated_without_conversation_id(self):
+        with patch(
+            "app.desktop.studio_server.chat.stream_session.spend_ledger.is_exhausted",
+            return_value=True,
+        ) as mock_exhausted:
+            with patch(
+                "app.desktop.studio_server.chat.stream_session.execute_tool",
+                new=AsyncMock(return_value="ran"),
+            ):
+                out = await execute_tool_batch([self._call_kiln_api_tc()], {})
+        assert out == {"c1": "ran"}
+        mock_exhausted.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_not_gated_when_budget_remaining(self):
+        with (
+            patch(
+                "app.desktop.studio_server.chat.stream_session.spend_ledger.is_exhausted",
+                return_value=False,
+            ),
+            patch(
+                "app.desktop.studio_server.chat.stream_session.execute_tool",
+                new=AsyncMock(return_value="ran"),
+            ) as mock_execute,
+        ):
+            out = await execute_tool_batch(
+                [self._call_kiln_api_tc()], {}, conversation_id=CONVERSATION_ID
+            )
+        assert out == {"c1": "ran"}
+        mock_execute.assert_called_once_with(
+            "call_kiln_api",
+            {"method": "GET", "url_path": "/api/projects"},
+            conversation_id=CONVERSATION_ID,
+        )
+
+    @pytest.mark.asyncio
+    async def test_approval_denial_takes_precedence_over_budget(self):
+        from app.desktop.studio_server.chat.constants import DENIED_TOOL_OUTPUT
+
+        tc = ToolCallInfo(
+            toolCallId="c1",
+            toolName="call_kiln_api",
+            input={},
+            requiresApproval=True,
+        )
+        with patch(
+            "app.desktop.studio_server.chat.stream_session.spend_ledger.is_exhausted",
+            return_value=True,
+        ):
+            out = await execute_tool_batch([tc], {}, conversation_id=CONVERSATION_ID)
+        assert out == {"c1": DENIED_TOOL_OUTPUT}
+
+
+class TestExecuteToolConversationContext:
+    @pytest.mark.asyncio
+    async def test_contextvar_set_during_tool_run(self):
+        from kiln_ai.utils import spend_ledger
+
+        seen: dict[str, str | None] = {}
+
+        class _ProbeTool:
+            async def run(self, **kwargs):
+                seen["cid"] = spend_ledger.current_conversation_id.get()
+
+                class R:
+                    output = "ok"
+
+                return R()
+
+        with patch(
+            "app.desktop.studio_server.chat.stream_session.tool_from_id",
+            return_value=_ProbeTool(),
+        ):
+            out = await execute_tool("multiply", {}, conversation_id=CONVERSATION_ID)
+        assert out == "ok"
+        assert seen["cid"] == CONVERSATION_ID
+        # Reset after the call.
+        assert spend_ledger.current_conversation_id.get() is None

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -31,6 +31,7 @@ from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.spec import SpecStatus
 from kiln_ai.datamodel.task import RunConfigProperties, TaskRunConfig
 from kiln_ai.datamodel.task_output import normalize_rating
+from kiln_ai.utils import spend_ledger
 from kiln_ai.utils.name_generator import generate_memorable_name
 from kiln_server.git_sync_decorators import build_save_context, no_write_lock
 from kiln_server.task_api import task_from_id
@@ -155,16 +156,31 @@ def task_run_config_from_id(
 
 
 async def run_eval_runner_with_status(eval_runner: EvalRunner) -> StreamingResponse:
+    # Captured in the endpoint's request context. The SSE body may be iterated
+    # from a different task/context than the endpoint function, so re-assert it
+    # inside the generator rather than trusting contextvar propagation.
+    conversation_id = spend_ledger.current_conversation_id.get()
+
     # Yields async messages designed to be used with server sent events (SSE)
     # https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
     async def event_generator():
-        async for progress in eval_runner.run():
+        spend_ledger.current_conversation_id.set(conversation_id)
+        runner_iter = eval_runner.run()
+        async for progress in runner_iter:
             data = {
                 "progress": progress.complete,
                 "total": progress.total,
                 "errors": progress.errors,
             }
             yield f"data: {json.dumps(data)}\n\n"
+            # Between-jobs budget stop for assistant-triggered runs: once the
+            # conversation budget is spent, stop scheduling new jobs (closing
+            # the runner generator cancels its workers). Overshoot is bounded
+            # to jobs already in flight. Completed rows are already saved.
+            if spend_ledger.is_exhausted(conversation_id):
+                await runner_iter.aclose()
+                yield f"data: {json.dumps({'budget_exhausted': True})}\n\n"
+                break
 
         # Send the final complete message the app expects, and uses to stop listening
         yield "data: complete\n\n"

--- a/app/desktop/studio_server/test_budget_middleware.py
+++ b/app/desktop/studio_server/test_budget_middleware.py
@@ -1,0 +1,64 @@
+import json
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+from kiln_ai.utils import spend_ledger
+
+from app.desktop.studio_server.budget_middleware import BudgetContextMiddleware
+
+CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+
+
+def build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(BudgetContextMiddleware)
+
+    @app.get("/probe")
+    def probe():
+        return {"conversation_id": spend_ledger.current_conversation_id.get()}
+
+    @app.get("/probe-stream")
+    def probe_stream():
+        # Mirrors the eval SSE endpoints: the generator body must still see
+        # the contextvar even though it is iterated by the response machinery,
+        # not the endpoint function.
+        async def gen():
+            yield json.dumps(
+                {"conversation_id": spend_ledger.current_conversation_id.get()}
+            )
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    return app
+
+
+def test_header_sets_contextvar():
+    client = TestClient(build_app())
+    r = client.get(
+        "/probe", headers={spend_ledger.CONVERSATION_ID_HEADER: CONVERSATION_ID}
+    )
+    assert r.json() == {"conversation_id": CONVERSATION_ID}
+
+
+def test_no_header_leaves_contextvar_unset():
+    client = TestClient(build_app())
+    r = client.get("/probe")
+    assert r.json() == {"conversation_id": None}
+
+
+def test_invalid_header_ignored():
+    client = TestClient(build_app())
+    r = client.get(
+        "/probe", headers={spend_ledger.CONVERSATION_ID_HEADER: "not-a-uuid"}
+    )
+    assert r.json() == {"conversation_id": None}
+
+
+def test_contextvar_propagates_into_streaming_response_body():
+    client = TestClient(build_app())
+    r = client.get(
+        "/probe-stream",
+        headers={spend_ledger.CONVERSATION_ID_HEADER: CONVERSATION_ID},
+    )
+    assert json.loads(r.text) == {"conversation_id": CONVERSATION_ID}

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -3369,3 +3369,59 @@ async def test_eval_results_summary_dataset_ids_cached_per_filter(client):
 
     assert response.status_code == 200
     assert runs_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_run_eval_config_stops_when_budget_exhausted(
+    client, mock_task_from_id, mock_task, mock_eval, mock_eval_config, mock_run_config
+):
+    """When the conversation budget runs out mid-eval, the SSE stops scheduling
+    new jobs after the current progress tick and reports budget_exhausted."""
+    mock_task_from_id.return_value = mock_task
+
+    progress_updates = [
+        Mock(complete=1, total=3, errors=0),
+        Mock(complete=2, total=3, errors=0),
+        Mock(complete=3, total=3, errors=0),
+    ]
+
+    closed = {"value": False}
+
+    async def mock_run():
+        try:
+            for progress in progress_updates:
+                yield progress
+        finally:
+            closed["value"] = True
+
+    with (
+        patch(
+            "app.desktop.studio_server.eval_api.task_run_config_from_id"
+        ) as mock_run_config_from_id,
+        patch("app.desktop.studio_server.eval_api.EvalRunner") as MockEvalRunner,
+        patch(
+            "app.desktop.studio_server.eval_api.spend_ledger.is_exhausted",
+            side_effect=[False, True],
+        ),
+    ):
+        mock_run_config_from_id.return_value = mock_run_config
+        mock_eval_runner = Mock()
+        mock_eval_runner.run.return_value = mock_run()
+        MockEvalRunner.return_value = mock_eval_runner
+
+        response = client.get(
+            "/api/projects/project1/tasks/task1/evals/eval1/eval_config/eval_config1/run_comparison",
+            params={"run_config_ids": ["run_config1", "run_config2"]},
+        )
+
+        assert response.status_code == 200
+        messages = [msg for msg in response.iter_lines() if msg]
+
+    # 2 progress ticks, then the budget stop marker, then complete.
+    assert len(messages) == 4
+    assert json.loads(messages[0].split("data: ")[1])["progress"] == 1
+    assert json.loads(messages[1].split("data: ")[1])["progress"] == 2
+    assert json.loads(messages[2].split("data: ")[1]) == {"budget_exhausted": True}
+    assert messages[-1] == "data: complete"
+    # The runner generator was closed early (cancels its workers).
+    assert closed["value"] is True

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -5680,6 +5680,8 @@ export interface components {
             enable_tool_call_id: string;
             /** Siblings */
             siblings?: components["schemas"]["ToolCallInfo"][];
+            /** Conversation Id */
+            conversation_id?: string | null;
         };
         /**
          * DeleteConfigResponse

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -3239,6 +3239,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/budget/{conversation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get conversation spend budget
+         * @description The conversation's spend-budget status; null when nothing recorded.
+         */
+        get: operations["get_chat_budget_api_chat_budget__conversation_id__get"];
+        put?: never;
+        /**
+         * Set conversation spend budget
+         * @description Set or extend (absolute value) the conversation's USD spend budget.
+         */
+        post: operations["set_chat_budget_api_chat_budget__conversation_id__post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/chat": {
         parameters: {
             query?: never;
@@ -4234,6 +4258,38 @@ export interface components {
             remove_tags?: string[] | null;
         };
         /**
+         * BudgetStatusResponse
+         * @description A conversation's spend-budget state, from the local spend ledger.
+         */
+        BudgetStatusResponse: {
+            /** Conversation Id */
+            conversation_id: string;
+            /** Budget Usd */
+            budget_usd?: number | null;
+            /**
+             * Spent Usd
+             * @default 0
+             */
+            spent_usd: number;
+            /** Remaining Usd */
+            remaining_usd?: number | null;
+            /**
+             * Exhausted
+             * @default false
+             */
+            exhausted: boolean;
+            /**
+             * Unpriced Runs
+             * @default 0
+             */
+            unpriced_runs: number;
+            /**
+             * Unpriced Tokens
+             * @default 0
+             */
+            unpriced_tokens: number;
+        };
+        /**
          * BuildPromptRequest
          * @description Request to build a prompt from examples.
          */
@@ -4471,6 +4527,8 @@ export interface components {
             messages: components["schemas"]["ChatRequestMessage"][];
             /** Trace Id */
             trace_id?: string | null;
+            /** Conversation Id */
+            conversation_id?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -4507,6 +4565,8 @@ export interface components {
             id: string;
             task_run: components["schemas"]["TaskRunSnapshot"];
             context_usage?: components["schemas"]["ContextUsage"] | null;
+            /** Conversation Id */
+            conversation_id?: string | null;
         };
         /**
          * ChatStrategy
@@ -5835,6 +5895,8 @@ export interface components {
             extra_messages?: {
                 [key: string]: unknown;
             }[];
+            /** Conversation Id */
+            conversation_id?: string | null;
             /** Reason */
             reason?: string | null;
         };
@@ -6475,6 +6537,8 @@ export interface components {
             decisions: {
                 [key: string]: boolean;
             };
+            /** Conversation Id */
+            conversation_id?: string | null;
         };
         /**
          * ExternalToolApiDescription
@@ -10042,6 +10106,11 @@ export interface components {
             content: string;
             /** Trace Id */
             trace_id?: string | null;
+        };
+        /** SetBudgetRequest */
+        SetBudgetRequest: {
+            /** Budget Usd */
+            budget_usd?: number | null;
         };
         /**
          * SkillContentResponse
@@ -19073,6 +19142,74 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_chat_budget_api_chat_budget__conversation_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Stable conversation id (uuid4). */
+                conversation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BudgetStatusResponse"] | null;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_chat_budget_api_chat_budget__conversation_id__post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Stable conversation id (uuid4). */
+                conversation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetBudgetRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BudgetStatusResponse"];
+                };
             };
             /** @description Validation Error */
             422: {

--- a/app/web_ui/src/lib/chat/auto_run_store.ts
+++ b/app/web_ui/src/lib/chat/auto_run_store.ts
@@ -44,6 +44,8 @@ export interface AutoRunChatSink {
   beginAssistantTurn: () => void
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   onChatTrace: (traceId: string) => void
+  /** Fired when a snapshot event echoes the stable ``conversation_id``. */
+  onConversationId?: (conversationId: string) => void
   /** Fired when an auto-burst snapshot event carries ``context_usage``. */
   onContextUsage: (usage: ContextUsage) => void
   /**
@@ -227,6 +229,7 @@ export function createAutoRunStore(): AutoRunStore {
         sink?.onAssistantMessage(update)
       },
       onChatTrace: (tid) => sink?.onChatTrace(tid),
+      onConversationId: (cid) => sink?.onConversationId?.(cid),
       onContextUsage: (usage) => sink?.onContextUsage(usage),
       onCompactionStatus: (compacting) => sink?.onCompactionStatus(compacting),
       onInlineError: (message, traceId, code) =>

--- a/app/web_ui/src/lib/chat/budget_store.test.ts
+++ b/app/web_ui/src/lib/chat/budget_store.test.ts
@@ -105,4 +105,36 @@ describe("createBudgetStore", () => {
     const result = await store.setBudget(-1)
     expect(result.ok).toBe(false)
   })
+
+  it("ignores a stale refresh response for a conversation switched away from", async () => {
+    const OTHER = "9e8d7c6b-5a49-4321-9fed-cba987654321"
+    // A deferred GET for conversation A that we resolve only after switching to B.
+    let resolveA: (v: unknown) => void = () => {}
+    const aPending = new Promise((r) => {
+      resolveA = r
+    })
+    mockGet.mockImplementation((_url, opts) => {
+      const cid = opts.params.path.conversation_id
+      if (cid === CONVERSATION_ID) return aPending
+      // B resolves immediately with its own status.
+      return Promise.resolve({
+        data: status({ conversation_id: OTHER, budget_usd: 99 }),
+        error: undefined,
+      })
+    })
+
+    const store = createBudgetStore()
+    store.setConversation(CONVERSATION_ID) // fires the slow A refresh
+    // Switch to B before A resolves, then settle B deterministically.
+    store.setConversation(OTHER)
+    await store.refresh()
+    expect(get(store)?.conversation_id).toBe(OTHER)
+
+    // Now A's slow response arrives — it must be dropped, not adopted.
+    resolveA({ data: status({ budget_usd: 5 }), error: undefined })
+    await aPending
+    await Promise.resolve()
+    expect(get(store)?.conversation_id).toBe(OTHER)
+    expect(get(store)?.budget_usd).toBe(99)
+  })
 })

--- a/app/web_ui/src/lib/chat/budget_store.test.ts
+++ b/app/web_ui/src/lib/chat/budget_store.test.ts
@@ -106,6 +106,27 @@ describe("createBudgetStore", () => {
     expect(result.ok).toBe(false)
   })
 
+  it("setBudget surfaces the server's error detail/message when present", async () => {
+    const store = createBudgetStore()
+    store.setConversation(CONVERSATION_ID)
+    mockPost.mockResolvedValue({
+      data: undefined,
+      error: { detail: "budget_usd must be a non-negative finite number" },
+    })
+    const detailResult = await store.setBudget(-1)
+    expect(detailResult.error).toBe(
+      "budget_usd must be a non-negative finite number",
+    )
+
+    // Also handles the desktop `{ message }` shape.
+    mockPost.mockResolvedValue({
+      data: undefined,
+      error: { message: "Invalid conversation id" },
+    })
+    const messageResult = await store.setBudget(1)
+    expect(messageResult.error).toBe("Invalid conversation id")
+  })
+
   it("ignores a stale refresh response for a conversation switched away from", async () => {
     const OTHER = "9e8d7c6b-5a49-4321-9fed-cba987654321"
     // A deferred GET for conversation A that we resolve only after switching to B.

--- a/app/web_ui/src/lib/chat/budget_store.test.ts
+++ b/app/web_ui/src/lib/chat/budget_store.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { get } from "svelte/store"
+
+const mockGet = vi.fn()
+const mockPost = vi.fn()
+vi.mock("$lib/api_client", () => ({
+  client: {
+    GET: (...args: unknown[]) => mockGet(...args),
+    POST: (...args: unknown[]) => mockPost(...args),
+  },
+}))
+
+import { createBudgetStore } from "./budget_store"
+
+const CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+
+function status(overrides: Record<string, unknown> = {}) {
+  return {
+    conversation_id: CONVERSATION_ID,
+    budget_usd: 5,
+    spent_usd: 1,
+    remaining_usd: 4,
+    exhausted: false,
+    unpriced_runs: 0,
+    unpriced_tokens: 0,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  mockGet.mockReset()
+  mockPost.mockReset()
+})
+
+describe("createBudgetStore", () => {
+  it("starts null and stays null with no conversation", async () => {
+    const store = createBudgetStore()
+    expect(get(store)).toBeNull()
+    await store.refresh()
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it("fetches status when a conversation is set", async () => {
+    mockGet.mockResolvedValue({ data: status(), error: undefined })
+    const store = createBudgetStore()
+    store.setConversation(CONVERSATION_ID)
+    // setConversation fires a background refresh; await an explicit one to
+    // deterministically observe the resolved status.
+    await store.refresh()
+    expect(mockGet).toHaveBeenCalledWith("/api/chat/budget/{conversation_id}", {
+      params: { path: { conversation_id: CONVERSATION_ID } },
+    })
+    expect(get(store)?.budget_usd).toBe(5)
+  })
+
+  it("clears status and does not refetch for the same conversation", async () => {
+    mockGet.mockResolvedValue({ data: status(), error: undefined })
+    const store = createBudgetStore()
+    store.setConversation(CONVERSATION_ID)
+    await Promise.resolve()
+    mockGet.mockClear()
+    store.setConversation(CONVERSATION_ID)
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it("resets to null when the conversation is cleared", async () => {
+    mockGet.mockResolvedValue({ data: status(), error: undefined })
+    const store = createBudgetStore()
+    store.setConversation(CONVERSATION_ID)
+    await Promise.resolve()
+    store.setConversation(null)
+    expect(get(store)).toBeNull()
+  })
+
+  it("setBudget POSTs and updates the store", async () => {
+    const store = createBudgetStore()
+    store.setConversation(CONVERSATION_ID)
+    mockPost.mockResolvedValue({
+      data: status({ budget_usd: 10, remaining_usd: 9 }),
+      error: undefined,
+    })
+    const result = await store.setBudget(10)
+    expect(result.ok).toBe(true)
+    expect(mockPost).toHaveBeenCalledWith(
+      "/api/chat/budget/{conversation_id}",
+      {
+        params: { path: { conversation_id: CONVERSATION_ID } },
+        body: { budget_usd: 10 },
+      },
+    )
+    expect(get(store)?.budget_usd).toBe(10)
+  })
+
+  it("setBudget fails cleanly with no conversation", async () => {
+    const store = createBudgetStore()
+    const result = await store.setBudget(10)
+    expect(result.ok).toBe(false)
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it("setBudget surfaces an API error", async () => {
+    const store = createBudgetStore()
+    store.setConversation(CONVERSATION_ID)
+    mockPost.mockResolvedValue({ data: undefined, error: { detail: "bad" } })
+    const result = await store.setBudget(-1)
+    expect(result.ok).toBe(false)
+  })
+})

--- a/app/web_ui/src/lib/chat/budget_store.ts
+++ b/app/web_ui/src/lib/chat/budget_store.ts
@@ -1,0 +1,94 @@
+import { writable, get, type Readable } from "svelte/store"
+import { client } from "$lib/api_client"
+import type { components } from "$lib/api_schema"
+
+export type BudgetStatus = components["schemas"]["BudgetStatusResponse"]
+
+export interface BudgetStore extends Readable<BudgetStatus | null> {
+  /** Point the store at a conversation. Clears state + refreshes when it changes. */
+  setConversation(conversationId: string | null): void
+  /** Re-fetch the current conversation's budget status. No-op without one. */
+  refresh(): Promise<void>
+  /** Set/extend (absolute) the budget; ``null`` clears it. Refreshes on success. */
+  setBudget(budgetUsd: number | null): Promise<{ ok: boolean; error?: string }>
+}
+
+/**
+ * Tracks the active conversation's spend-budget status (from the local ledger
+ * on the desktop server). Read-through cache: the chat store refreshes it after
+ * tool rounds / trace events, and a light poll keeps the meter live during long
+ * assistant-triggered operations (see chat.svelte).
+ */
+export function createBudgetStore(): BudgetStore {
+  const status = writable<BudgetStatus | null>(null)
+  let conversationId: string | null = null
+
+  function setConversation(next: string | null): void {
+    if (next === conversationId) return
+    conversationId = next
+    status.set(null)
+    if (next) void refresh()
+  }
+
+  async function refresh(): Promise<void> {
+    const cid = conversationId
+    if (!cid) return
+    try {
+      const { data, error } = await client.GET(
+        "/api/chat/budget/{conversation_id}",
+        { params: { path: { conversation_id: cid } } },
+      )
+      // Ignore a response for a conversation we've since switched away from.
+      if (cid !== conversationId) return
+      if (error) return
+      status.set(data ?? null)
+    } catch {
+      /* network/desktop error — keep the last known status */
+    }
+  }
+
+  async function setBudget(
+    budgetUsd: number | null,
+  ): Promise<{ ok: boolean; error?: string }> {
+    const cid = conversationId
+    if (!cid) return { ok: false, error: "No active conversation" }
+    try {
+      const { data, error } = await client.POST(
+        "/api/chat/budget/{conversation_id}",
+        {
+          params: { path: { conversation_id: cid } },
+          body: { budget_usd: budgetUsd },
+        },
+      )
+      if (error) {
+        return { ok: false, error: "Couldn't update the budget" }
+      }
+      if (cid === conversationId && data) status.set(data)
+      return { ok: true }
+    } catch (e) {
+      return { ok: false, error: e instanceof Error ? e.message : String(e) }
+    }
+  }
+
+  return {
+    subscribe: status.subscribe,
+    setConversation,
+    refresh,
+    setBudget,
+  }
+}
+
+export const budget_store: BudgetStore = createBudgetStore()
+
+/** True when a budget is set and fully spent. */
+export function isBudgetExhausted(status: BudgetStatus | null): boolean {
+  return !!status?.exhausted
+}
+
+/** True when some model calls couldn't be priced (partial tracking). */
+export function isBudgetPartiallyTracked(status: BudgetStatus | null): boolean {
+  return (status?.unpriced_runs ?? 0) > 0
+}
+
+// Re-export get for consumers that need a one-shot read.
+export { get as getBudgetSnapshot }

--- a/app/web_ui/src/lib/chat/budget_store.ts
+++ b/app/web_ui/src/lib/chat/budget_store.ts
@@ -61,7 +61,17 @@ export function createBudgetStore(): BudgetStore {
         },
       )
       if (error) {
-        return { ok: false, error: "Couldn't update the budget" }
+        // Surface the server's own message when it sent one (e.g. a validation
+        // detail), falling back to a generic message. The desktop error shape
+        // is `{ message }` or FastAPI's `{ detail }`.
+        const detail =
+          (error as { detail?: unknown; message?: unknown })?.detail ??
+          (error as { message?: unknown })?.message
+        return {
+          ok: false,
+          error:
+            typeof detail === "string" ? detail : "Couldn't update the budget",
+        }
       }
       if (cid === conversationId && data) status.set(data)
       return { ok: true }

--- a/app/web_ui/src/lib/chat/chat_history_apply.ts
+++ b/app/web_ui/src/lib/chat/chat_history_apply.ts
@@ -4,4 +4,5 @@ export type LoadedChatSessionDetail = {
   messages: ChatMessage[]
   continuationTraceId: string
   contextUsage: ContextUsage | null
+  conversationId: string | null
 }

--- a/app/web_ui/src/lib/chat/chat_session_store.test.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.test.ts
@@ -2089,3 +2089,88 @@ describe("compacting (Phase 5)", () => {
     expect(persisted).not.toContain("compacting")
   })
 })
+
+describe("conversation id", () => {
+  const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+  it("mints a uuid4 on the first send and sends it to streamChat", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore()
+
+    await store.sendMessage("hi")
+
+    const cid = get(store).conversationId
+    expect(cid).toMatch(UUID_RE)
+    expect(capture.options!.conversationId).toBe(cid)
+  })
+
+  it("reuses the same conversation id across sends", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore()
+
+    await store.sendMessage("first")
+    const first = get(store).conversationId
+    // End the turn so the second send dispatches instead of queueing.
+    capture.options!.onFinish?.()
+    await store.sendMessage("second")
+
+    expect(get(store).conversationId).toBe(first)
+    expect(capture.options!.conversationId).toBe(first)
+  })
+
+  it("adopts the server-echoed conversation id", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    const capture: { options: StreamChatOptions | null } = { options: null }
+    streamChatMock.mockImplementation(capturingStreamChat(capture))
+    const store = createChatSessionStore()
+
+    await store.sendMessage("hi")
+    const echoed = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+    capture.options!.onConversationId?.(echoed)
+
+    expect(get(store).conversationId).toBe(echoed)
+  })
+
+  it("clears the conversation id on reset", async () => {
+    const { createChatSessionStore, streamChatMock } =
+      await importFreshWithMock()
+    streamChatMock.mockImplementation(noopStreamChat)
+    const store = createChatSessionStore()
+
+    await store.sendMessage("hi")
+    expect(get(store).conversationId).toMatch(UUID_RE)
+    store.reset()
+    expect(get(store).conversationId).toBeNull()
+  })
+
+  it("restores the conversation id from a persisted session", async () => {
+    const KEY = "kiln_chat_session_cid"
+    const cid = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+    storage.store[KEY] = JSON.stringify({
+      messages: [],
+      collapsedPartKeys: {},
+      lastSentAppState: null,
+      contextUsage: null,
+      conversationId: cid,
+    })
+    const { createChatSessionStore } = await importFreshWithMock()
+    const store = createChatSessionStore(KEY)
+    expect(get(store).conversationId).toBe(cid)
+  })
+
+  it("loadSession sets the conversation id from a restored snapshot", async () => {
+    const { createChatSessionStore } = await importFreshWithMock()
+    const store = createChatSessionStore()
+    const cid = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+    store.loadSession([], "0000000001_" + "a".repeat(8), null, cid)
+    expect(get(store).conversationId).toBe(cid)
+  })
+})

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -736,6 +736,7 @@ export function createChatSessionStore(
         trace_id: traceId,
         enable_tool_call_id: payload.enableToolCallId,
         siblings,
+        conversation_id: ensureConversationId(),
       }
       await autoRunStore.decline(req)
     }

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -40,6 +40,13 @@ export interface PersistedChatSession {
    * sessionStorage reload keeps the gauge. ``null`` before the first turn.
    */
   contextUsage: ContextUsage | null
+  /**
+   * Stable, client-minted conversation identity (plain lowercase uuid4 —
+   * unlike message ids). Minted on the first send, persisted upstream on every
+   * snapshot, and re-learned from the session snapshot / kiln_chat_trace echo
+   * on restore. Keys the conversation's spend budget.
+   */
+  conversationId: string | null
 }
 
 export interface ToolApprovalWaiter {
@@ -120,6 +127,7 @@ export interface ChatSessionStore extends Readable<ChatSessionState> {
     messages: ChatMessage[],
     continuationTraceId: string,
     contextUsage?: ContextUsage | null,
+    conversationId?: string | null,
   ): void
   /**
    * Resync the restored-from-sessionStorage conversation back to its true
@@ -147,6 +155,7 @@ const EMPTY_PERSISTED: PersistedChatSession = {
   collapsedPartKeys: {},
   lastSentAppState: null,
   contextUsage: null,
+  conversationId: null,
 }
 
 export function createChatSessionStore(
@@ -174,6 +183,8 @@ export function createChatSessionStore(
 
   const combined = writable<ChatSessionState>({
     ...get(persisted),
+    // Pre-feature sessionStorage payloads lack the key; normalize to null.
+    conversationId: get(persisted).conversationId ?? null,
     status,
     abortController,
     toolApprovalWaiter: null,
@@ -198,6 +209,7 @@ export function createChatSessionStore(
       collapsedPartKeys: $persisted.collapsedPartKeys,
       lastSentAppState: $persisted.lastSentAppState,
       contextUsage: $persisted.contextUsage,
+      conversationId: $persisted.conversationId ?? null,
     }))
   })
 
@@ -277,6 +289,29 @@ export function createChatSessionStore(
     persisted.update((p) => ({ ...p, contextUsage: usage }))
   }
 
+  // Adopt/refresh the stable conversation id (snapshot hydration or the
+  // kiln_chat_trace echo). The server carries the prior snapshot's id forward,
+  // so an echoed value is authoritative.
+  function setConversationId(conversationId: string | null) {
+    persisted.update((p) =>
+      p.conversationId === conversationId
+        ? p
+        : { ...p, conversationId: conversationId },
+    )
+  }
+
+  // The conversation id sent with every request. Minted lazily on the first
+  // send (plain lowercase uuid4 — the copilot backend validates the format).
+  // Also covers lazy adoption: a pre-feature conversation gets an id on its
+  // next send, which the backend adopts onto the chain.
+  function ensureConversationId(): string {
+    const existing = get(persisted).conversationId
+    if (existing) return existing
+    const minted = crypto.randomUUID()
+    setConversationId(minted)
+    return minted
+  }
+
   // Runtime-only (not persisted): drives the "Summarizing earlier messages…"
   // indicator while the server compacts the conversation for this turn.
   function setCompacting(compacting: boolean) {
@@ -325,6 +360,7 @@ export function createChatSessionStore(
     beginAssistantTurn,
     onAssistantMessage: updateLastAssistant,
     onChatTrace: setLastAssistantTraceId,
+    onConversationId: setConversationId,
     onContextUsage: setContextUsage,
     onCompactionStatus: setCompacting,
     onInlineError: (message, traceId, code) =>
@@ -396,6 +432,7 @@ export function createChatSessionStore(
     void resumePendingToolCalls({
       apiUrl: CHAT_API_URL,
       traceId,
+      conversationId: get(persisted).conversationId ?? undefined,
       items,
       onToolCallsPending: (payload) => {
         if (isStale()) return Promise.resolve({})
@@ -514,6 +551,11 @@ export function createChatSessionStore(
       apiUrl: CHAT_API_URL,
       messages: [apiMessage],
       traceId,
+      conversationId: ensureConversationId(),
+      onConversationId: (cid) => {
+        if (isStale()) return
+        setConversationId(cid)
+      },
       onToolCallsPending: (payload) => {
         if (isStale()) return Promise.resolve({})
         return handleToolCallsPending(payload)
@@ -678,6 +720,7 @@ export function createChatSessionStore(
         enable_tool_call_id: payload.enableToolCallId,
         pending_tool_calls: siblings,
         reason: payload.reason,
+        conversation_id: ensureConversationId(),
       }
       // Surface enable failures (e.g. 429 "Too many auto runs") instead of
       // silently dropping them — the dialog has already closed, so the inline
@@ -895,6 +938,7 @@ export function createChatSessionStore(
     const apiContent = header ? header + "\n" + text : text
     const seed: EnableAutoRequest = {
       extra_messages: [{ role: "user", content: apiContent }],
+      conversation_id: ensureConversationId(),
     }
     const result = await autoRunStore.requestEnable(seed)
     if (!result.ok) {
@@ -947,6 +991,7 @@ export function createChatSessionStore(
       collapsedPartKeys: {},
       lastSentAppState: null,
       contextUsage: null,
+      conversationId: null,
     })
     combined.update((s) => ({
       ...s,
@@ -962,6 +1007,7 @@ export function createChatSessionStore(
     messages: ChatMessage[],
     traceId: string,
     contextUsage: ContextUsage | null = null,
+    conversationId: string | null = null,
   ): void {
     if (abortController) {
       abortController.abort()
@@ -977,6 +1023,7 @@ export function createChatSessionStore(
       collapsedPartKeys: {},
       lastSentAppState: null,
       contextUsage,
+      conversationId,
     })
     combined.update((s) => ({
       ...s,
@@ -1050,10 +1097,11 @@ export function createChatSessionStore(
           messages,
           continuationTraceId: traceId,
           contextUsage,
+          conversationId,
         } = hydrateSessionFromSnapshot(snapshot)
         // loadSession detaches any prior observer, sets the messages + trace
         // id, and resets runtime state — identical to the history-restore path.
-        loadSession(messages, traceId, contextUsage)
+        loadSession(messages, traceId, contextUsage, conversationId)
       }
     } catch {
       // Hydration failed (network/parse). Fall back: still attach so the user at

--- a/app/web_ui/src/lib/chat/chat_session_store.ts
+++ b/app/web_ui/src/lib/chat/chat_session_store.ts
@@ -446,6 +446,10 @@ export function createChatSessionStore(
         if (isStale()) return
         setLastAssistantTraceId(tid)
       },
+      onConversationId: (cid) => {
+        if (isStale()) return
+        setConversationId(cid)
+      },
       onContextUsage: (usage) => {
         if (isStale()) return
         setContextUsage(usage)
@@ -1102,7 +1106,15 @@ export function createChatSessionStore(
         } = hydrateSessionFromSnapshot(snapshot)
         // loadSession detaches any prior observer, sets the messages + trace
         // id, and resets runtime state — identical to the history-restore path.
-        loadSession(messages, traceId, contextUsage, conversationId)
+        // Preserve the already-known conversation id when the snapshot omits it
+        // (a pre-feature / not-yet-echoed snapshot) so a hard-refresh resync of
+        // the SAME conversation never clears its budget-tracking identity.
+        loadSession(
+          messages,
+          traceId,
+          contextUsage,
+          conversationId ?? get(persisted).conversationId,
+        )
       }
     } catch {
       // Hydration failed (network/parse). Fall back: still attach so the user at

--- a/app/web_ui/src/lib/chat/session_messages.ts
+++ b/app/web_ui/src/lib/chat/session_messages.ts
@@ -81,6 +81,7 @@ export function hydrateSessionFromSnapshot(snapshot: ChatSessionSnapshot): {
   messages: ChatMessage[]
   continuationTraceId: string
   contextUsage: ContextUsage | null
+  conversationId: string | null
 } {
   const trace = snapshot.task_run.trace ?? []
   const messages: ChatMessage[] = []
@@ -140,5 +141,6 @@ export function hydrateSessionFromSnapshot(snapshot: ChatSessionSnapshot): {
     messages,
     continuationTraceId: snapshot.id,
     contextUsage: normalizeContextUsage(snapshot.context_usage),
+    conversationId: snapshot.conversation_id ?? null,
   }
 }

--- a/app/web_ui/src/lib/chat/streaming_chat.test.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.test.ts
@@ -550,3 +550,128 @@ describe("StreamEventProcessor kiln-chat-retry", () => {
     expect(clears).toBe(0)
   })
 })
+
+describe("streamChat conversation_id", () => {
+  const CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("includes conversation_id in the POST body when set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: {
+        getReader: () =>
+          ({
+            read: () => Promise.resolve({ done: true, value: undefined }),
+          }) as ReadableStreamDefaultReader<Uint8Array>,
+      },
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    await streamChat({
+      apiUrl: "https://example.test/api/chat",
+      messages: [{ id: "u1", role: "user", content: "hi" }],
+      conversationId: CONVERSATION_ID,
+      onAssistantMessage: () => {},
+      onFinish: () => {},
+      onError: () => {},
+    })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(JSON.parse(init.body as string)).toEqual({
+      messages: [{ role: "user", content: "hi" }],
+      conversation_id: CONVERSATION_ID,
+    })
+  })
+
+  it("omits conversation_id when not set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: {
+        getReader: () =>
+          ({
+            read: () => Promise.resolve({ done: true, value: undefined }),
+          }) as ReadableStreamDefaultReader<Uint8Array>,
+      },
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    await streamChat({
+      apiUrl: "https://example.test/api/chat",
+      messages: [{ id: "u1", role: "user", content: "hi" }],
+      onAssistantMessage: () => {},
+      onFinish: () => {},
+      onError: () => {},
+    })
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect(JSON.parse(init.body as string)).not.toHaveProperty(
+      "conversation_id",
+    )
+  })
+
+  it("forwards conversation_id on the execute-tools POST and reports the echo", async () => {
+    const lines = [
+      'data: {"type":"kiln_chat_trace","trace_id":"trace-1","conversation_id":"' +
+        CONVERSATION_ID +
+        '"}\n\n',
+      'data: {"type":"tool-calls-pending","items":[{"toolCallId":"tc1","toolName":"t","input":{},"requiresApproval":true}]}\n\n',
+    ]
+    let i = 0
+    let executeToolsBody: Record<string, unknown> | null = null
+    const fetchMock = vi
+      .fn()
+      .mockImplementation((url: string, init?: RequestInit) => {
+        if (url.endsWith("/execute-tools")) {
+          executeToolsBody = JSON.parse(init?.body as string) as Record<
+            string,
+            unknown
+          >
+          return Promise.resolve({
+            ok: true,
+            body: {
+              getReader: () => ({
+                read: () => Promise.resolve({ done: true, value: undefined }),
+              }),
+            },
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: () => {
+                if (i >= lines.length) {
+                  return Promise.resolve({ done: true, value: undefined })
+                }
+                const enc = new TextEncoder()
+                const line = lines[i]
+                i += 1
+                return Promise.resolve({ done: false, value: enc.encode(line) })
+              },
+            }),
+          },
+        })
+      })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const seenConversationIds: string[] = []
+    await streamChat({
+      apiUrl: "https://example.test/api/chat",
+      messages: [{ id: "u1", role: "user", content: "hi" }],
+      conversationId: CONVERSATION_ID,
+      onConversationId: (cid) => seenConversationIds.push(cid),
+      onAssistantMessage: () => {},
+      onToolCallsPending: async () => ({ tc1: true }),
+      onFinish: () => {},
+      onError: () => {},
+    })
+
+    const body = executeToolsBody as Record<string, unknown> | null
+    expect(body).not.toBeNull()
+    expect(body?.conversation_id).toBe(CONVERSATION_ID)
+    expect(seenConversationIds).toContain(CONVERSATION_ID)
+  })
+})

--- a/app/web_ui/src/lib/chat/streaming_chat.test.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.test.ts
@@ -314,6 +314,63 @@ describe("resumePendingToolCalls (graceful-stop handoff)", () => {
 
     vi.unstubAllGlobals()
   })
+
+  it("forwards conversation_id on the execute-tools POST and reports the echo", async () => {
+    const CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+    const contLines = [
+      'data: {"type":"kiln_chat_trace","trace_id":"trace-2","conversation_id":"' +
+        CONVERSATION_ID +
+        '"}\n\n',
+    ]
+    let i = 0
+    let sentBody: Record<string, unknown> | null = null
+    const fetchMock = vi.fn().mockImplementation((_url, init?: RequestInit) => {
+      sentBody = JSON.parse(init?.body as string) as Record<string, unknown>
+      return Promise.resolve({
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: () => {
+              if (i >= contLines.length) {
+                return Promise.resolve({ done: true, value: undefined })
+              }
+              const enc = new TextEncoder()
+              const line = contLines[i]
+              i += 1
+              return Promise.resolve({ done: false, value: enc.encode(line) })
+            },
+          }),
+        },
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const seenConversationIds: string[] = []
+    await resumePendingToolCalls({
+      apiUrl: "https://example.test/api/chat",
+      traceId: "trace-stop",
+      conversationId: CONVERSATION_ID,
+      items: [
+        {
+          toolCallId: "tc1",
+          toolName: "call_kiln_api",
+          input: {},
+          requiresApproval: true,
+        },
+      ],
+      onToolCallsPending: async () => ({ tc1: true }),
+      onConversationId: (cid) => seenConversationIds.push(cid),
+      onAssistantMessage: () => {},
+      onFinish: () => {},
+      onError: () => {},
+    })
+
+    const body = sentBody as Record<string, unknown> | null
+    expect(body?.conversation_id).toBe(CONVERSATION_ID)
+    expect(seenConversationIds).toContain(CONVERSATION_ID)
+
+    vi.unstubAllGlobals()
+  })
 })
 
 describe("normalizeContextUsage", () => {

--- a/app/web_ui/src/lib/chat/streaming_chat.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.ts
@@ -938,6 +938,8 @@ export interface ResumePendingToolCallsOptions {
   ) => Promise<Record<string, boolean>>
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   onChatTrace?: (traceId: string) => void
+  /** Fired when the execute-tools continuation echoes the conversation id. */
+  onConversationId?: (conversationId: string) => void
   onContextUsage?: (usage: ContextUsage) => void
   onCompactionStatus?: (compacting: boolean) => void
   onInlineError?: (message: string, traceId?: string, code?: string) => void
@@ -974,6 +976,7 @@ export async function resumePendingToolCalls(
     onToolCallsPending,
     onAssistantMessage,
     onChatTrace,
+    onConversationId,
     onContextUsage,
     onCompactionStatus,
     onInlineError,
@@ -993,6 +996,7 @@ export async function resumePendingToolCalls(
       currentTraceId = tid
       onChatTrace?.(tid)
     },
+    onConversationId,
     onContextUsage,
     onCompactionStatus,
     onInlineError,

--- a/app/web_ui/src/lib/chat/streaming_chat.ts
+++ b/app/web_ui/src/lib/chat/streaming_chat.ts
@@ -43,6 +43,12 @@ export interface BackendChatRequest {
     parts?: Array<Record<string, unknown>>
   }>
   trace_id?: string
+  /**
+   * Client-minted stable conversation identity (uuid4). Persisted by the
+   * copilot backend on every snapshot and used locally to key the
+   * conversation's spend budget.
+   */
+  conversation_id?: string
 }
 
 function toBackendMessage(m: ChatMessage): BackendChatRequest["messages"][0] {
@@ -149,6 +155,8 @@ export interface StreamEvent {
   status_code?: number
   /** Approximate context usage carried on the ``kiln_chat_trace`` snapshot event */
   context_usage?: RawContextUsage
+  /** Stable conversation identity echoed on the ``kiln_chat_trace`` event */
+  conversation_id?: string
   /** ``kiln_compaction_status`` carries the lifecycle state ("started" / "finished") */
   state?: string
   /** Preferred client version from a ``kiln_client_upgrade_nudge`` event */
@@ -185,9 +193,17 @@ export interface StreamChatOptions {
   messages: ChatMessage[]
   /** Prior-turn id from kiln_chat_trace; send with the new user message only */
   traceId?: string
+  /** Stable conversation identity (uuid4); sent on every request for spend budgeting */
+  conversationId?: string
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   /** Fired when upstream sends ``kiln_chat_trace`` (typically end of a turn) */
   onChatTrace?: (traceId: string) => void
+  /**
+   * Fired when the ``kiln_chat_trace`` event echoes the conversation's stable
+   * ``conversation_id`` — lets the client (re-)learn it (lazy adoption on
+   * pre-feature conversations, restore after lost local state).
+   */
+  onConversationId?: (conversationId: string) => void
   /**
    * Fired when the ``kiln_chat_trace`` snapshot event carries ``context_usage``;
    * drives the context gauge. Shared by ``StreamChatOptions`` (interactive
@@ -266,6 +282,7 @@ type PartSlot = { kind: "text"; id: string } | { kind: "tool"; id: string }
 export interface StreamEventProcessorOptions {
   onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   onChatTrace?: (traceId: string) => void
+  onConversationId?: (conversationId: string) => void
   onContextUsage?: (usage: ContextUsage) => void
   onCompactionStatus?: (compacting: boolean) => void
   onInlineError?: (message: string, traceId?: string, code?: string) => void
@@ -301,6 +318,7 @@ export class StreamEventProcessor {
 
   private onAssistantMessage: (update: (draft: ChatMessage) => void) => void
   private onChatTrace?: (traceId: string) => void
+  private onConversationId?: (conversationId: string) => void
   private onContextUsage?: (usage: ContextUsage) => void
   private onCompactionStatus?: (compacting: boolean) => void
   private onInlineError?: (
@@ -323,6 +341,7 @@ export class StreamEventProcessor {
   constructor(opts: StreamEventProcessorOptions) {
     this.onAssistantMessage = opts.onAssistantMessage
     this.onChatTrace = opts.onChatTrace
+    this.onConversationId = opts.onConversationId
     this.onContextUsage = opts.onContextUsage
     this.onCompactionStatus = opts.onCompactionStatus
     this.onInlineError = opts.onInlineError
@@ -552,6 +571,10 @@ export class StreamEventProcessor {
     if (typeof tid === "string" && tid) {
       this.onChatTrace?.(tid)
     }
+    const cid = event.conversation_id
+    if (typeof cid === "string" && cid) {
+      this.onConversationId?.(cid)
+    }
     const usage = normalizeContextUsage(event.context_usage)
     if (usage) {
       this.onContextUsage?.(usage)
@@ -665,8 +688,10 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
     apiUrl,
     messages,
     traceId,
+    conversationId,
     onAssistantMessage,
     onChatTrace,
+    onConversationId,
     onContextUsage,
     onCompactionStatus,
     onInlineError,
@@ -688,6 +713,9 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
   }
   if (traceId) {
     body.trace_id = traceId
+  }
+  if (conversationId) {
+    body.conversation_id = conversationId
   }
 
   let response: Response
@@ -750,6 +778,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
       currentTraceId = tid
       onChatTrace?.(tid)
     },
+    onConversationId,
     onContextUsage,
     onCompactionStatus,
     onInlineError,
@@ -842,6 +871,9 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
                     trace_id: currentTraceId,
                     tool_calls: toolCallsPayload,
                     decisions: decisionsPayload,
+                    ...(conversationId
+                      ? { conversation_id: conversationId }
+                      : {}),
                   }),
                   signal,
                 })
@@ -896,6 +928,8 @@ export interface ResumePendingToolCallsOptions {
   apiUrl: string
   /** Trace id of the conversation the surfaced tool calls belong to. */
   traceId: string
+  /** Stable conversation identity (uuid4); sent for spend budgeting. */
+  conversationId?: string
   /** The tool calls surfaced for approval (from a ``tool-calls-pending`` event). */
   items: ToolCallsPendingItem[]
   /** Reuses the normal approval gate: toolCallId → allowed. */
@@ -935,6 +969,7 @@ export async function resumePendingToolCalls(
   const {
     apiUrl,
     traceId,
+    conversationId,
     items,
     onToolCallsPending,
     onAssistantMessage,
@@ -1005,6 +1040,7 @@ export async function resumePendingToolCalls(
           trace_id: currentTraceId,
           tool_calls: toolCallsPayload,
           decisions: decisionsPayload,
+          ...(conversationId ? { conversation_id: conversationId } : {}),
         }),
       })
     } catch (err) {

--- a/app/web_ui/src/routes/(app)/assistant/auto_mode_consent_dialog.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/auto_mode_consent_dialog.svelte
@@ -2,6 +2,11 @@
   import posthog from "posthog-js"
   import Dialog from "$lib/ui/dialog.svelte"
   import type { AutoModeConsentRequiredPayload } from "$lib/chat/streaming_chat"
+  import type { BudgetStatus } from "$lib/chat/budget_store"
+
+  // Current conversation budget, surfaced so the user sees what auto mode may
+  // spend before turning it on. Null when no budget is set.
+  export let budgetStatus: BudgetStatus | null = null
 
   let dialog: Dialog
 
@@ -96,6 +101,18 @@
             example, reflective optimization runs) that
             <span class="font-semibold">use tokens and can incur real cost</span
             >.
+            {#if budgetStatus?.budget_usd != null}
+              This conversation has a spend budget of
+              <span class="font-semibold"
+                >${budgetStatus.budget_usd.toFixed(2)}</span
+              >
+              ({@const remaining = budgetStatus.remaining_usd ?? 0}<span
+                class="font-semibold">${remaining.toFixed(2)}</span
+              > remaining), after which it stops.
+            {:else}
+              No spend budget is set for this conversation — consider setting
+              one from the budget control below the chat.
+            {/if}
           </span>
         </li>
         <li class="flex items-start gap-2">

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -28,10 +28,13 @@
   import BrailleSpinner from "./braille_spinner.svelte"
   import ToolStatusLine from "./tool_status_line.svelte"
   import ContextUsageGauge from "$lib/ui/context_usage_gauge.svelte"
+  import { budget_store } from "$lib/chat/budget_store"
+  import ChatBudgetControl from "./chat_budget_control.svelte"
 
   export let store: ChatSessionStore = chatSessionStore
 
   let costDisclaimer: ChatCostDisclaimer
+  let budgetControl: ChatBudgetControl
   $: store.onConsentNeeded = () => costDisclaimer.prompt()
   let consentDialog: AutoModeConsentDialog
   let stopDialog: AutoModeStopDialog
@@ -149,6 +152,27 @@
   // Retry affordance from either source (auto burst or interactive stream).
   $: activeRetry = $autoRetry ?? $store.retry
   $: contextUsage = $store.contextUsage
+  // Point the budget store at the active conversation; it clears + refetches
+  // when the id changes (new chat, history restore, lazy adoption).
+  $: budget_store.setConversation($store.conversationId ?? null)
+  $: budgetStatus = $budget_store
+  // A live spend meter needs polling during long assistant-triggered operations
+  // (a single eval can run for minutes): usage is recorded server-side as the
+  // operation progresses, but nothing pushes it to the client. Poll while a tool
+  // round or auto burst is active; a final refresh lands when it settles.
+  $: budgetPollActive =
+    !!$store.conversationId && ($store.toolExecuting || autoWorking)
+  let budgetPollTimer: ReturnType<typeof setInterval> | null = null
+  $: {
+    if (budgetPollActive && !budgetPollTimer) {
+      budgetPollTimer = setInterval(() => void budget_store.refresh(), 5000)
+    } else if (!budgetPollActive && budgetPollTimer) {
+      clearInterval(budgetPollTimer)
+      budgetPollTimer = null
+      // One last refresh so the settled total is exact.
+      if ($store.conversationId) void budget_store.refresh()
+    }
+  }
   $: upgradeNudgeVersion = $store.upgradeNudgeVersion
   $: versionRequired = $store.versionRequired
   // A message typed while a turn was in flight, held client-side and surfaced
@@ -406,6 +430,10 @@
     messagesContainer?.removeEventListener("touchmove", handleTouchMove)
     scrollObserver?.disconnect()
     scrollObserver = null
+    if (budgetPollTimer) {
+      clearInterval(budgetPollTimer)
+      budgetPollTimer = null
+    }
   })
 
   function handleTextareaKeydown(e: KeyboardEvent): void {
@@ -470,6 +498,7 @@
       e.detail.messages,
       e.detail.continuationTraceId,
       e.detail.contextUsage,
+      e.detail.conversationId,
     )
     userNearBottom = true
     tick().then(() => {
@@ -881,6 +910,28 @@
       </div>
     {/if}
 
+    {#if budgetStatus?.exhausted}
+      <div class="flex-none w-full md:max-w-3xl md:mx-auto px-1 pt-2">
+        <div
+          class="flex items-center gap-2 rounded-lg border border-warning/40 bg-warning/5 px-3 py-2"
+        >
+          <div class="flex-1 min-w-0 text-xs text-base-content/80">
+            This conversation's spend budget (${budgetStatus.budget_usd?.toFixed(
+              2,
+            )}) is used up. The assistant can't run more operations until you
+            extend it.
+          </div>
+          <button
+            type="button"
+            class="shrink-0 btn btn-xs btn-warning"
+            on:click={() => budgetControl?.openExtend()}
+          >
+            Extend budget
+          </button>
+        </div>
+      </div>
+    {/if}
+
     {#if queuedMessage}
       <div class="flex-none w-full md:max-w-3xl md:mx-auto px-1 pt-2">
         <div
@@ -1001,17 +1052,23 @@
           Auto mode
         </button>
       {/if}
-      {#if contextUsage}
-        <div class="ml-auto">
+      <div class="ml-auto flex items-center gap-x-3">
+        <ChatBudgetControl
+          bind:this={budgetControl}
+          status={budgetStatus}
+          disabled={!$store.conversationId}
+          on:setbudget={(e) => budget_store.setBudget(e.detail.budgetUsd)}
+        />
+        {#if contextUsage}
           <ContextUsageGauge usage={contextUsage} />
-        </div>
-      {/if}
+        {/if}
+      </div>
     </div>
   </div>
 </div>
 
 <ChatCostDisclaimer bind:this={costDisclaimer} />
-<AutoModeConsentDialog bind:this={consentDialog} />
+<AutoModeConsentDialog bind:this={consentDialog} {budgetStatus} />
 <AutoModeStopDialog bind:this={stopDialog} />
 
 <style>

--- a/app/web_ui/src/routes/(app)/assistant/chat.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat.svelte
@@ -1057,7 +1057,7 @@
           bind:this={budgetControl}
           status={budgetStatus}
           disabled={!$store.conversationId}
-          on:setbudget={(e) => budget_store.setBudget(e.detail.budgetUsd)}
+          onSetBudget={(budgetUsd) => budget_store.setBudget(budgetUsd)}
         />
         {#if contextUsage}
           <ContextUsageGauge usage={contextUsage} />

--- a/app/web_ui/src/routes/(app)/assistant/chat_budget_control.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat_budget_control.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte"
   import Dialog from "$lib/ui/dialog.svelte"
   import type { BudgetStatus } from "$lib/chat/budget_store"
 
@@ -9,12 +8,16 @@
   // Disabled before a conversation exists (no id to key a budget by).
   export let disabled = false
 
-  const dispatch = createEventDispatcher<{
-    setbudget: { budgetUsd: number | null }
-  }>()
+  // Caller persists the value and reports success/failure so we can keep the
+  // dialog open and surface an error on failure.
+  export let onSetBudget: (
+    budgetUsd: number | null,
+  ) => Promise<{ ok: boolean; error?: string }> = async () => ({ ok: true })
 
   let dialog: Dialog
-  let inputValue = ""
+  // Bound to <input type="number">, so Svelte writes back a `number` (or `null`
+  // when the field is cleared) — NOT a string. Must be typed accordingly.
+  let inputValue: number | null = null
   let inputError: string | null = null
 
   $: hasBudget = status?.budget_usd != null
@@ -36,27 +39,29 @@
 
   function open(): void {
     if (disabled) return
-    inputValue = status?.budget_usd != null ? String(status.budget_usd) : ""
+    inputValue = status?.budget_usd ?? null
     inputError = null
     dialog.show()
   }
 
-  function save(): boolean {
-    const trimmed = inputValue.trim()
-    if (trimmed === "") {
-      // Empty clears the budget (spend tracking continues).
-      dispatch("setbudget", { budgetUsd: null })
-      return true
-    }
-    const parsed = Number(trimmed)
-    if (!Number.isFinite(parsed) || parsed < 0) {
+  // Returns whether the dialog should close. Keeps it open (surfacing an error)
+  // on invalid input or a failed persist, so failures aren't silently swallowed.
+  async function save(): Promise<boolean> {
+    inputError = null
+    // Empty field → null → clear the budget (spend tracking continues).
+    if (
+      inputValue !== null &&
+      (!Number.isFinite(inputValue) || inputValue < 0)
+    ) {
       inputError = "Enter a non-negative dollar amount."
-      return false // keep dialog open
+      return false
     }
-    // Guard against setting a new budget already below what's been spent — the
-    // conversation would be immediately exhausted. Allowed, but warn-worthy;
-    // we still permit it (the user may want to hard-stop).
-    dispatch("setbudget", { budgetUsd: parsed })
+    const result = await onSetBudget(inputValue)
+    if (!result.ok) {
+      inputError =
+        result.error ?? "Couldn't update the budget. Please try again."
+      return false
+    }
     return true
   }
 </script>
@@ -87,7 +92,7 @@
   subtitle="Cap the total cost of operations the assistant runs in this conversation — evals, data generation, task runs. These bill to your own model providers."
   action_buttons={[
     { label: "Cancel", isCancel: true },
-    { label: "Save", isPrimary: true, action: save },
+    { label: "Save", isPrimary: true, asyncAction: save },
   ]}
 >
   <div class="flex flex-col gap-3">

--- a/app/web_ui/src/routes/(app)/assistant/chat_budget_control.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat_budget_control.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte"
+  import Dialog from "$lib/ui/dialog.svelte"
+  import type { BudgetStatus } from "$lib/chat/budget_store"
+
+  // Current budget status for the active conversation, or null when none is set
+  // / nothing recorded yet.
+  export let status: BudgetStatus | null = null
+  // Disabled before a conversation exists (no id to key a budget by).
+  export let disabled = false
+
+  const dispatch = createEventDispatcher<{
+    setbudget: { budgetUsd: number | null }
+  }>()
+
+  let dialog: Dialog
+  let inputValue = ""
+  let inputError: string | null = null
+
+  $: hasBudget = status?.budget_usd != null
+  $: spent = status?.spent_usd ?? 0
+  $: partiallyTracked = (status?.unpriced_runs ?? 0) > 0
+
+  function fmt(n: number): string {
+    return `$${n.toFixed(2)}`
+  }
+
+  // Footer label: "Budget: $0.30 / $5.00" when set, else "Set budget".
+  $: label = hasBudget
+    ? `Budget: ${fmt(spent)} / ${fmt(status?.budget_usd ?? 0)}`
+    : "Set budget"
+
+  export function openExtend(): void {
+    open()
+  }
+
+  function open(): void {
+    if (disabled) return
+    inputValue = status?.budget_usd != null ? String(status.budget_usd) : ""
+    inputError = null
+    dialog.show()
+  }
+
+  function save(): boolean {
+    const trimmed = inputValue.trim()
+    if (trimmed === "") {
+      // Empty clears the budget (spend tracking continues).
+      dispatch("setbudget", { budgetUsd: null })
+      return true
+    }
+    const parsed = Number(trimmed)
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      inputError = "Enter a non-negative dollar amount."
+      return false // keep dialog open
+    }
+    // Guard against setting a new budget already below what's been spent — the
+    // conversation would be immediately exhausted. Allowed, but warn-worthy;
+    // we still permit it (the user may want to hard-stop).
+    dispatch("setbudget", { budgetUsd: parsed })
+    return true
+  }
+</script>
+
+<button
+  type="button"
+  class="btn btn-ghost btn-xs text-base-content/50 hover:text-base-content/80 disabled:bg-transparent disabled:text-base-content/25"
+  class:text-warning={status?.exhausted}
+  on:click={open}
+  {disabled}
+  title="Cap the spend of operations the assistant runs in this conversation."
+>
+  <span aria-hidden="true">◔</span>
+  {label}
+  {#if partiallyTracked}
+    <span
+      class="ml-1 text-base-content/40"
+      title="Some model calls couldn't be priced (e.g. local/custom models), so the budget only partially tracks spend."
+    >
+      *
+    </span>
+  {/if}
+</button>
+
+<Dialog
+  bind:this={dialog}
+  title="Conversation spend budget"
+  subtitle="Cap the total cost of operations the assistant runs in this conversation — evals, data generation, task runs. These bill to your own model providers."
+  action_buttons={[
+    { label: "Cancel", isCancel: true },
+    { label: "Save", isPrimary: true, action: save },
+  ]}
+>
+  <div class="flex flex-col gap-3">
+    <label class="form-control w-full">
+      <span class="label-text text-sm mb-1">Budget (USD)</span>
+      <input
+        type="number"
+        min="0"
+        step="0.01"
+        inputmode="decimal"
+        placeholder="e.g. 5.00 — leave empty for no cap"
+        class="input input-bordered w-full"
+        bind:value={inputValue}
+      />
+    </label>
+    {#if inputError}
+      <p class="text-xs text-error">{inputError}</p>
+    {/if}
+    {#if status}
+      <div class="text-xs text-base-content/60">
+        Spent so far: {fmt(spent)}
+        {#if partiallyTracked}
+          <span class="block mt-1">
+            Note: {status.unpriced_runs} model call{status.unpriced_runs === 1
+              ? ""
+              : "s"} couldn't be priced (e.g. local/custom models), so the tracked
+            total may be lower than the real cost.
+          </span>
+        {/if}
+      </div>
+    {/if}
+    <p class="text-xs text-base-content/50">
+      Once the budget is reached, the assistant stops running new operations
+      until you extend it. A long operation already running stops between steps.
+    </p>
+  </div>
+</Dialog>

--- a/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
+++ b/app/web_ui/src/routes/(app)/assistant/chat_compacting_indicator.test.ts
@@ -73,6 +73,7 @@ function baseState(
     collapsedPartKeys: {},
     lastSentAppState: null,
     contextUsage: null as ContextUsage | null,
+    conversationId: null as string | null,
     status: "submitted",
     abortController: null,
     toolApprovalWaiter: null,

--- a/app/web_ui/src/routes/(app)/assistant/chat_history.svelte
+++ b/app/web_ui/src/routes/(app)/assistant/chat_history.svelte
@@ -77,9 +77,14 @@
         sessionsError = createKilnError(error)
         return
       }
-      const { messages, continuationTraceId, contextUsage } =
+      const { messages, continuationTraceId, contextUsage, conversationId } =
         hydrateSessionFromSnapshot(snapshot)
-      dispatch("apply", { messages, continuationTraceId, contextUsage })
+      dispatch("apply", {
+        messages,
+        continuationTraceId,
+        contextUsage,
+        conversationId,
+      })
       posthog.capture("chat_history_session_loaded", {
         message_count: messages.length,
         auto_active: !!row.auto_active,

--- a/app/web_ui/src/routes/(app)/assistant/chat_queued_message.test.ts
+++ b/app/web_ui/src/routes/(app)/assistant/chat_queued_message.test.ts
@@ -65,6 +65,7 @@ function baseState(
     collapsedPartKeys: {},
     lastSentAppState: null,
     contextUsage: null as ContextUsage | null,
+    conversationId: null as string | null,
     status: "ready",
     abortController: null,
     toolApprovalWaiter: null,

--- a/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
@@ -20,6 +20,7 @@ from kiln_ai.adapters.model_adapters.stream_events import (
 )
 from kiln_ai.adapters.run_output import RunOutput
 from kiln_ai.datamodel import MessageUsage, Usage
+from kiln_ai.utils import spend_ledger
 
 if TYPE_CHECKING:
     from kiln_ai.adapters.model_adapters.litellm_adapter import LiteLlmAdapter
@@ -180,6 +181,13 @@ class AdapterStream:
             usage.total_llm_latency_ms = (
                 usage.total_llm_latency_ms or 0
             ) + call_latency_ms
+
+            # Same per-conversation spend credit as the non-streaming turn in
+            # LiteLlmAdapter._run_model_turn: once per LLM call, no-op unless
+            # an assistant-triggered request set the conversation contextvar.
+            spend_ledger.record_spend_for_current_conversation(
+                call_usage.cost, call_usage.total_tokens
+            )
 
             content = response_choice.message.content
             tool_calls = response_choice.message.tool_calls

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -51,6 +51,7 @@ from kiln_ai.tools.base_tool import (
     ToolCallDefinition,
 )
 from kiln_ai.tools.kiln_task_tool import KilnTaskToolResult
+from kiln_ai.utils import spend_ledger
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 from kiln_ai.utils.litellm import get_litellm_provider_info
 from kiln_ai.utils.open_ai_types import (
@@ -159,6 +160,15 @@ class LiteLlmAdapter(BaseAdapter):
             usage.total_llm_latency_ms = (
                 usage.total_llm_latency_ms or 0
             ) + call_latency_ms
+
+            # Credit the per-conversation spend ledger when this call happens
+            # inside an assistant-triggered request (contextvar set by the
+            # budget middleware / tool execution). Once per LLM call, so every
+            # in-process spend source (task runs, judges, data gen) is counted
+            # exactly once. No-op otherwise.
+            spend_ledger.record_spend_for_current_conversation(
+                call_usage.cost, call_usage.total_tokens
+            )
 
             # Extract content and tool calls
             if not hasattr(response_choice, "message"):

--- a/libs/core/kiln_ai/adapters/model_adapters/test_adapter_stream.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_adapter_stream.py
@@ -801,3 +801,90 @@ class TestFindToolName:
             function=Function(name=None, arguments="{}"),
         )
         assert _find_tool_name([tc], "call_1") == "unknown"
+
+
+class TestStreamingSpendCredit:
+    """The streaming turn credits the per-conversation spend ledger once per LLM
+    call — the mirror of test_run_model_turn_credits_spend_ledger for the
+    streaming path (adapter_stream.py). Assistant chat streams, so this is the
+    path that actually runs in production."""
+
+    CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+
+    @pytest.mark.asyncio
+    async def test_credits_once_when_contextvar_set(self, mock_adapter, mock_provider):
+        from kiln_ai.utils import spend_ledger
+
+        response = _make_model_response(content="Hello world")
+        fake_stream = FakeStreamingCompletion(response)
+        formatter = FakeChatFormatter()
+        call_usage = MessageUsage(
+            input_tokens=10, output_tokens=5, total_tokens=15, cost=0.5
+        )
+        mock_adapter.usage_from_response = MagicMock(return_value=call_usage)
+
+        token = spend_ledger.current_conversation_id.set(self.CONVERSATION_ID)
+        try:
+            with (
+                patch(
+                    "kiln_ai.adapters.model_adapters.adapter_stream.StreamingCompletion",
+                    return_value=fake_stream,
+                ),
+                patch.object(
+                    spend_ledger, "record_spend_for_current_conversation"
+                ) as mock_record,
+            ):
+                stream = AdapterStream(
+                    adapter=mock_adapter,
+                    provider=mock_provider,
+                    chat_formatter=formatter,
+                    initial_messages=[],
+                    top_logprobs=None,
+                )
+                async for _ in stream:
+                    pass
+        finally:
+            spend_ledger.current_conversation_id.reset(token)
+
+        mock_record.assert_called_once_with(0.5, 15)
+
+    @pytest.mark.asyncio
+    async def test_noop_when_contextvar_unset(self, mock_adapter, mock_provider):
+        # The contextvar is unset (normal, non-assistant run). The credit call
+        # still fires but is a no-op internally; verify it never records against
+        # a conversation. (Uses the real ledger indirection with the contextvar
+        # cleared, so a stray recording would create ledger state.)
+        from kiln_ai.utils import spend_ledger
+
+        response = _make_model_response(content="Hi")
+        fake_stream = FakeStreamingCompletion(response)
+        formatter = FakeChatFormatter()
+        mock_adapter.usage_from_response = MagicMock(
+            return_value=MessageUsage(total_tokens=3, cost=0.1)
+        )
+
+        # Ensure unset.
+        token = spend_ledger.current_conversation_id.set(None)
+        try:
+            with (
+                patch(
+                    "kiln_ai.adapters.model_adapters.adapter_stream.StreamingCompletion",
+                    return_value=fake_stream,
+                ),
+                patch.object(spend_ledger, "record_spend") as mock_record_spend,
+            ):
+                stream = AdapterStream(
+                    adapter=mock_adapter,
+                    provider=mock_provider,
+                    chat_formatter=formatter,
+                    initial_messages=[],
+                    top_logprobs=None,
+                )
+                async for _ in stream:
+                    pass
+        finally:
+            spend_ledger.current_conversation_id.reset(token)
+
+        # record_spend is the ledger-mutating call; it must never fire with no
+        # conversation in scope.
+        mock_record_spend.assert_not_called()

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -3237,3 +3237,49 @@ class TestUsageTracking:
         assert new_usage.input_tokens == 3
         assert new_usage.output_tokens == 4
         assert new_usage.cost == 0.05
+
+
+@pytest.mark.asyncio
+async def test_run_model_turn_credits_spend_ledger(tmp_path, config):
+    """Each LLM call credits the per-conversation spend ledger (when the
+    conversation contextvar is set — set by the desktop budget middleware)."""
+    from kiln_ai.utils import spend_ledger
+
+    project_path = tmp_path / "test_project" / "project.kiln"
+    project_path.parent.mkdir()
+    project = Project(name="Test Project", path=str(project_path))
+    project.save_to_file()
+    task = Task(name="Spend Task", instruction="Do the thing", parent=project)
+    task.save_to_file()
+
+    config.run_config_properties.model_name = "gpt-4o-mini"
+    config.run_config_properties.model_provider_name = ModelProviderName.openai
+    adapter = LiteLlmAdapter(config=config, kiln_task=task)
+
+    mock_response = ModelResponse(
+        model="gpt-4o-mini",
+        choices=[{"message": {"content": "done"}}],
+    )
+    mock_config_obj = Mock()
+    mock_config_obj.open_ai_api_key = "mock_api_key"
+    mock_config_obj.user_id = "test_user"
+
+    call_usage = MessageUsage(
+        input_tokens=10, output_tokens=5, total_tokens=15, cost=0.5
+    )
+
+    with (
+        patch.object(
+            LiteLlmAdapter,
+            "acompletion_checking_response",
+            new=AsyncMock(return_value=(mock_response, mock_response.choices[0])),
+        ),
+        patch.object(LiteLlmAdapter, "usage_from_response", return_value=call_usage),
+        patch.object(
+            spend_ledger, "record_spend_for_current_conversation"
+        ) as mock_record,
+        patch("kiln_ai.utils.config.Config.shared", return_value=mock_config_obj),
+    ):
+        await adapter.invoke("hello")
+
+    mock_record.assert_called_once_with(0.5, 15)

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -8,6 +8,7 @@ import jq
 
 from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
 from kiln_ai.tools.base_tool import KilnTool, ToolCallContext, ToolCallResult
+from kiln_ai.utils import spend_ledger
 
 # httpx read timeout is per-read (idle), not a wall-clock cap: it resets every
 # time a chunk arrives. So this bounds the gap *between* reads, not total
@@ -122,6 +123,13 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
         # timeout applies to SSE and non-SSE responses: read is per-read (idle),
         # so it bounds silence on the channel rather than total duration.
         headers = {"Content-Type": "application/json"}
+        # Attribute this request (and any model runs it spawns) to the current
+        # assistant conversation so the budget middleware can credit the spend
+        # ledger. Set by the desktop server around assistant tool execution;
+        # absent for any other use of this tool.
+        conversation_id = spend_ledger.current_conversation_id.get()
+        if conversation_id is not None:
+            headers[spend_ledger.CONVERSATION_ID_HEADER] = conversation_id
         # Per-request client: tool instances are short-lived (created per call
         # via tool_from_id), so a shared client wouldn't persist across calls anyway.
         timeout = httpx.Timeout(

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -781,3 +781,41 @@ class TestSSEReadTimeout:
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
             assert parsed["body"]["event_count"] == 8
+
+
+class TestConversationIdHeader:
+    """The tool stamps X-Kiln-Conversation-Id from the spend-ledger contextvar
+    so assistant-triggered requests can be attributed to a conversation."""
+
+    CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+
+    @pytest.mark.asyncio
+    async def test_header_present_when_contextvar_set(self, tool):
+        from kiln_ai.utils import spend_ledger
+
+        with respx.mock:
+            route = respx.get("http://test-server:8757/test").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            token = spend_ledger.current_conversation_id.set(self.CONVERSATION_ID)
+            try:
+                await tool.run(method="GET", url_path="/test")
+            finally:
+                spend_ledger.current_conversation_id.reset(token)
+            request = route.calls.last.request
+            assert (
+                request.headers[spend_ledger.CONVERSATION_ID_HEADER]
+                == self.CONVERSATION_ID
+            )
+
+    @pytest.mark.asyncio
+    async def test_header_absent_when_contextvar_unset(self, tool):
+        from kiln_ai.utils import spend_ledger
+
+        with respx.mock:
+            route = respx.get("http://test-server:8757/test").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            await tool.run(method="GET", url_path="/test")
+            request = route.calls.last.request
+            assert spend_ledger.CONVERSATION_ID_HEADER not in request.headers

--- a/libs/core/kiln_ai/utils/spend_ledger.py
+++ b/libs/core/kiln_ai/utils/spend_ledger.py
@@ -62,9 +62,25 @@ _LEDGER_FILENAME = "conversation_budgets.json"
 # writer would drop the other's update (os.replace still prevents corruption).
 # If Kiln is ever run multi-worker, replace this with a cross-process file lock.
 # The gate's "checked per call" correctness also relies on record_spend having
-# written to disk before the next is_exhausted read observes it — that coupling
-# holds because both go through this lock and the ledger is re-read each call.
+# observed the latest write before the next is_exhausted read — that coupling
+# holds because both go through this lock and read the same (cached) ledger.
 _lock = threading.Lock()
+
+# In-memory cache of the ledger, so is_exhausted (called per tool call and per
+# eval progress tick) and get_status don't hit disk every time. Keyed on the
+# ledger path so a settings-dir change (e.g. between tests) invalidates it. Kept
+# coherent with disk because every write goes through _write_ledger, which
+# updates the cache under _lock — consistent with the single-process assumption
+# above (a second process's writes would not be observed).
+_ledger_cache: dict[str, dict] | None = None
+_cached_path: str | None = None
+
+
+def _reset_cache() -> None:
+    """Drop the in-memory cache. For tests that write the ledger file directly."""
+    global _ledger_cache, _cached_path
+    _ledger_cache = None
+    _cached_path = None
 
 
 def is_valid_conversation_id(conversation_id: str) -> bool:
@@ -128,27 +144,39 @@ def _coerce_budget(value: object) -> float | None:
 
 
 def _load_ledger() -> dict[str, dict]:
+    global _ledger_cache, _cached_path
     path = _ledger_path()
+    if _ledger_cache is not None and _cached_path == path:
+        return _ledger_cache
+    _cached_path = path
     if not os.path.isfile(path):
-        return {}
+        _ledger_cache = {}
+        return _ledger_cache
     try:
         with open(path, "r") as f:
             data = json.load(f)
     except (json.JSONDecodeError, OSError):
         # A corrupt ledger should never break assistant chat; better to lose
         # budget state than to hard-fail every tool call.
-        return {}
+        _ledger_cache = {}
+        return _ledger_cache
     if not isinstance(data, dict):
-        return {}
-    return {k: v for k, v in data.items() if isinstance(v, dict)}
+        _ledger_cache = {}
+        return _ledger_cache
+    _ledger_cache = {k: v for k, v in data.items() if isinstance(v, dict)}
+    return _ledger_cache
 
 
 def _write_ledger(ledger: dict[str, dict]) -> None:
+    global _ledger_cache, _cached_path
     now = time.time()
+    # A missing/invalid updated_at defaults to `now` so a freshly-written entry
+    # (or a legacy one that predates the field) is never spuriously pruned.
     pruned = {
         cid: entry
         for cid, entry in ledger.items()
-        if now - _coerce_float(entry.get("updated_at")) < _PRUNE_AFTER_SECONDS
+        if now - _coerce_float(entry.get("updated_at"), default=now)
+        < _PRUNE_AFTER_SECONDS
     }
     path = _ledger_path()
     tmp_path = f"{path}.tmp"
@@ -158,6 +186,9 @@ def _write_ledger(ledger: dict[str, dict]) -> None:
     with open(tmp_path, "w") as f:
         json.dump(pruned, f, indent=2, ensure_ascii=False, allow_nan=False)
     os.replace(tmp_path, path)
+    # Keep the cache coherent with what we just persisted.
+    _ledger_cache = pruned
+    _cached_path = path
 
 
 def _entry_to_status(conversation_id: str, entry: dict) -> BudgetStatus:
@@ -212,13 +243,18 @@ def record_spend(
     with _lock:
         ledger = _load_ledger()
         entry = ledger.get(conversation_id, {})
+        # Coerce defensively (same as the read path): a wrong-typed stored field
+        # must not raise here. record_spend_for_current_conversation swallows any
+        # exception, so a raw float()/int() on a tampered entry would silently
+        # stop all further crediting for the conversation — i.e. fail OPEN, the
+        # budget cap effectively disabled. Coercion keeps it fail-safe.
         if cost_usd is not None and cost_usd > 0:
-            entry["spent_usd"] = float(entry.get("spent_usd") or 0.0) + cost_usd
+            entry["spent_usd"] = _coerce_float(entry.get("spent_usd")) + cost_usd
         elif cost_usd is None:
-            entry["unpriced_runs"] = int(entry.get("unpriced_runs") or 0) + 1
+            entry["unpriced_runs"] = _coerce_int(entry.get("unpriced_runs")) + 1
             if total_tokens:
                 entry["unpriced_tokens"] = (
-                    int(entry.get("unpriced_tokens") or 0) + total_tokens
+                    _coerce_int(entry.get("unpriced_tokens")) + total_tokens
                 )
         entry["updated_at"] = time.time()
         ledger[conversation_id] = entry

--- a/libs/core/kiln_ai/utils/spend_ledger.py
+++ b/libs/core/kiln_ai/utils/spend_ledger.py
@@ -55,6 +55,15 @@ _PRUNE_AFTER_SECONDS = 90 * 24 * 60 * 60
 
 _LEDGER_FILENAME = "conversation_budgets.json"
 
+# Serializes the load→mutate→write cycle so concurrent in-process credits can't
+# lose updates or expose a torn file (writes finish with an atomic os.replace).
+# NOTE: this is thread-safe, not process-safe — it assumes the desktop app runs
+# as a single process. Two processes could each load→mutate→write and the last
+# writer would drop the other's update (os.replace still prevents corruption).
+# If Kiln is ever run multi-worker, replace this with a cross-process file lock.
+# The gate's "checked per call" correctness also relies on record_spend having
+# written to disk before the next is_exhausted read observes it — that coupling
+# holds because both go through this lock and the ledger is re-read each call.
 _lock = threading.Lock()
 
 
@@ -87,6 +96,37 @@ def _ledger_path() -> str:
     return os.path.join(Config.settings_dir(), _LEDGER_FILENAME)
 
 
+def _coerce_float(value: object, default: float = 0.0) -> float:
+    """Best-effort float from a ledger field. A wrong-typed value (from manual
+    tampering or a future format change) falls back to the default rather than
+    raising — budget tracking must degrade, never break a run."""
+    try:
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    return result if math.isfinite(result) else default
+
+
+def _coerce_int(value: object, default: int = 0) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_budget(value: object) -> float | None:
+    """A stored ``budget_usd`` as a finite float, or None. A missing or
+    wrong-typed value → None ("no cap") rather than 0.0, so a tampered field
+    can never silently mark a conversation exhausted."""
+    if value is None:
+        return None
+    try:
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) and result >= 0 else None
+
+
 def _load_ledger() -> dict[str, dict]:
     path = _ledger_path()
     if not os.path.isfile(path):
@@ -108,22 +148,28 @@ def _write_ledger(ledger: dict[str, dict]) -> None:
     pruned = {
         cid: entry
         for cid, entry in ledger.items()
-        if now - float(entry.get("updated_at") or 0) < _PRUNE_AFTER_SECONDS
+        if now - _coerce_float(entry.get("updated_at")) < _PRUNE_AFTER_SECONDS
     }
     path = _ledger_path()
     tmp_path = f"{path}.tmp"
+    # ``allow_nan=False`` rejects non-finite floats (a stray inf/nan would emit
+    # the non-standard ``Infinity``/``NaN`` tokens, which are invalid JSON for
+    # any strict / other-language reader of the shared ledger file).
     with open(tmp_path, "w") as f:
-        json.dump(pruned, f, indent=2)
+        json.dump(pruned, f, indent=2, ensure_ascii=False, allow_nan=False)
     os.replace(tmp_path, path)
 
 
 def _entry_to_status(conversation_id: str, entry: dict) -> BudgetStatus:
+    # Coerce defensively: a structurally-valid entry with a wrong-typed field
+    # must not raise on the read path (is_exhausted → get_status), which the gate
+    # call sites invoke bare during tool execution / eval runs.
     return BudgetStatus(
         conversation_id=conversation_id,
-        budget_usd=entry.get("budget_usd"),
-        spent_usd=float(entry.get("spent_usd") or 0.0),
-        unpriced_runs=int(entry.get("unpriced_runs") or 0),
-        unpriced_tokens=int(entry.get("unpriced_tokens") or 0),
+        budget_usd=_coerce_budget(entry.get("budget_usd")),
+        spent_usd=_coerce_float(entry.get("spent_usd")),
+        unpriced_runs=_coerce_int(entry.get("unpriced_runs")),
+        unpriced_tokens=_coerce_int(entry.get("unpriced_tokens")),
     )
 
 
@@ -135,8 +181,10 @@ def set_budget(conversation_id: str, budget_usd: float | None) -> BudgetStatus:
     """
     if not is_valid_conversation_id(conversation_id):
         raise ValueError(f"Invalid conversation id: {conversation_id[:80]!r}")
-    if budget_usd is not None and (budget_usd < 0 or math.isnan(budget_usd)):
-        raise ValueError("budget_usd must be a non-negative number")
+    if budget_usd is not None and (not math.isfinite(budget_usd) or budget_usd < 0):
+        # Reject inf/nan too: they can't be serialized as valid JSON, and an
+        # "infinite budget" is just a confusing spelling of None ("no cap").
+        raise ValueError("budget_usd must be a non-negative finite number")
     with _lock:
         ledger = _load_ledger()
         entry = ledger.get(conversation_id, {})

--- a/libs/core/kiln_ai/utils/spend_ledger.py
+++ b/libs/core/kiln_ai/utils/spend_ledger.py
@@ -1,0 +1,218 @@
+"""Per-conversation spend ledger for assistant-triggered operations.
+
+The Kiln assistant triggers local operations (evals, data gen, task runs) via
+its ``call_kiln_api`` tool; those operations run against the user's own model
+providers and cost real money. This module tracks that spend per conversation
+and enforces an optional user-set USD budget:
+
+- ``current_conversation_id`` is set from the ``X-Kiln-Conversation-Id`` request
+  header by the desktop server's middleware (and around assistant tool
+  execution), so any model call made while handling an assistant-triggered
+  request can be attributed to the conversation.
+- The LiteLLM adapter calls :func:`record_spend` once per LLM call when the
+  contextvar is set; calls with no LiteLLM-reported cost (local/custom models)
+  debit nothing but are counted so the UI can surface "budget partially
+  tracked".
+- Budgets and running totals persist in ``~/.kiln_ai/conversation_budgets.json``
+  so they survive app restarts. Conversations are client-minted uuid4 ids.
+
+The budget number itself never blocks normal (user-initiated) UI operations:
+nothing sets the contextvar outside assistant tool execution.
+"""
+
+import json
+import math
+import os
+import re
+import threading
+import time
+from contextvars import ContextVar
+
+from pydantic import BaseModel
+
+from kiln_ai.utils.config import Config
+
+# Conversation id currently being served, set from the assistant's tool
+# execution path / the desktop server's budget middleware. None outside
+# assistant-triggered work.
+current_conversation_id: ContextVar[str | None] = ContextVar(
+    "kiln_current_conversation_id", default=None
+)
+
+# Header used by the assistant's call_kiln_api tool to attribute the local API
+# requests it makes (and everything they spawn) to a conversation.
+CONVERSATION_ID_HEADER = "X-Kiln-Conversation-Id"
+
+# Client-minted conversation ids are lowercase uuid4 (mirrors the copilot
+# backend's validation). ``\Z`` so a trailing newline can't pass the anchor.
+_CONVERSATION_ID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
+)
+
+# Entries untouched for this long are pruned on write; a conversation's budget
+# is not meaningful long after the conversation itself is gone.
+_PRUNE_AFTER_SECONDS = 90 * 24 * 60 * 60
+
+_LEDGER_FILENAME = "conversation_budgets.json"
+
+_lock = threading.Lock()
+
+
+def is_valid_conversation_id(conversation_id: str) -> bool:
+    return bool(_CONVERSATION_ID_PATTERN.match(conversation_id))
+
+
+class BudgetStatus(BaseModel):
+    conversation_id: str
+    # None means spend is tracked but no cap is set.
+    budget_usd: float | None = None
+    spent_usd: float = 0.0
+    # Model calls LiteLLM couldn't price (local/custom models). They debit
+    # nothing, so when > 0 the budget is only partially tracked.
+    unpriced_runs: int = 0
+    unpriced_tokens: int = 0
+
+    @property
+    def remaining_usd(self) -> float | None:
+        if self.budget_usd is None:
+            return None
+        return max(0.0, self.budget_usd - self.spent_usd)
+
+    @property
+    def exhausted(self) -> bool:
+        return self.budget_usd is not None and self.spent_usd >= self.budget_usd
+
+
+def _ledger_path() -> str:
+    return os.path.join(Config.settings_dir(), _LEDGER_FILENAME)
+
+
+def _load_ledger() -> dict[str, dict]:
+    path = _ledger_path()
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        # A corrupt ledger should never break assistant chat; better to lose
+        # budget state than to hard-fail every tool call.
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {k: v for k, v in data.items() if isinstance(v, dict)}
+
+
+def _write_ledger(ledger: dict[str, dict]) -> None:
+    now = time.time()
+    pruned = {
+        cid: entry
+        for cid, entry in ledger.items()
+        if now - float(entry.get("updated_at") or 0) < _PRUNE_AFTER_SECONDS
+    }
+    path = _ledger_path()
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(pruned, f, indent=2)
+    os.replace(tmp_path, path)
+
+
+def _entry_to_status(conversation_id: str, entry: dict) -> BudgetStatus:
+    return BudgetStatus(
+        conversation_id=conversation_id,
+        budget_usd=entry.get("budget_usd"),
+        spent_usd=float(entry.get("spent_usd") or 0.0),
+        unpriced_runs=int(entry.get("unpriced_runs") or 0),
+        unpriced_tokens=int(entry.get("unpriced_tokens") or 0),
+    )
+
+
+def set_budget(conversation_id: str, budget_usd: float | None) -> BudgetStatus:
+    """Set (or clear, with None) the USD budget for a conversation.
+
+    An absolute set: extending a budget means setting a new, larger total.
+    Spend already recorded is preserved.
+    """
+    if not is_valid_conversation_id(conversation_id):
+        raise ValueError(f"Invalid conversation id: {conversation_id[:80]!r}")
+    if budget_usd is not None and (budget_usd < 0 or math.isnan(budget_usd)):
+        raise ValueError("budget_usd must be a non-negative number")
+    with _lock:
+        ledger = _load_ledger()
+        entry = ledger.get(conversation_id, {})
+        entry["budget_usd"] = budget_usd
+        entry["updated_at"] = time.time()
+        ledger[conversation_id] = entry
+        _write_ledger(ledger)
+        return _entry_to_status(conversation_id, entry)
+
+
+def record_spend(
+    conversation_id: str,
+    cost_usd: float | None,
+    total_tokens: int | None,
+) -> None:
+    """Credit one model call's cost against the conversation.
+
+    ``cost_usd=None`` (LiteLLM couldn't price the model) debits nothing but
+    increments the unpriced counters so the UI can flag partial tracking.
+    Recording works even before a budget is set, so a budget applied mid-way
+    covers the conversation's full history.
+    """
+    if not is_valid_conversation_id(conversation_id):
+        return
+    with _lock:
+        ledger = _load_ledger()
+        entry = ledger.get(conversation_id, {})
+        if cost_usd is not None and cost_usd > 0:
+            entry["spent_usd"] = float(entry.get("spent_usd") or 0.0) + cost_usd
+        elif cost_usd is None:
+            entry["unpriced_runs"] = int(entry.get("unpriced_runs") or 0) + 1
+            if total_tokens:
+                entry["unpriced_tokens"] = (
+                    int(entry.get("unpriced_tokens") or 0) + total_tokens
+                )
+        entry["updated_at"] = time.time()
+        ledger[conversation_id] = entry
+        _write_ledger(ledger)
+
+
+def get_status(conversation_id: str) -> BudgetStatus | None:
+    """The conversation's budget status, or None if nothing was ever recorded."""
+    if not is_valid_conversation_id(conversation_id):
+        return None
+    with _lock:
+        entry = _load_ledger().get(conversation_id)
+    if entry is None:
+        return None
+    return _entry_to_status(conversation_id, entry)
+
+
+def is_exhausted(conversation_id: str | None) -> bool:
+    """True only when the conversation has a budget set and it is spent.
+
+    None / unknown conversations and conversations without a budget are never
+    exhausted — the feature is strictly opt-in.
+    """
+    if conversation_id is None:
+        return False
+    status = get_status(conversation_id)
+    return status is not None and status.exhausted
+
+
+def record_spend_for_current_conversation(
+    cost_usd: float | None, total_tokens: int | None
+) -> None:
+    """Credit spend to the contextvar's conversation, if one is set.
+
+    The single call site for adapters: a no-op outside assistant-triggered
+    requests, and never raises (budget tracking must not break model calls).
+    """
+    conversation_id = current_conversation_id.get()
+    if conversation_id is None:
+        return
+    try:
+        record_spend(conversation_id, cost_usd, total_tokens)
+    except Exception:
+        # Deliberately swallow: ledger IO problems must not fail the run.
+        pass

--- a/libs/core/kiln_ai/utils/test_spend_ledger.py
+++ b/libs/core/kiln_ai/utils/test_spend_ledger.py
@@ -1,0 +1,200 @@
+import json
+import time
+
+import pytest
+
+from kiln_ai.utils import spend_ledger
+
+CONVERSATION_ID = "1f2e3d4c-5b6a-4789-8abc-def012345678"
+OTHER_CONVERSATION_ID = "9e8d7c6b-5a49-4321-9fed-cba987654321"
+
+
+@pytest.fixture(autouse=True)
+def tmp_settings_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        spend_ledger.Config,
+        "settings_dir",
+        classmethod(lambda cls, create=True: str(tmp_path)),
+    )
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def clear_contextvar():
+    token = spend_ledger.current_conversation_id.set(None)
+    yield
+    spend_ledger.current_conversation_id.reset(token)
+
+
+class TestValidation:
+    def test_valid_uuid4(self):
+        assert spend_ledger.is_valid_conversation_id(CONVERSATION_ID)
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        ["", "not-a-uuid", CONVERSATION_ID.upper(), CONVERSATION_ID + "\n"],
+    )
+    def test_invalid_ids(self, bad_id):
+        assert not spend_ledger.is_valid_conversation_id(bad_id)
+
+    def test_set_budget_rejects_invalid_id(self):
+        with pytest.raises(ValueError, match="conversation id"):
+            spend_ledger.set_budget("junk", 5.0)
+
+    @pytest.mark.parametrize("bad_budget", [-1.0, float("nan")])
+    def test_set_budget_rejects_bad_amounts(self, bad_budget):
+        with pytest.raises(ValueError, match="non-negative"):
+            spend_ledger.set_budget(CONVERSATION_ID, bad_budget)
+
+
+class TestBudgetLifecycle:
+    def test_status_none_when_never_seen(self):
+        assert spend_ledger.get_status(CONVERSATION_ID) is None
+
+    def test_set_and_get_budget(self):
+        status = spend_ledger.set_budget(CONVERSATION_ID, 5.0)
+        assert status.budget_usd == 5.0
+        assert status.spent_usd == 0.0
+        assert status.remaining_usd == 5.0
+        assert not status.exhausted
+
+        loaded = spend_ledger.get_status(CONVERSATION_ID)
+        assert loaded is not None
+        assert loaded.budget_usd == 5.0
+
+    def test_extend_budget_preserves_spend(self):
+        spend_ledger.set_budget(CONVERSATION_ID, 1.0)
+        spend_ledger.record_spend(CONVERSATION_ID, 0.75, 1000)
+        spend_ledger.set_budget(CONVERSATION_ID, 2.0)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.budget_usd == 2.0
+        assert status.spent_usd == 0.75
+        assert status.remaining_usd == 1.25
+
+    def test_clear_budget_with_none(self):
+        spend_ledger.set_budget(CONVERSATION_ID, 1.0)
+        spend_ledger.set_budget(CONVERSATION_ID, None)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.budget_usd is None
+        assert not spend_ledger.is_exhausted(CONVERSATION_ID)
+
+
+class TestRecordSpend:
+    def test_record_before_budget_set_is_tracked(self):
+        spend_ledger.record_spend(CONVERSATION_ID, 0.10, 500)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.spent_usd == pytest.approx(0.10)
+        assert status.budget_usd is None
+
+    def test_spend_accumulates(self):
+        spend_ledger.record_spend(CONVERSATION_ID, 0.10, 100)
+        spend_ledger.record_spend(CONVERSATION_ID, 0.25, 100)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.spent_usd == pytest.approx(0.35)
+
+    def test_unpriced_runs_counted_not_debited(self):
+        spend_ledger.set_budget(CONVERSATION_ID, 1.0)
+        spend_ledger.record_spend(CONVERSATION_ID, None, 12345)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.spent_usd == 0.0
+        assert status.unpriced_runs == 1
+        assert status.unpriced_tokens == 12345
+        assert not status.exhausted
+
+    def test_spend_isolated_per_conversation(self):
+        spend_ledger.record_spend(CONVERSATION_ID, 0.10, 100)
+        spend_ledger.record_spend(OTHER_CONVERSATION_ID, 0.99, 100)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.spent_usd == pytest.approx(0.10)
+
+    def test_record_invalid_id_is_noop(self):
+        spend_ledger.record_spend("junk", 0.10, 100)
+        assert spend_ledger.get_status(CONVERSATION_ID) is None
+
+
+class TestExhaustion:
+    def test_exhausted_when_spend_reaches_budget(self):
+        spend_ledger.set_budget(CONVERSATION_ID, 0.5)
+        assert not spend_ledger.is_exhausted(CONVERSATION_ID)
+        spend_ledger.record_spend(CONVERSATION_ID, 0.5, 100)
+        assert spend_ledger.is_exhausted(CONVERSATION_ID)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.remaining_usd == 0.0
+
+    def test_no_budget_never_exhausted(self):
+        spend_ledger.record_spend(CONVERSATION_ID, 100.0, 100)
+        assert not spend_ledger.is_exhausted(CONVERSATION_ID)
+
+    def test_none_conversation_never_exhausted(self):
+        assert not spend_ledger.is_exhausted(None)
+
+    def test_zero_budget_immediately_exhausted(self):
+        spend_ledger.set_budget(CONVERSATION_ID, 0.0)
+        assert spend_ledger.is_exhausted(CONVERSATION_ID)
+
+
+class TestPersistence:
+    def test_ledger_survives_reload(self, tmp_settings_dir):
+        spend_ledger.set_budget(CONVERSATION_ID, 3.0)
+        spend_ledger.record_spend(CONVERSATION_ID, 1.0, 100)
+        # Read straight from disk to prove persistence, not caching.
+        with open(tmp_settings_dir / "conversation_budgets.json") as f:
+            raw = json.load(f)
+        assert raw[CONVERSATION_ID]["budget_usd"] == 3.0
+        assert raw[CONVERSATION_ID]["spent_usd"] == 1.0
+
+    def test_corrupt_ledger_degrades_gracefully(self, tmp_settings_dir):
+        (tmp_settings_dir / "conversation_budgets.json").write_text("{not json")
+        assert spend_ledger.get_status(CONVERSATION_ID) is None
+        # Writes still work (corrupt state is discarded).
+        spend_ledger.set_budget(CONVERSATION_ID, 1.0)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+
+    def test_old_entries_pruned_on_write(self, tmp_settings_dir):
+        stale = {
+            OTHER_CONVERSATION_ID: {
+                "budget_usd": 1.0,
+                "spent_usd": 0.0,
+                "updated_at": time.time() - spend_ledger._PRUNE_AFTER_SECONDS - 1,
+            }
+        }
+        (tmp_settings_dir / "conversation_budgets.json").write_text(json.dumps(stale))
+        spend_ledger.set_budget(CONVERSATION_ID, 1.0)
+        with open(tmp_settings_dir / "conversation_budgets.json") as f:
+            raw = json.load(f)
+        assert OTHER_CONVERSATION_ID not in raw
+        assert CONVERSATION_ID in raw
+
+
+class TestContextvarCredit:
+    def test_records_when_contextvar_set(self):
+        token = spend_ledger.current_conversation_id.set(CONVERSATION_ID)
+        try:
+            spend_ledger.record_spend_for_current_conversation(0.2, 100)
+        finally:
+            spend_ledger.current_conversation_id.reset(token)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.spent_usd == pytest.approx(0.2)
+
+    def test_noop_when_contextvar_unset(self):
+        spend_ledger.record_spend_for_current_conversation(0.2, 100)
+        assert spend_ledger.get_status(CONVERSATION_ID) is None
+
+    def test_never_raises_on_ledger_errors(self, monkeypatch):
+        token = spend_ledger.current_conversation_id.set(CONVERSATION_ID)
+        monkeypatch.setattr(
+            spend_ledger, "record_spend", lambda *a, **k: (_ for _ in ()).throw(OSError)
+        )
+        try:
+            spend_ledger.record_spend_for_current_conversation(0.2, 100)
+        finally:
+            spend_ledger.current_conversation_id.reset(token)

--- a/libs/core/kiln_ai/utils/test_spend_ledger.py
+++ b/libs/core/kiln_ai/utils/test_spend_ledger.py
@@ -16,6 +16,9 @@ def tmp_settings_dir(tmp_path, monkeypatch):
         "settings_dir",
         classmethod(lambda cls, create=True: str(tmp_path)),
     )
+    # Drop the module-level ledger cache so a test that writes the ledger file
+    # directly (rather than via the ledger API) isn't served a stale cache.
+    spend_ledger._reset_cache()
     return tmp_path
 
 
@@ -161,6 +164,26 @@ class TestPersistence:
         spend_ledger.set_budget(CONVERSATION_ID, 1.0)
         status = spend_ledger.get_status(CONVERSATION_ID)
         assert status is not None
+
+    def test_record_spend_tolerates_wrong_typed_entry(self, tmp_settings_dir):
+        # The write path (record_spend) must also coerce: a tampered entry must
+        # not raise, otherwise record_spend_for_current_conversation swallows it
+        # and crediting silently stops forever (fail-open — cap disabled).
+        tampered = {
+            CONVERSATION_ID: {
+                "budget_usd": 5.0,
+                "spent_usd": "not-a-number",
+                "unpriced_runs": "x",
+            }
+        }
+        (tmp_settings_dir / "conversation_budgets.json").write_text(
+            json.dumps(tampered)
+        )
+        # Does not raise; the bad spent_usd coerces to 0, then adds the new cost.
+        spend_ledger.record_spend(CONVERSATION_ID, 2.0, 100)
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.spent_usd == pytest.approx(2.0)
 
     def test_wrong_typed_entry_degrades_on_read_path(self, tmp_settings_dir):
         # A structurally-valid entry with wrong-typed fields (manual tampering /

--- a/libs/core/kiln_ai/utils/test_spend_ledger.py
+++ b/libs/core/kiln_ai/utils/test_spend_ledger.py
@@ -41,9 +41,13 @@ class TestValidation:
         with pytest.raises(ValueError, match="conversation id"):
             spend_ledger.set_budget("junk", 5.0)
 
-    @pytest.mark.parametrize("bad_budget", [-1.0, float("nan")])
+    @pytest.mark.parametrize(
+        "bad_budget", [-1.0, float("nan"), float("inf"), float("-inf")]
+    )
     def test_set_budget_rejects_bad_amounts(self, bad_budget):
-        with pytest.raises(ValueError, match="non-negative"):
+        # Non-finite values must be rejected: they can't serialize as valid JSON
+        # (would write the non-standard Infinity/NaN tokens into the shared file).
+        with pytest.raises(ValueError):
             spend_ledger.set_budget(CONVERSATION_ID, bad_budget)
 
 
@@ -157,6 +161,36 @@ class TestPersistence:
         spend_ledger.set_budget(CONVERSATION_ID, 1.0)
         status = spend_ledger.get_status(CONVERSATION_ID)
         assert status is not None
+
+    def test_wrong_typed_entry_degrades_on_read_path(self, tmp_settings_dir):
+        # A structurally-valid entry with wrong-typed fields (manual tampering /
+        # a future format change) must NOT raise out of the read path — the gate
+        # (is_exhausted) calls it bare during tool execution / eval runs.
+        tampered = {
+            CONVERSATION_ID: {
+                "budget_usd": "oops",
+                "spent_usd": "not-a-number",
+                "unpriced_runs": None,
+                "updated_at": "yesterday",
+            }
+        }
+        (tmp_settings_dir / "conversation_budgets.json").write_text(
+            json.dumps(tampered)
+        )
+        # None of these raise; the malformed budget coerces to "no cap".
+        status = spend_ledger.get_status(CONVERSATION_ID)
+        assert status is not None
+        assert status.budget_usd is None
+        assert status.spent_usd == 0.0
+        assert spend_ledger.is_exhausted(CONVERSATION_ID) is False
+
+    def test_ledger_written_as_valid_json(self, tmp_settings_dir):
+        # allow_nan=False guarantees the file is standard JSON any reader accepts.
+        spend_ledger.set_budget(CONVERSATION_ID, 2.0)
+        spend_ledger.record_spend(CONVERSATION_ID, 0.5, 100)
+        text = (tmp_settings_dir / "conversation_budgets.json").read_text()
+        assert "Infinity" not in text and "NaN" not in text
+        json.loads(text)  # parses cleanly
 
     def test_old_entries_pruned_on_write(self, tmp_settings_dir):
         stale = {

--- a/libs/server/kiln_server/utils/agent_checks/annotations/get_api_chat_budget_conversation_id.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/get_api_chat_budget_conversation_id.json
@@ -1,0 +1,8 @@
+{
+  "method": "get",
+  "path": "/api/chat/budget/{conversation_id}",
+  "agent_policy": {
+    "permission": "allow",
+    "requires_approval": false
+  }
+}

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_chat_budget_conversation_id.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_chat_budget_conversation_id.json
@@ -1,0 +1,8 @@
+{
+  "method": "post",
+  "path": "/api/chat/budget/{conversation_id}",
+  "agent_policy": {
+    "permission": "deny",
+    "requires_approval": false
+  }
+}


### PR DESCRIPTION
## What & why

Adds a **per-conversation USD spend budget** that caps the cost of operations the assistant triggers client-side — evals, data generation, task runs via the `call_kiln_api` tool. It deliberately excludes the copilot's own inference (that's billed separately); this budget only governs work that runs against the user's own model providers.

This is the client-side half of the feature (core library + desktop server + web UI). The copilot backend half — persisting the client-minted `conversation_id` on chat snapshots — is a companion PR in `kiln_server` (into `leonard/kil-692-assistant-auto-mode`).

## How it works

- **Identity:** the web UI mints a stable `conversation_id` (uuid4), persists it in the session, and sends it on every request. The copilot backend persists it on each snapshot and echoes it back, so it survives tab loss / history restore.
- **Tracking:** a `ContextVar` is set from the `X-Kiln-Conversation-Id` header (a new `BudgetContextMiddleware`) and around assistant tool execution. The LiteLLM adapter credits a local ledger (`~/.kiln_ai/conversation_budgets.json`) once per LLM call. Unpriced models (Ollama/custom) count \$0 but are surfaced as "partially tracked".
- **Enforcement, two ways:** a pre-dispatch gate on `call_kiln_api` returns a normal tool error when the budget is exhausted, and the eval runner stops scheduling new jobs between jobs (overshoot bounded to in-flight work).
- **Boundary:** the budget-set endpoint is `DENY_AGENT` — the assistant can never raise its own cap.

## UI

Budget control in the chat footer (set / extend / clear), a live "spent / remaining" readout, an "exhausted — extend" banner, and the remaining budget surfaced in the auto-mode consent dialog.

## Review

This branch was deep-code-reviewed (7 phases; artifacts under `reviews/projects/conversation-spend-budget/`). Two criticals and eight moderates were found and fixed:
- **C1:** the budget dialog's number-input binding threw on every interaction — fixed the type + validation.
- **C2:** auto idle-resume dropped `conversation_id`, silently disabling the gate — now persisted on the run record and recovered into the resume seed.
- Moderates: decline-path threading, non-finite budget → invalid JSON, defensive read-path for tampered ledger entries, surfacing set-budget failures, and two previously-untested risk paths (streaming credit, budget-store race guard).

## Testing

Python suites (core adapters, spend ledger, desktop chat, auto registry/api, eval, middleware) and web UI vitest all pass; `svelte-check` clean; `ruff` / `ty` / `eslint` / `prettier` clean. OpenAPI schema + agent-check annotations regenerated.

> **Note:** the commit includes a `.vscode/settings.json` change (personal `cursorpyright` editor settings) that predates this work and isn't part of the feature — drop it before merge if unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYhHTf3hgDWDnGricBNcxV