### PR TITLE
KIL-761: persist eval-time driven conversations, reuse per (eval_input, run_config)

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -1,7 +1,8 @@
+import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from typing import AsyncGenerator, Dict, List, Literal, Set
+from typing import AsyncGenerator, Dict, List, Literal, Set, Tuple
 
 import litellm
 
@@ -25,6 +26,7 @@ from kiln_ai.datamodel.eval import (
     EvalRun,
     EvalScores,
     EvalTaskInput,
+    MultiTurnDriveConfig,
     MultiTurnSyntheticEvalInputData,
     SingleTurnEvalInputData,
     SkippedReason,
@@ -114,6 +116,10 @@ class EvalRunner:
         self.eval = target_eval
         self._skills: SkillsDict = self._preload_skills()
         self._save_context: SaveContext = save_context or default_save_context
+        # Single-flight guard for multi-turn drives: concurrent jobs for the
+        # same (eval_input, run_config) pair (e.g. two eval configs scoring
+        # the same input) must not both drive the conversation.
+        self._drive_locks: Dict[Tuple[str, str], asyncio.Lock] = {}
 
     def collect_tasks(self) -> List[EvalJob]:
         if self.eval_run_type == "eval_config_eval":
@@ -625,11 +631,14 @@ class EvalRunner:
 
         The run config under evaluation drives the agent while the eval's
         multi_turn_drive_config plays the synthetic user, so each run config
-        gets its own fresh conversation — the property that makes run-config
-        comparison meaningful for multi-turn. The drive is transient (nothing
-        persisted); for full_trace evals the EvalRun record carries the
-        serialized conversation when scoring succeeds, otherwise the driven
-        conversation is not retained.
+        gets its own conversation — the property that makes run-config
+        comparison meaningful for multi-turn. Driven conversations persist as
+        real TaskRuns keyed by (eval_input, run_config): the leaf carries a
+        `sei_<eval_input_id>` tag and the adapter stamps
+        `output.source.run_config_id`, so any eval scoring the same pair
+        reuses the stored conversation instead of re-driving it (KIL-761).
+        For full_trace evals the EvalRun record additionally carries the
+        serialized conversation when scoring succeeds.
         """
         drive_config = self.eval.multi_turn_drive_config
         if drive_config is None:
@@ -674,34 +683,9 @@ class EvalRunner:
 
         if job.task_run_config is None:
             raise ValueError("Task run eval requires a run config")
-        try:
-            agent_run_config = as_kiln_agent_run_config(
-                job.task_run_config.run_config_properties
-            )
-        except ValueError as e:
-            raise ValueError(
-                "Multi-turn re-drive requires a Kiln agent run config; "
-                f"run config '{job.task_run_config.name}' is a different type"
-            ) from e
-        try:
-            su_provider = ModelProviderName(drive_config.model_provider)
-        except ValueError as e:
-            raise ValueError(
-                "Invalid synthetic-user model provider on the eval's "
-                f"multi_turn_drive_config: {drive_config.model_provider}"
-            ) from e
 
-        leaf = await drive_case_for_eval(
-            seed_prompt=seed,
-            synthetic_user_info=data.synthetic_user_info,
-            target_task=self.task,
-            target_run_config=agent_run_config,
-            su_driver_config=SyntheticUserDriverConfig(
-                model_name=drive_config.model_name,
-                model_provider_name=su_provider,
-            ),
-            turns=drive_config.turns,
-            skills=self._skills,
+        leaf = await self._stored_or_driven_leaf(
+            job, eval_input, data, seed, drive_config
         )
 
         eval_task_input = EvalTaskInput.from_eval_input(eval_input, leaf)
@@ -741,6 +725,77 @@ class EvalRunner:
             )
             eval_run.save_to_file()
         return True
+
+    async def _stored_or_driven_leaf(
+        self,
+        job: EvalJob,
+        eval_input: EvalInput,
+        data: MultiTurnSyntheticEvalInputData,
+        seed: str,
+        drive_config: MultiTurnDriveConfig,
+    ) -> TaskRun:
+        """The persisted conversation for this job's (eval_input, run_config)
+        pair: reused if any eval already drove it, freshly driven otherwise.
+
+        Driven leaves carry a `sei_<eval_input_id>` tag and the adapter
+        stamps `output.source.run_config_id` — together the reuse key. A
+        per-pair lock single-flights scan+drive+tag so concurrent jobs (e.g.
+        two eval configs over one input) share one drive. The eval-scoped
+        `synthetic_eval_drive_<eval_id>` tag lets cleanup sweeps find driven
+        conversations.
+        """
+        assert job.task_run_config is not None  # caller-guarded
+        pair_tag = f"sei_{eval_input.id}"
+        pair_key = (str(eval_input.id), str(job.task_run_config.id))
+        pair_lock = self._drive_locks.setdefault(pair_key, asyncio.Lock())
+        async with pair_lock:
+            for run in self.task.runs(readonly=True):
+                if (
+                    pair_tag in (run.tags or [])
+                    and run.trace
+                    and run.output is not None
+                    and run.output.source is not None
+                    and run.output.source.run_config_id == job.task_run_config.id
+                ):
+                    return run
+
+            try:
+                agent_run_config = as_kiln_agent_run_config(
+                    job.task_run_config.run_config_properties
+                )
+            except ValueError as e:
+                raise ValueError(
+                    "Multi-turn re-drive requires a Kiln agent run config; "
+                    f"run config '{job.task_run_config.name}' is a different type"
+                ) from e
+            try:
+                su_provider = ModelProviderName(drive_config.model_provider)
+            except ValueError as e:
+                raise ValueError(
+                    "Invalid synthetic-user model provider on the eval's "
+                    f"multi_turn_drive_config: {drive_config.model_provider}"
+                ) from e
+
+            leaf = await drive_case_for_eval(
+                seed_prompt=seed,
+                synthetic_user_info=data.synthetic_user_info,
+                target_task=self.task,
+                target_run_config=agent_run_config,
+                su_driver_config=SyntheticUserDriverConfig(
+                    model_name=drive_config.model_name,
+                    model_provider_name=su_provider,
+                ),
+                turns=drive_config.turns,
+                skills=self._skills,
+                task_run_config_id=job.task_run_config.id,
+            )
+            async with self._save_context():
+                leaf.tags = sorted(
+                    set(leaf.tags or [])
+                    | {pair_tag, f"synthetic_eval_drive_{self.eval.id}"}
+                )
+                leaf.save_to_file()
+            return leaf
 
 
 def _trace_json_default(obj: object) -> object:

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -120,6 +120,9 @@ class EvalRunner:
         # same (eval_input, run_config) pair (e.g. two eval configs scoring
         # the same input) must not both drive the conversation.
         self._drive_locks: Dict[Tuple[str, str], asyncio.Lock] = {}
+        # Leaves already resolved (found or driven) this run, so repeat jobs
+        # for a pair skip the disk scan.
+        self._driven_leaves: Dict[Tuple[str, str], TaskRun] = {}
 
     def collect_tasks(self) -> List[EvalJob]:
         if self.eval_run_type == "eval_config_eval":
@@ -743,12 +746,24 @@ class EvalRunner:
         two eval configs over one input) share one drive. The eval-scoped
         `synthetic_eval_drive_<eval_id>` tag lets cleanup sweeps find driven
         conversations.
+
+        Sampling: the stored conversation is pinned per pair — re-running an
+        eval re-scores the same sample. To draw a fresh sample, remove the
+        `sei_` tag from (or delete) the stored leaf and re-run; both
+        conversations stay persisted. First-class N-samples-per-pair needs a
+        sample ordinal in the reuse key (follow-up, not covered here).
         """
         assert job.task_run_config is not None  # caller-guarded
         pair_tag = f"sei_{eval_input.id}"
         pair_key = (str(eval_input.id), str(job.task_run_config.id))
+        if pair_key in self._driven_leaves:
+            return self._driven_leaves[pair_key]
+
         pair_lock = self._drive_locks.setdefault(pair_key, asyncio.Lock())
         async with pair_lock:
+            if pair_key in self._driven_leaves:
+                return self._driven_leaves[pair_key]
+
             for run in self.task.runs(readonly=True):
                 if (
                     pair_tag in (run.tags or [])
@@ -757,6 +772,7 @@ class EvalRunner:
                     and run.output.source is not None
                     and run.output.source.run_config_id == job.task_run_config.id
                 ):
+                    self._driven_leaves[pair_key] = run
                     return run
 
             try:
@@ -776,6 +792,7 @@ class EvalRunner:
                     f"multi_turn_drive_config: {drive_config.model_provider}"
                 ) from e
 
