### PR TITLE
Eval V2: Review only (do not merge): eval trace reuse — drive once, score with every config

### DIFF
--- a/app/desktop/studio_server/test_eval_builder_e2e_paid.py
+++ b/app/desktop/studio_server/test_eval_builder_e2e_paid.py
@@ -60,7 +60,12 @@ calls, so the harness starts at Step 4 with the spec text already "written":
                        per config. run_calibration validates the judge
                        against the golden answer key over the STORED rated
                        traces, and the harness reports the judge-vs-human
-                       agreement.)
+                       agreement. A REUSE leg then adds a second judge
+                       config and re-runs the comparison: the drive was
+                       paid once per (scenario, run config), so the second
+                       judge must consume the stored conversations —
+                       byte-identical traces, equal drive fingerprints,
+                       zero new drives — at judge-only speed.)
   Step 8   READ        GET .../score_summary, .../eval_results_summary,
                        .../run_configs/{id}/eval_scores
                        (The endpoints the post-save spec detail page,
@@ -90,8 +95,9 @@ Requirements (hard failures, never skips — a broken pipeline must be loud):
 Cost per run: one plan, one SU batch call, the 4x2 drive + judge + claim
 builder, one refine call at save, plus the runner's work over the saved
 eval: a fresh 4x2 re-drive per run config (two configs) with a judge call
-each, and the golden calibration judge calls — ~70 small model calls,
-still cents.
+each, the golden calibration judge calls, and the reuse leg's 8 judge-only
+calls (no drives — that's the assertion) — ~80 small model calls, still
+cents.
 
 A second paid test (`test_eval_builder_pipeline_tools_e2e`) drives a
 tool-calling task via its SAVED run config (2x2, built-in calculator tools)
@@ -102,6 +108,7 @@ cost.
 
 import json
 import os
+import time
 import warnings
 
 import httpx
@@ -777,11 +784,13 @@ def test_eval_builder_pipeline_e2e(preflight, temp_task, client):
         run_config_properties=KilnAgentRunConfigProperties(**COMPARISON_RUN_CONFIG),
     )
     run_config_b.save_to_file()
+    drive_pass_started = time.monotonic()
     _run_sse_complete(
         f"/api/projects/p/tasks/t/evals/{saved_eval.id}"
         f"/eval_config/{judge_config.id}/run_comparison",
         params={"run_config_ids": [run_config_a.id, run_config_b.id]},
     )
+    drive_pass_seconds = time.monotonic() - drive_pass_started
     eval_set_runs = [
         r for r in judge_config.runs(readonly=True) if not r.eval_config_eval
     ]
@@ -824,6 +833,13 @@ def test_eval_builder_pipeline_e2e(preflight, temp_task, client):
             len(assistant_turns) == TURNS_PER_CASE,
             f"eval run for input {run.eval_input_id} drove "
             f"{len(assistant_turns)} assistant turns, expected {TURNS_PER_CASE}",
+        )
+        # Driven records carry the drive's content identity — the key the
+        # reuse leg below (and any later judge) matches on.
+        _require(
+            bool(run.drive_fingerprint) and run.drive_fingerprint.startswith("v1:"),
+            f"eval run for input {run.eval_input_id} has no drive_fingerprint: "
+            f"{run.drive_fingerprint}",
         )
 
     # THE RE-DRIVE PROOF: for every scenario, the two run configs produced
@@ -890,6 +906,89 @@ def test_eval_builder_pipeline_e2e(preflight, temp_task, client):
             "agreement not computed this run",
             stacklevel=1,
         )
+
+    # ── Step 7 reuse leg — A SECOND JUDGE SCORES THE SAME CONVERSATIONS ─
+    # The drive above was paid once per (scenario, run config); every later
+    # v2 judge — this eval's or any other eval on the task — must consume the
+    # stored conversation via the (drive_fingerprint, run_config) reuse index
+    # instead of re-driving. A second, genuinely different judge config on
+    # the saved eval re-runs the comparison: same-sample scoring is the point
+    # (two judges' verdicts join per conversation), so its records must carry
+    # byte-identical traces and equal fingerprints, with zero new drives.
+    from kiln_ai.datamodel.eval import EvalConfig, EvalConfigType
+
+    second_judge_props = judge_config.properties.model_copy(deep=True)
+    # Different judge instructions on purpose: reuse keys on drive identity
+    # (drive config + run config + scenario), never on judge identity.
+    second_judge_props.prompt_template += (
+        "\nBe strict: when compliance is ambiguous, lean FAIL."
+    )
+    second_judge = EvalConfig(
+        name="E2E Second Judge",
+        config_type=EvalConfigType.v2,
+        properties=second_judge_props,
+        parent=saved_eval,
+    )
+    second_judge.save_to_file()
+
+    reuse_pass_started = time.monotonic()
+    _run_sse_complete(
+        f"/api/projects/p/tasks/t/evals/{saved_eval.id}"
+        f"/eval_config/{second_judge.id}/run_comparison",
+        params={"run_config_ids": [run_config_a.id, run_config_b.id]},
+    )
+    reuse_pass_seconds = time.monotonic() - reuse_pass_started
+
+    second_judge_runs = [
+        r for r in second_judge.runs(readonly=True) if not r.eval_config_eval
+    ]
+    _require(
+        {(r.eval_input_id, r.task_run_config_id) for r in second_judge_runs}
+        == set(trace_by_pair),
+        "second judge's run_comparison did not cover EvalInput x run-config "
+        f"exactly: {sorted((str(r.eval_input_id), str(r.task_run_config_id)) for r in second_judge_runs)}",
+    )
+    fingerprint_by_pair = {
+        (r.eval_input_id, r.task_run_config_id): r.drive_fingerprint
+        for r in eval_set_runs
+    }
+    for run in second_judge_runs:
+        pair = (run.eval_input_id, run.task_run_config_id)
+        _require(
+            run.skipped_reason is None,
+            f"second judge skipped input {run.eval_input_id} "
+            f"({run.skipped_reason}): {run.skipped_detail}",
+        )
+        _require(
+            run.scores.get(score_key) in (0.0, 1.0),
+            f"second judge produced no {score_key} verdict for input "
+            f"{run.eval_input_id}: {run.scores}",
+        )
+        # THE REUSE PROOF: byte-identical trace + equal fingerprint mean the
+        # second judge scored the first pass's stored conversation — a fresh
+        # drive could never reproduce the exact bytes.
+        _require(
+            run.task_run_trace == trace_by_pair[pair],
+            f"second judge RE-DROVE {pair}: its trace differs from the "
+            f"stored conversation — reuse did not engage",
+        )
+        _require(
+            run.drive_fingerprint == fingerprint_by_pair[pair],
+            f"second judge's fingerprint differs for {pair}: "
+            f"{run.drive_fingerprint} vs {fingerprint_by_pair[pair]}",
+        )
+    # Reuse keeps the dataset transient too: still zero TaskRuns since
+    # before the FIRST comparison pass.
+    _require(
+        len(temp_task.runs(include_intermediate_runs=True)) == runs_on_disk_before,
+        "second judge's run_comparison persisted TaskRuns — reuse must not "
+        "write to the dataset",
+    )
+    # Judge-only speed is a report, not a gate (latency gates flake).
+    print(
+        f"\ntrace reuse: second judge pass took {reuse_pass_seconds:.1f}s "
+        f"vs {drive_pass_seconds:.1f}s for the drive pass"
+    )
 
     # ── Step 8 — READ THE RESULTS (the endpoints the UI renders from) ───
     # The read path is slice-source-aware (6.8): score_summary, the

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -7072,6 +7072,11 @@ export interface components {
              * @description Case-specific detail for skipped runs (e.g. missing key name).
              */
             skipped_detail?: string | null;
+            /**
+             * Drive Fingerprint
+             * @description Identity of the drive that produced task_run_trace for multi-turn synthetic (EvalInput) runs: a versioned hash of drive config + run config properties + scenario content. Enables reuse of the stored conversation by other eval configs; None for non-driven records.
+             */
+            drive_fingerprint?: string | null;
             /** Model Type */
             readonly model_type: string;
         };

