### PR TITLE
Add GLM 5.2 Fast, Hunyuan Hy3, and GLM 5.2 SiliconFlow provider to model list

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -262,6 +262,7 @@ class ModelName(str, Enum):
     glm_z1_32b_0414 = "glm_z1_32b_0414"
     glm_z1_9b_0414 = "glm_z1_9b_0414"
     ernie_4_5_300b_a47b = "ernie_4_5_300b_a47b"
+    hunyuan_hy3 = "hunyuan_hy3"
     hunyuan_a13b = "hunyuan_a13b"
     hunyuan_a13b_no_thinking = "hunyuan_a13b_no_thinking"
     minimax_m3 = "minimax_m3"
@@ -7200,6 +7201,13 @@ built_in_models: List[KilnModel] = [
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
             ),
+            KilnModelProvider(
+                name=ModelProviderName.siliconflow_cn,
+                model_id="zai-org/GLM-5.2",
+                structured_output_mode=StructuredOutputMode.json_instructions,
+                suggested_for_evals=True,
+                suggested_for_data_gen=True,
+            ),
         ],
     ),
     # GLM 5.2 Fast — Fireworks speed-optimized serving of GLM 5.2 (routers/ slug, ~2x throughput)
@@ -7899,6 +7907,20 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_data_gen=True,
                 supports_function_calling=False,
+            ),
+        ],
+    ),
+    # Hunyuan Hy3 — Tencent's 295B MoE (21B active), 256K context, text-only reasoning + tool-calling model.
+    # reasoning_capable left False: Hy3 has adaptive/hybrid thinking (a no_think toggle) and can return no reasoning.
+    KilnModel(
+        family=ModelFamily.hunyuan,
+        name=ModelName.hunyuan_hy3,
+        friendly_name="Hunyuan Hy3",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="tencent/hy3",
+                structured_output_mode=StructuredOutputMode.json_schema,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -246,6 +246,7 @@ class ModelName(str, Enum):
     kimi_k2_5 = "kimi_k2_5"
     kimi_dev_72b = "kimi_dev_72b"
     glm_5_2 = "glm_5_2"
+    glm_5_2_fast = "glm_5_2_fast"
     glm_5_1 = "glm_5_1"
     glm_5_turbo = "glm_5_turbo"
     glm_5v_turbo = "glm_5v_turbo"
@@ -7198,6 +7199,19 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
+            ),
+        ],
+    ),
+    # GLM 5.2 Fast — Fireworks speed-optimized serving of GLM 5.2 (routers/ slug, ~2x throughput)
+    KilnModel(
+        family=ModelFamily.glm,
+        name=ModelName.glm_5_2_fast,
+        friendly_name="GLM 5.2 Fast",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                model_id="accounts/fireworks/routers/glm-5p2-fast",
+                structured_output_mode=StructuredOutputMode.json_instructions,
             ),
         ],
     ),


### PR DESCRIPTION
## What does this PR do?

Adds two new models and one provider backfill, found during a last-10-days model-discovery scan. Slack thread: https://getkiln.slack.com/archives/C0AG8U78MNG/p1783521355261089

- **GLM 5.2 Fast** (`fireworks_ai`) — Fireworks' speed-optimized serving of GLM 5.2 via the `routers/` slug `accounts/fireworks/routers/glm-5p2-fast` (~2x throughput). This is the first entry in the list to use a Fireworks `routers/` path rather than `models/`; Kiln passes `model_id` through to LiteLLM verbatim (`utils/litellm.py`), so no adapter change was required. Fireworks-direct only — see the Test Results note on why OpenRouter can't reach this tier.
- **Hunyuan Hy3** (`openrouter`) — Tencent's 295B-MoE (21B active), 256K-context, text-only reasoning + tool-calling model (`tencent/hy3`, released 2026-07-06). OpenRouter is the only Kiln-routable provider (Fireworks/Together/SiliconFlow don't carry it yet).
- **GLM 5.2 → SiliconFlow backfill** — added a `siliconflow_cn` provider (`zai-org/GLM-5.2`) to the existing GLM 5.2 entry, so GLM 5.2 is now available on OpenRouter + Fireworks + Together + SiliconFlow.

### Test Results

`reasoning_capable` was left False on both GLM 5.2 Fast and Hunyuan Hy3, per the skill's adaptive-reasoning default: both use hybrid/adaptive thinking (Hy3 has an explicit `no_think` toggle) and can return no reasoning, which would otherwise trip Kiln's "reasoning required" runtime error. GLM 5.2 Fast mirrors the base GLM 5.2 config (`json_instructions`) and does not carry the `suggested_for_*` flags, keeping base 5.2 as the recommended entry. Hunyuan Hy3 confirmed working on `json_schema` structured output (no fallback to `json_instructions` was needed — no 400/schema rejection ever occurred). The GLM 5.2 SiliconFlow slug is the base `zai-org/GLM-5.2` with no `Pro/` prefix — verified against models.dev and SiliconFlow's own catalog, which (unlike GLM 5 / 5.1, which use `Pro/`) list 5.2 only under the bare slug.