+            drive_tag = f"synthetic_eval_drive_{self.eval.id}"
             leaf = await drive_case_for_eval(
                 seed_prompt=seed,
                 synthetic_user_info=data.synthetic_user_info,
@@ -788,13 +805,16 @@ class EvalRunner:
                 turns=drive_config.turns,
                 skills=self._skills,
                 task_run_config_id=job.task_run_config.id,
+                # Stamped on every turn at save time, so chains orphaned by a
+                # mid-drive failure remain findable by cleanup sweeps.
+                default_tags=[drive_tag],
             )
+            # The pair tag marks only the successful leaf — it is the reuse
+            # key, so partial chains never satisfy the scan.
             async with self._save_context():
-                leaf.tags = sorted(
-                    set(leaf.tags or [])
-                    | {pair_tag, f"synthetic_eval_drive_{self.eval.id}"}
-                )
+                leaf.tags = sorted(set(leaf.tags or []) | {pair_tag, drive_tag})
                 leaf.save_to_file()
+            self._driven_leaves[pair_key] = leaf
             return leaf
 
 

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -2855,17 +2856,27 @@ def multi_turn_eval_input(mock_task):
     return ei
 
 
-def _fresh_leaf(task: Task, data_source: DataSource) -> TaskRun:
-    """The in-memory leaf drive_case_for_eval would return: id-less,
-    trace-carrying, never saved."""
+def _fresh_leaf(
+    task: Task, data_source: DataSource, run_config_id: str | None = None
+) -> TaskRun:
+    """The leaf drive_case_for_eval returns: a persisted, trace-carrying
+    TaskRun (KIL-761) with the run config stamped on its output source, not
+    yet tagged — tagging is the runner's job."""
+    output_source = data_source
+    if run_config_id is not None:
+        output_source = DataSource(
+            type=data_source.type,
+            properties=dict(data_source.properties),
+            run_config_id=run_config_id,
+        )
     leaf = TaskRun(
         input="opening message",
         input_source=data_source,
-        output=TaskOutput(output="fresh reply", source=data_source),
+        output=TaskOutput(output="fresh reply", source=output_source),
         trace=MULTI_TURN_TRACE,
         parent=task,
     )