--- a/libs/core/kiln_ai/adapters/eval/drive_fingerprint.py
+++ b/libs/core/kiln_ai/adapters/eval/drive_fingerprint.py
@@ -1,0 +1,53 @@
+"""Content identity for eval-time multi-turn drives.
+
+A drive fingerprint hashes everything that shapes a driven conversation —
+the synthetic-user drive config, the resolved run-config properties of the
+agent under test, and the scenario content. Two records with equal
+fingerprints (and the same run config) were driven under identical
+conditions, so one stored trace can stand in for the other's drive.
+"""
+
+import hashlib
+import json
+
+from kiln_ai.datamodel.eval import (
+    MultiTurnDriveConfig,
+    MultiTurnSyntheticEvalInputData,
+)
+from kiln_ai.datamodel.run_config import RunConfigProperties
+
+# Version prefix on every fingerprint: bumping it makes all old fingerprints
+# implicitly non-matching if the hash recipe ever changes (v1 never equals v2).
+_FINGERPRINT_VERSION = "v1"
+
+
+def compute_drive_fingerprint(
+    drive_config: MultiTurnDriveConfig,
+    run_config_properties: RunConfigProperties,
+    data: MultiTurnSyntheticEvalInputData,
+) -> str:
+    """sha256 over canonical JSON of the drive-shaping inputs, as "v1:<hex>".
+
+    Includes only what shapes the conversation. Deliberately excluded:
+    EvalInput reference data and judge/eval-config properties (they shape the
+    judgment, not the drive) and the EvalInput id (identical scenarios must
+    fingerprint identically regardless of which eval's input carries them).
+    """
+    payload = {
+        "drive": {
+            "model_name": drive_config.model_name,
+            "model_provider": drive_config.model_provider,
+            "turns": drive_config.turns,
+        },
+        # Resolved properties rather than the TaskRunConfig id: ids stay
+        # stable while the properties behind them are edited, which would
+        # silently reuse traces from a different agent configuration.
+        "run_config": run_config_properties.model_dump(mode="json"),
+        "scenario": {
+            "first_message": data.first_message.text if data.first_message else None,
+            "synthetic_user_info": data.synthetic_user_info.model_dump(mode="json"),
+        },
+    }
+    canonical = json.dumps(payload, sort_keys=True, ensure_ascii=False)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"{_FINGERPRINT_VERSION}:{digest}"

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -70,10 +70,11 @@ class EvalRunner:
        output per run config. Inputs come from stored TaskRuns
        (eval_set_filter_id) or EvalInput items (eval_input_filter_id).
        Multi-turn synthetic EvalInputs are driven as a full conversation
-       per run config using the eval's multi_turn_drive_config — or, when a
-       sibling config already drove the identical setup, judged on that
-       stored conversation (see _run_v2_multi_turn_synthetic_job); stored
-       multi-turn TaskRun chains are judged on their stored trace instead.
+       per run config using the eval's multi_turn_drive_config — or, when
+       any v2 config on the task already drove the identical setup, judged
+       on that stored conversation (see _run_v2_multi_turn_synthetic_job);
+       stored multi-turn TaskRun chains are judged on their stored trace
+       instead.
     """
 
     def __init__(
@@ -642,10 +643,11 @@ class EvalRunner:
         multi_turn_drive_config plays the synthetic user, so each run config
         gets its own fresh conversation — the property that makes run-config
         comparison meaningful for multi-turn. Before driving, the reuse index
-        is consulted: a sibling config that already drove the identical
-        (drive config, run config, scenario) supplies its stored trace, so
-        every judge scores the same conversation and the drive cost is paid
-        once. The drive itself is transient (no TaskRuns written); the EvalRun
+        is consulted: any v2 config on the task that already drove the
+        identical (drive config, run config, scenario) supplies its stored
+        trace, so every judge scores the same conversation and the drive cost
+        is paid once — including judges on separate Evals (Mike's two-judge
+        case). The drive itself is transient (no TaskRuns written); the EvalRun
         record always carries the serialized conversation plus its
         drive_fingerprint, success or skip.
         """
@@ -714,8 +716,9 @@ class EvalRunner:
         )
         reused_trace = self._find_reusable_trace(fingerprint, job.task_run_config.id)
         if reused_trace is not None:
-            # A sibling config already drove this exact conversation setup:
-            # judge its stored trace instead of paying for a fresh drive.
+            # Another v2 config (this eval's or a task sibling's) already
+            # drove this exact conversation setup: judge its stored trace
+            # instead of paying for a fresh drive.
             eval_task_input = EvalTaskInput.from_eval_input_trace(
                 eval_input, reused_trace
             )
@@ -810,8 +813,11 @@ class EvalRunner:
         return self._trace_reuse_index
 
     def _build_trace_reuse_index(self) -> Dict[Tuple[str, ID_TYPE], _ReusableTrace]:
-        """One pass over the sibling eval configs' persisted runs, keeping the
-        healthiest deterministic pick per (fingerprint, run config).
+        """One pass over every v2 eval config's persisted runs task-wide,
+        keeping the healthiest deterministic pick per (fingerprint, run
+        config). The scan crosses evals because the fingerprint is content
+        keyed: two evals judging the identical (drive config, run config,
+        scenario) share one conversation instead of paying for two.
 
         Only healthy traces enter the index: skip tombstones and partial
         conversations must trigger a fresh drive, not get re-judged. The
@@ -822,20 +828,25 @@ class EvalRunner:
         drive_config = self.eval.multi_turn_drive_config
         if drive_config is None:
             return index
-        for eval_config in self.eval.configs(readonly=True):
-            if eval_config.config_type != EvalConfigType.v2:
-                continue
-            for run in eval_config.runs(readonly=True):
-                if run.drive_fingerprint is None or run.task_run_config_id is None:
+        for task_eval in self.task.evals(readonly=True):
+            for eval_config in task_eval.configs(readonly=True):
+                if eval_config.config_type != EvalConfigType.v2:
                     continue
-                trace = _parse_healthy_trace(run.task_run_trace, drive_config.turns)
-                if trace is None:
-                    continue
-                key = (run.drive_fingerprint, run.task_run_config_id)
-                sort_key = (str(self.eval.id), str(eval_config.id), str(run.id))
-                existing = index.get(key)
-                if existing is None or sort_key < existing.sort_key:
-                    index[key] = _ReusableTrace(trace=trace, sort_key=sort_key)
+                for run in eval_config.runs(readonly=True):
+                    if run.drive_fingerprint is None or run.task_run_config_id is None:
+                        continue
+                    # Health is judged against THIS eval's turn setting: a
+                    # record driven with different turns fails it, but its
+                    # fingerprint embeds those turns so no job in this
+                    # invocation could look it up anyway.
+                    trace = _parse_healthy_trace(run.task_run_trace, drive_config.turns)
+                    if trace is None:
+                        continue
+                    key = (run.drive_fingerprint, run.task_run_config_id)
+                    sort_key = (str(task_eval.id), str(eval_config.id), str(run.id))
+                    existing = index.get(key)
+                    if existing is None or sort_key < existing.sort_key:
+                        index[key] = _ReusableTrace(trace=trace, sort_key=sort_key)
         return index
 
 

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -1,13 +1,14 @@
 import json
 import logging
 from dataclasses import dataclass
-from typing import AsyncGenerator, Dict, List, Literal, Set
+from typing import Any, AsyncGenerator, Dict, List, Literal, Set, Tuple
 
 import litellm
 
 from kiln_ai.adapters.adapter_registry import load_skills_for_task
 from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.eval.base_eval import BaseEval, BaseV2EvalBridge
+from kiln_ai.adapters.eval.drive_fingerprint import compute_drive_fingerprint
 from kiln_ai.adapters.eval.registry import legacy_eval_adapter_from_type
 from kiln_ai.adapters.model_adapters.base_adapter import SkillsDict
 from kiln_ai.datamodel.basemodel import ID_TYPE
@@ -49,6 +50,15 @@ class EvalJob:
     task_run_config: TaskRunConfig | None = None
 
 
+@dataclass
+class _ReusableTrace:
+    """Reuse-index entry: a healthy stored conversation plus the sort key
+    (eval id, config id, run id) that made it the deterministic pick."""
+
+    trace: list[dict[str, Any]]
+    sort_key: tuple[str, str, str]
+
+
 class EvalRunner:
     """
     Runs an eval. Async execution is supported to make it faster when using remote/fast model providers.
@@ -59,8 +69,10 @@ class EvalRunner:
     2) task_run_eval: evaluate a range of task run configs, generating fresh
        output per run config. Inputs come from stored TaskRuns
        (eval_set_filter_id) or EvalInput items (eval_input_filter_id).
-       Multi-turn synthetic EvalInputs are re-driven as a full conversation
-       per run config using the eval's multi_turn_drive_config; stored
+       Multi-turn synthetic EvalInputs are driven as a full conversation
+       per run config using the eval's multi_turn_drive_config — or, when a
+       sibling config already drove the identical setup, judged on that
+       stored conversation (see _run_v2_multi_turn_synthetic_job); stored
        multi-turn TaskRun chains are judged on their stored trace instead.
     """
 
@@ -114,6 +126,10 @@ class EvalRunner:
         self.eval = target_eval
         self._skills: SkillsDict = self._preload_skills()
         self._save_context: SaveContext = save_context or default_save_context
+        # Trace-reuse index for multi-turn synthetic jobs, built once per
+        # runner invocation (lazily) so each job does an O(1) lookup instead
+        # of rescanning every persisted run.
+        self._trace_reuse_index: Dict[Tuple[str, ID_TYPE], _ReusableTrace] | None = None
 
     def collect_tasks(self) -> List[EvalJob]:
         if self.eval_run_type == "eval_config_eval":
@@ -466,20 +482,13 @@ class EvalRunner:
             eval_task_input = EvalTaskInput.from_task_run(leaf)
             result = await evaluator.evaluate(eval_task_input)
 
-            # Like the legacy runner, only successful task-run-eval records of
-            # a full_trace eval carry the serialized trace.
+            # Task-run-eval records always carry the evaluated conversation
+            # (even on judge skips — the trace is what was scored, or would
+            # have been). eval_config_eval (golden calibration) records stay
+            # scores-only: their trace already lives on the golden TaskRun.
             trace_json: str | None = None
-            if (
-                job.type == "task_run_eval"
-                and result.skipped_reason is None
-                and self.eval.evaluation_data_type == EvalDataType.full_trace
-            ):
-                trace_json = json.dumps(
-                    eval_task_input.trace,
-                    indent=2,
-                    ensure_ascii=False,
-                    default=_trace_json_default,
-                )
+            if job.type == "task_run_eval":
+                trace_json = _serialize_trace(eval_task_input.trace)
 
             async with self._save_context():
                 eval_run = EvalRun(
@@ -550,6 +559,9 @@ class EvalRunner:
                     else None,
                     skipped_detail=result.skipped_detail,
                     intermediate_outputs=result.intermediate_outputs,
+                    # Fresh generations are transient — the record is the only
+                    # place the evaluated conversation survives.
+                    task_run_trace=_serialize_trace(eval_task_input.trace),
                 )
                 eval_run.save_to_file()
             return True
@@ -580,6 +592,9 @@ class EvalRunner:
                     else None,
                     skipped_detail=result.skipped_detail,
                     intermediate_outputs=result.intermediate_outputs,
+                    # The fresh run's conversation, when the adapter produced
+                    # one — kept regardless of scoring outcome.
+                    task_run_trace=_serialize_trace(eval_task_input.trace),
                 )
                 eval_run.save_to_file()
             return True
@@ -626,10 +641,13 @@ class EvalRunner:
         The run config under evaluation drives the agent while the eval's
         multi_turn_drive_config plays the synthetic user, so each run config
         gets its own fresh conversation — the property that makes run-config
