### PR TITLE
Fix KIL-764 + KilnEvalHelpers extensions (KA2-Full port fixes)

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_helpers.py
@@ -66,14 +66,44 @@ class KilnEvalHelpers:
 
     @staticmethod
     def get_tool_results(trace: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
-        """Return all tool-result entries from a trace."""
+        """Return all tool-result entries from a trace.
+
+        Matches OpenAI-format ``role: "tool"`` messages — the shape Kiln
+        actually stores (``ChatCompletionToolMessageParamWrapper``) — as well
+        as the ``role``/``type`` == "tool_result" variants.
+        """
         if not trace:
             return []
         return [
             entry
             for entry in trace
-            if entry.get("role") == "tool_result" or entry.get("type") == "tool_result"
+            if entry.get("role") in ("tool", "tool_result")
+            or entry.get("type") == "tool_result"
         ]
+
+    @staticmethod
+    def get_tool_result_content(
+        trace: list[dict[str, Any]] | None, tool_call_id: str
+    ) -> str:
+        """Return the text content of the tool result answering *tool_call_id*.
+
+        Pairs OpenAI-format tool results (``role: "tool"``) with their
+        originating call by ``tool_call_id``. List-of-blocks content is
+        flattened to text. Returns ``""`` when no result matches.
+        """
+        for entry in KilnEvalHelpers.get_tool_results(trace):
+            if entry.get("tool_call_id") != tool_call_id:
+                continue
+            content = entry.get("content")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                return "\n".join(
+                    block.get("text", "") if isinstance(block, dict) else str(block)
+                    for block in content
+                )
+            return "" if content is None else str(content)
+        return ""
 
     # -- Tool-call matching -------------------------------------------------
 
@@ -157,3 +187,14 @@ class KilnEvalHelpers:
             return re.search(pattern, text) is not None
         except Exception:
             return False
+
+    @staticmethod
+    def get_markdown_links(text: str | None) -> list[tuple[str, str]]:
+        """Return ``(link_text, target)`` pairs for every markdown link in *text*.
+
+        Never raises; ``None``/empty input yields ``[]``.
+        """
+        try:
+            return re.findall(r"\[([^\]]+)\]\(([^)]+)\)", text or "")
+        except Exception:
+            return []

--- a/libs/core/kiln_ai/adapters/eval/eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_helpers.py
@@ -188,6 +188,109 @@ class KilnEvalHelpers:
         except Exception:
             return False
 
+    # -- Health / usage metrics ----------------------------------------------
+
+    @staticmethod
+    def _field(obj: Any, name: str) -> Any:
+        """Read *name* from a dict or an attribute-bearing object.
+
+        Trace messages arrive as plain dicts over JSON transports but may carry
+        Pydantic objects (e.g. ``usage`` as ``MessageUsage``) over the in-process
+        pickle transport — duck-type both.
+        """
+        if isinstance(obj, dict):
+            return obj.get(name)
+        return getattr(obj, name, None)
+
+    @staticmethod
+    def get_usage_totals(trace: list[dict[str, Any]] | None) -> dict[str, float]:
+        """Sum per-message ``usage`` across assistant messages.
+
+        Returns ``{"input_tokens", "output_tokens", "total_tokens",
+        "cached_tokens", "cost"}`` (floats, 0.0 when absent). ``usage`` values
+        may be dicts or objects (see ``_field``).
+        """
+        totals = {
+            "input_tokens": 0.0,
+            "output_tokens": 0.0,
+            "total_tokens": 0.0,
+            "cached_tokens": 0.0,
+            "cost": 0.0,
+        }
+        for msg in trace or []:
+            if msg.get("role") != "assistant":
+                continue
+            usage = msg.get("usage")
+            if usage is None:
+                continue
+            for key in totals:
+                value = KilnEvalHelpers._field(usage, key)
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    totals[key] += float(value)
+        return totals
+
+    @staticmethod
+    def get_total_latency_ms(trace: list[dict[str, Any]] | None) -> float:
+        """Sum assistant messages' ``latency_ms`` (0.0 when absent)."""
+        total = 0.0
+        for msg in trace or []:
+            if msg.get("role") != "assistant":
+                continue
+            value = msg.get("latency_ms")
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                total += float(value)
+        return total
+
+    @staticmethod
+    def count_messages(trace: list[dict[str, Any]] | None, role: str) -> int:
+        """Count messages with the given ``role``."""
+        return sum(1 for msg in trace or [] if msg.get("role") == role)
+
+    @staticmethod
+    def get_error_tool_results(
+        trace: list[dict[str, Any]] | None,
+    ) -> list[dict[str, Any]]:
+        """Tool results flagged as errors (truthy ``is_error`` or a non-empty
+        ``error_message``)."""
+        return [
+            entry
+            for entry in KilnEvalHelpers.get_tool_results(trace)
+            if entry.get("is_error") or entry.get("error_message")
+        ]
+
+    @staticmethod
+    def get_assistant_emitted_text(trace: list[dict[str, Any]] | None) -> str:
+        """Everything the assistant itself emitted: message text (including
+        list-of-blocks content), reasoning, and tool-call names/arguments —
+        but NOT tool results. The surface for output-corruption checks."""
+        parts: list[str] = []
+        for msg in trace or []:
+            if msg.get("role") != "assistant":
+                continue
+            content = msg.get("content")
+            if isinstance(content, str):
+                parts.append(content)
+            elif isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict):
+                        text = block.get("text") or block.get("content") or ""
+                        if isinstance(text, str):
+                            parts.append(text)
+                    elif isinstance(block, str):
+                        parts.append(block)
+            reasoning = msg.get("reasoning") or msg.get("reasoning_content")
+            if isinstance(reasoning, str):
+                parts.append(reasoning)
+            for tc in msg.get("tool_calls") or []:
+                func = tc.get("function", {}) if isinstance(tc, dict) else {}
+                name = func.get("name")
+                if isinstance(name, str):
+                    parts.append(name)
+                args = func.get("arguments")
+                if isinstance(args, str):
+                    parts.append(args)
+        return "\n".join(p for p in parts if p)
+
     @staticmethod
     def get_markdown_links(text: str | None) -> list[tuple[str, str]]:
         """Return ``(link_text, target)`` pairs for every markdown link in *text*.

--- a/libs/core/kiln_ai/adapters/eval/test_eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_helpers.py
@@ -114,10 +114,47 @@ class TestTraceNavigation:
         trace = [
             {"role": "tool_result", "content": "result1"},
             {"type": "tool_result", "content": "result2"},
+            # OpenAI format — the shape Kiln actually stores
+            {"role": "tool", "tool_call_id": "tc1", "content": "result3"},
         ]
         results = helpers.get_tool_results(trace)
-        assert len(results) == 2
+        assert len(results) == 3
         assert results[0]["content"] == "result1"
+        assert results[2]["tool_call_id"] == "tc1"
+
+    def test_get_tool_results_openai_dialect(self, helpers: KilnEvalHelpers):
+        """Stored Kiln traces use role "tool" (ChatCompletionToolMessageParamWrapper)."""
+        results = helpers.get_tool_results(_OPENAI_FORMAT_TRACE)
+        assert len(results) >= 1
+        assert all(r.get("role") == "tool" for r in results)
+
+    def test_get_tool_result_content(self, helpers: KilnEvalHelpers):
+        trace = [
+            {"role": "tool", "tool_call_id": "tc1", "content": "plain text"},
+            {
+                "role": "tool",
+                "tool_call_id": "tc2",
+                "content": [
+                    {"type": "text", "text": "block a"},
+                    {"type": "text", "text": "block b"},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc3", "content": None},
+        ]
+        assert helpers.get_tool_result_content(trace, "tc1") == "plain text"
+        assert helpers.get_tool_result_content(trace, "tc2") == "block a\nblock b"
+        assert helpers.get_tool_result_content(trace, "tc3") == ""
+        assert helpers.get_tool_result_content(trace, "missing") == ""
+        assert helpers.get_tool_result_content(None, "tc1") == ""
+
+    def test_get_markdown_links(self, helpers: KilnEvalHelpers):
+        text = "See [the task](/optimize/1/2) and [docs](https://docs.kiln.tech)."
+        assert helpers.get_markdown_links(text) == [
+            ("the task", "/optimize/1/2"),
+            ("docs", "https://docs.kiln.tech"),
+        ]
+        assert helpers.get_markdown_links("") == []
+        assert helpers.get_markdown_links(None) == []
 
 
 # ---------------------------------------------------------------------------

--- a/libs/core/kiln_ai/adapters/eval/test_eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_helpers.py
@@ -1,5 +1,7 @@
 """Tests for KilnEvalHelpers -- pure-Python helper class for user scorers."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from kiln_ai.adapters.eval.eval_helpers import KilnEvalHelpers