-    leaf.id = None
+    leaf.save_to_file()
     return leaf
 
 
@@ -2915,6 +2926,15 @@ class TestRunV2MultiTurnRedrive:
             drive_kwargs["target_run_config"].model_name
             == mock_run_config.run_config_properties.model_name
         )
+        # Every driven run stamps the run config id — the reuse-scan key.
+        assert drive_kwargs["task_run_config_id"] == mock_run_config.id
+
+        # The driven leaf persists in the dataset, tagged for pair reuse
+        # (sei_<eval_input_id>) and for cleanup sweeps (per-eval tag).
+        task_runs = mock_task.runs(readonly=True)
+        assert len(task_runs) == 1
+        assert "sei_ei_redrive" in task_runs[0].tags
+        assert "synthetic_eval_drive_v2_redrive_eval" in task_runs[0].tags
 
         # The judge saw the FRESH conversation, not stored data.
         assert len(stub.seen_inputs) == 1
@@ -2936,6 +2956,201 @@ class TestRunV2MultiTurnRedrive:
         # full_trace eval: the scored conversation rides the record.
         assert saved.task_run_trace is not None
         assert json.loads(saved.task_run_trace) == MULTI_TURN_TRACE
+
+    @pytest.mark.asyncio
+    async def test_reuses_stored_conversation_for_same_pair(
+        self,
+        mock_task,
+        mock_run_config,
+        mock_v2_redrive_config,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """A conversation another eval already drove for this
+        (eval_input, run_config) pair — leaf tagged sei_<eval_input_id>,
+        run config stamped on output.source — is scored as-is, no re-drive
+        (KIL-761)."""
+        stored_source = DataSource(
+            type=DataSourceType.synthetic,
+            properties={
+                "model_name": "gpt-4",
+                "model_provider": "openai",
+                "adapter_name": "test_adapter",
+            },
+            run_config_id=mock_run_config.id,
+        )
+        stored = TaskRun(
+            input="opening message",
+            input_source=data_source,
+            output=TaskOutput(output="stored reply", source=stored_source),
+            trace=MULTI_TURN_TRACE,
+            tags=["sei_ei_redrive"],
+            parent=mock_task,
+        )
+        stored.save_to_file()
+
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        job = EvalJob(
+            item=multi_turn_eval_input,
+            eval_config=mock_v2_redrive_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+        stub = RecordingStubV2Eval(mock_v2_redrive_config)
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(),
+            ) as mock_drive,
+        ):
+            result = await runner.run_job(job)
+
+        assert result is True
+        mock_drive.assert_not_awaited()
+        # The judge scored the STORED conversation.
+        assert len(stub.seen_inputs) == 1
+        assert stub.seen_inputs[0].final_message == "stored reply"
+        assert stub.seen_inputs[0].trace == MULTI_TURN_TRACE
+
+        runs = mock_v2_redrive_config.runs(readonly=True)
+        assert len(runs) == 1
+        assert runs[0].scores == {"accuracy": 1.0}
+        assert runs[0].output == "stored reply"
+
+    @pytest.mark.asyncio
+    async def test_redrives_when_stored_pair_has_other_run_config(
+        self,
+        mock_task,
+        mock_run_config,
+        mock_v2_redrive_config,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """Reuse keys on (eval_input, run_config): a conversation driven by a
+        DIFFERENT run config never satisfies this job — comparison integrity
+        depends on each run config getting its own conversation."""
+        other_source = DataSource(
+            type=DataSourceType.synthetic,
+            properties={
+                "model_name": "gpt-4",
+                "model_provider": "openai",
+                "adapter_name": "test_adapter",
+            },
+            run_config_id="some_other_run_config",
+        )
+        stored = TaskRun(
+            input="opening message",
+            input_source=data_source,
+            output=TaskOutput(output="stored reply", source=other_source),
+            trace=MULTI_TURN_TRACE,
+            tags=["sei_ei_redrive"],
+            parent=mock_task,
+        )
+        stored.save_to_file()
+
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        job = EvalJob(
+            item=multi_turn_eval_input,
+            eval_config=mock_v2_redrive_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+        stub = RecordingStubV2Eval(mock_v2_redrive_config)
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+            ) as mock_drive,
+        ):
+            result = await runner.run_job(job)
+
+        assert result is True
+        mock_drive.assert_awaited_once()
+        # The judge scored the freshly driven conversation, not the stored
+        # other-config one.
+        assert len(stub.seen_inputs) == 1
+        assert stub.seen_inputs[0].final_message == "fresh reply"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_jobs_share_one_drive(
+        self,
+        mock_task,
+        mock_run_config,
+        mock_v2_redrive_eval,
+        mock_v2_redrive_config,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """Two eval configs scoring the same (eval_input, run_config) pair
+        concurrently share one drive: the per-pair lock single-flights
+        scan+drive+tag, so the second job reuses the persisted leaf instead
+        of racing into a duplicate conversation."""
+        second_config = EvalConfig(
+            name="v2 redrive config 2",
+            config_type=EvalConfigType.v2,
+            properties=ExactMatchProperties(expected_value="reply"),
+            parent=mock_v2_redrive_eval,
+        )
+        second_config.save_to_file()
+
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config, second_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        jobs = [
+            EvalJob(
+                item=multi_turn_eval_input,
+                eval_config=config,
+                type="task_run_eval",
+                task_run_config=mock_run_config,
+            )
+            for config in (mock_v2_redrive_config, second_config)
+        ]
+
+        async def _yielding_drive(**kwargs):
+            # Yield control so the second job interleaves mid-drive — without
+            # the per-pair lock both jobs would miss the scan and drive.
+            await asyncio.sleep(0)
+            return _fresh_leaf(mock_task, data_source, run_config_id=mock_run_config.id)
+
+        stub = RecordingStubV2Eval(mock_v2_redrive_config)
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(side_effect=_yielding_drive),
+            ) as mock_drive,
+        ):
+            results = await asyncio.gather(*(runner.run_job(job) for job in jobs))
+
+        assert results == [True, True]
+        # One drive; the other job reused the persisted conversation.
+        assert mock_drive.await_count == 1
+        # Both eval configs scored a conversation with the same content.
+        assert len(stub.seen_inputs) == 2
+        assert {i.final_message for i in stub.seen_inputs} == {"fresh reply"}
+        assert len(mock_v2_redrive_config.runs(readonly=True)) == 1
+        assert len(second_config.runs(readonly=True)) == 1
 
     @pytest.mark.asyncio
     async def test_missing_drive_config_skips(

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -2909,7 +2909,11 @@ class TestRunV2MultiTurnRedrive:
             ),
             patch(
                 "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
-                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+                new=AsyncMock(
+                    return_value=_fresh_leaf(
+                        mock_task, data_source, run_config_id=mock_run_config.id
+                    )
+                ),
             ) as mock_drive,
         ):
             result = await runner.run_job(job)
