### PR TITLE
Add GPT-5.6 (Sol, Terra, Luna) to model list

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -654,7 +654,7 @@ built_in_models: List[KilnModel] = [
                 default_thinking_level="none",
                 # Use OpenRouter's reasoning object so reasoning is preserved
                 # when tools are sent (the bare reasoning_effort param is
-                # silently dropped on tool calls for openai/gpt-5.5).
+                # silently dropped on tool calls for these models).
                 openrouter_reasoning_object=True,
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
@@ -711,7 +711,7 @@ built_in_models: List[KilnModel] = [
                 default_thinking_level="none",
                 # Use OpenRouter's reasoning object so reasoning is preserved
                 # when tools are sent (the bare reasoning_effort param is
-                # silently dropped on tool calls for openai/gpt-5.5).
+                # silently dropped on tool calls for these models).
                 openrouter_reasoning_object=True,
                 supports_doc_extraction=True,
                 supports_vision=True,
@@ -766,7 +766,7 @@ built_in_models: List[KilnModel] = [
                 default_thinking_level="none",
                 # Use OpenRouter's reasoning object so reasoning is preserved
                 # when tools are sent (the bare reasoning_effort param is
-                # silently dropped on tool calls for openai/gpt-5.5).
+                # silently dropped on tool calls for these models).
                 openrouter_reasoning_object=True,
                 supports_doc_extraction=True,
                 supports_vision=True,

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -678,7 +678,7 @@ built_in_models: List[KilnModel] = [
         family=ModelFamily.gpt,
         name=ModelName.gpt_5_6_terra,
         friendly_name="GPT-5.6 Terra",
-        editorial_notes="OpenAI's most capable GPT model. Powerful reasoning and multimodal.",
+        editorial_notes="OpenAI's balanced GPT-5.6 model. Strong reasoning and multimodal at a lower cost.",
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openai,
@@ -733,7 +733,7 @@ built_in_models: List[KilnModel] = [
         family=ModelFamily.gpt,
         name=ModelName.gpt_5_6_luna,
         friendly_name="GPT-5.6 Luna",
-        editorial_notes="OpenAI's most capable GPT model. Powerful reasoning and multimodal.",
+        editorial_notes="OpenAI's fast, cost-efficient GPT-5.6 model. Optimized for speed and high-volume tasks.",
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openai,

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -843,7 +843,6 @@ built_in_models: List[KilnModel] = [
         family=ModelFamily.gpt,
         name=ModelName.gpt_5_4,
         friendly_name="GPT-5.4",
-        featured_rank=1,
         editorial_notes="OpenAI's most capable GPT model. Powerful reasoning and multimodal.",
         providers=[
             KilnModelProvider(

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -66,6 +66,9 @@ class ModelName(str, Enum):
     llama_3_3_70b = "llama_3_3_70b"
     llama_4_maverick = "llama_4_maverick"
     llama_4_scout = "llama_4_scout"
+    gpt_5_6_sol = "gpt_5_6_sol"
+    gpt_5_6_terra = "gpt_5_6_terra"
+    gpt_5_6_luna = "gpt_5_6_luna"
     gpt_5_5 = "gpt_5_5"
     gpt_5_4 = "gpt_5_4"
     gpt_5_4_pro = "gpt_5_4_pro"
@@ -610,17 +613,17 @@ FUGU_ULTRA_OPENROUTER_THINKING_LEVELS = {
 
 
 built_in_models: List[KilnModel] = [
-    # GPT 5.5
+    # GPT 5.6 Sol
     KilnModel(
         family=ModelFamily.gpt,
-        name=ModelName.gpt_5_5,
-        friendly_name="GPT-5.5",
+        name=ModelName.gpt_5_6_sol,
+        friendly_name="GPT-5.6 Sol",
         featured_rank=1,
         editorial_notes="OpenAI's most capable GPT model. Powerful reasoning and multimodal.",
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openai,
-                model_id="gpt-5.5",
+                model_id="gpt-5.6-sol",
                 structured_output_mode=StructuredOutputMode.json_schema,
                 available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
                 default_thinking_level="none",
@@ -645,7 +648,7 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                model_id="openai/gpt-5.5",
+                model_id="openai/gpt-5.6-sol",
                 structured_output_mode=StructuredOutputMode.json_schema,
                 available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
                 default_thinking_level="none",
@@ -655,6 +658,171 @@ built_in_models: List[KilnModel] = [
                 openrouter_reasoning_object=True,
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+    # GPT 5.6 Terra
+    KilnModel(
+        family=ModelFamily.gpt,
+        name=ModelName.gpt_5_6_terra,
+        friendly_name="GPT-5.6 Terra",
+        editorial_notes="OpenAI's most capable GPT model. Powerful reasoning and multimodal.",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openai,
+                model_id="gpt-5.6-terra",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
+                default_thinking_level="none",
+                # OpenAI rejects reasoning_effort + tools on /v1/chat/completions
+                # for gpt-5.4+. Disable function calling until Kiln routes these
+                # models to /v1/responses.
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="openai/gpt-5.6-terra",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
+                default_thinking_level="none",
+                # Use OpenRouter's reasoning object so reasoning is preserved
+                # when tools are sent (the bare reasoning_effort param is
+                # silently dropped on tool calls for openai/gpt-5.5).
+                openrouter_reasoning_object=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+    # GPT 5.6 Luna
+    KilnModel(
+        family=ModelFamily.gpt,
+        name=ModelName.gpt_5_6_luna,
+        friendly_name="GPT-5.6 Luna",
+        editorial_notes="OpenAI's most capable GPT model. Powerful reasoning and multimodal.",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openai,
+                model_id="gpt-5.6-luna",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
+                default_thinking_level="none",
+                # OpenAI rejects reasoning_effort + tools on /v1/chat/completions
+                # for gpt-5.4+. Disable function calling until Kiln routes these
+                # models to /v1/responses.
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="openai/gpt-5.6-luna",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
+                default_thinking_level="none",
+                # Use OpenRouter's reasoning object so reasoning is preserved
+                # when tools are sent (the bare reasoning_effort param is
+                # silently dropped on tool calls for openai/gpt-5.5).
+                openrouter_reasoning_object=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+        ],
+    ),
+    # GPT 5.5
+    KilnModel(
+        family=ModelFamily.gpt,
+        name=ModelName.gpt_5_5,
+        friendly_name="GPT-5.5",
+        editorial_notes="OpenAI's most capable GPT model. Powerful reasoning and multimodal.",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openai,
+                model_id="gpt-5.5",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
+                default_thinking_level="none",
+                # OpenAI rejects reasoning_effort + tools on /v1/chat/completions
+                # for gpt-5.4+. Disable function calling until Kiln routes these
+                # models to /v1/responses.
+                supports_function_calling=False,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="openai/gpt-5.5",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                available_thinking_levels=GPT_5_4_OPENAI_THINKING_LEVELS,
+                default_thinking_level="none",
+                # Use OpenRouter's reasoning object so reasoning is preserved
+                # when tools are sent (the bare reasoning_effort param is
+                # silently dropped on tool calls for openai/gpt-5.5).
+                openrouter_reasoning_object=True,
                 supports_doc_extraction=True,
                 supports_vision=True,
                 multimodal_capable=True,


### PR DESCRIPTION
## What does this PR do?

Adds OpenAI's **GPT-5.6** family — **Sol** (flagship), **Terra** (balanced), and **Luna** (fast) — to the built-in model list, on both the `openai` and `openrouter` providers. GPT-5.6 launched July 9, 2026. Configuration is inherited from the GPT-5.5 predecessor: 1.05M context, vision + document extraction (PDF/TXT/MD/JPG/PNG), `json_schema` structured output, `supports_function_calling=False` on the OpenAI provider (pending `/v1/responses` routing, matching the existing GPT-5.4+ note), and `openrouter_reasoning_object=True`. Sol becomes the featured GPT flagship: `featured_rank=1` and the `suggested_for_evals` / `suggested_for_data_gen` flags were moved from GPT-5.5 to Sol (zero-sum swap, so the suggested-model count stays stable).

Slack thread: https://getkiln.slack.com/archives/C0AG8U78MNG/p1783627798733649

### Test Results

Web and secondary sources claimed Sol supported a `max` reasoning-effort level, but paid testing proved the API rejects it deterministically on both providers (`400 - 'reasoning_effort' does not support 'max' with this model. Supported values are: 'none', 'low', 'medium', 'high', 'xhigh'`). I dropped `max` — all three tiers use the standard `GPT_5_4_OPENAI_THINKING_LEVELS` (none/low/medium/high/xhigh), and the Sol-specific thinking-levels constant that had been added was removed. After that fix there are no ❌ real errors.

Two categories of non-blocking noise remain. (1) `test_thinking_level_reasoning_content` asserts reasoning content is present per effort level, but OpenAI's chat/completions route (which Kiln uses for these models) does not surface reasoning summaries, so it returns `None` for low/medium/high/xhigh. I confirmed the predecessor **GPT-5.5 fails this test identically** on both providers — pre-existing behavior, not a regression introduced here. (2) The shared OpenAI key intermittently returns `401 insufficient permissions` on ~15–20% of calls; these shift run-to-run and pass on rerun (OpenRouter is clean every time). Both are marked ⚠️ below.

GPT-5.6 Sol (openrouter):
- All functional + extraction tests passed
- ⚠️ pre-existing reasoning-content-None on low/medium/high/xhigh

GPT-5.6 Terra (openrouter):
- All functional + extraction tests passed
- ⚠️ pre-existing reasoning-content-None on low/medium/high/xhigh

GPT-5.6 Luna (openrouter):
- All functional + extraction tests passed
- ⚠️ pre-existing reasoning-content-None on low/medium/high/xhigh

GPT-5.6 Sol (openai):
- All functional + extraction tests passed
- ⚠️ pre-existing reasoning-content-None on low/medium/high/xhigh; ⚠️ intermittent 401 flakes (pass on rerun)

GPT-5.6 Terra (openai):
- All functional + extraction tests passed
- ⚠️ pre-existing reasoning-content-None on low/medium/high/xhigh; ⚠️ intermittent 401 flakes (pass on rerun)

GPT-5.6 Luna (openai):
- All functional + extraction tests passed
- ⚠️ pre-existing reasoning-content-None on low/medium/high/xhigh; ⚠️ intermittent 401 flakes (pass on rerun)

---
GPT-5.6 Sol (openai):
✅ test_supports_vision_is_coherent[gpt_5_6_sol-openai]
✅ test_provider_bad_request[gpt_5_6_sol-openai]
✅ test_data_gen_all_models_providers[gpt_5_6_sol-openai]
✅ test_data_gen_sample_all_models_providers[gpt_5_6_sol-openai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[gpt_5_6_sol-openai]
✅ test_all_built_in_models_llm_as_judge[gpt_5_6_sol-openai]
✅ test_all_built_in_models_structured_output[gpt_5_6_sol-openai]
✅ test_all_built_in_models_structured_input[gpt_5_6_sol-openai]
✅ test_structured_input_cot_prompt_builder[gpt_5_6_sol-openai]
⚠️ test_structured_output_cot_prompt_builder[gpt_5_6_sol-openai] — intermittent 401 insufficient-permissions (passes on rerun)
✅ test_all_models_providers_plaintext[gpt_5_6_sol-openai]
✅ test_cot_prompt_builder[gpt_5_6_sol-openai]
✅ test_extract_document_success[application/pdf-*-gpt_5_6_sol-openai]
⚠️ test_extract_document_success[image/png-*-gpt_5_6_sol-openai] — intermittent 401 (passes on rerun)
⚠️ test_extract_document_success[image/jpeg-*-gpt_5_6_sol-openai] — intermittent 401 (passes on rerun)
✅ test_thinking_level_reasoning_content[...-gpt_5_6_sol-none]
⚠️ test_thinking_level_reasoning_content[...-gpt_5_6_sol-low|medium|high|xhigh] — reasoning content None (pre-existing; GPT-5.5 identical)

GPT-5.6 Terra (openai):
✅ test_supports_vision_is_coherent[gpt_5_6_terra-openai]
✅ test_provider_bad_request[gpt_5_6_terra-openai]
✅ test_data_gen_all_models_providers[gpt_5_6_terra-openai]
✅ test_data_gen_sample_all_models_providers[gpt_5_6_terra-openai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[gpt_5_6_terra-openai]
✅ test_all_built_in_models_llm_as_judge[gpt_5_6_terra-openai]
✅ test_all_built_in_models_structured_output[gpt_5_6_terra-openai]
⚠️ test_all_built_in_models_structured_input[gpt_5_6_terra-openai] — intermittent 401 (passes on rerun)
⚠️ test_structured_input_cot_prompt_builder[gpt_5_6_terra-openai] — intermittent 401 (passes on rerun)
✅ test_structured_output_cot_prompt_builder[gpt_5_6_terra-openai]
⚠️ test_all_models_providers_plaintext[gpt_5_6_terra-openai] — intermittent 401 (passes on rerun)
✅ test_cot_prompt_builder[gpt_5_6_terra-openai]
✅ test_extract_document_success[application/pdf-*-gpt_5_6_terra-openai]
⚠️ test_extract_document_success[image/png|jpeg-*-gpt_5_6_terra-openai] — intermittent 401 (passes on rerun)
✅ test_thinking_level_reasoning_content[...-gpt_5_6_terra-none]
⚠️ test_thinking_level_reasoning_content[...-gpt_5_6_terra-low|medium|high|xhigh] — reasoning content None (pre-existing; GPT-5.5 identical)

GPT-5.6 Luna (openai):
✅ test_supports_vision_is_coherent[gpt_5_6_luna-openai]
✅ test_provider_bad_request[gpt_5_6_luna-openai]
✅ test_data_gen_all_models_providers[gpt_5_6_luna-openai]
✅ test_data_gen_sample_all_models_providers[gpt_5_6_luna-openai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[gpt_5_6_luna-openai]
✅ test_all_built_in_models_llm_as_judge[gpt_5_6_luna-openai]
✅ test_all_built_in_models_structured_output[gpt_5_6_luna-openai]
✅ test_all_built_in_models_structured_input[gpt_5_6_luna-openai]
✅ test_structured_input_cot_prompt_builder[gpt_5_6_luna-openai]
✅ test_structured_output_cot_prompt_builder[gpt_5_6_luna-openai]
✅ test_all_models_providers_plaintext[gpt_5_6_luna-openai]
⚠️ test_cot_prompt_builder[gpt_5_6_luna-openai] — intermittent 401 (passes on rerun)
⚠️ test_extract_document_success[application/pdf-*-gpt_5_6_luna-openai] — intermittent 401 (passes on rerun)
⚠️ test_extract_document_success[image/png-*-gpt_5_6_luna-openai] — intermittent 401 (passes on rerun)
✅ test_extract_document_success[image/jpeg-*-gpt_5_6_luna-openai]
✅ test_thinking_level_reasoning_content[...-gpt_5_6_luna-none]
⚠️ test_thinking_level_reasoning_content[...-gpt_5_6_luna-low|medium|high|xhigh] — reasoning content None (pre-existing; GPT-5.5 identical)

GPT-5.6 Sol (openrouter):
✅ test_supports_vision_is_coherent[gpt_5_6_sol-openrouter]
✅ test_provider_bad_request[gpt_5_6_sol-openrouter]
✅ test_data_gen_all_models_providers[gpt_5_6_sol-openrouter]
✅ test_data_gen_sample_all_models_providers[gpt_5_6_sol-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[gpt_5_6_sol-openrouter]
✅ test_all_built_in_models_llm_as_judge[gpt_5_6_sol-openrouter]
✅ test_all_built_in_models_structured_output[gpt_5_6_sol-openrouter]
✅ test_all_built_in_models_structured_input[gpt_5_6_sol-openrouter]
✅ test_structured_input_cot_prompt_builder[gpt_5_6_sol-openrouter]
✅ test_structured_output_cot_prompt_builder[gpt_5_6_sol-openrouter]
✅ test_all_models_providers_plaintext[gpt_5_6_sol-openrouter]
✅ test_cot_prompt_builder[gpt_5_6_sol-openrouter]
✅ test_extract_document_success[application/pdf|image/png|image/jpeg-*-gpt_5_6_sol-openrouter]
✅ test_thinking_level_reasoning_content[...-gpt_5_6_sol-none]
⚠️ test_thinking_level_reasoning_content[...-gpt_5_6_sol-low|medium|high|xhigh] — reasoning content None (pre-existing; GPT-5.5 identical)

GPT-5.6 Terra (openrouter):
✅ test_supports_vision_is_coherent[gpt_5_6_terra-openrouter]
✅ test_provider_bad_request[gpt_5_6_terra-openrouter]
✅ test_data_gen_all_models_providers[gpt_5_6_terra-openrouter]
✅ test_data_gen_sample_all_models_providers[gpt_5_6_terra-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[gpt_5_6_terra-openrouter]
✅ test_all_built_in_models_llm_as_judge[gpt_5_6_terra-openrouter]
✅ test_all_built_in_models_structured_output[gpt_5_6_terra-openrouter]
✅ test_all_built_in_models_structured_input[gpt_5_6_terra-openrouter]
✅ test_structured_input_cot_prompt_builder[gpt_5_6_terra-openrouter]
✅ test_structured_output_cot_prompt_builder[gpt_5_6_terra-openrouter]
✅ test_all_models_providers_plaintext[gpt_5_6_terra-openrouter]
✅ test_cot_prompt_builder[gpt_5_6_terra-openrouter]
✅ test_extract_document_success[application/pdf|image/png|image/jpeg-*-gpt_5_6_terra-openrouter]
✅ test_thinking_level_reasoning_content[...-gpt_5_6_terra-none]
⚠️ test_thinking_level_reasoning_content[...-gpt_5_6_terra-low|medium|high|xhigh] — reasoning content None (pre-existing; GPT-5.5 identical)

GPT-5.6 Luna (openrouter):
✅ test_supports_vision_is_coherent[gpt_5_6_luna-openrouter]
✅ test_provider_bad_request[gpt_5_6_luna-openrouter]
✅ test_data_gen_all_models_providers[gpt_5_6_luna-openrouter]
✅ test_data_gen_sample_all_models_providers[gpt_5_6_luna-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[gpt_5_6_luna-openrouter]
✅ test_all_built_in_models_llm_as_judge[gpt_5_6_luna-openrouter]
✅ test_all_built_in_models_structured_output[gpt_5_6_luna-openrouter]
✅ test_all_built_in_models_structured_input[gpt_5_6_luna-openrouter]
✅ test_structured_input_cot_prompt_builder[gpt_5_6_luna-openrouter]
✅ test_structured_output_cot_prompt_builder[gpt_5_6_luna-openrouter]
✅ test_all_models_providers_plaintext[gpt_5_6_luna-openrouter]
✅ test_cot_prompt_builder[gpt_5_6_luna-openrouter]
✅ test_extract_document_success[application/pdf|image/png|image/jpeg-*-gpt_5_6_luna-openrouter]
✅ test_thinking_level_reasoning_content[...-gpt_5_6_luna-none]
⚠️ test_thinking_level_reasoning_content[...-gpt_5_6_luna-low|medium|high|xhigh] — reasoning content None (pre-existing; GPT-5.5 identical)

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib