### PR TITLE
Deprecate 54 dead provider entries (Fireworks + Together serverless purges, Anthropic/OpenRouter/SiliconFlow removals)

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -3705,6 +3705,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="meta-llama/Llama-4-Scout-17B-16E-Instruct",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
@@ -3791,6 +3792,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+                deprecated=True,
                 supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
                 provider_finetune_id="meta-llama/Meta-Llama-3.1-8B-Instruct-Reference",
@@ -3851,6 +3853,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+                deprecated=True,
                 supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
                 provider_finetune_id="meta-llama/Meta-Llama-3.1-70B-Instruct-Reference",
@@ -4757,6 +4760,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="Qwen/QwQ-32B",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 parser=ModelParserID.r1_thinking,
                 reasoning_capable=True,
@@ -4841,6 +4845,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="Qwen/Qwen2.5-VL-72B-Instruct",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
@@ -5475,6 +5480,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 parser=ModelParserID.r1_thinking,
                 supports_function_calling=False,
@@ -5521,6 +5527,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 parser=ModelParserID.r1_thinking,
                 supports_function_calling=False,
@@ -5659,6 +5666,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 parser=ModelParserID.r1_thinking,
                 supports_structured_output=False,
@@ -6155,6 +6163,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="Qwen/Qwen3.5-397B-A17B",
+                deprecated=True,
                 supports_data_gen=False,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_doc_extraction=True,
@@ -7440,6 +7449,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="zai-org/GLM-5.1",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
             ),
@@ -7518,13 +7528,13 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="zai-org/GLM-5",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
             ),
             KilnModelProvider(
                 name=ModelProviderName.siliconflow_cn,
                 model_id="Pro/zai-org/GLM-5",
-                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
                 reasoning_optional_for_structured_output=True,

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -2260,6 +2260,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.anthropic,
                 model_id="claude-sonnet-4-20250514",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.function_calling,
             ),
         ],
@@ -2553,6 +2554,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.anthropic,
                 model_id="claude-opus-4-20250514",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.function_calling,
             ),
         ],
@@ -3302,6 +3304,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 model_id="google/gemini-2.0-flash-001",
+                deprecated=True,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
                 supports_vision=True,
@@ -3361,6 +3364,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 model_id="google/gemini-2.0-flash-lite-001",
+                deprecated=True,
                 supports_doc_extraction=True,
                 multimodal_capable=True,
                 supports_vision=True,
@@ -3594,6 +3598,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/llama4-maverick-instruct-basic",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
@@ -3681,6 +3686,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/llama4-scout-instruct-basic",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
@@ -3779,6 +3785,7 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=False,
                 model_id="accounts/fireworks/models/llama-v3p1-8b-instruct",
+                deprecated=True,
                 supports_function_calling=False,
             ),
             KilnModelProvider(
@@ -3839,6 +3846,7 @@ built_in_models: List[KilnModel] = [
                 # Tool calling forces schema -- fireworks doesn't support json_schema, just json_mode
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
                 model_id="accounts/fireworks/models/llama-v3p1-70b-instruct",
+                deprecated=True,
             ),
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
@@ -3878,6 +3886,7 @@ built_in_models: List[KilnModel] = [
                 # No finetune support. https://docs.fireworks.ai/fine-tuning/fine-tuning-models
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
                 model_id="accounts/fireworks/models/llama-v3p1-405b-instruct",
+                deprecated=True,
             ),
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
@@ -4023,6 +4032,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/mistral-large-3-fp8",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
             ),
         ],
@@ -4263,6 +4273,7 @@ built_in_models: List[KilnModel] = [
                 # Tool calling forces schema -- fireworks doesn't support json_schema, just json_mode
                 structured_output_mode=StructuredOutputMode.function_calling_weak,
                 model_id="accounts/fireworks/models/llama-v3p3-70b-instruct",
+                deprecated=True,
                 supports_function_calling=False,
             ),
             KilnModelProvider(
@@ -4910,6 +4921,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen2p5-vl-32b-instruct",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_function_calling=False,
                 supports_doc_extraction=True,
@@ -5140,6 +5152,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/deepseek-r1-0528",
+                deprecated=True,
                 parser=ModelParserID.r1_thinking,
                 supports_data_gen=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
@@ -5268,6 +5281,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/deepseek-v3p2",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=True,
             ),
@@ -5294,6 +5308,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/deepseek-v3p1-terminus",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_data_gen=True,
                 # the model page states it supports function calling, but our test fails
@@ -5317,6 +5332,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/deepseek-v3p1",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=True,
             ),
@@ -5343,6 +5359,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/deepseek-v3",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_structured_output=True,
                 supports_data_gen=False,
@@ -5378,6 +5395,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/deepseek-r1",
+                deprecated=True,
                 parser=ModelParserID.r1_thinking,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
@@ -5404,6 +5422,7 @@ built_in_models: List[KilnModel] = [
                 reasoning_capable=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 model_id="deepseek/deepseek-r1-distill-qwen-32b",
+                deprecated=True,
                 r1_openrouter_options=True,
                 parser=ModelParserID.r1_thinking,
                 require_openrouter_reasoning=True,
@@ -6068,6 +6087,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen3p6-plus",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=True,
                 supports_function_calling=True,
@@ -6512,6 +6532,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen3-30b-a3b",
+                deprecated=True,
                 supports_data_gen=True,
                 reasoning_capable=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
@@ -6695,6 +6716,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen3-vl-235b-a22b-instruct",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 formatter=ModelFormatterID.qwen3_style_no_think,
                 supports_data_gen=False,
@@ -6775,6 +6797,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen3-vl-30b-a3b-instruct",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_data_gen=False,
                 reasoning_capable=False,
@@ -6872,6 +6895,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen3-vl-235b-a22b-thinking",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 parser=ModelParserID.r1_thinking,
                 supports_data_gen=False,
@@ -6992,6 +7016,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen3-vl-30b-a3b-thinking",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 parser=ModelParserID.r1_thinking,
                 supports_data_gen=False,
@@ -7169,6 +7194,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen3-235b-a22b-thinking-2507",
+                deprecated=True,
                 supports_data_gen=True,
                 reasoning_capable=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
@@ -7211,6 +7237,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen3-235b-a22b",
+                deprecated=True,
                 supports_data_gen=True,
                 reasoning_capable=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
@@ -7261,12 +7288,14 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/qwen3-235b-a22b-instruct-2507",
+                deprecated=True,
                 supports_data_gen=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
             ),
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="Qwen/Qwen3-235B-A22B-Instruct-2507-tput",
+                deprecated=True,
                 supports_data_gen=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
             ),
@@ -7482,6 +7511,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/glm-5",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
             ),
@@ -7494,6 +7524,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.siliconflow_cn,
                 model_id="Pro/zai-org/GLM-5",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
                 reasoning_optional_for_structured_output=True,
@@ -7515,6 +7546,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.siliconflow_cn,
                 model_id="Pro/zai-org/GLM-4.7",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
                 reasoning_optional_for_structured_output=True,
@@ -7688,6 +7720,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/glm-4p5",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
             ),
@@ -7716,6 +7749,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/glm-4p5-air",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
             ),
@@ -7872,6 +7906,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/kimi-k2-instruct",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_data_gen=True,
             ),
@@ -7922,6 +7957,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/kimi-k2-instruct-0905",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_data_gen=True,
             ),
@@ -7963,6 +7999,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/kimi-k2-thinking",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
                 supports_data_gen=True,
@@ -8062,6 +8099,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 model_id="baidu/ernie-4.5-300b-a47b",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_data_gen=True,
                 r1_openrouter_options=True,
@@ -8208,6 +8246,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/minimax-m2p5",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 reasoning_capable=True,
                 supports_data_gen=True,
@@ -8245,6 +8284,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/minimax-m2p1",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 reasoning_capable=True,
                 supports_data_gen=True,
@@ -8280,6 +8320,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
                 model_id="accounts/fireworks/models/minimax-m2",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 reasoning_capable=True,
                 supports_data_gen=True,
@@ -8529,6 +8570,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 model_id="xiaomi/mimo-v2-pro",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=True,
             ),
@@ -8543,6 +8585,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 model_id="xiaomi/mimo-v2-flash",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=True,
             ),
@@ -8557,6 +8600,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 model_id="xiaomi/mimo-v2-omni",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=True,
                 supports_vision=True,


### PR DESCRIPTION
## What does this PR do?

Marks `deprecated=True` on **54 provider entries** in `ml_model_list.py` that no longer serve inference, following the pre-release test failure on `qwen_3p6_plus` (Fireworks 404 – model not deployed) and a full deprecation audit across all providers.

**Every entry in this PR was verified with a real 1-token inference call** (not just listing checks), with a live positive-control model per provider to rule out auth/quota issues. This mattered: listing-based checks alone produced both false negatives (Fireworks/Together catalogs still list undeployed models) and one false positive (SiliconFlow GLM-5 is delisted but still serving — caught and excluded before merge).

### Finding 1: Fireworks serverless purge (32 entries)

The pre-release failure on `qwen3p6-plus` was the tip of an iceberg: Fireworks has removed serverless deployment for **32 of Kiln's 43 Fireworks entries**. Their catalog detail API (`GET /v1/{model_id}`) still returns `200 / state=READY` for all of them, but each has a past `deprecationDate` in its metadata and returns `404 "Model not found, inaccessible, and/or not deployed"` from the chat-completions endpoint. The 404/OK split correlates exactly with the `deprecationDate` field.

Survivors (verified serving): deepseek-v4-flash, deepseek-v4-pro, glm-5p1, glm-5p2, gpt-oss-120b, gpt-oss-20b, kimi-k2p6, minimax-m3, nemotron-3-ultra-nvfp4, qwen3p7-plus, and the glm-5p2-fast router. `qwen_3p6_plus` needs no re-pin — Qwen 3.7 Plus is already in the list and serving.

Deprecated (all verified 404 at inference): deepseek-r1, deepseek-r1-0528, deepseek-v3, deepseek-v3p1, deepseek-v3p1-terminus, deepseek-v3p2, glm-4p5, glm-4p5-air, glm-5, kimi-k2-instruct, kimi-k2-instruct-0905, kimi-k2-thinking, llama-v3p1-405b-instruct, llama-v3p1-70b-instruct, llama-v3p1-8b-instruct, llama-v3p3-70b-instruct, llama4-maverick-instruct-basic, llama4-scout-instruct-basic, minimax-m2, minimax-m2p1, minimax-m2p5, mistral-large-3-fp8, qwen2p5-vl-32b-instruct, qwen3-235b-a22b, qwen3-235b-a22b-instruct-2507, qwen3-235b-a22b-thinking-2507, qwen3-30b-a3b, qwen3-vl-235b-a22b-instruct, qwen3-vl-235b-a22b-thinking, qwen3-vl-30b-a3b-instruct, qwen3-vl-30b-a3b-thinking, qwen3p6-plus

### Finding 2: Together serverless purge (12 entries)

Probing revealed Together has done the same thing: 12 of Kiln's 17 Together entries return `model_not_available` — *"Unable to access non-serverless model … create and start a new dedicated endpoint"* (confirmed twice per model). Their `/v1/models` listing still contains 11 of the 12 with no distinguishing metadata (`type: chat, running: false` on live and dead models alike), so listing checks can't catch this.