-        comparison meaningful for multi-turn. The drive is transient (nothing
-        persisted); for full_trace evals the EvalRun record carries the
-        serialized conversation when scoring succeeds, otherwise the driven
-        conversation is not retained.
+        comparison meaningful for multi-turn. Before driving, the reuse index
+        is consulted: a sibling config that already drove the identical
+        (drive config, run config, scenario) supplies its stored trace, so
+        every judge scores the same conversation and the drive cost is paid
+        once. The drive itself is transient (no TaskRuns written); the EvalRun
+        record always carries the serialized conversation plus its
+        drive_fingerprint, success or skip.
         """
         drive_config = self.eval.multi_turn_drive_config
         if drive_config is None:
@@ -691,35 +709,38 @@ class EvalRunner:
                 f"multi_turn_drive_config: {drive_config.model_provider}"
             ) from e
 
-        leaf = await drive_case_for_eval(
-            seed_prompt=seed,
-            synthetic_user_info=data.synthetic_user_info,
-            target_task=self.task,
-            target_run_config=agent_run_config,
-            su_driver_config=SyntheticUserDriverConfig(
-                model_name=drive_config.model_name,
-                model_provider_name=su_provider,
-            ),
-            turns=drive_config.turns,
-            skills=self._skills,
+        fingerprint = compute_drive_fingerprint(
+            drive_config, job.task_run_config.run_config_properties, data
         )
-
-        eval_task_input = EvalTaskInput.from_eval_input(eval_input, leaf)
-        result = await evaluator.evaluate(eval_task_input)
-
-        # Like the stored-trace path, only successful records of a full_trace
-        # eval carry the serialized conversation.
-        trace_json: str | None = None
-        if (
-            result.skipped_reason is None
-            and self.eval.evaluation_data_type == EvalDataType.full_trace
-        ):
-            trace_json = json.dumps(
-                eval_task_input.trace,
-                indent=2,
-                ensure_ascii=False,
-                default=_trace_json_default,
+        reused_trace = self._find_reusable_trace(fingerprint, job.task_run_config.id)
+        if reused_trace is not None:
+            # A sibling config already drove this exact conversation setup:
+            # judge its stored trace instead of paying for a fresh drive.
+            eval_task_input = EvalTaskInput.from_eval_input_trace(
+                eval_input, reused_trace
             )
+        else:
+            leaf = await drive_case_for_eval(
+                seed_prompt=seed,
+                synthetic_user_info=data.synthetic_user_info,
+                target_task=self.task,
+                target_run_config=agent_run_config,
+                su_driver_config=SyntheticUserDriverConfig(
+                    model_name=drive_config.model_name,
+                    model_provider_name=su_provider,
+                ),
+                turns=drive_config.turns,
+                skills=self._skills,
+            )
+            eval_task_input = EvalTaskInput.from_eval_input(eval_input, leaf)
+            # Publish the fresh trace so same-invocation sibling jobs reuse
+            # it without waiting for this record to hit disk.
+            if eval_task_input.trace is not None:
+                self._record_driven_trace(
+                    fingerprint, job.task_run_config.id, eval_task_input.trace
+                )
+
+        result = await evaluator.evaluate(eval_task_input)
 
         async with self._save_context():
             eval_run = EvalRun(
@@ -730,17 +751,92 @@ class EvalRunner:
                 eval_config_eval=False,
                 scores=result.scores,
                 input=seed,
-                output=leaf.output.output if result.skipped_reason is None else None,
+                output=eval_task_input.final_message
+                if result.skipped_reason is None
+                else None,
                 reference_data=eval_input.reference,
                 skipped_reason=result.skipped_reason.value
                 if result.skipped_reason
                 else None,
                 skipped_detail=result.skipped_detail,
                 intermediate_outputs=result.intermediate_outputs,
-                task_run_trace=trace_json,
+                # Trace + fingerprint persist on every driven/reused record —
+                # a judge skip after a full-cost drive must not discard the
+                # conversation, and self-contained records survive deletion
+                # of the sibling that originally drove them.
+                task_run_trace=_serialize_trace(eval_task_input.trace),
+                drive_fingerprint=fingerprint,
             )
             eval_run.save_to_file()
         return True
+
+    def _find_reusable_trace(
+        self, fingerprint: str, run_config_id: ID_TYPE
+    ) -> list[dict[str, Any]] | None:
+        """O(1) lookup of a healthy stored conversation for (fingerprint,
+        run config). Reuse never crosses run configs: identical scenario
+        content under a different agent config is a different conversation."""
+        entry = self._reuse_index().get((fingerprint, run_config_id))
+        return entry.trace if entry is not None else None
+
+    def _record_driven_trace(
+        self,
+        fingerprint: str,
+        run_config_id: ID_TYPE,
+        trace: list[dict[str, Any]],
+    ) -> None:
+        """Append a just-driven conversation to the reuse index. Insert-only:
+        if a concurrent sibling already published one, the first write wins."""
+        drive_config = self.eval.multi_turn_drive_config
+        if drive_config is None or not _trace_has_full_turn_count(
+            trace, drive_config.turns
+        ):
+            return
+        self._reuse_index().setdefault(
+            (fingerprint, run_config_id),
+            # Copy the message dicts so the index entry doesn't alias the
+            # driving job's judge input (same copy discipline as
+            # EvalTaskInput.from_task_run). Empty sort key: in-memory entries
+            # only matter within this invocation, where insert order (first
+            # driver) is the pick.
+            _ReusableTrace(trace=[dict(msg) for msg in trace], sort_key=("", "", "")),
+        )
+
+    def _reuse_index(self) -> Dict[Tuple[str, ID_TYPE], _ReusableTrace]:
+        """The trace-reuse index, built lazily and exactly once per runner
+        invocation: a per-job disk scan would be O(jobs x records)."""
+        if self._trace_reuse_index is None:
+            self._trace_reuse_index = self._build_trace_reuse_index()
+        return self._trace_reuse_index
+
+    def _build_trace_reuse_index(self) -> Dict[Tuple[str, ID_TYPE], _ReusableTrace]:
+        """One pass over the sibling eval configs' persisted runs, keeping the
+        healthiest deterministic pick per (fingerprint, run config).
+
+        Only healthy traces enter the index: skip tombstones and partial
+        conversations must trigger a fresh drive, not get re-judged. The
+        deterministic pick (min sort key) makes racing writers converge on
+        one trace across separate invocations.
+        """
+        index: Dict[Tuple[str, ID_TYPE], _ReusableTrace] = {}
+        drive_config = self.eval.multi_turn_drive_config
+        if drive_config is None:
+            return index
+        for eval_config in self.eval.configs(readonly=True):
+            if eval_config.config_type != EvalConfigType.v2:
+                continue
+            for run in eval_config.runs(readonly=True):
+                if run.drive_fingerprint is None or run.task_run_config_id is None:
+                    continue
+                trace = _parse_healthy_trace(run.task_run_trace, drive_config.turns)
+                if trace is None:
+                    continue
+                key = (run.drive_fingerprint, run.task_run_config_id)
+                sort_key = (str(self.eval.id), str(eval_config.id), str(run.id))
+                existing = index.get(key)
+                if existing is None or sort_key < existing.sort_key:
+                    index[key] = _ReusableTrace(trace=trace, sort_key=sort_key)
+        return index
 
 
 def _trace_json_default(obj: object) -> object:
@@ -750,6 +846,54 @@ def _trace_json_default(obj: object) -> object:
     if isinstance(obj, MessageUsage):
         return obj.model_dump(mode="json")
     raise TypeError(f"{type(obj).__name__} is not JSON serializable")
+
+
+def _serialize_trace(trace: list[dict[str, Any]] | None) -> str | None:
+    """Serialize a conversation for EvalRun.task_run_trace; None only when
+    there is no conversation to keep. One shared shape so reused traces
+    re-serialize byte-identical to the record they came from."""
+    if not trace:
+        return None
+    return json.dumps(trace, indent=2, ensure_ascii=False, default=_trace_json_default)
+
+
+def _trace_has_full_turn_count(
+    trace: list[dict[str, Any]], expected_turns: int
+) -> bool:
+    """A complete drive has exactly one user message per turn (assistant
+    messages can be several per turn when tools fire, so they can't be
+    counted) and ends with assistant text — the judges' final_message.
+    Requiring the LAST message to be assistant text keeps a degraded record
+    from promoting a mid-conversation reply to the final answer."""
+    user_turns = sum(1 for msg in trace if msg.get("role") == "user")
+    if user_turns != expected_turns:
+        return False
+    last = trace[-1] if trace else None
+    if last is None:
+        return False
+    content = last.get("content")
+    return (
+        last.get("role") == "assistant" and isinstance(content, str) and bool(content)
+    )
+
+
+def _parse_healthy_trace(
+    trace_json: str | None, expected_turns: int
+) -> list[dict[str, Any]] | None:
+    """Parse a stored trace and vet it for reuse. Partial conversations,
+    serialization fallbacks, and skip tombstones (no trace at all) fail here —
+    reusing them would silently judge a degraded sample."""
+    if not trace_json:
+        return None
+    try:
+        trace = json.loads(trace_json)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(trace, list) or not all(isinstance(msg, dict) for msg in trace):
+        return None
+    if not _trace_has_full_turn_count(trace, expected_turns):
+        return None
+    return trace
 
 
 def _unwrap_kiln_run_error(e: BaseException) -> BaseException:

--- a/libs/core/kiln_ai/adapters/eval/test_drive_fingerprint.py
+++ b/libs/core/kiln_ai/adapters/eval/test_drive_fingerprint.py
@@ -1,0 +1,178 @@
+import pytest
+
+from kiln_ai.adapters.eval.drive_fingerprint import compute_drive_fingerprint
+from kiln_ai.datamodel.datamodel_enums import ModelProviderName, StructuredOutputMode
+from kiln_ai.datamodel.eval import (
+    MultiTurnDriveConfig,
+    MultiTurnSyntheticEvalInputData,
+    SyntheticUserInfo,
+    UserMessage,
+)
+from kiln_ai.datamodel.run_config import (
+    KilnAgentRunConfigProperties,
+    ToolsRunConfig,
+)
+
+
+def make_drive_config(**overrides) -> MultiTurnDriveConfig:
+    defaults = dict(
+        model_name="claude_4_5_haiku",
+        model_provider="openrouter",
+        turns=3,
+    )
+    defaults.update(overrides)
+    return MultiTurnDriveConfig(**defaults)
+
+
+def make_run_config_properties(**overrides) -> KilnAgentRunConfigProperties:
+    defaults = dict(
+        model_name="gpt-4",
+        model_provider_name=ModelProviderName.openai,
+        prompt_id="simple_prompt_builder",
+        structured_output_mode=StructuredOutputMode.json_schema,
+    )
+    defaults.update(overrides)
+    return KilnAgentRunConfigProperties(**defaults)
+
+
+def make_data(**overrides) -> MultiTurnSyntheticEvalInputData:
+    defaults = dict(
+        first_message=UserMessage(text="opening message"),
+        synthetic_user_info=SyntheticUserInfo(
+            persona="frustrated customer",
+            goal="get a refund",
+            behavior_guidance="be polite then escalate",
+        ),
+    )
+    defaults.update(overrides)
+    return MultiTurnSyntheticEvalInputData(**defaults)
+
+
+def baseline_fingerprint() -> str:
+    return compute_drive_fingerprint(
+        make_drive_config(), make_run_config_properties(), make_data()
+    )
+
+
+class TestDeterminism:
+    def test_same_inputs_same_fingerprint(self):
+        # Fresh model instances each call: the hash must depend on content
+        # only, never on object identity or construction order.
+        assert baseline_fingerprint() == baseline_fingerprint()
+
+    def test_version_prefix_and_shape(self):
+        fingerprint = baseline_fingerprint()
+        prefix, _, digest = fingerprint.partition(":")
+        assert prefix == "v1"
+        assert len(digest) == 64
+        assert all(c in "0123456789abcdef" for c in digest)
+
+
+class TestSensitivity:
+    """Every input that shapes the conversation must change the fingerprint."""
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"model_name": "other-su-model"},
+            {"model_provider": "other-provider"},
+            {"turns": 4},
+        ],
+    )
+    def test_drive_config_changes(self, override):
+        changed = compute_drive_fingerprint(
+            make_drive_config(**override), make_run_config_properties(), make_data()
+        )
+        assert changed != baseline_fingerprint()
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"model_name": "gpt-5"},
+            {"prompt_id": "few_shot_prompt_builder"},
+            {"temperature": 0.2},
+            {"top_p": 0.9},
+            {"structured_output_mode": StructuredOutputMode.json_mode},
+            {"tools_config": ToolsRunConfig(tools=["kiln_task::some_task_tool"])},
+        ],
+    )
+    def test_run_config_property_changes(self, override):
+        changed = compute_drive_fingerprint(
+            make_drive_config(), make_run_config_properties(**override), make_data()
+        )
+        assert changed != baseline_fingerprint()
+
+    def test_first_message_change(self):
+        changed = compute_drive_fingerprint(
+            make_drive_config(),
+            make_run_config_properties(),
+            make_data(first_message=UserMessage(text="different opener")),
+        )
+        assert changed != baseline_fingerprint()
+
+    def test_missing_first_message_differs_from_present(self):
+        changed = compute_drive_fingerprint(
+            make_drive_config(),
+            make_run_config_properties(),
+            make_data(first_message=None),
+        )
+        assert changed != baseline_fingerprint()
+
+    @pytest.mark.parametrize(
+        "su_info",
+        [
+            SyntheticUserInfo(
+                persona="calm customer",
+                goal="get a refund",
+                behavior_guidance="be polite then escalate",
+            ),
+            SyntheticUserInfo(
+                persona="frustrated customer",
+                goal="cancel the account",
+                behavior_guidance="be polite then escalate",
+            ),
+            SyntheticUserInfo(
+                persona="frustrated customer",
+                goal="get a refund",
+                behavior_guidance=None,
+            ),
+        ],
+    )
+    def test_synthetic_user_info_changes(self, su_info):
+        changed = compute_drive_fingerprint(
+            make_drive_config(),
+            make_run_config_properties(),
+            make_data(synthetic_user_info=su_info),
+        )
+        assert changed != baseline_fingerprint()
+
+    def test_synthetic_user_info_extra_fields_change_fingerprint(self):
+        # SyntheticUserInfo is extra="allow": unknown generator fields shape
+        # the SU prompt at drive time, so they must shape the identity too.
+        su_info = SyntheticUserInfo.model_validate(
+            {
+                "persona": "frustrated customer",
+                "goal": "get a refund",
+                "behavior_guidance": "be polite then escalate",
+                "mood": "impatient",
+            }
+        )
+        changed = compute_drive_fingerprint(
+            make_drive_config(),
+            make_run_config_properties(),
+            make_data(synthetic_user_info=su_info),
+        )
+        assert changed != baseline_fingerprint()
+
+
+class TestInsensitivity:
+    def test_identical_content_matches_across_separate_authors(self):
+        # Two evals minting their own copies of the same scenario (the
+        # builder's convention) must converge on one fingerprint: the key is
+        # content, never input identity or the eval that owns it. Reference
+        # data isn't an input at all — it shapes judgment, not the drive.
+        assert compute_drive_fingerprint(
+            make_drive_config(), make_run_config_properties(), make_data()
+        ) == compute_drive_fingerprint(
+            make_drive_config(), make_run_config_properties(), make_data()
+        )

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -10,6 +10,7 @@ import pytest
 from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.eval.base_eval import BaseEval
 from kiln_ai.adapters.eval.conftest import SkippingStubV2Eval, StubV2Eval
+from kiln_ai.adapters.eval.drive_fingerprint import compute_drive_fingerprint
 from kiln_ai.adapters.eval.eval_runner import (
     EvalJob,
     EvalRunner,
@@ -1608,7 +1609,8 @@ class TestRunV2Job:
         assert saved.task_run_config_id is None
         assert saved.input == "turn 1"
         assert saved.output == "reply"
-        # mock_v2_eval defaults to final_answer, so no trace on the record.
+        # eval_config_eval records stay scores-only: the trace already lives
+        # on the golden TaskRun being scored.
         assert saved.task_run_trace is None
 
     @pytest.mark.asyncio
@@ -1927,6 +1929,63 @@ class TestV2FreshGeneration:
         assert saved.dataset_id == fresh_task_run.id
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("stub_cls", [StubV2Eval, SkippingStubV2Eval])
+    async def test_task_run_eval_persists_fresh_run_trace(
+        self,
+        mock_v2_task_run_eval_runner,
+        mock_v2_task_run_eval_config,
+        mock_run_config,
+        data_source,
+        stub_cls,
+    ):
+        """A traced fresh generation lands its conversation on the record
+        whether the judge scored or skipped — always-persist has no success
+        gate and no evaluation_data_type gate (this eval is final_answer)."""
+        single_turn_trace: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "test input"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        stale_task_run = TaskRun(
+            input="test input",
+            output=TaskOutput(output="stale output", source=data_source),
+            parent=mock_v2_task_run_eval_runner.task,
+        )
+        stale_task_run.save_to_file()
+        fresh_task_run = TaskRun(
+            input="test input",
+            output=TaskOutput(output="hello", source=data_source),
+            trace=single_turn_trace,
+            parent=mock_v2_task_run_eval_runner.task,
+        )
+        fresh_task_run.save_to_file()
+
+        job = EvalJob(
+            item=stale_task_run,
+            eval_config=mock_v2_task_run_eval_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+        stub = stub_cls(mock_v2_task_run_eval_config)
+        with (
+            patch.object(stub, "run_task", return_value=fresh_task_run),
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+        ):
+            result = await mock_v2_task_run_eval_runner.run_job(job)
+
+        assert result is True
+        runs = mock_v2_task_run_eval_config.runs(readonly=True)
+        assert len(runs) == 1
+        saved = runs[0]
+        assert saved.task_run_trace is not None
+        assert json.loads(saved.task_run_trace) == single_turn_trace
+        if stub_cls is SkippingStubV2Eval:
+            assert saved.skipped_reason == SkippedReason.extraction_failed.value
+            assert saved.output is None
+
+    @pytest.mark.asyncio
     async def test_task_run_eval_multi_turn_scores_stored_trace_without_regen(
         self,
         mock_v2_task_run_eval_runner,
@@ -1969,8 +2028,12 @@ class TestV2FreshGeneration:
         assert saved.eval_config_eval is False
         assert saved.task_run_config_id == mock_run_config.id
         assert saved.skipped_reason is None
-        # The parent eval defaults to final_answer, so no trace on the record.
-        assert saved.task_run_trace is None
+        # Task-run-eval records always carry the evaluated conversation,
+        # regardless of the eval's evaluation_data_type (here: final_answer).
+        assert saved.task_run_trace is not None
+        assert json.loads(saved.task_run_trace) == MULTI_TURN_TRACE
+        # Stored-chain scoring involves no drive, so no fingerprint.
+        assert saved.drive_fingerprint is None
 
     @pytest.mark.asyncio
     async def test_task_run_eval_multi_turn_full_trace_serializes_trace(
@@ -2204,6 +2267,62 @@ class TestV2EvalInputFreshGeneration:
         assert saved.output is None
         assert saved.scores == {}
         assert saved.reference_data == {"answer": "hello"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stub_cls", [StubV2Eval, SkippingStubV2Eval])
+    async def test_eval_input_task_run_eval_persists_trace(
+        self,
+        mock_v2_ei_tr_runner,
+        mock_v2_ei_tr_eval_config,
+        mock_eval_inputs,
+        mock_run_config,
+        data_source,
+        stub_cls,
+    ):
+        """A traced fresh generation from an EvalInput lands its conversation
+        on the record, scored or skipped — the run is transient, so the
+        record is the only place the conversation survives."""
+        single_turn_trace: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "4"},
+        ]
+        ei = mock_eval_inputs[0]
+        fresh_task_run = TaskRun(
+            input="What is 2+2?",
+            output=TaskOutput(output="4", source=data_source),
+            trace=single_turn_trace,
+            parent=mock_v2_ei_tr_runner.task,
+        )
+        fresh_task_run.save_to_file()
+
+        job = EvalJob(
+            item=ei,
+            eval_config=mock_v2_ei_tr_eval_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+        stub = stub_cls(mock_v2_ei_tr_eval_config)
+        with (
+            patch.object(stub, "run_task", return_value=fresh_task_run),
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+        ):
+            result = await mock_v2_ei_tr_runner.run_job(job)
+
+        assert result is True
+        runs = mock_v2_ei_tr_eval_config.runs(readonly=True)
+        assert len(runs) == 1
+        saved = runs[0]
+        assert saved.eval_input_id == ei.id
+        assert saved.task_run_trace is not None
+        assert json.loads(saved.task_run_trace) == single_turn_trace
+        # Single-turn records are never driven, so no fingerprint.
+        assert saved.drive_fingerprint is None
+        if stub_cls is SkippingStubV2Eval:
+            assert saved.skipped_reason == SkippedReason.extraction_failed.value
+            assert saved.output is None
 
     @pytest.mark.asyncio
     async def test_eval_input_task_run_eval_no_reference(
@@ -2933,9 +3052,11 @@ class TestRunV2MultiTurnRedrive:
         assert saved.input == "opening message"
         assert saved.output == "fresh reply"
         assert saved.skipped_reason is None
-        # full_trace eval: the scored conversation rides the record.
+        # The scored conversation and its drive identity ride the record.
         assert saved.task_run_trace is not None
         assert json.loads(saved.task_run_trace) == MULTI_TURN_TRACE
+        assert saved.drive_fingerprint is not None
+        assert saved.drive_fingerprint.startswith("v1:")
 
     @pytest.mark.asyncio
     async def test_missing_drive_config_skips(
@@ -3050,7 +3171,7 @@ class TestRunV2MultiTurnRedrive:
         assert "first_message" in saved.skipped_detail
 
     @pytest.mark.asyncio
-    async def test_adapter_skip_records_no_trace(
+    async def test_adapter_skip_keeps_trace(
         self,
         mock_task,
         mock_run_config,
@@ -3058,7 +3179,8 @@ class TestRunV2MultiTurnRedrive:
         multi_turn_eval_input,
         data_source,
     ):
-        """A judge-side skip after the drive persists the skip, not the trace."""
+        """A judge-side skip after the drive keeps the full-cost conversation
+        on the skip record (with its fingerprint) — only scores are absent."""
         runner = EvalRunner(
             eval_configs=[mock_v2_redrive_config],
             run_configs=[mock_run_config],
@@ -3088,7 +3210,10 @@ class TestRunV2MultiTurnRedrive:
         saved = runs[0]
         assert saved.skipped_reason == SkippedReason.extraction_failed.value
         assert saved.output is None
-        assert saved.task_run_trace is None
+        assert saved.task_run_trace is not None
+        assert json.loads(saved.task_run_trace) == MULTI_TURN_TRACE
+        assert saved.drive_fingerprint is not None
+        assert saved.drive_fingerprint.startswith("v1:")
 
     @pytest.mark.asyncio
     async def test_transient_drive_error_classifies_retryable(
@@ -3133,3 +3258,517 @@ class TestRunV2MultiTurnRedrive:
         assert "rate limit exceeded, please try again later" in str(exc_info.value)
         assert "Wait a moment" not in str(exc_info.value)
         assert len(mock_v2_redrive_config.runs(readonly=True)) == 0
+
+
+# -------------------------------------------------------------------
+# Trace reuse: drive once, judge with every sibling config
+# -------------------------------------------------------------------
+@pytest.fixture
+def reuse_eval(mock_task):
+    """EvalInput-sourced eval whose drive turns match MULTI_TURN_TRACE's two
+    user/assistant exchanges, so stored copies of that trace are healthy."""
+    eval = Eval(
+        id="reuse_eval",
+        name="reuse eval",
+        description="trace reuse eval",
+        eval_input_filter_id="all",
+        eval_configs_filter_id="all",
+        multi_turn_drive_config=MultiTurnDriveConfig(
+            model_name="claude_4_5_haiku",
+            model_provider="openrouter",
+            turns=2,
+        ),
+        output_scores=[
+            EvalOutputScore(
+                name="Accuracy",
+                instruction="Check if the output is accurate",
+                type=TaskOutputRatingType.pass_fail,
+            ),
+        ],
+        parent=mock_task,
+    )
+    eval.save_to_file()
+    return eval
+
+
+def make_reuse_config(reuse_eval: Eval, config_id: str) -> EvalConfig:
+    config = EvalConfig(
+        id=config_id,
+        name=f"cfg {config_id}",
+        config_type=EvalConfigType.v2,
+        properties=ExactMatchProperties(expected_value="reply"),
+        parent=reuse_eval,
+    )
+    config.save_to_file()
+    return config
+
+
+@pytest.fixture
+def reuse_config_a(reuse_eval):
+    return make_reuse_config(reuse_eval, "config_a")
+
+
+@pytest.fixture
+def reuse_config_b(reuse_eval):
+    return make_reuse_config(reuse_eval, "config_b")
+
+
+def serialized_trace(trace: list[ChatCompletionMessageParam]) -> str:
+    """The exact bytes the runner writes for a trace, for byte-equality asserts."""
+    return json.dumps(trace, indent=2, ensure_ascii=False)
+
+
+def reuse_fingerprint(
+    eval: Eval, eval_input: EvalInput, run_config: TaskRunConfig
+) -> str:
+    assert eval.multi_turn_drive_config is not None
+    assert isinstance(eval_input.data, MultiTurnSyntheticEvalInputData)
+    return compute_drive_fingerprint(
+        eval.multi_turn_drive_config,
+        run_config.run_config_properties,
+        eval_input.data,
+    )
+
+
+def seed_driven_run(
+    config: EvalConfig,
+    eval_input: EvalInput,
+    run_config: TaskRunConfig,
+    fingerprint: str | None,
+    trace_json: str | None,
+    run_id: str | None = None,
+) -> EvalRun:
+    """Persist an EvalRun shaped like a prior driven+judged record."""
+    run = EvalRun(
+        parent=config,
+        task_run_config_id=run_config.id,
+        dataset_id=None,
+        eval_input_id=eval_input.id,
+        eval_config_eval=False,
+        scores={"accuracy": 1.0},
+        input="opening message",
+        output="reply",
+        task_run_trace=trace_json,
+        drive_fingerprint=fingerprint,
+    )
+    if run_id is not None:
+        run.id = run_id
+    run.save_to_file()
+    return run
+
+
+def make_reuse_job(
+    eval_input: EvalInput, config: EvalConfig, run_config: TaskRunConfig
+) -> EvalJob:
+    return EvalJob(
+        item=eval_input,
+        eval_config=config,
+        type="task_run_eval",
+        task_run_config=run_config,
+    )
+
+
+@pytest.fixture
+def second_run_config(mock_task):
+    """Same resolved properties as mock_run_config, different id — the shape
+    where fingerprints collide but the reuse key must still separate them."""
+    rc = TaskRunConfig(
+        name="test twin",
+        description="identical properties, distinct config",
+        run_config_properties=KilnAgentRunConfigProperties(
+            model_name="gpt-4",
+            model_provider_name=ModelProviderName.openai,
+            prompt_id="simple_prompt_builder",
+            structured_output_mode=StructuredOutputMode.json_schema,
+        ),
+        parent=mock_task,
+    )
+    rc.save_to_file()
+    return rc
+
+
+class TestTraceReuse:
+    @pytest.mark.asyncio
+    async def test_reuse_hit_skips_drive_and_persists_identical_trace(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_a,
+        reuse_config_b,
+        multi_turn_eval_input,
+    ):
+        """A sibling config's healthy driven record satisfies a later
+        invocation's job: no drive, judge sees the stored conversation, and
+        the new record re-persists trace + fingerprint byte-identically."""
+        fingerprint = reuse_fingerprint(
+            reuse_eval, multi_turn_eval_input, mock_run_config
+        )
+        seeded_trace = serialized_trace(MULTI_TURN_TRACE)
+        seed_driven_run(
+            reuse_config_a,
+            multi_turn_eval_input,
+            mock_run_config,
+            fingerprint,
+            seeded_trace,
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        stub = RecordingStubV2Eval(reuse_config_b)
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(),
+            ) as mock_drive,
+        ):
+            result = await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, mock_run_config)
+            )
+
+        assert result is True
+        mock_drive.assert_not_awaited()
+
+        # The judge scored the stored conversation with the input's own data.
+        assert len(stub.seen_inputs) == 1
+        judged = stub.seen_inputs[0]
+        assert judged.trace == MULTI_TURN_TRACE
+        assert judged.final_message == "reply"
+        assert judged.task_input == "opening message"
+
+        runs = reuse_config_b.runs(readonly=True)
+        assert len(runs) == 1
+        saved = runs[0]
+        assert saved.scores == {"accuracy": 1.0}
+        assert saved.output == "reply"
+        assert saved.task_run_trace == seeded_trace
+        assert saved.drive_fingerprint == fingerprint
+        # Reuse writes no TaskRuns: the driven dataset stays transient.
+        assert len(mock_task.runs(readonly=True)) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_trace_json",
+        [
+            None,  # tombstone: skip record that never got a conversation
+            "[]",  # empty conversation
+            serialized_trace(
+                [
+                    {"role": "user", "content": "turn 1"},
+                    {"role": "assistant", "content": "hi"},
+                ]
+            ),  # one turn where the drive config demands two
+            serialized_trace(
+                [
+                    {"role": "user", "content": "turn 1"},
+                    {"role": "assistant", "content": None, "tool_calls": []},
+                    {"role": "user", "content": "turn 2"},
+                    {"role": "assistant", "content": None, "tool_calls": []},
+                ]
+            ),  # full turn count but no assistant text to judge
+            serialized_trace(
+                [
+                    {"role": "user", "content": "turn 1"},
+                    {"role": "assistant", "content": "hi"},
+                    {"role": "user", "content": "turn 2"},
+                ]
+            ),  # full user count but the final reply is missing
+            serialized_trace(
+                [
+                    {"role": "user", "content": "turn 1"},
+                    {"role": "assistant", "content": "hi"},
+                    {"role": "user", "content": "turn 2"},
+                    {"role": "assistant", "content": None, "tool_calls": [{"id": "t"}]},
+                ]
+            ),  # ends mid tool call: reusing it would promote turn 1's reply
+            "not json at all",
+        ],
+    )
+    async def test_unhealthy_records_never_satisfy_reuse(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_a,
+        reuse_config_b,
+        multi_turn_eval_input,
+        data_source,
+        bad_trace_json,
+    ):
+        fingerprint = reuse_fingerprint(
+            reuse_eval, multi_turn_eval_input, mock_run_config
+        )
+        seed_driven_run(
+            reuse_config_a,
+            multi_turn_eval_input,
+            mock_run_config,
+            fingerprint,
+            bad_trace_json,
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=StubV2Eval(reuse_config_b),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+            ) as mock_drive,
+        ):
+            result = await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, mock_run_config)
+            )
+
+        assert result is True
+        mock_drive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fingerprint_mismatch_redrives(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_a,
+        reuse_config_b,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """A healthy record under a different fingerprint (edited drive or
+        scenario) never matches — content identity is the whole key."""
+        seed_driven_run(
+            reuse_config_a,
+            multi_turn_eval_input,
+            mock_run_config,
+            "v1:" + "0" * 64,
+            serialized_trace(MULTI_TURN_TRACE),
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=StubV2Eval(reuse_config_b),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+            ) as mock_drive,
+        ):
+            await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, mock_run_config)
+            )
+
+        mock_drive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_legacy_records_without_fingerprint_never_reused(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_a,
+        reuse_config_b,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        seed_driven_run(
+            reuse_config_a,
+            multi_turn_eval_input,
+            mock_run_config,
+            None,
+            serialized_trace(MULTI_TURN_TRACE),
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=StubV2Eval(reuse_config_b),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+            ) as mock_drive,
+        ):
+            await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, mock_run_config)
+            )
+
+        mock_drive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reuse_never_crosses_run_configs(
+        self,
+        mock_task,
+        mock_run_config,
+        second_run_config,
+        reuse_eval,
+        reuse_config_a,
+        reuse_config_b,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """Two run configs with identical properties fingerprint identically,
+        but a job for one must never consume the other's conversation."""
+        fingerprint = reuse_fingerprint(
+            reuse_eval, multi_turn_eval_input, mock_run_config
+        )
+        assert fingerprint == reuse_fingerprint(
+            reuse_eval, multi_turn_eval_input, second_run_config
+        )
+        seed_driven_run(
+            reuse_config_a,
+            multi_turn_eval_input,
+            mock_run_config,
+            fingerprint,
+            serialized_trace(MULTI_TURN_TRACE),
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[second_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=StubV2Eval(reuse_config_b),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+            ) as mock_drive,
+        ):
+            await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, second_run_config)
+            )
+
+        mock_drive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_same_invocation_siblings_share_one_drive(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_a,
+        reuse_config_b,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """Within one runner invocation the first drive is published in
+        memory, so the sibling config's job reuses it before it hits disk."""
+        runner = EvalRunner(
+            eval_configs=[reuse_config_a, reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                side_effect=lambda config, *_: StubV2Eval(config),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+            ) as mock_drive,
+        ):
+            for config in (reuse_config_a, reuse_config_b):
+                assert await runner.run_job(
+                    make_reuse_job(multi_turn_eval_input, config, mock_run_config)
+                )
+
+        assert mock_drive.await_count == 1
+        run_a = reuse_config_a.runs(readonly=True)[0]
+        run_b = reuse_config_b.runs(readonly=True)[0]
+        assert run_a.task_run_trace == run_b.task_run_trace
+        assert run_a.task_run_trace is not None
+        assert run_a.drive_fingerprint == run_b.drive_fingerprint
+
+    @pytest.mark.asyncio
+    async def test_deterministic_pick_across_racing_writers(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_a,
+        reuse_config_b,
+        multi_turn_eval_input,
+    ):
+        """When racing drives left two healthy records for one key, every
+        later read picks the same one (lowest config id, run id)."""
+        fingerprint = reuse_fingerprint(
+            reuse_eval, multi_turn_eval_input, mock_run_config
+        )
+        first_trace: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "turn 1"},
+            {"role": "assistant", "content": "first writer"},
+            {"role": "user", "content": "turn 2"},
+            {"role": "assistant", "content": "first writer final"},
+        ]
+        second_trace: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "turn 1"},
+            {"role": "assistant", "content": "second writer"},
+            {"role": "user", "content": "turn 2"},
+            {"role": "assistant", "content": "second writer final"},
+        ]
+        seed_driven_run(
+            reuse_config_a,
+            multi_turn_eval_input,
+            mock_run_config,
+            fingerprint,
+            serialized_trace(first_trace),
+            run_id="run_1",
+        )
+        seed_driven_run(
+            reuse_config_a,
+            multi_turn_eval_input,
+            mock_run_config,
+            fingerprint,
+            serialized_trace(second_trace),
+            run_id="run_2",
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        stub = RecordingStubV2Eval(reuse_config_b)
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(),
+            ) as mock_drive,
+        ):
+            await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, mock_run_config)
+            )
+
+        mock_drive.assert_not_awaited()
+        assert stub.seen_inputs[0].trace == first_trace

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -3303,6 +3303,45 @@ def make_reuse_config(reuse_eval: Eval, config_id: str) -> EvalConfig:
     return config
 
 
+def make_cross_eval(task, eval_id: str, su_model: str = "claude_4_5_haiku") -> Eval:
+    """A SEPARATE Eval on the same task sharing reuse_eval's drive setup —
+    the two-judges-two-evals shape the task-wide reuse scan exists for."""
+    eval = Eval(
+        id=eval_id,
+        name=f"cross eval {eval_id}",
+        description="separate eval sharing the drive setup",
+        eval_input_filter_id="all",
+        eval_configs_filter_id="all",
+        multi_turn_drive_config=MultiTurnDriveConfig(
+            model_name=su_model,
+            model_provider="openrouter",
+            turns=2,
+        ),
+        output_scores=[
+            EvalOutputScore(
+                name="Accuracy",
+                instruction="Check if the output is accurate",
+                type=TaskOutputRatingType.pass_fail,
+            ),
+        ],
+        parent=task,
+    )
+    eval.save_to_file()
+    return eval
+
+
+@pytest.fixture
+def cross_eval(mock_task):
+    # Id sorts before reuse_eval's so the deterministic-pick test below can
+    # prove cross-eval records participate in the (eval, config, run) order.
+    return make_cross_eval(mock_task, "aaa_cross_eval")
+
+
+@pytest.fixture
+def cross_eval_config(cross_eval):
+    return make_reuse_config(cross_eval, "cross_config")
+
+
 @pytest.fixture
 def reuse_config_a(reuse_eval):
     return make_reuse_config(reuse_eval, "config_a")