On OpenRouter and GLM 5.2 Fast: OpenRouter has no separate "GLM 5.2 Fast" slug — it exposes a single `z-ai/glm-5.2` slug, and "Fast" is an endpoint tag (`fireworks/fast`) within it. Kiln has no mechanism to pin a specific OpenRouter endpoint tag (the provider `order` list in `litellm_adapter.py` uses bare provider slugs), so the fast tier is only reachable via the direct Fireworks `routers/` slug used here.

Hunyuan Hy3 note: 6 of its API tests passed cleanly (proving the slug + json_schema config are correct), but the remaining tests could not be confirmed green because the shared OpenRouter key hit persistent upstream 429 rate-limiting on `tencent/hy3` (provider AtlasCloud) across 20–40+ retries with backoff. These are transient upstream rate limits, not code defects — the blocked tests fail on the identical code path as the ones that passed. They should be re-run once the upstream limit clears or with a dedicated (BYOK) OpenRouter key.

GLM 5.2 Fast (fireworks_ai):
- 11 passed, 1 skipped, 0 failed

GLM 5.2 (siliconflow_cn):
- 11 passed, 1 skipped, 0 failed

Hunyuan Hy3 (openrouter):
- 6 passed, 1 skipped, 5 blocked by transient upstream 429 (AtlasCloud rate-limiting tencent/hy3 on the shared OpenRouter key — not a config defect)

---
GLM 5.2 Fast (fireworks_ai):
✅ test_data_gen_all_models_providers[glm_5_2_fast-fireworks_ai]
✅ test_data_gen_sample_all_models_providers[glm_5_2_fast-fireworks_ai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[glm_5_2_fast-fireworks_ai]
✅ test_all_built_in_models_llm_as_judge[glm_5_2_fast-fireworks_ai]
✅ test_tools_all_built_in_models[glm_5_2_fast-fireworks_ai]
✅ test_all_built_in_models_structured_output[glm_5_2_fast-fireworks_ai]
✅ test_all_built_in_models_structured_input[glm_5_2_fast-fireworks_ai]
✅ test_structured_input_cot_prompt_builder[glm_5_2_fast-fireworks_ai]
✅ test_structured_output_cot_prompt_builder[glm_5_2_fast-fireworks_ai]
✅ test_all_models_providers_plaintext[glm_5_2_fast-fireworks_ai]
✅ test_cot_prompt_builder[glm_5_2_fast-fireworks_ai]
⏭️ test_all_built_in_models_logprobs_geval[glm_5_2_fast-fireworks_ai] — skipped: logprobs unsupported on Fireworks (expected)

GLM 5.2 (siliconflow_cn):
✅ test_data_gen_all_models_providers[glm_5_2-siliconflow_cn]
✅ test_data_gen_sample_all_models_providers[glm_5_2-siliconflow_cn]
✅ test_data_gen_sample_all_models_providers_with_structured_output[glm_5_2-siliconflow_cn]
✅ test_all_built_in_models_llm_as_judge[glm_5_2-siliconflow_cn]
✅ test_tools_all_built_in_models[glm_5_2-siliconflow_cn]
✅ test_all_built_in_models_structured_output[glm_5_2-siliconflow_cn]
✅ test_all_built_in_models_structured_input[glm_5_2-siliconflow_cn]
✅ test_structured_input_cot_prompt_builder[glm_5_2-siliconflow_cn]
✅ test_structured_output_cot_prompt_builder[glm_5_2-siliconflow_cn]
✅ test_all_models_providers_plaintext[glm_5_2-siliconflow_cn]
✅ test_cot_prompt_builder[glm_5_2-siliconflow_cn]
⏭️ test_all_built_in_models_logprobs_geval[glm_5_2-siliconflow_cn] — skipped: logprobs unsupported (expected)

Hunyuan Hy3 (openrouter):
✅ test_all_built_in_models_structured_output[hunyuan_hy3-openrouter]
✅ test_all_built_in_models_structured_input[hunyuan_hy3-openrouter]
✅ test_structured_output_cot_prompt_builder[hunyuan_hy3-openrouter]
✅ test_data_gen_all_models_providers[hunyuan_hy3-openrouter]
✅ test_data_gen_sample_all_models_providers[hunyuan_hy3-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[hunyuan_hy3-openrouter]
⏭️ test_all_built_in_models_logprobs_geval[hunyuan_hy3-openrouter] — skipped: logprobs unsupported (expected)
⚠️ test_all_built_in_models_llm_as_judge[hunyuan_hy3-openrouter] — blocked: persistent upstream 429 (AtlasCloud), not a config defect
⚠️ test_structured_input_cot_prompt_builder[hunyuan_hy3-openrouter] — blocked: persistent upstream 429 (AtlasCloud)
⚠️ test_tools_all_built_in_models[hunyuan_hy3-openrouter] — blocked: persistent upstream 429 (AtlasCloud)
⚠️ test_all_models_providers_plaintext[hunyuan_hy3-openrouter] — blocked: persistent upstream 429 (AtlasCloud)
⚠️ test_cot_prompt_builder[hunyuan_hy3-openrouter] — blocked: persistent upstream 429 (AtlasCloud)

## Checklists

- [X] Tests have been run locally and passed (GLM 5.2 Fast and GLM 5.2 SiliconFlow fully green; Hunyuan Hy3 partially validated — see the upstream-429 note above)
- [X] New tests have been added to any work in /lib

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoR534onKozPRFyk7F5BUL)_