@@ -2926,15 +2930,19 @@ class TestRunV2MultiTurnRedrive:
             drive_kwargs["target_run_config"].model_name
             == mock_run_config.run_config_properties.model_name
         )
-        # Every driven run stamps the run config id — the reuse-scan key.
+        # Every driven run stamps the run config id — the reuse-scan key —
+        # and carries the drive tag from creation (orphan discoverability).
         assert drive_kwargs["task_run_config_id"] == mock_run_config.id
+        assert drive_kwargs["default_tags"] == ["synthetic_eval_drive_v2_redrive_eval"]
 
         # The driven leaf persists in the dataset, tagged for pair reuse
-        # (sei_<eval_input_id>) and for cleanup sweeps (per-eval tag).
+        # (sei_<eval_input_id>) and for cleanup sweeps (per-eval tag), with
+        # the reuse key stamped on its output source.
         task_runs = mock_task.runs(readonly=True)
         assert len(task_runs) == 1
         assert "sei_ei_redrive" in task_runs[0].tags
         assert "synthetic_eval_drive_v2_redrive_eval" in task_runs[0].tags
+        assert task_runs[0].output.source.run_config_id == mock_run_config.id
 
         # The judge saw the FRESH conversation, not stored data.
         assert len(stub.seen_inputs) == 1