@@ -281,3 +283,110 @@ class TestAssertions:
 
     def test_assert_matches_full_pattern(self, helpers: KilnEvalHelpers):
         assert helpers.assert_matches("abc123def", r"^abc\d+def$") is True
+
+
+class TestHealthHelpers:
+    """Usage/latency/error helpers — duck-typed usage (dict, Pydantic object,
+    SimpleNamespace) per the pickle-transport quirk."""
+
+    def _trace(self, usage_factory):
+        return [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "a",
+                "latency_ms": 1200,
+                "usage": usage_factory(10, 5, 15, 2, 0.01),
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "latency_ms": 800,
+                "usage": usage_factory(20, 8, 28, 0, 0.02),
+                "tool_calls": [
+                    {
+                        "id": "t1",
+                        "function": {"name": "skill", "arguments": '{"resource": "x"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "t1", "content": "r", "is_error": True},
+            {"role": "tool", "tool_call_id": "t2", "content": "ok"},
+        ]
+
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            lambda i, o, t, c, cost: {
+                "input_tokens": i,
+                "output_tokens": o,
+                "total_tokens": t,
+                "cached_tokens": c,
+                "cost": cost,
+            },
+            lambda i, o, t, c, cost: SimpleNamespace(
+                input_tokens=i,
+                output_tokens=o,
+                total_tokens=t,
+                cached_tokens=c,
+                cost=cost,
+            ),
+        ],
+        ids=["dict", "object"],
+    )
+    def test_get_usage_totals(self, helpers: KilnEvalHelpers, factory):
+        totals = helpers.get_usage_totals(self._trace(factory))
+        assert totals == {
+            "input_tokens": 30.0,
+            "output_tokens": 13.0,
+            "total_tokens": 43.0,
+            "cached_tokens": 2.0,
+            "cost": 0.03,
+        }
+
+    def test_get_usage_totals_absent_and_partial(self, helpers: KilnEvalHelpers):
+        trace = [
+            {"role": "assistant", "content": "a"},
+            {"role": "assistant", "content": "b", "usage": {"input_tokens": 7}},
+        ]
+        totals = helpers.get_usage_totals(trace)
+        assert totals["input_tokens"] == 7.0
+        assert totals["cost"] == 0.0
+        assert helpers.get_usage_totals(None)["total_tokens"] == 0.0
+
+    def test_get_total_latency_ms(self, helpers: KilnEvalHelpers):
+        assert helpers.get_total_latency_ms(self._trace(lambda *a: None)) == 2000.0
+        assert helpers.get_total_latency_ms([]) == 0.0
+
+    def test_count_messages(self, helpers: KilnEvalHelpers):
+        trace = self._trace(lambda *a: None)
+        assert helpers.count_messages(trace, "user") == 1
+        assert helpers.count_messages(trace, "assistant") == 2
+        assert helpers.count_messages(trace, "tool") == 2
+        assert helpers.count_messages(None, "user") == 0
+
+    def test_get_error_tool_results(self, helpers: KilnEvalHelpers):
+        errors = helpers.get_error_tool_results(self._trace(lambda *a: None))
+        assert len(errors) == 1
+        assert errors[0]["tool_call_id"] == "t1"
+        assert helpers.get_error_tool_results(
+            [
+                {
+                    "role": "tool",
+                    "tool_call_id": "x",
+                    "content": "c",
+                    "error_message": "boom",
+                }
+            ]
+        )
+
+    def test_get_assistant_emitted_text(self, helpers: KilnEvalHelpers):
+        trace = self._trace(lambda *a: None)
+        trace[1]["reasoning"] = "thinking here"
+        trace[1]["content"] = [{"type": "text", "text": "block text"}]
+        text = helpers.get_assistant_emitted_text(trace)
+        assert "block text" in text
+        assert "thinking here" in text
+        assert "skill" in text  # tool-call name
+        assert '"resource": "x"' in text  # tool-call args
+        assert "r" != text  # tool results excluded

--- a/libs/core/kiln_ai/adapters/eval/test_v2_eval_code_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_eval_code_eval.py
@@ -333,3 +333,49 @@ class TestExecutionSerialization:
         assert max_concurrency == 1, (
             f"Expected serialized execution (max concurrency 1), got {max_concurrency}"
         )
+
+
+class TestFiniteScoreValidation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    async def test_non_finite_rejected(self, bad):
+        cfg = _make_config()
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust("/fake/project/path")
+
+        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
+            mock_run.return_value = {"ok": {"accuracy": bad}}
+            with pytest.raises(RuntimeError, match="finite"):
+                await adapter.evaluate(_inp())
+
+
+class TestUsageObjectTransport:
+    @pytest.mark.asyncio
+    async def test_message_usage_objects_survive_to_scorer(self):
+        """Live-path traces carry Pydantic MessageUsage OBJECTS (pickle
+        transport), not dicts — a scorer using get_usage_totals must work
+        end-to-end through the real sandbox."""
+        from kiln_ai.datamodel.usage import MessageUsage
+
+        code = (
+            "from kiln_ai.adapters.eval.eval_helpers import KilnEvalHelpers as H\n"
+            "def score(trace):\n"
+            "    return {'accuracy': min(H.get_usage_totals(trace)['total_tokens'], 5.0)}\n"
+        )
+        cfg = _make_config(code=code)
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust("/fake/project/path")
+
+        trace = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "reply",
+                "latency_ms": 100,
+                "usage": MessageUsage(
+                    input_tokens=100, output_tokens=50, total_tokens=150
+                ),
+            },
+        ]
+        result = await adapter.evaluate(_inp(trace=trace))
+        assert result.scores == {"accuracy": 5.0}