@@ -3772,3 +3811,222 @@ class TestTraceReuse:
 
         mock_drive.assert_not_awaited()
         assert stub.seen_inputs[0].trace == first_trace
+
+    @pytest.mark.asyncio
+    async def test_cross_eval_reuse_hit_skips_drive(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_b,
+        cross_eval,
+        cross_eval_config,
+        multi_turn_eval_input,
+    ):
+        """A healthy driven record under a DIFFERENT eval on the same task
+        satisfies this eval's job: the fingerprint is content-keyed, so two
+        judges forced onto separate Evals still score one conversation."""
+        fingerprint = reuse_fingerprint(
+            cross_eval, multi_turn_eval_input, mock_run_config
+        )
+        # Identical drive configs fingerprint identically from either eval.
+        assert fingerprint == reuse_fingerprint(
+            reuse_eval, multi_turn_eval_input, mock_run_config
+        )
+        seeded_trace = serialized_trace(MULTI_TURN_TRACE)
+        seed_driven_run(
+            cross_eval_config,
+            multi_turn_eval_input,
+            mock_run_config,
+            fingerprint,
+            seeded_trace,
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        stub = RecordingStubV2Eval(reuse_config_b)
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(),
+            ) as mock_drive,
+        ):
+            result = await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, mock_run_config)
+            )
+
+        assert result is True
+        mock_drive.assert_not_awaited()
+        assert stub.seen_inputs[0].trace == MULTI_TURN_TRACE
+
+        # The reused record is self-contained: byte-identical trace + the
+        # shared fingerprint persist under THIS eval's config.
+        saved = reuse_config_b.runs(readonly=True)[0]
+        assert saved.task_run_trace == seeded_trace
+        assert saved.drive_fingerprint == fingerprint
+        assert len(mock_task.runs(readonly=True)) == 0
+
+    @pytest.mark.asyncio
+    async def test_cross_eval_different_drive_config_never_reused(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_b,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """Another eval driving with a different SU model (same turns, so its
+        trace is healthy) fingerprints differently — never reused here."""
+        other_eval = make_cross_eval(mock_task, "other_su_eval", su_model="gpt_4o")
+        other_config = make_reuse_config(other_eval, "other_su_config")
+        other_fingerprint = reuse_fingerprint(
+            other_eval, multi_turn_eval_input, mock_run_config
+        )
+        assert other_fingerprint != reuse_fingerprint(
+            reuse_eval, multi_turn_eval_input, mock_run_config
+        )
+        seed_driven_run(
+            other_config,
+            multi_turn_eval_input,
+            mock_run_config,
+            other_fingerprint,
+            serialized_trace(MULTI_TURN_TRACE),
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=StubV2Eval(reuse_config_b),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+            ) as mock_drive,
+        ):
+            await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, mock_run_config)
+            )
+
+        mock_drive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cross_eval_never_crosses_run_configs(
+        self,
+        mock_task,
+        mock_run_config,
+        second_run_config,
+        reuse_eval,
+        reuse_config_b,
+        cross_eval,
+        cross_eval_config,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """Widening the scan across evals must not loosen the run-config
+        boundary: another eval's record for run config A never serves B."""
+        fingerprint = reuse_fingerprint(
+            cross_eval, multi_turn_eval_input, mock_run_config
+        )
+        seed_driven_run(
+            cross_eval_config,
+            multi_turn_eval_input,
+            mock_run_config,
+            fingerprint,
+            serialized_trace(MULTI_TURN_TRACE),
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[second_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=StubV2Eval(reuse_config_b),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+            ) as mock_drive,
+        ):
+            await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, second_run_config)
+            )
+
+        mock_drive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cross_eval_deterministic_pick(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_a,
+        reuse_config_b,
+        cross_eval,
+        cross_eval_config,
+        multi_turn_eval_input,
+    ):
+        """With healthy records under TWO evals for one key, every reader
+        picks by (eval id, config id, run id) — here the cross eval's record,
+        whose eval id sorts first."""
+        fingerprint = reuse_fingerprint(
+            reuse_eval, multi_turn_eval_input, mock_run_config
+        )
+        cross_trace: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "turn 1"},
+            {"role": "assistant", "content": "cross-eval writer"},
+            {"role": "user", "content": "turn 2"},
+            {"role": "assistant", "content": "cross-eval final"},
+        ]
+        seed_driven_run(
+            cross_eval_config,
+            multi_turn_eval_input,
+            mock_run_config,
+            fingerprint,
+            serialized_trace(cross_trace),
+        )
+        seed_driven_run(
+            reuse_config_a,
+            multi_turn_eval_input,
+            mock_run_config,
+            fingerprint,
+            serialized_trace(MULTI_TURN_TRACE),
+        )
+
+        runner = EvalRunner(
+            eval_configs=[reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        stub = RecordingStubV2Eval(reuse_config_b)
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(),
+            ) as mock_drive,
+        ):
+            await runner.run_job(
+                make_reuse_job(multi_turn_eval_input, reuse_config_b, mock_run_config)
+            )
+
+        mock_drive.assert_not_awaited()
+        assert stub.seen_inputs[0].trace == cross_trace

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -519,6 +519,41 @@ class EvalTaskInput(BaseModel):
             task_input=task_input,
         )
 