@@ -3151,6 +3159,68 @@ class TestRunV2MultiTurnRedrive:
         assert {i.final_message for i in stub.seen_inputs} == {"fresh reply"}
         assert len(mock_v2_redrive_config.runs(readonly=True)) == 1
         assert len(second_config.runs(readonly=True)) == 1
+
+    @pytest.mark.asyncio
+    async def test_pair_cache_skips_disk_rescan(
+        self,
+        mock_task,
+        mock_run_config,
+        mock_v2_redrive_eval,
+        mock_v2_redrive_config,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """Sequential jobs for the same pair hit the in-memory cache: the
+        second job neither re-drives nor rescans the dataset."""
+        second_config = EvalConfig(
+            name="v2 redrive config 2",
+            config_type=EvalConfigType.v2,
+            properties=ExactMatchProperties(expected_value="reply"),
+            parent=mock_v2_redrive_eval,
+        )
+        second_config.save_to_file()
+
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config, second_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        jobs = [
+            EvalJob(
+                item=multi_turn_eval_input,
+                eval_config=config,
+                type="task_run_eval",
+                task_run_config=mock_run_config,
+            )
+            for config in (mock_v2_redrive_config, second_config)
+        ]
+        stub = RecordingStubV2Eval(mock_v2_redrive_config)
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(
+                    return_value=_fresh_leaf(
+                        mock_task, data_source, run_config_id=mock_run_config.id
+                    )
+                ),
+            ) as mock_drive,
+        ):
+            assert await runner.run_job(jobs[0]) is True
+            # Any further dataset scan would explode — the cache must serve it.
+            with patch.object(
+                Task, "runs", side_effect=AssertionError("rescanned disk")
+            ):
+                assert await runner.run_job(jobs[1]) is True
+
+        assert mock_drive.await_count == 1
+        assert [i.final_message for i in stub.seen_inputs] == [
+            "fresh reply",
+            "fresh reply",
+        ]
 
     @pytest.mark.asyncio
     async def test_missing_drive_config_skips(

--- a/libs/core/kiln_ai/synthetic_user/eval_drive.py
+++ b/libs/core/kiln_ai/synthetic_user/eval_drive.py
@@ -5,10 +5,12 @@ agent under test comes from the run config being evaluated; the synthetic
 user (customer) comes from the eval's drive config, held constant so a
 comparison varies only the agent.
 
-Nothing is persisted — the drive is transient and the EvalRun record carries
-the scored trace, mirroring how single-turn fresh generation runs with
-allow_saving=False. Conversation continuity rides `prior_trace`, so no
-parent_task_run chaining (which requires persisted parents) is involved.
+Driven conversations persist as real TaskRuns: every turn saves via the
+adapter with parent_task_run chaining, exactly like an SU batch drive, so
+the conversation lands in the dataset — visible in the runs UI, taggable,
+ratable. The eval runner tags the leaf `sei_<eval_input_id>`, letting any
+eval scoring the same (eval_input, run_config) pair reuse the stored
+conversation instead of re-driving it (KIL-761).
 """
 
 from kiln_ai.adapters.adapter_registry import adapter_for_task
@@ -25,9 +27,8 @@ from kiln_ai.synthetic_user.models import (
 )
 from kiln_ai.utils.open_ai_types import ChatCompletionMessageParam
 
-# Identifies this code path in `input_source.properties.adapter_name` — the
-# runs are in-memory only, but anything inspecting one should still see who
-# authored the user side.
+# Identifies this code path in `input_source.properties.adapter_name` so
+# anything inspecting a driven run can see who authored the user side.
 _EVAL_DRIVER_ADAPTER_NAME = "kiln_synthetic_user_eval_driver"
 
 
@@ -40,18 +41,22 @@ async def drive_case_for_eval(
     su_driver_config: SyntheticUserDriverConfig,
     turns: int,
     skills: SkillsDict,
+    task_run_config_id: str | None = None,
 ) -> TaskRun:
-    """Drive one case in memory and return the leaf TaskRun (never saved).
+    """Drive one case and return the persisted leaf TaskRun.
 
-    The leaf's `.trace` holds the full cumulative conversation and its id is
-    None (nothing touches disk). `skills` must be preloaded by the caller —
-    the adapter raises on skill tools with no injected dict.
+    The leaf's `.trace` holds the full cumulative conversation and its
+    `output.source.run_config_id` carries `task_run_config_id` — the key the
+    eval runner's reuse scan matches on. `skills` must be preloaded by the
+    caller — the adapter raises on skill tools with no injected dict.
     """
     su_driver = SyntheticUserDriver(synthetic_user_info, su_driver_config)
     adapter = adapter_for_task(
         target_task,
         target_run_config,
-        base_adapter_config=AdapterConfig(allow_saving=False, skills=skills),
+        base_adapter_config=AdapterConfig(
+            skills=skills, task_run_config_id=task_run_config_id
+        ),
     )
     input_source = DataSource(
         type=DataSourceType.synthetic,
@@ -68,13 +73,11 @@ async def drive_case_for_eval(
         prior_trace: list[ChatCompletionMessageParam] | None,
         parent_task_run: TaskRun | None,
     ) -> TaskRun:
-        # Chaining is deliberately dropped: parent runs are unsaved (id None)
-        # and the conversation already continues through prior_trace.
-        _ = parent_task_run
         return await adapter.invoke(
             input=input,
             input_source=input_source,
             prior_trace=prior_trace,
+            parent_task_run=parent_task_run,
         )
 
     result = await drive_case(

--- a/libs/core/kiln_ai/synthetic_user/eval_drive.py
+++ b/libs/core/kiln_ai/synthetic_user/eval_drive.py
@@ -42,20 +42,25 @@ async def drive_case_for_eval(
     turns: int,
     skills: SkillsDict,
     task_run_config_id: str | None = None,
+    default_tags: list[str] | None = None,
 ) -> TaskRun:
     """Drive one case and return the persisted leaf TaskRun.
 
     The leaf's `.trace` holds the full cumulative conversation and its
     `output.source.run_config_id` carries `task_run_config_id` — the key the
-    eval runner's reuse scan matches on. `skills` must be preloaded by the
-    caller — the adapter raises on skill tools with no injected dict.
+    eval runner's reuse scan matches on. `default_tags` are stamped on every
+    turn as it saves, so even a chain orphaned by a mid-drive failure stays
+    discoverable. `skills` must be preloaded by the caller — the adapter
+    raises on skill tools with no injected dict.
     """
     su_driver = SyntheticUserDriver(synthetic_user_info, su_driver_config)
     adapter = adapter_for_task(
         target_task,
         target_run_config,
         base_adapter_config=AdapterConfig(
-            skills=skills, task_run_config_id=task_run_config_id
+            skills=skills,
+            task_run_config_id=task_run_config_id,
+            default_tags=default_tags,
         ),
     )
     input_source = DataSource(

--- a/libs/core/kiln_ai/synthetic_user/test_eval_drive.py
+++ b/libs/core/kiln_ai/synthetic_user/test_eval_drive.py
@@ -172,11 +172,13 @@ async def test_adapter_configured_to_persist(fake_adapter, fake_su_driver) -> No
         turns=1,
         skills=skills,
         task_run_config_id="rc_123",
+        default_tags=["drive_tag_1"],
     )
 
     assert captured["task"] is task
     assert captured["adapter_config"].allow_saving is True
     assert captured["adapter_config"].task_run_config_id == "rc_123"
+    assert captured["adapter_config"].default_tags == ["drive_tag_1"]
     assert captured["adapter_config"].skills is skills
 
 

--- a/libs/core/kiln_ai/synthetic_user/test_eval_drive.py
+++ b/libs/core/kiln_ai/synthetic_user/test_eval_drive.py
@@ -1,8 +1,9 @@
 """Unit tests for drive_case_for_eval.
 
 `adapter_for_task` and `SyntheticUserDriver` are monkeypatched — no model
-calls. The tests pin the transient-drive contract: nothing persisted, no
-parent chaining, conversation continuity through prior_trace.
+calls. The tests pin the persisted-drive contract (KIL-761): every turn
+saves via the adapter with parent_task_run chaining, the adapter stamps
+run_config_id, and conversation continuity rides prior_trace.
 """
 
 from typing import Any
@@ -45,11 +46,11 @@ def _target_run_config() -> KilnAgentRunConfigProperties:
     )
 
 
-def _fake_unsaved_run(trace: list[dict]) -> Mock:
-    """What adapter.invoke returns with allow_saving=False: an id-less
-    TaskRun carrying the cumulative trace."""
+def _fake_saved_run(trace: list[dict], run_id: str) -> Mock:
+    """What adapter.invoke returns with allow_saving on: a persisted TaskRun
+    carrying the cumulative trace."""
     run = Mock(spec=TaskRun)
-    run.id = None
+    run.id = run_id
     run.trace = trace
     return run
 
@@ -60,13 +61,17 @@ class _FakeAdapter:
 
     def __init__(self):
         self.calls: list[dict[str, Any]] = []
+        self.returned: list[Mock] = []
 
-    async def invoke(self, *, input, input_source=None, prior_trace=None):
+    async def invoke(
+        self, *, input, input_source=None, prior_trace=None, parent_task_run=None
+    ):
         self.calls.append(
             {
                 "input": input,
                 "input_source": input_source,
                 "prior_trace": prior_trace,
+                "parent_task_run": parent_task_run,
             }
         )
         new_trace = [
@@ -74,7 +79,9 @@ class _FakeAdapter:
             {"role": "user", "content": input},
             {"role": "assistant", "content": f"reply-{len(self.calls)}"},
         ]
-        return _fake_unsaved_run(new_trace)
+        run = _fake_saved_run(new_trace, run_id=f"run_{len(self.calls)}")
+        self.returned.append(run)
+        return run
 
 
 @pytest.fixture
@@ -133,8 +140,13 @@ async def test_drives_turns_and_returns_leaf(fake_adapter, fake_su_driver) -> No
     # Continuity rides prior_trace, growing turn over turn.
     assert adapter.calls[0]["prior_trace"] is None
     assert len(adapter.calls[2]["prior_trace"]) == 4
-    # The leaf is the last turn's run: unsaved, full cumulative trace.
-    assert leaf.id is None
+    # Persisted runs chain: each turn's parent is the previous turn's run.
+    assert adapter.calls[0]["parent_task_run"] is None
+    assert adapter.calls[1]["parent_task_run"] is adapter.returned[0]
+    assert adapter.calls[2]["parent_task_run"] is adapter.returned[1]
+    # The leaf is the last turn's run: persisted, full cumulative trace.
+    assert leaf is adapter.returned[2]
+    assert leaf.id is not None
     assert len(leaf.trace) == 6
 
     # The SU driver was built from the typed persona.
@@ -143,9 +155,10 @@ async def test_drives_turns_and_returns_leaf(fake_adapter, fake_su_driver) -> No
 
 
 @pytest.mark.asyncio
-async def test_adapter_configured_transient(fake_adapter, fake_su_driver) -> None:
-    """The target adapter must never save (transient drive) and must get the
-    caller's preloaded skills."""
+async def test_adapter_configured_to_persist(fake_adapter, fake_su_driver) -> None:
+    """The target adapter saves every driven turn (KIL-761), stamps the run
+    config id for the runner's reuse scan, and gets the caller's preloaded
+    skills."""
     _, captured = fake_adapter
     task = Mock(spec=Task)
     skills = {"skill_tool": Mock()}
@@ -158,10 +171,12 @@ async def test_adapter_configured_transient(fake_adapter, fake_su_driver) -> Non
         su_driver_config=_SU_CONFIG,
         turns=1,
         skills=skills,
+        task_run_config_id="rc_123",
     )
 
     assert captured["task"] is task
-    assert captured["adapter_config"].allow_saving is False
+    assert captured["adapter_config"].allow_saving is True
+    assert captured["adapter_config"].task_run_config_id == "rc_123"
     assert captured["adapter_config"].skills is skills
 
 


### PR DESCRIPTION
## What

Two commits implementing KIL-761 on the current megabranch tip:

1. **Drives persist as chained TaskRuns** — `drive_case_for_eval` saves every turn through the adapter with `parent_task_run` chaining (exactly like an SU batch drive) and stamps `output.source.run_config_id` via a new `task_run_config_id` param. Driven conversations land in the dataset: visible in the runs UI, taggable, ratable.
2. **Reuse per (eval_input, run_config)** — a new `EvalRunner._stored_or_driven_leaf` tags fresh leaves `sei_<eval_input_id>` (+ `synthetic_eval_drive_<eval_id>` for cleanup sweeps) and reuses any stored leaf whose tag and `run_config_id` match, so every eval scores the identical conversation. A per-pair `asyncio.Lock` single-flights concurrent jobs (two eval configs over one input drive once). Reuse never crosses run configs — per-run-config comparison integrity is preserved.

## Why

The motivating case: score the SAME driven conversation with a deterministic code eval and LLM judges, and join the scores per case. With transient per-eval drives, the judges and the code eval score different samples — the scores can't be correlated — and each additional eval re-pays the full drive cost. This also unblocks golden tagging/rating of driven conversations for judge calibration.

This deliberately replaces the transient-drive design; if you'd rather build KIL-761 differently, happy to close in favor of yours — the tests may still be useful.

## Testing

`synthetic_user/` + `adapters/eval/`: 713 passed. New coverage: parent chaining in the drive loop, leaf persisted + tagged, reuse hit for the same pair, fresh drive for a different run config, concurrent single-flight (verified to fail with the lock removed).

Replaces #1581 (WIP iteration; will be closed and its branch deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)