### PR TITLE
Close MCP session exit stacks in LIFO order

### DIFF
--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -134,8 +134,11 @@ class MCPSessionManager:
                 _, exit_stack = self._session_cache.pop(key)
                 to_cleanup.append((key, exit_stack))
 
-        # Close outside the lock to avoid holding it during I/O
-        for key, exit_stack in to_cleanup:
+        # Close outside the lock to avoid holding it during I/O.
+        # LIFO order: each session leaves anyio cancel scopes open on this
+        # task; closing in creation order corrupts the cancel-scope stack
+        # when two+ sessions are live (KIL-759).
+        for key, exit_stack in reversed(to_cleanup):
             try:
                 await exit_stack.aclose()
             except Exception:


### PR DESCRIPTION
## TLDR

Any run config whose tools span **two different local MCP servers** fails every `POST .../run` with HTTP 500 `{"message": "No response returned."}` before a single tool call is made. Root cause is a one-liner: `MCPSessionManager.cleanup_session` closes per-session `AsyncExitStack`s in creation (FIFO) order, violating anyio's LIFO cancel-scope requirement. Pre-existing on `main`; independent of any eval/multi-turn work. Full analysis on [KIL-759](https://linear.app/kiln-ai/issue/KIL-759).

## How we found it

Found 2026-07-10 while building **KA2-Full** (the full kiln-chat port) in the integration-tests bed. For prod parity the run config registers `call_kiln_api` as a normal *local MCP tool* (like real clients do) alongside a second local MCP server (`model_info`). Every run through that config 500'd instantly with `"No response returned."` and **zero tool calls in the trace** — while each MCP server alone worked, and one MCP server + built-in/skill/code tools worked. Model-independent (repro'd on `claude_sonnet_4_6@openrouter` and `glm_5_2@fireworks_ai`). Bisecting the tool combinations isolated "2+ local MCP servers" as the exact trigger, and tracing the 500 backwards from the middleware landed on session teardown.

The error is nowhere near the cause, which is what made it nasty:

1. Both sessions open during tool-definition loading (one `AsyncExitStack` per server). Each `stdio_client` + `ClientSession` leaves anyio cancel scopes open **on the request task**, so the task's scope stack is `[A_stdio, A_session, B_stdio, B_session]`.
2. Teardown (`base_adapter` finally → `cleanup_session`) iterates the session cache in **dict insertion order** — it closes A's stack first, while B's session scope is the innermost/current one. anyio raises `RuntimeError("Attempted to exit a cancel scope that isn't the current tasks's current cancel scope")` *before* its internal state fixup, leaving the task's cancel-scope list corrupted.
3. The `except Exception` around `aclose()` **swallows that error but not the corruption**, which then detonates later in Starlette's `BaseHTTPMiddleware` unwind → `RuntimeError("No response returned.")` → the generic 500 the client sees.

Provenance: `mcp_session_manager.py` is byte-identical back to merge-base `67b55324` — this ships in released Kiln and bites anyone who wires up a second local MCP server.

## Fix

Close exit stacks in `reversed(to_cleanup)` order. Per-session scope blocks are contiguous on the task, so reverse-creation order == strict LIFO, which is exactly what anyio requires. Comment added since the ordering is load-bearing and invisible.

## How to test

**Repro (before/after), ~2 minutes in the desktop app or via API:**

1. Register two local MCP servers — any two stdio servers work, e.g. an API MCP exposing `call_kiln_api` and a second one exposing anything else.
2. Create a run config with at least one tool from **each** (`mcp::local::<A>::tool_a`, `mcp::local::<B>::tool_b`).
3. `POST /api/projects/{pid}/tasks/{tid}/run` with any input.
   - **Without this fix:** instant 500 `"No response returned."`, no tool calls in the trace, and the swallowed cancel-scope `RuntimeError` visible in server logs at warning level ("Error closing MCP session").
   - **With it:** the run completes normally.

**Regression suites:** `libs/core/kiln_ai/tools/` green on top of main — 338 passed, 5 skipped. Note the existing `test_mcp_session_manager.py` only exercises single-session paths (which is why CI never caught this); happy to add a two-server teardown regression test to this PR if wanted.

**Soak evidence:** the fix has been running in anger since 2026-07-10 — a 109-case multi-turn benchmark cycle (hundreds of runs, every one through a two-MCP run config) completed on a branch carrying exactly this commit; without it, run #1 fails.

## Related

Originally rode in #1568 (megabranch train) — pulled out to target `main` directly since it's a shipped core bug. Whichever lands first, the other side picks it up on the next merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