Survivors (verified serving): MiniMaxAI/MiniMax-M2.7, deepseek-ai/DeepSeek-V4-Pro, meta-llama/Llama-3.3-70B-Instruct-Turbo, nvidia/nemotron-3-ultra-550b-a55b, zai-org/GLM-5.2.

Deprecated: Qwen/QwQ-32B, Qwen/Qwen2.5-VL-72B-Instruct, Qwen/Qwen3-235B-A22B-Instruct-2507-tput, Qwen/Qwen3.5-397B-A17B, deepseek-ai/DeepSeek-R1-Distill-Llama-70B, deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B, deepseek-ai/DeepSeek-R1-Distill-Qwen-14B, meta-llama/Llama-4-Scout-17B-16E-Instruct, meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo, meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo, zai-org/GLM-5, zai-org/GLM-5.1

Note: re-pinning the Qwen3-235B `-tput` slug to the remaining `-FP8` slug is NOT viable — the FP8 variant is also dedicated-endpoint-only (verified).

### Other providers

**anthropic (2)** — retired; verified 404 `not_found_error` at inference (control: claude-haiku-4-5 OK): claude-opus-4-20250514, claude-sonnet-4-20250514

**openrouter (7)** — verified 404 at inference ("No endpoints found"; the xiaomi ones explicitly say "deprecated, migrate to mimo-v2.5"): baidu/ernie-4.5-300b-a47b, deepseek/deepseek-r1-distill-qwen-32b, google/gemini-2.0-flash-001, google/gemini-2.0-flash-lite-001, xiaomi/mimo-v2-flash, xiaomi/mimo-v2-omni, xiaomi/mimo-v2-pro

**siliconflow_cn (1)** — verified 403 "Model disabled" (control: GLM-5.2 OK): Pro/zai-org/GLM-4.7
⚠️ `Pro/zai-org/GLM-5` is delisted from their `/v1/models` but **still serves inference** — initially marked, then reverted after probing. Worth watching; likely on its way out.

### Models that lose their last active provider

These 4 are now fully deprecated (consider removal in a future cleanup): ernie_4_5_300b_a47b, mimo_v2_flash, mimo_v2_omni, mimo_v2_pro.

### Flagged but NOT marked (maintainer's call)

- **openrouter meta-llama/llama-3.2-11b-vision-instruct expires 2026-07-17 (tomorrow)** — will need deprecation almost immediately.
- openai/gpt-5.2-chat and openai/gpt-5.3-chat expire 2026-08-10 on OpenRouter.
- z-ai/glm-4.5 expires 2026-12-31 on OpenRouter.

### Not checked

- **vertex** — gcloud auth unavailable in this session.
- **groq** — no GROQ_API_KEY in env.
- **amazon_bedrock** — no aws CLI on this machine.
- Listed-and-presumed-alive entries on other providers (openai, gemini, cerebras, remaining openrouter/siliconflow) were not inference-probed — only entries flagged by listing checks were. The Fireworks/Together experience says listing-present ≠ serving, so a periodic full inference sweep may be worth automating.

### Follow-up: the deprecation checker needs hardening

`kiln-check-deprecation` missed both purges and produced one false positive. Concretely: the Fireworks detail-API check treats `200 READY` as available (false negatives; also a 403 on the `routers/` path aborts the whole provider), and Together/SiliconFlow listing checks don't reflect serverless reality in either direction. Cheap 1-token inference probes with positive controls were the only reliable signal.

### Test results

- `libs/core/kiln_ai/adapters/test_ml_model_list.py`: 50 passed.
- `checks.sh --staged-only`: all checks pass except `test_document_api.py::test_create_document_content_type_detection[document.md-...]`, which also fails on clean origin/main in this environment (local MIME-detection issue, unrelated).
- Deprecated-entry count: 111 → 165 (+54, matches).

## Related Issues

Pre-release testing failure: qwen_3p6_plus on Fireworks returning 404 – model not deployed.

## Contributor License Agreement

I, @tawnymanticore, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib (flag-only change, covered by existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