--- a/libs/core/kiln_ai/adapters/eval/v2_eval_code_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/v2_eval_code_eval.py
@@ -1,6 +1,7 @@
 """V2 adapter for code_eval: runs user-authored Python scorer in a sandboxed subprocess."""
 
 import asyncio
+import math
 from threading import Lock
 from typing import TYPE_CHECKING, Any
 
@@ -119,6 +120,10 @@ class CodeEvalAdapter(BaseV2EvalBridge):
             if not isinstance(value, float):
                 raise RuntimeError(
                     f"Score '{key}' must be a float, got {type(value).__name__}"
+                )
+            if not math.isfinite(value):
+                raise RuntimeError(
+                    f"Score '{key}' must be a finite number, got {value}"
                 )
             validated[key] = value
 

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -1,4 +1,5 @@
 import json
+import math
 from enum import Enum
 from threading import Lock
 from typing import TYPE_CHECKING, Annotated, Any, Dict, List, Literal, Union
@@ -304,7 +305,11 @@ def validate_scores_against_output_scores(
     """
 
     def _is_numeric(v: object) -> bool:
-        return isinstance(v, (int, float)) and not isinstance(v, bool)
+        # bool is an int subclass; NaN/inf compare False against range bounds,
+        # so finiteness must be explicit or NaN slips through every range check.
+        return (
+            isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v)
+        )
 
     problems: list[str] = []
     for output_score in output_scores:
@@ -330,9 +335,11 @@ def validate_scores_against_output_scores(
                         f"Score {output_score.name} is a pass_fail_critical rating and must be a number between -1.0 and 1.0 inclusive. Got: {value}"
                     )
             case TaskOutputRatingType.custom:
-                problems.append(
-                    f"Custom scores are not supported in evaluators. '{output_score.name}' was set to a custom score."
-                )
+                # Unbounded numeric metric: any finite number is valid.
+                if not _is_numeric(value):
+                    problems.append(
+                        f"Score {output_score.name} is a custom metric and must be a finite number. Got: {value}"
+                    )
             case _:
                 raise_exhaustive_enum_error(output_score.type)
     return problems
@@ -536,10 +543,10 @@ class EvalOutputScore(BaseModel):
 
     @model_validator(mode="after")
     def validate_type(self) -> Self:
-        if self.type == TaskOutputRatingType.custom:
-            raise ValueError(
-                f"Custom scores are not supported in evaluators. Score '{self.name}' was set to a custom score."
-            )
+        # All rating types are valid for evaluators, including `custom`
+        # (unbounded numeric metrics — tokens, cost, latency, counts).
+        # Custom scores are code-eval only: judges can't emit them (their
+        # structured-output schema skips custom keys), enforced on EvalConfig.
         return self
 
 
@@ -756,6 +763,37 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
         if self.parent is not None and self.parent.__class__.__name__ != "Eval":
             raise ValueError("parent must be an Eval")
         return self.parent  # type: ignore
+
+    @model_validator(mode="after")
+    def validate_no_judge_on_custom_scores(self) -> Self:
+        """Judge configs can't serve evals with custom-typed output scores.
+
+        Judges structurally cannot emit custom keys (build_score_schema skips
+        them), so every EvalRun save would fail exact-key validation. Custom
+        metrics are code-eval only. Best-effort: skipped when the parent eval
+        isn't linked yet (e.g. construction before parenting).
+        """
+        is_judge = self.config_type in (
+            EvalConfigType.g_eval,
+            EvalConfigType.llm_as_judge,
+        ) or (
+            self.config_type == EvalConfigType.v2
+            and isinstance(self.properties, LlmJudgeProperties)
+        )
+        if not is_judge:
+            return self
+        try:
+            parent = self.parent_eval()
+        except ValueError:
+            return self
+        if parent is not None and any(
+            score.type == TaskOutputRatingType.custom for score in parent.output_scores
+        ):
+            raise ValueError(
+                "LLM-judge eval configs cannot be used on evals with custom-typed "
+                "output scores (judges cannot emit custom keys); use a code eval."
+            )
+        return self
 
     def runs(self, readonly: bool = False) -> list[EvalRun]:
         return super().runs(readonly=readonly)  # type: ignore

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -791,20 +791,61 @@ def test_eval_run_score_keys_must_match(valid_eval_config, valid_eval_run_data):
         )
 
 
-def test_eval_run_custom_scores_not_allowed(valid_eval_config, valid_eval_run_data):
-    with pytest.raises(
-        ValueError, match="Custom scores are not supported in evaluators"
-    ):
-        Eval(
-            name="Test Eval",
-            eval_set_filter_id="tag::tag1",
-            eval_configs_filter_id="tag::tag2",
-            output_scores=[
-                EvalOutputScore(
-                    name="custom",
-                    type=TaskOutputRatingType.custom,
-                )
-            ],
+def test_eval_custom_scores_allowed(valid_eval_config, valid_eval_run_data):
+    """Custom-typed output scores are unbounded numeric metrics (tokens, cost,
+    latency, counts) — valid on evals, code-eval only at scoring time."""
+    eval = Eval(
+        name="Test Eval",
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        output_scores=[
+            EvalOutputScore(
+                name="total cost usd",
+                type=TaskOutputRatingType.custom,
+            )
+        ],
+    )
+    assert eval.output_scores[0].json_key() == "total_cost_usd"
+
+
+@pytest.mark.parametrize(
+    "score_type,value,ok",
+    [
+        (TaskOutputRatingType.custom, 12345.6, True),
+        (TaskOutputRatingType.custom, 0.0, True),
+        (TaskOutputRatingType.custom, -3.5, True),
+        (TaskOutputRatingType.custom, float("nan"), False),
+        (TaskOutputRatingType.custom, float("inf"), False),
+        (TaskOutputRatingType.pass_fail, float("nan"), False),
+        (TaskOutputRatingType.five_star, float("nan"), False),
+        (TaskOutputRatingType.pass_fail_critical, float("inf"), False),
+    ],
+)
+def test_score_validation_finiteness(score_type, value, ok):
+    """NaN/inf must never pass validation — NaN compares False against every
+    range bound, so without an explicit finiteness check it slipped through."""
+    score = EvalOutputScore(name="metric", type=score_type)
+    problems = validate_scores_against_output_scores({"metric": value}, [score])
+    assert (problems == []) is ok
+
+
+def test_judge_config_rejected_on_custom_score_eval():
+    """Judges structurally can't emit custom-typed keys — the config is
+    rejected up front instead of failing every EvalRun save."""
+    eval = Eval(
+        name="Custom Metric Eval",
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        output_scores=[
+            EvalOutputScore(name="latency seconds", type=TaskOutputRatingType.custom)
+        ],
+    )
+    with pytest.raises(ValueError, match="custom-typed"):
+        EvalConfig(
+            name="judge",
+            config_type=EvalConfigType.g_eval,
+            properties={"eval_steps": ["step"]},
+            parent=eval,
         )
 
 


### PR DESCRIPTION
Re-pointing our KA2-Full / kintsugi-benchmark fixes at the new megabranch per Daniel's branch consolidation. Three commits, cherry-picked clean from `mike/kil-761-eval-runner-execute-multi_turn_synthetic-evalinputs-su-drive`; original implementation notes are on the tickets.

> **Scope notes:**
> - **KIL-759** (MCP LIFO teardown) moved to its own PR against main — #1569 — since it's a shipped core bug. Whichever lands first, the other side picks it up on the next merge.
> - **KIL-760** (tool raises → is_error messages) was dropped from this PR after scope review: the built-in `call_kiln_api` lane it primarily protects is not a user path (clients register `call_kiln_api` via local MCP, whose errors already return in-band), and across the 109-case benchmark cycle the loop-level wrapper never fired on the MCP lane. The implementation exists at `591f221ad` if the residual scope (MCP transport raises, weak-model malformed tool args) is still wanted on the ticket.

## Commits

- **KilnEvalHelpers: trace dialect + pairing + markdown links**: `get_tool_results` now matches `role: "tool"` (the shape Kiln actually stores via `ChatCompletionToolMessageParamWrapper`) as well as the `"tool_result"` variants — without this, code evals see zero tool results on real stored traces. Adds `get_tool_result_content`, tool-call/result pairing, `get_markdown_links`.
- **KilnEvalHelpers: health-metric primitives**: `get_usage_totals` (duck-types the MessageUsage pickle transport), `get_total_latency_ms`, `count_messages`, `get_error_tool_results`, `get_assistant_emitted_text`. Needed by the kintsugi health eval (KIL-764 context).
- **KIL-764 — `Allow custom-typed eval output scores; enforce finite score values`**: `custom` score type = any finite numeric, code-eval only (judge configs rejected on custom-score evals). Also closes the NaN validation hole for ALL score types — NaN previously passed range checks.

## Testing

Full `adapters/eval/`, `datamodel/`, `tools/` suites + litellm adapter tool tests on top of the megabranch after the rebase: **2417 passed, 0 failed** (skips are the API-key-gated tests).

## Notes

- No data-migration path is needed for any of this: the old per-EvalInput SU-config format from our frozen-branch work never shipped — the only project using it is our integration test bed, which we've already migrated by hand.
- Follow-up (not in this PR): drive-reuse across evals per (eval_input, run_config) — our `566e724db` conflicts with the megabranch's new `_run_v2_multi_turn_synthetic_job`, and it's a design question first. Details on KIL-761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
