### PR TITLE
Merge blocker: gate judge_feedback_batch from main pending design review

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py
@@ -1,3 +1,9 @@
+# TODO (merge blocker — do not merge toward main until resolved): this runner is under design
+# review. Concerns 3–5 are implemented here — the parallel eval-result store (JudgeFeedbackBatchRun
+# vs EvalRun), the cache bypass on identical re-runs, and the paired-gate logic retrofitted onto
+# tag-based sampling. Full write-up and rationale in the header of
+# kiln_ai/datamodel/judge_feedback_batch.py. Resolve there before merging toward main.
+
 """Execute a JudgeFeedbackBatch: sample dataset items by tag, judge them, persist per-item results.
 
 A JudgeFeedbackBatch samples dataset items carrying its target tags, runs the configured judge (eval config)

--- a/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py
@@ -1,3 +1,7 @@
+# TODO (merge blocker — do not merge toward main until resolved): tests for a runner under design
+# review — see the header of kiln_ai/datamodel/judge_feedback_batch.py. Resolve before merging
+# toward main.
+
 import random
 from typing import Callable, Dict
 

--- a/libs/core/kiln_ai/datamodel/judge_feedback_batch.py
+++ b/libs/core/kiln_ai/datamodel/judge_feedback_batch.py
@@ -1,3 +1,46 @@
+# TODO (merge blocker — do not merge toward main until resolved):
+# This feature grew out of a reflection helper (failing_train_examples, PR #1536) and was
+# reshaped several times under review. Re-validate the design before it becomes API surface:
+#
+# 1. Re-validate the driving use case. Built to feed judge feedback text to reflective
+#    prompt optimization. Does that consumer still exist and still need this shape?
+#    If nothing needs it, delete rather than merge.
+#
+# 2. Selection by tags leaves user-visible, long-lived side effects. A one-off or
+#    targeted run (specific items) forces the caller to mutate dataset tags — shared,
+#    user-visible state — to express what is really a query parameter. If item-level
+#    selection is needed, accept item IDs (and/or a named dataset split). Callers
+#    should never have to write tags to make a read-shaped call.
+#
+# 3. Do NOT introduce a second store of eval results. JudgeFeedbackBatchRun duplicates
+#    EvalRun's job (scores for eval_config × run_config × dataset item) as a parallel,
+#    API-shaped model — the name is the smell: it's shaped like a request/response, not
+#    like the domain. It is also lossier than what it duplicates: generate mode discards
+#    the TaskRun (allow_saving=False), so no input/output/trace/usage survives for
+#    debugging an item's failure, while EvalRun keeps all four. And it creates two
+#    sources of truth — these scores never feed the eval score summaries, so the same
+#    (eval × run config) can answer differently here vs the scorecard. If EvalRun lacks
+#    something (e.g. the judge's feedback/reasoning text), EXTEND EvalRun. Extend,
+#    don't duplicate.
+#
+# 4. Re-running identical work must hit the cache. Same run config + same input
+#    (temperature aside) yields the same result — a "fresh" re-run of an unchanged
+#    (eval_config × run_config × item) triple is cost without information. EvalRunner
+#    already has the correct semantics (run only missing triples, return stored results
+#    otherwise); this runner bypasses it: its own persisted runs are consulted only
+#    within a single batch, and never in generate mode. Re-run when the run config or
+#    input changed; otherwise return instantly from stored results.
+#
+# 5. The paired-gate capability is retrofitted onto a sampling tool. Pairing by
+#    task_run_id was silently broken by random sampling whenever the matching set
+#    exceeded max_samples (two runs judged disjoint subsets; patched with a
+#    deterministic sort). A paired candidate-vs-baseline gate wants full, stable
+#    coverage — the eval lane's shape, not a minibatch sampler's.
+#
+# Also before any merge: consolidate the API surface — the synchronous run /
+# create-and-run endpoints were kept "for callers not yet migrated" alongside the
+# job route, leaving a three-way agent-policy matrix. One blessed path.
+
 from typing import TYPE_CHECKING, List, Union
 
 from pydantic import Field, model_validator

--- a/libs/core/kiln_ai/datamodel/test_judge_feedback_batch.py
+++ b/libs/core/kiln_ai/datamodel/test_judge_feedback_batch.py
@@ -1,3 +1,7 @@
+# TODO (merge blocker — do not merge toward main until resolved): tests for a datamodel under
+# design review — see the header of kiln_ai/datamodel/judge_feedback_batch.py. Resolve before
+# merging toward main.
+
 import pytest
 
 from kiln_ai.datamodel import JudgeFeedbackBatch, JudgeFeedbackBatchRun, Project, Task


### PR DESCRIPTION
## What does this PR do?

Adds **merge-blocker `TODO`s** to the `judge_feedback_batch` feature so it cannot reach `main` until its design is re-validated. `main`'s `debug_detector` CI job fails on any `TODO`/`FIXME` anywhere in the tree, so these markers block a merge toward `main` while leaving PRs that target this feature branch (`leonard/kil-686-eval-job`) unaffected — this PR itself is not gated.

The authoritative write-up lives at the top of `libs/core/kiln_ai/datamodel/judge_feedback_batch.py` (the datamodel is the locus of the concern). Pointer `TODO`s in the runner and both test files each independently trip the check and refer back to it, so the block can't be defeated by editing a single file:

- `libs/core/kiln_ai/datamodel/judge_feedback_batch.py` — full design-review block
- `libs/core/kiln_ai/adapters/eval/judge_feedback_batch_runner.py` — pointer (concerns 3–5 are implemented here)
- `libs/core/kiln_ai/datamodel/test_judge_feedback_batch.py` — pointer
- `libs/core/kiln_ai/adapters/eval/test_judge_feedback_batch_runner.py` — pointer

Comment-only change (57 insertions, no behavior change); all four files still compile and the runner's module docstring is preserved.

### The concerns to resolve before this becomes API surface

This feature grew out of a reflection helper (`failing_train_examples`, #1536) and was reshaped several times under review:

1. **Re-validate the driving use case.** Built to feed judge feedback text to reflective prompt optimization. Does that consumer still exist and still need this shape? If nothing needs it, delete rather than merge.

2. **Selection by tags leaves user-visible, long-lived side effects.** A one-off or targeted run (specific items) forces the caller to mutate dataset tags — shared, user-visible state — to express what is really a query parameter. If item-level selection is needed, accept item IDs (and/or a named dataset split). Callers should never have to write tags to make a read-shaped call.

3. **Do NOT introduce a second store of eval results.** `JudgeFeedbackBatchRun` duplicates `EvalRun`'s job (scores for eval_config × run_config × dataset item) as a parallel, API-shaped model — the name is the smell: it's shaped like a request/response, not like the domain. It is also lossier than what it duplicates: generate mode discards the `TaskRun` (`allow_saving=False`), so no input/output/trace/usage survives for debugging an item's failure, while `EvalRun` keeps all four. And it creates two sources of truth — these scores never feed the eval score summaries, so the same (eval × run config) can answer differently here vs the scorecard. If `EvalRun` lacks something (e.g. the judge's feedback/reasoning text), **extend `EvalRun`**. Extend, don't duplicate.

4. **Re-running identical work must hit the cache.** Same run config + same input (temperature aside) yields the same result — a "fresh" re-run of an unchanged (eval_config × run_config × item) triple is cost without information. `EvalRunner` already has the correct semantics (run only missing triples, return stored results otherwise); this runner bypasses it: its own persisted runs are consulted only within a single batch, and never in generate mode. Re-run when the run config or input changed; otherwise return instantly from stored results.

5. **The paired-gate capability is retrofitted onto a sampling tool.** Pairing by `task_run_id` was silently broken by random sampling whenever the matching set exceeded `max_samples` (two runs judged disjoint subsets; patched with a deterministic sort). A paired candidate-vs-baseline gate wants full, stable coverage — the eval lane's shape, not a minibatch sampler's.

Also before any merge: **consolidate the API surface** — the synchronous run / create-and-run endpoints were kept "for callers not yet migrated" alongside the job route, leaving a three-way agent-policy matrix. One blessed path.

Everything cited above is verifiable in this branch and in #1536's own history (the `allow_saving=False` discard, the shuffle → deterministic-sort pairing fix, and the three coexisting endpoints).

## Related Issues

- Origin / context: #1536 (merged the `judge_feedback_batch` subsystem into `leonard/kil-686-eval-job`).

## Contributor License Agreement

## Checklists

- [ ] Tests have been run locally and passed — comment-only change; the four edited files were compile-checked (`py_compile`) and the runner's module docstring verified intact. No test suite run because there is no behavior change.
- [ ] New tests have been added to any work in /lib — N/A: this PR adds only merge-blocker comments, no code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uooi7AG76fWyV3v93smT23

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uooi7AG76fWyV3v93smT23)_