### PR TITLE
Eval API: make train_set_filter_id settable at creation, document schema constraints

### DIFF
--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -624,8 +624,8 @@ def connect_evals_api(app: FastAPI):
         task = task_from_id(project_id, task_id)
         # Derive the default eagerly so the POST response matches subsequent GETs
         # (the load-time migration would otherwise fill it on the next read)
-        train_set_filter_id = request.train_set_filter_id or default_train_set_filter_id(
-            request.name
+        train_set_filter_id = (
+            request.train_set_filter_id or default_train_set_filter_id(request.name)
         )
         eval = Eval(
             name=request.name,

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -16,6 +16,8 @@ from kiln_ai.datamodel import BasePrompt, Task, TaskRun
 from kiln_ai.datamodel.basemodel import ID_TYPE
 from kiln_ai.datamodel.dataset_filters import DatasetFilterId, dataset_filter_from_id
 from kiln_ai.datamodel.eval import (
+    EVAL_CONFIG_PROPERTIES_DESCRIPTION,
+    TEMPLATE_PROPERTIES_DESCRIPTION,
     Eval,
     EvalConfig,
     EvalConfigType,
@@ -23,6 +25,7 @@ from kiln_ai.datamodel.eval import (
     EvalOutputScore,
     EvalRun,
     EvalTemplateId,
+    default_train_set_filter_id,
 )
 from kiln_ai.datamodel.json_schema import string_to_json_key
 from kiln_ai.datamodel.prompt_id import is_frozen_prompt
@@ -192,13 +195,18 @@ class CreateEvaluatorRequest(BaseModel):
         description="The dataset filter for the eval set."
     )
     eval_configs_filter_id: DatasetFilterId | None = Field(
-        default=None, description="The dataset filter for comparing eval configs."
+        default=None,
+        description="The dataset filter for comparing eval configs (the 'golden' set with human ratings). Required for all templates except 'rag', including evals with no template.",
     )
     template_properties: dict[str, str | float | int | bool] | None = Field(
-        default=None, description="Template-specific properties."
+        default=None, description=TEMPLATE_PROPERTIES_DESCRIPTION
     )
     evaluation_data_type: EvalDataType = Field(
         description="The type of task output to evaluate."
+    )
+    train_set_filter_id: DatasetFilterId | None = Field(
+        default=None,
+        description="The dataset filter for the eval's training set (used by fine-tuning and prompt optimization), e.g. 'tag::train_my_eval'. Optional: if omitted, defaults to tag::train_{name_slug} derived from the eval name. Immutable after creation, so set it here if you need a non-default value.",
     )
 
 
@@ -207,9 +215,7 @@ class CreateEvalConfigRequest(BaseModel):
 
     name: str | None = Field(default=None, description="The name of the eval config.")
     type: EvalConfigType = Field(description="The type of eval config.")
-    properties: dict[str, Any] = Field(
-        description="Properties for the eval config, specific to the type."
-    )
+    properties: dict[str, Any] = Field(description=EVAL_CONFIG_PROPERTIES_DESCRIPTION)
     model_name: str = Field(description="The model to use for evaluation.")
     provider: ModelProviderName = Field(
         description="The provider of the evaluation model."
@@ -295,8 +301,9 @@ class UpdateEvalRequest(BaseModel):
     description: str | None = Field(
         default=None, description="The updated description."
     )
-    train_set_filter_id: str | None = Field(
-        default=None, description="The updated train set filter ID."
+    train_set_filter_id: DatasetFilterId | None = Field(
+        default=None,
+        description="The train set filter ID. Only accepted when the eval has no value yet; the value is immutable once set and a change returns 400. Evals always have a value after creation (an omitted value defaults to tag::train_{name_slug}), so in practice this cannot be changed via PATCH — set it via create_evaluator instead. Re-sending the current value is accepted as a no-op.",
     )
 
 
@@ -615,6 +622,11 @@ def connect_evals_api(app: FastAPI):
         request: CreateEvaluatorRequest,
     ) -> Eval:
         task = task_from_id(project_id, task_id)
+        # Derive the default eagerly so the POST response matches subsequent GETs
+        # (the load-time migration would otherwise fill it on the next read)
+        train_set_filter_id = request.train_set_filter_id or default_train_set_filter_id(
+            request.name
+        )
         eval = Eval(
             name=request.name,
             description=request.description,
@@ -622,6 +634,7 @@ def connect_evals_api(app: FastAPI):
             output_scores=request.output_scores,
             eval_set_filter_id=request.eval_set_filter_id,
             eval_configs_filter_id=request.eval_configs_filter_id,
+            train_set_filter_id=train_set_filter_id,
             template_properties=request.template_properties,
             evaluation_data_type=request.evaluation_data_type,
             parent=task,
@@ -709,17 +722,17 @@ def connect_evals_api(app: FastAPI):
         if request.description is not None:
             eval.description = request.description
 
-        # legacy evals (not created with Specs) do not have a train set filter, but we need one
-        # for some features such as prompt optimization
+        # train_set_filter_id is set-once: creation (or the load-time migration for old
+        # files) always fills it, and changing it would make results before and after
+        # the change incomparable
         if request.train_set_filter_id is not None:
-            # if the eval already has a train set filter, we do not allow changing it because it
-            # would make comparing results before and after the change very confusing
-            if eval.train_set_filter_id is not None:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Train set filter is already set and cannot be changed. Please create a new eval if you need a different train set.",
-                )
-            eval.train_set_filter_id = request.train_set_filter_id
+            if request.train_set_filter_id != eval.train_set_filter_id:
+                if eval.train_set_filter_id is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"train_set_filter_id is already set to '{eval.train_set_filter_id}' and cannot be changed, because changing it would make existing results incomparable. It is set at creation (pass train_set_filter_id to create_evaluator, or omit it to accept the default tag::train_{{name_slug}}). Create a new eval if you need a different train set.",
+                    )
+                eval.train_set_filter_id = request.train_set_filter_id
 
         eval.save_to_file()
         return eval

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -255,6 +255,46 @@ async def test_create_evaluator(
     assert saved_eval.template_properties["test_property"] == "test_value"
     assert saved_eval.template_properties["numeric_property"] == 42
 
+    # train_set_filter_id was omitted, so it's derived from the name at creation
+    assert result["train_set_filter_id"] == "tag::train_test_evaluator"
+    assert saved_eval.train_set_filter_id == "tag::train_test_evaluator"
+
+
+@pytest.mark.asyncio
+async def test_create_evaluator_with_explicit_train_set_filter_id(
+    client, mock_task_from_id, valid_evaluator_request, mock_task
+):
+    mock_task_from_id.return_value = mock_task
+
+    request_json = valid_evaluator_request.model_dump()
+    request_json["train_set_filter_id"] = "tag::train_custom"
+
+    response = client.post(
+        "/api/projects/project1/tasks/task1/create_evaluator",
+        json=request_json,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["train_set_filter_id"] == "tag::train_custom"
+    assert mock_task.evals()[0].train_set_filter_id == "tag::train_custom"
+
+
+@pytest.mark.asyncio
+async def test_create_evaluator_with_invalid_train_set_filter_id(
+    client, mock_task_from_id, valid_evaluator_request, mock_task
+):
+    mock_task_from_id.return_value = mock_task
+
+    request_json = valid_evaluator_request.model_dump()
+    request_json["train_set_filter_id"] = "not_a_filter"
+
+    response = client.post(
+        "/api/projects/project1/tasks/task1/create_evaluator",
+        json=request_json,
+    )
+
+    assert response.status_code == 422
+
 
 @pytest.mark.asyncio
 async def test_create_task_run_config_with_freezing(
@@ -1608,9 +1648,31 @@ def test_update_eval_train_set_filter_id_when_already_set(
 
     assert response.status_code == 400
     assert (
-        "Train set filter is already set and cannot be changed"
+        "train_set_filter_id is already set to 'tag::existing_train_set' and cannot be changed"
         in response.json()["message"]
     )
+
+
+def test_update_eval_train_set_filter_id_same_value_noop(
+    client, mock_task_from_id, mock_eval, mock_task
+):
+    """Test that re-sending the current train_set_filter_id is accepted as a no-op."""
+    mock_eval.train_set_filter_id = "tag::existing_train_set"
+
+    with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id:
+        mock_eval_from_id.return_value = mock_eval
+
+        update_request = {
+            "train_set_filter_id": "tag::existing_train_set",
+        }
+
+        response = client.patch(
+            "/api/projects/project1/tasks/task1/evals/eval1",
+            json=update_request,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["train_set_filter_id"] == "tag::existing_train_set"
 
 
 def test_update_eval_partial_update(client, mock_task_from_id, mock_eval, mock_task):

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -4473,7 +4473,7 @@ export interface components {
             type: components["schemas"]["EvalConfigType"];
             /**
              * Properties
-             * @description Properties for the eval config, specific to the type.
+             * @description Properties used to execute the eval config, specific to config_type. Must serialize to a JSON dict. For 'g_eval' and 'llm_as_judge': eval_steps (required, list of strings) contains the evaluation instructions for the judge model — they are concatenated into the judge's chain-of-thought instructions, as a numbered list when the list has multiple items or as a single instruction block when it has exactly one (to provide one free-form judge instruction, pass a single-item list); task_description (optional, string) is a short description of the task being evaluated, included as context in the judge's instructions.
              */
             properties: {
                 [key: string]: unknown;
@@ -4515,18 +4515,23 @@ export interface components {
             eval_set_filter_id: string;
             /**
              * Eval Configs Filter Id
-             * @description The dataset filter for comparing eval configs.
+             * @description The dataset filter for comparing eval configs (the 'golden' set with human ratings). Required for all templates except 'rag', including evals with no template.
              */
             eval_configs_filter_id?: string | null;
             /**
              * Template Properties
-             * @description Template-specific properties.
+             * @description Template-specific properties as a flat map of string/number/boolean values. Required and optional keys depend on the eval's template: 'kiln_issue' requires issue_prompt (string describing the issue the judge should detect), with optional failure_example and pass_example (strings); 'tool_call' requires tool (Kiln tool ID), tool_function_name and appropriate_tool_use_guidelines (strings), plus evaluation_data_type set to full_trace, with optional inappropriate_tool_use_guidelines (string). All other templates, and evals without a template, require no properties — pass null.
              */
             template_properties?: {
                 [key: string]: string | number | boolean;
             } | null;
             /** @description The type of task output to evaluate. */
             evaluation_data_type: components["schemas"]["EvalDataType"];
+            /**
+             * Train Set Filter Id
+             * @description The dataset filter for the eval's training set (used by fine-tuning and prompt optimization), e.g. 'tag::train_my_eval'. Optional: if omitted, defaults to tag::train_{name_slug} derived from the eval name. Immutable after creation, so set it here if you need a non-default value.
+             */
+            train_set_filter_id?: string | null;
         };
         /** CreateExtractorConfigRequest */
         CreateExtractorConfigRequest: {
@@ -5547,12 +5552,12 @@ export interface components {
             eval_set_filter_id: string;
             /**
              * Eval Configs Filter Id
-             * @description The id of the dataset filter which defines which dataset items are included when comparing the quality of the eval configs under this eval. Should consist of dataset items with ratings. Should be mutually exclusive with eval_set_filter_id.
+             * @description The id of the dataset filter which defines which dataset items are included when comparing the quality of the eval configs under this eval. Should consist of dataset items with ratings. Should be mutually exclusive with eval_set_filter_id. Required for all templates except 'rag', including evals with no template.
              */
             eval_configs_filter_id?: string | null;
             /**
              * Train Set Filter Id
-             * @description The id of the dataset filter which defines which dataset items are included in the training set for fine-tuning. Should be mutually exclusive with eval_set_filter_id.
+             * @description The id of the dataset filter which defines which dataset items are included in the training set for fine-tuning and prompt optimization. Set once at creation and immutable afterwards. If omitted at creation, defaults to tag::train_{name_slug} derived from the eval name (lowercased, spaces replaced with underscores). Should be mutually exclusive with eval_set_filter_id.
              */
             train_set_filter_id?: string | null;
             /**
@@ -5568,7 +5573,7 @@ export interface components {
             favourite: boolean;
             /**
              * Template Properties
-             * @description Properties to be used to execute the eval. This is template_type specific and should serialize to a json dict.
+             * @description Template-specific properties as a flat map of string/number/boolean values. Required and optional keys depend on the eval's template: 'kiln_issue' requires issue_prompt (string describing the issue the judge should detect), with optional failure_example and pass_example (strings); 'tool_call' requires tool (Kiln tool ID), tool_function_name and appropriate_tool_use_guidelines (strings), plus evaluation_data_type set to full_trace, with optional inappropriate_tool_use_guidelines (string). All other templates, and evals without a template, require no properties — pass null.
              */
             template_properties?: {
                 [key: string]: string | number | boolean;
@@ -5637,7 +5642,7 @@ export interface components {
             config_type: components["schemas"]["EvalConfigType"];
             /**
              * Properties
-             * @description Properties to be used to execute the eval config. This is config_type specific and should serialize to a json dict.
+             * @description Properties used to execute the eval config, specific to config_type. Must serialize to a JSON dict. For 'g_eval' and 'llm_as_judge': eval_steps (required, list of strings) contains the evaluation instructions for the judge model — they are concatenated into the judge's chain-of-thought instructions, as a numbered list when the list has multiple items or as a single instruction block when it has exactly one (to provide one free-form judge instruction, pass a single-item list); task_description (optional, string) is a short description of the task being evaluated, included as context in the judge's instructions.
              * @default {}
              */
             properties: {
@@ -10689,7 +10694,7 @@ export interface components {
             description?: string | null;
             /**
              * Train Set Filter Id
-             * @description The updated train set filter ID.
+             * @description The train set filter ID. Only accepted when the eval has no value yet; the value is immutable once set and a change returns 400. Evals always have a value after creation (an omitted value defaults to tag::train_{name_slug}), so in practice this cannot be changed via PATCH — set it via create_evaluator instead. Re-sending the current value is accepted as a no-op.
              */
             train_set_filter_id?: string | null;
         };

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -55,6 +55,42 @@ class EvalConfigType(str, Enum):
     llm_as_judge = "llm_as_judge"
 
 
+def default_train_set_filter_id(eval_name: str) -> str:
+    """The default train set filter id for an eval: tag::train_{name_slug}."""
+    return f"tag::train_{eval_name.lower().replace(' ', '_')}"
+
+
+TRAIN_SET_FILTER_ID_DESCRIPTION = (
+    "The id of the dataset filter which defines which dataset items are included in the "
+    "training set for fine-tuning and prompt optimization. Set once at creation and "
+    "immutable afterwards. If omitted at creation, defaults to tag::train_{name_slug} "
+    "derived from the eval name (lowercased, spaces replaced with underscores). Should "
+    "be mutually exclusive with eval_set_filter_id."
+)
+
+TEMPLATE_PROPERTIES_DESCRIPTION = (
+    "Template-specific properties as a flat map of string/number/boolean values. "
+    "Required and optional keys depend on the eval's template: 'kiln_issue' requires "
+    "issue_prompt (string describing the issue the judge should detect), with optional "
+    "failure_example and pass_example (strings); 'tool_call' requires tool (Kiln tool "
+    "ID), tool_function_name and appropriate_tool_use_guidelines (strings), plus "
+    "evaluation_data_type set to full_trace, with optional "
+    "inappropriate_tool_use_guidelines (string). All other templates, and evals without "
+    "a template, require no properties — pass null."
+)
+
+EVAL_CONFIG_PROPERTIES_DESCRIPTION = (
+    "Properties used to execute the eval config, specific to config_type. Must "
+    "serialize to a JSON dict. For 'g_eval' and 'llm_as_judge': eval_steps (required, "
+    "list of strings) contains the evaluation instructions for the judge model — they "
+    "are concatenated into the judge's chain-of-thought instructions, as a numbered "
+    "list when the list has multiple items or as a single instruction block when it "
+    "has exactly one (to provide one free-form judge instruction, pass a single-item "
+    "list); task_description (optional, string) is a short description of the task "
+    "being evaluated, included as context in the judge's instructions."
+)
+
+
 class EvalOutputScore(BaseModel):
     """
     A definition of a score that an evaluator will produce.
@@ -276,7 +312,7 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
     )
     properties: dict[str, Any] = Field(
         default={},
-        description="Properties to be used to execute the eval config. This is config_type specific and should serialize to a json dict.",
+        description=EVAL_CONFIG_PROPERTIES_DESCRIPTION,
     )
 
     def parent_eval(self) -> Union["Eval", None]:
@@ -289,6 +325,7 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
 
     @model_validator(mode="after")
     def validate_properties(self) -> Self:
+        # Keep EVAL_CONFIG_PROPERTIES_DESCRIPTION in sync with this validator
         if (
             self.config_type == EvalConfigType.g_eval
             or self.config_type == EvalConfigType.llm_as_judge
@@ -345,11 +382,11 @@ class Eval(KilnParentedModel, KilnParentModel, parent_of={"configs": EvalConfig}
     )
     eval_configs_filter_id: DatasetFilterId | None = Field(
         default=None,
-        description="The id of the dataset filter which defines which dataset items are included when comparing the quality of the eval configs under this eval. Should consist of dataset items with ratings. Should be mutually exclusive with eval_set_filter_id.",
+        description="The id of the dataset filter which defines which dataset items are included when comparing the quality of the eval configs under this eval. Should consist of dataset items with ratings. Should be mutually exclusive with eval_set_filter_id. Required for all templates except 'rag', including evals with no template.",
     )
     train_set_filter_id: DatasetFilterId | None = Field(
         default=None,
-        description="The id of the dataset filter which defines which dataset items are included in the training set for fine-tuning. Should be mutually exclusive with eval_set_filter_id.",
+        description=TRAIN_SET_FILTER_ID_DESCRIPTION,
     )
     output_scores: List[EvalOutputScore] = Field(
         description="The scores this evaluator should produce."
@@ -360,7 +397,7 @@ class Eval(KilnParentedModel, KilnParentModel, parent_of={"configs": EvalConfig}
     )
     template_properties: dict[str, str | int | bool | float] | None = Field(
         default=None,
-        description="Properties to be used to execute the eval. This is template_type specific and should serialize to a json dict.",
+        description=TEMPLATE_PROPERTIES_DESCRIPTION,
     )
     evaluation_data_type: EvalDataType = Field(
         default=EvalDataType.final_answer,
@@ -454,8 +491,7 @@ class Eval(KilnParentedModel, KilnParentModel, parent_of={"configs": EvalConfig}
         if self.train_set_filter_id is not None:
             return self
 
-        tag_suffix = self.name.lower().replace(" ", "_")
-        self.train_set_filter_id = f"tag::train_{tag_suffix}"
+        self.train_set_filter_id = default_train_set_filter_id(self.name)
         return self
 
     @model_validator(mode="after")
@@ -475,6 +511,7 @@ class Eval(KilnParentedModel, KilnParentModel, parent_of={"configs": EvalConfig}
 
     @model_validator(mode="after")
     def validate_template_properties(self) -> Self:
+        # Keep TEMPLATE_PROPERTIES_DESCRIPTION in sync with this validator
         # eval_configs_filter_id is required for all templates except "rag"
         if (
             self.template is not EvalTemplateId.rag

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -10,6 +10,7 @@ from kiln_ai.datamodel.eval import (
     EvalOutputScore,
     EvalRun,
     EvalTemplateId,
+    default_train_set_filter_id,
 )
 from kiln_ai.datamodel.task import Task
 from kiln_ai.datamodel.task_output import TaskOutputRatingType
@@ -207,6 +208,20 @@ def test_migrate_train_set_filter_id_not_on_new_eval():
         ],
     )
     assert eval.train_set_filter_id is None
+
+
+@pytest.mark.parametrize(
+    "eval_name,expected_tag",
+    [
+        ("Simple", "tag::train_simple"),
+        ("Two Words", "tag::train_two_words"),
+        ("UPPER CASE", "tag::train_upper_case"),
+        ("mixed Case Name", "tag::train_mixed_case_name"),
+        ("already_underscored", "tag::train_already_underscored"),
+    ],
+)
+def test_default_train_set_filter_id(eval_name, expected_tag):
+    assert default_train_set_filter_id(eval_name) == expected_tag
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Fixes the eval-creation API gaps surfaced by customer feedback from Kiln-Assistant-driven eval creation (2026-07-01): an API consumer reading the OpenAPI spec was misled about `train_set_filter_id`, `template_properties`, and `eval_steps` in ways that only surfaced as runtime errors.

**The `train_set_filter_id` trap (behavior fix):** it wasn't settable on `POST /create_evaluator`; a load-time migration then derived `tag::train_{name_slug}` on the next file read. Net effect: POST returned `null`, the following GET returned a derived value, and PATCH *always* 400ed ("already set") because the migration had backfilled it — the set-once PATCH branch was unreachable dead code, and nothing in the schema hinted at any of this.

Changes:

- `CreateEvaluatorRequest` accepts optional `train_set_filter_id`; `create_evaluator` derives the `tag::train_{name_slug}` default **eagerly** so the POST response matches subsequent GETs. Derivation is shared with the load migration via a new `default_train_set_filter_id()` helper.
- PATCH: re-sending the current value is a no-op; a real change still 400s, with a message that names the current value, explains why it's immutable (results would become incomparable), and points to `create_evaluator`.
- `UpdateEvalRequest.train_set_filter_id` tightened `str` → `DatasetFilterId` (invalid values now 422 at parse instead of failing on assignment).
- Field descriptions (the source for OpenAPI → TS types → assistant api_docs) now document the set-once/derivation semantics, per-template `template_properties` requirements (`kiln_issue` → `issue_prompt`; `tool_call` → `tool`, `tool_function_name`, `appropriate_tool_use_guidelines`), and `eval_steps` concatenation semantics (including the single-item-list idiom for one free-form judge instruction). Descriptions are shared constants defined next to the validators they describe, with sync-pointer comments.
- Regenerated `api_schema.d.ts`.

Considered and rejected: a `judge_instruction` alias for `eval_steps` (adds a second write path across GEvalTask, the copilot seeding, and the UI utils; a single-item list already does this) and new validation for `desired_behaviour` (nothing consumes `desired_behaviour_description` on the legacy template path — that requirement exists only on the typed Spec path, which is already reflected in the schema).

Behavior notes:

- Eval files now persist an explicit `train_set_filter_id` at creation (same value the migration would derive, so GETs are unchanged). One nuance: a rename-then-load no longer re-derives the value — it's pinned at creation, which is more predictable.
- Pre-existing files without the field are still handled by the retained load migration.

Companion change: kiln_server api_docs regenerated from this spec (Kiln-AI/kiln_server#249), and assistant playbook guidance updated in the canonical skill source.

## Related Issues

Addresses customer feedback on API-driven eval creation (2026-07-01); no GitHub issue filed.

## Contributor License Agreement

I, @tawnymanticore, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed (`checks.sh` green; plus an end-to-end pass against the real app: POST/GET consistency, PATCH semantics, descriptions present in served `openapi.json`)
- [x] New tests have been added to any work in /lib (`default_train_set_filter_id` unit tests in `test_eval_model.py`; create/PATCH coverage in `test_eval_api.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