+    @classmethod
+    def from_eval_input_trace(
+        cls, eval_input: "EvalInput", trace: list[dict[str, Any]]
+    ) -> "EvalTaskInput":
+        """Assemble evaluator input from an EvalInput plus an already-driven
+        conversation: used when a stored trace stands in for a fresh drive,
+        so there is no TaskRun to compose from. Mirrors from_eval_input."""
+        if not isinstance(eval_input, EvalInput):
+            raise TypeError("Expected an EvalInput instance")
+        if not isinstance(eval_input.data, MultiTurnSyntheticEvalInputData):
+            raise ValueError(
+                "Trace-based assembly requires a multi-turn synthetic input; "
+                f"got: {type(eval_input.data).__name__}"
+            )
+
+        # The final model output is the last assistant text in the trace
+        # (assistant tool-call messages can carry no text content).
+        final_message: str | None = None
+        for msg in reversed(trace):
+            content = msg.get("content")
+            if msg.get("role") == "assistant" and isinstance(content, str) and content:
+                final_message = content
+                break
+        if final_message is None:
+            raise ValueError("Trace has no assistant message with text content")
+
+        return cls(
+            final_message=final_message,
+            trace=[dict(msg) for msg in trace],
+            reference_data=eval_input.reference,
+            task_input=eval_input.data.first_message.text
+            if eval_input.data.first_message
+            else None,
+        )
+
 
 class EvalOutputScore(BaseModel):
     """
@@ -612,6 +647,14 @@ class EvalRun(KilnParentedModel):
     skipped_detail: str | None = Field(
         default=None,
         description="Case-specific detail for skipped runs (e.g. missing key name).",
+    )
+    drive_fingerprint: str | None = Field(
+        default=None,
+        description="Identity of the drive that produced task_run_trace for "
+        "multi-turn synthetic (EvalInput) runs: a versioned hash of drive "
+        "config + run config properties + scenario content. Enables reuse of "
+        "the stored conversation by other eval configs; None for non-driven "
+        "records.",
     )
 
     def parent_eval_config(self) -> Union["EvalConfig", None]:

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -403,6 +403,57 @@ def test_eval_run_valid_creation():
     assert eval_run.scores == {"accuracy": 0.95}
 
 
+def test_eval_run_drive_fingerprint_defaults_none_and_round_trips(tmp_path):
+    """drive_fingerprint is additive: absent on existing records (None), and
+    a set value survives the disk round-trip."""
+    task = Task(
+        name="Test Task", instruction="Test instruction", path=tmp_path / "task.kiln"
+    )
+    task.save_to_file()
+    eval = Eval(
+        name="FP Eval",
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        output_scores=[
+            EvalOutputScore(name="quality", type=TaskOutputRatingType.pass_fail),
+        ],
+        parent=task,
+    )
+    eval.save_to_file()
+    config = EvalConfig(
+        name="cfg",
+        config_type=EvalConfigType.v2,
+        properties=ExactMatchProperties(expected_value="out"),
+        parent=eval,
+    )
+    config.save_to_file()
+
+    plain = EvalRun(
+        task_run_config_id="rc1",
+        scores={"quality": 1.0},
+        input="in",
+        output="out",
+        dataset_id="d1",
+        parent=config,
+    )
+    assert plain.drive_fingerprint is None
+    plain.save_to_file()
+    assert EvalRun.load_from_file(plain.path).drive_fingerprint is None
+
+    fingerprinted = EvalRun(
+        task_run_config_id="rc1",
+        scores={"quality": 1.0},
+        input="in",
+        output="out",
+        dataset_id="d2",
+        drive_fingerprint="v1:" + "a" * 64,
+        parent=config,
+    )
+    fingerprinted.save_to_file()
+    reloaded = EvalRun.load_from_file(fingerprinted.path)
+    assert reloaded.drive_fingerprint == "v1:" + "a" * 64
+
+
 def test_eval_run_plaintext():
     """Test creating an EvalRun with plaintext input/output"""
     eval_run = EvalRun(
@@ -2736,6 +2787,85 @@ class TestEvalTaskInputFromEvalInput:
             ),
         )
         eti = EvalTaskInput.from_eval_input(ei, self._run_output(mock_task))
+        assert eti.task_input is None
+
+
+class TestEvalTaskInputFromEvalInputTrace:
+    """from_eval_input_trace: assembly from a stored conversation, used when
+    a reused trace stands in for a fresh drive (no TaskRun exists)."""
+
+    def _multi_turn_input(self, reference=None) -> EvalInput:
+        return EvalInput(
+            data=MultiTurnSyntheticEvalInputData(
+                first_message=UserMessage(text="opening message"),
+                synthetic_user_info=SyntheticUserInfo(persona="p", goal="g"),
+            ),
+            reference=reference,
+        )
+
+    def test_happy_path(self):
+        trace = [
+            {"role": "user", "content": "opening message"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "turn 2"},
+            {"role": "assistant", "content": "final reply"},
+        ]
+        eti = EvalTaskInput.from_eval_input_trace(
+            self._multi_turn_input(reference={"expected": "A"}), trace
+        )
+        assert eti.final_message == "final reply"
+        assert eti.task_input == "opening message"
+        assert eti.reference_data == {"expected": "A"}
+        assert eti.trace == trace
+
+    def test_final_message_skips_toolcall_only_assistant_turns(self):
+        trace = [
+            {"role": "user", "content": "opening message"},
+            {"role": "assistant", "content": "real answer"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "content": "tool result"},
+        ]
+        eti = EvalTaskInput.from_eval_input_trace(self._multi_turn_input(), trace)
+        assert eti.final_message == "real answer"
+
+    def test_trace_is_copied_not_aliased(self):
+        """The trace may be shared through a reuse index; mutating the
+        assembled input must not corrupt the shared copy."""
+        trace = [
+            {"role": "user", "content": "opening message"},
+            {"role": "assistant", "content": "final reply"},
+        ]
+        eti = EvalTaskInput.from_eval_input_trace(self._multi_turn_input(), trace)
+        assert eti.trace is not None
+        eti.trace[0]["content"] = "mutated"
+        assert trace[0]["content"] == "opening message"
+
+    def test_no_assistant_text_raises(self):
+        trace = [
+            {"role": "user", "content": "opening message"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "t1"}]},
+        ]
+        with pytest.raises(ValueError, match="no assistant message"):
+            EvalTaskInput.from_eval_input_trace(self._multi_turn_input(), trace)
+
+    def test_single_turn_input_rejected(self):
+        ei = EvalInput(
+            data=SingleTurnEvalInputData(user_message=UserMessage(text="Q")),
+        )
+        with pytest.raises(ValueError, match="multi-turn synthetic"):
+            EvalTaskInput.from_eval_input_trace(
+                ei, [{"role": "assistant", "content": "a"}]
+            )
+
+    def test_missing_first_message_gives_none_task_input(self):
+        ei = EvalInput(
+            data=MultiTurnSyntheticEvalInputData(
+                synthetic_user_info=SyntheticUserInfo(persona="p", goal="g"),
+            ),
+        )
+        eti = EvalTaskInput.from_eval_input_trace(
+            ei, [{"role": "assistant", "content": "a"}]
+        )
         assert eti.task_input is None
 
 


### PR DESCRIPTION
Review vehicle for the two trace-reuse commits already on dchiang/multiturn-eval-megabranch (f0d024a50, 14fde35cb), pinned between marker branches so comments can thread inline on the exact diff. Do not merge — requested changes will land as follow-up commits on the megabranch and this PR closes unmerged when review is done.

What it does: multi-turn EvalInput evals drive each conversation once per (scenario, run config), and every v2 eval config task-wide scores that same stored conversation. EvalRun gains an additive drive_fingerprint ("v1:" + sha256 of drive config + resolved run-config properties + scenario content; reference data and judge properties are excluded — they shape judgment, not the drive). Traces now always persist on v2 EvalRuns, including judge skips. This supersedes #1438 "Always persist task_run_trace on eval runs", which removed the same full_trace/success-only gates — credit to that PR for the direction; legacy g_eval and golden-calibration paths are untouched.

Reuse mechanics: index built once per runner invocation (O(1) per job), healthy traces only (full turn count, ends with assistant text), reuse never crosses run configs, first-write-wins with a deterministic pick, tombstones never satisfy reuse, and zero TaskRuns are written by eval-time drives. The paid harness gained a reuse leg: a second judge config re-running run_comparison consumes stored conversations byte-identically (equal fingerprints, no new drives) with the transience assertions unchanged.

Diffs to eval_runner.py and datamodel/eval.py were kept deliberately surgical.

Data model, before and after:

```mermaid
flowchart LR
  subgraph BEFORE ["Before"]
    direction TB
    EI1["EvalInput (scenario)"] -->|"fresh drive per eval config"| D1["transient TaskRun chain (discarded)"]
    D1 --> ER1["EvalRun
    task_run_trace: only if full_trace eval AND scoring succeeded
    no fingerprint — stored traces unfindable/unreusable"]
  end
  subgraph AFTER ["After"]
    direction TB
    EI2["EvalInput (scenario)"] -->|"one drive per (scenario, run config) — still zero TaskRuns"| D2["transient drive"]
    D2 --> ER2["EvalRun
    + drive_fingerprint: 'v1:' + sha256(drive config, resolved run-config properties, scenario content)
    task_run_trace: always persisted on v2 (judge skips included)"]
    ER2 -->|"reuse key: (drive_fingerprint, task_run_config_id)
    task-wide, healthy traces only, never across run configs"| J2["every other v2 eval config judges the same stored conversation"]
  end
```

Field-level delta on EvalRun (datamodel/eval.py): one additive optional field drive_fingerprint (None on all pre-existing and non-driven records — no migration), plus classmethod EvalTaskInput.from_eval_input_trace to build judge input from a stored conversation instead of a live TaskRun. Everything else on EvalRun is unchanged; task_run_trace changes are behavioral (when it is populated), not structural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
