### PR TITLE
refactor(code-trust): scope trust to code authoring, not running saved code

### DIFF
--- a/app/desktop/studio_server/code_tool_api.py
+++ b/app/desktop/studio_server/code_tool_api.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Annotated, Any
 
 from fastapi import FastAPI, HTTPException, Path
-from kiln_ai.adapters.eval.v2_eval_code_eval import is_code_eval_trusted
+from kiln_ai.adapters.eval.v2_eval_code_eval import has_add_code_trust
 from kiln_ai.datamodel.code_tool import CodeTool
 from kiln_ai.datamodel.json_schema import validate_schema_with_value_error
 from kiln_ai.datamodel.tool_id import ToolId
@@ -210,7 +210,7 @@ def connect_code_tool_api(app: FastAPI):
     ) -> CodeToolCreateResponse:
         project = project_from_id(project_id)
 
-        if not is_code_eval_trusted(str(project.path)):
+        if not has_add_code_trust(str(project.path)):
             return CodeToolCreateResponse(not_trusted=True)
 
         existing = project.code_tools(readonly=True)
@@ -272,7 +272,7 @@ def connect_code_tool_api(app: FastAPI):
         except (ValueError, PydanticValidationError) as e:
             raise HTTPException(status_code=400, detail=str(e))
 
-        if not is_code_eval_trusted(str(project.path)):
+        if not has_add_code_trust(str(project.path)):
             return TestCodeToolResponse(not_trusted=True)
 
         schema_str = json.dumps(request.parameters_schema, ensure_ascii=False)

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -23,10 +23,12 @@ from kiln_ai.adapters.eval.base_eval import (
 )
 from kiln_ai.adapters.eval.registry import v2_eval_adapter_from_config
 from kiln_ai.adapters.eval.v2_eval_code_eval import (
-    grant_code_eval_trust,
-    is_code_eval_trusted,
+    CodeEvalAdapter,
+    add_code_trust,
+    has_add_code_trust,
 )
 from kiln_ai.datamodel.eval import (
+    CodeEvalProperties,
     Eval,
     EvalConfig,
     EvalConfigType,
@@ -36,6 +38,7 @@ from kiln_ai.datamodel.eval import (
     EvalScores,
     EvalTaskInput,
     EvalTemplateId,
+    SkippedReason,
     V2EvalConfigProperties,
     validate_scores_against_output_scores,
 )
@@ -293,8 +296,8 @@ class TestV2EvalResponse(BaseModel):
     intermediate_outputs: dict[str, str] | None = None
 
 
-class CodeEvalTrustResponse(BaseModel):
-    """Response indicating whether code eval is trusted for a project."""
+class CodeTrustResponse(BaseModel):
+    """Response indicating whether code is trusted for a project in this session."""
 
     trusted: bool
 
@@ -1061,6 +1064,18 @@ def connect_evals_api(app: FastAPI):
                 status_code=400,
                 detail=str(e),
             )
+
+        # Trust-conferral gate: saving a code eval admits new code as
+        # trusted-forever, so it requires code trust for this session.
+        # (Defense-in-depth: the frontend pre-checks trust before calling.)
+        if isinstance(eval_config.properties, CodeEvalProperties):
+            project = project_from_id(project_id)
+            if not has_add_code_trust(str(project.path)):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Project not trusted to add code evals. Grant code trust and retry.",
+                )
+
         eval_config.save_to_file()
         return eval_config
 
@@ -1175,6 +1190,17 @@ def connect_evals_api(app: FastAPI):
                 parent=eval_obj,
             )
             adapter = v2_eval_adapter_from_config(transient_config)
+
+            # Trust-conferral gate: executing not-yet-saved code in the test pane
+            # requires code trust for this session. Saved code needs no gate.
+            if isinstance(adapter, CodeEvalAdapter):
+                project = project_from_id(project_id)
+                if not has_add_code_trust(str(project.path)):
+                    return TestV2EvalResponse(
+                        skipped_reason=SkippedReason.code_eval_not_trusted.value,
+                        skipped_detail="Project not trusted for code eval execution.",
+                    )
+
             result = await adapter.evaluate(request.eval_input)
 
             score_range_errors: list[str] | None = None
@@ -1934,30 +1960,30 @@ def connect_evals_api(app: FastAPI):
         )
 
     @app.post(
-        "/api/projects/{project_id}/grant_code_eval_trust",
-        summary="Grant code eval trust for a project",
+        "/api/projects/{project_id}/add_code_trust",
+        summary="Add code trust for a project",
         tags=["Evals"],
         openapi_extra=DENY_AGENT,
     )
-    async def grant_code_eval_trust_endpoint(
+    async def add_code_trust_endpoint(
         project_id: Annotated[
             str, Path(description="The unique identifier of the project.")
         ],
-    ) -> CodeEvalTrustResponse:
+    ) -> CodeTrustResponse:
         project = project_from_id(project_id)
-        grant_code_eval_trust(str(project.path))
-        return CodeEvalTrustResponse(trusted=True)
+        add_code_trust(str(project.path))
+        return CodeTrustResponse(trusted=True)
 
     @app.get(
-        "/api/projects/{project_id}/code_eval_trust",
-        summary="Check code eval trust for a project",
+        "/api/projects/{project_id}/add_code_trust",
+        summary="Check code trust for a project",
         tags=["Evals"],
         openapi_extra=DENY_AGENT,
     )
-    async def check_code_eval_trust_endpoint(
+    async def check_add_code_trust_endpoint(
         project_id: Annotated[
             str, Path(description="The unique identifier of the project.")
         ],
-    ) -> CodeEvalTrustResponse:
+    ) -> CodeTrustResponse:
         project = project_from_id(project_id)
-        return CodeEvalTrustResponse(trusted=is_code_eval_trusted(str(project.path)))
+        return CodeTrustResponse(trusted=has_add_code_trust(str(project.path)))

--- a/app/desktop/studio_server/test_code_tool_api.py
+++ b/app/desktop/studio_server/test_code_tool_api.py
@@ -17,7 +17,7 @@ SIMPLE_SCHEMA = {
     "required": ["x"],
 }
 
-TRUST_PATCH = "app.desktop.studio_server.code_tool_api.is_code_eval_trusted"
+TRUST_PATCH = "app.desktop.studio_server.code_tool_api.has_add_code_trust"
 
 
 @pytest.fixture

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -597,6 +597,77 @@ async def test_create_eval_config_invalid_v2_properties(
     assert "v2" in body["message"]
 
 
+CODE_EVAL_PROPERTIES = {
+    "type": "code_eval",
+    "code": "def score(output, **kwargs):\n    return {'accuracy': 1.0}\n",
+}
+
+
+@pytest.mark.asyncio
+async def test_create_eval_config_code_eval_untrusted_403(
+    client, mock_task_from_id, mock_v2_eval, mock_task
+):
+    mock_task_from_id.return_value = mock_task
+
+    with (
+        patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id,
+        patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj,
+        patch(
+            "app.desktop.studio_server.eval_api.has_add_code_trust",
+            return_value=False,
+        ),
+    ):
+        mock_eval_from_id.return_value = mock_v2_eval
+        mock_proj.return_value = Mock()
+
+        response = client.post(
+            "/api/projects/project1/tasks/task1/evals/eval_v2/create_eval_config",
+            json={
+                "name": "Code Eval Config",
+                "type": "v2",
+                "properties": CODE_EVAL_PROPERTIES,
+            },
+        )
+
+    assert response.status_code == 403
+    assert "not trusted" in response.json()["message"].lower()
+    # Nothing should have been persisted.
+    assert len(mock_v2_eval.configs()) == 0
+
+
+@pytest.mark.asyncio
+async def test_create_eval_config_code_eval_trusted_succeeds(
+    client, mock_task_from_id, mock_v2_eval, mock_task
+):
+    mock_task_from_id.return_value = mock_task
+
+    with (
+        patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eval_from_id,
+        patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj,
+        patch(
+            "app.desktop.studio_server.eval_api.has_add_code_trust",
+            return_value=True,
+        ),
+    ):
+        mock_eval_from_id.return_value = mock_v2_eval
+        mock_proj.return_value = Mock()
+
+        response = client.post(
+            "/api/projects/project1/tasks/task1/evals/eval_v2/create_eval_config",
+            json={
+                "name": "Code Eval Config",
+                "type": "v2",
+                "properties": CODE_EVAL_PROPERTIES,
+            },
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["properties"]["type"] == "code_eval"
+    # Persisted to disk.
+    assert len(mock_v2_eval.configs()) == 1
+
+
 def test_get_eval_config(
     client, mock_task_from_id, mock_eval, mock_task, mock_eval_config
 ):
@@ -3725,40 +3796,40 @@ async def test_eval_results_summary_dataset_ids_cached_per_filter(client):
 class TestCodeEvalTrustEndpoints:
     @pytest.fixture(autouse=True)
     def _clear_trust(self):
-        from kiln_ai.adapters.eval.v2_eval_code_eval import _trusted_projects
+        from kiln_ai.adapters.eval.v2_eval_code_eval import _reset_add_code_trust
 
-        _trusted_projects.clear()
+        _reset_add_code_trust()
         yield
-        _trusted_projects.clear()
+        _reset_add_code_trust()
 
-    def test_grant_trust(self, client):
+    def test_add_trust(self, client):
         with patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj:
             mock_proj.return_value = Mock()
-            response = client.post("/api/projects/proj-1/grant_code_eval_trust")
+            response = client.post("/api/projects/proj-1/add_code_trust")
 
         assert response.status_code == 200
         assert response.json() == {"trusted": True}
 
-    def test_grant_trust_invalid_project(self, client):
+    def test_add_trust_invalid_project(self, client):
         with patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj:
             mock_proj.side_effect = HTTPException(status_code=404, detail="Not found")
-            response = client.post("/api/projects/bad-id/grant_code_eval_trust")
+            response = client.post("/api/projects/bad-id/add_code_trust")
 
         assert response.status_code == 404
 
     def test_check_trust_untrusted(self, client):
         with patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj:
             mock_proj.return_value = Mock()
-            response = client.get("/api/projects/proj-1/code_eval_trust")
+            response = client.get("/api/projects/proj-1/add_code_trust")
         assert response.status_code == 200
         assert response.json() == {"trusted": False}
 
-    def test_check_trust_after_grant(self, client):
+    def test_check_trust_after_add(self, client):
         mock_project = Mock()
         with patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj:
             mock_proj.return_value = mock_project
-            client.post("/api/projects/proj-1/grant_code_eval_trust")
-            response = client.get("/api/projects/proj-1/code_eval_trust")
+            client.post("/api/projects/proj-1/add_code_trust")
+            response = client.get("/api/projects/proj-1/add_code_trust")
         assert response.status_code == 200
         assert response.json() == {"trusted": True}
 
@@ -3833,8 +3904,16 @@ class TestTestV2Eval:
                 "final_message": "test",
             },
         }
-        with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eid:
+        with (
+            patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eid,
+            patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj,
+            patch(
+                "app.desktop.studio_server.eval_api.has_add_code_trust",
+                return_value=False,
+            ),
+        ):
             mock_eid.return_value = mock_v2_eval
+            mock_proj.return_value = Mock()
             response = client.post(self._url(), json=payload)
         assert response.status_code == 200
         body = response.json()
@@ -3854,8 +3933,9 @@ class TestTestV2Eval:
         }
         with (
             patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eid,
+            patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj,
             patch(
-                "kiln_ai.adapters.eval.v2_eval_code_eval.is_code_eval_trusted",
+                "app.desktop.studio_server.eval_api.has_add_code_trust",
                 return_value=True,
             ),
             patch(
@@ -3864,6 +3944,7 @@ class TestTestV2Eval:
             ),
         ):
             mock_eid.return_value = mock_v2_eval
+            mock_proj.return_value = Mock()
             response = client.post(self._url(), json=payload)
         assert response.status_code == 200
         body = response.json()
@@ -4018,8 +4099,9 @@ class TestTestV2Eval:
         }
         with (
             patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eid,
+            patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj,
             patch(
-                "kiln_ai.adapters.eval.v2_eval_code_eval.is_code_eval_trusted",
+                "app.desktop.studio_server.eval_api.has_add_code_trust",
                 return_value=True,
             ),
             patch(
@@ -4028,6 +4110,7 @@ class TestTestV2Eval:
             ),
         ):
             mock_eid.return_value = mock_v2_eval
+            mock_proj.return_value = Mock()
             response = client.post(self._url(), json=payload)
         assert response.status_code == 200
         body = response.json()
@@ -4047,8 +4130,16 @@ class TestTestV2Eval:
                 "final_message": "test",
             },
         }
-        with patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eid:
+        with (
+            patch("app.desktop.studio_server.eval_api.eval_from_id") as mock_eid,
+            patch("app.desktop.studio_server.eval_api.project_from_id") as mock_proj,
+            patch(
+                "app.desktop.studio_server.eval_api.has_add_code_trust",
+                return_value=False,
+            ),
+        ):
             mock_eid.return_value = mock_v2_eval
+            mock_proj.return_value = Mock()
             response = client.post(self._url(), json=payload)
         assert response.status_code == 200
         body = response.json()

--- a/app/web_ui/src/lib/api/v2_eval_api.test.ts
+++ b/app/web_ui/src/lib/api/v2_eval_api.test.ts
@@ -4,8 +4,8 @@ import {
   testV2EvalLlmJudge,
   fetchTaskRuns,
   createEvalConfig,
-  checkCodeEvalTrust,
-  grantCodeEvalTrust,
+  checkAddCodeTrust,
+  addCodeTrust,
   type TestV2EvalRequest,
   type CreateEvalConfigRequest,
 } from "./v2_eval_api"
@@ -133,18 +133,18 @@ describe("createEvalConfig", () => {
   })
 })
 
-describe("checkCodeEvalTrust", () => {
+describe("checkAddCodeTrust", () => {
   it("calls client.GET with correct path and params", async () => {
     mockGet.mockResolvedValue({
       data: { trusted: false },
       error: undefined,
     })
 
-    await checkCodeEvalTrust("proj-1")
+    await checkAddCodeTrust("proj-1")
 
     expect(mockGet).toHaveBeenCalledTimes(1)
     const [path, options] = mockGet.mock.calls[0]
-    expect(path).toBe("/api/projects/{project_id}/code_eval_trust")
+    expect(path).toBe("/api/projects/{project_id}/add_code_trust")
     expect(options.params.path).toEqual({ project_id: "proj-1" })
   })
 
@@ -154,23 +154,23 @@ describe("checkCodeEvalTrust", () => {
       error: undefined,
     })
 
-    const result = await checkCodeEvalTrust("proj-1")
+    const result = await checkAddCodeTrust("proj-1")
     expect(result.trusted).toBe(true)
   })
 })
 
-describe("grantCodeEvalTrust", () => {
+describe("addCodeTrust", () => {
   it("calls client.POST with correct path and params", async () => {
     mockPost.mockResolvedValue({
       data: { trusted: true },
       error: undefined,
     })
 
-    await grantCodeEvalTrust("proj-1")
+    await addCodeTrust("proj-1")
 
     expect(mockPost).toHaveBeenCalledTimes(1)
     const [path, options] = mockPost.mock.calls[0]
-    expect(path).toBe("/api/projects/{project_id}/grant_code_eval_trust")
+    expect(path).toBe("/api/projects/{project_id}/add_code_trust")
     expect(options.params.path).toEqual({ project_id: "proj-1" })
   })
 
@@ -180,7 +180,7 @@ describe("grantCodeEvalTrust", () => {
       error: undefined,
     })
 
-    const result = await grantCodeEvalTrust("proj-1")
+    const result = await addCodeTrust("proj-1")
     expect(result.trusted).toBe(true)
   })
 })
@@ -315,18 +315,18 @@ describe.each([
     expectedPrefix: "create_eval_config failed",
   },
   {
-    fnName: "checkCodeEvalTrust",
-    callFn: () => checkCodeEvalTrust("proj-1"),
+    fnName: "checkAddCodeTrust",
+    callFn: () => checkAddCodeTrust("proj-1"),
     setupMock: (error: Record<string, unknown>) =>
       mockGet.mockResolvedValue({ data: undefined, error }),
-    expectedPrefix: "code_eval_trust check failed",
+    expectedPrefix: "add_code_trust check failed",
   },
   {
-    fnName: "grantCodeEvalTrust",
-    callFn: () => grantCodeEvalTrust("proj-1"),
+    fnName: "addCodeTrust",
+    callFn: () => addCodeTrust("proj-1"),
     setupMock: (error: Record<string, unknown>) =>
       mockPost.mockResolvedValue({ data: undefined, error }),
-    expectedPrefix: "grant_code_eval_trust failed",
+    expectedPrefix: "add_code_trust failed",
   },
 ])("$fnName error handling", ({ callFn, setupMock, expectedPrefix }) => {
   it("throws on error response with message field", async () => {

--- a/app/web_ui/src/lib/api/v2_eval_api.ts
+++ b/app/web_ui/src/lib/api/v2_eval_api.ts
@@ -191,13 +191,13 @@ export async function fetchTaskRuns(
 }
 
 /**
- * Check whether the current session has granted code_eval trust for a project.
+ * Check whether the current session has code trust for a project.
  */
-export async function checkCodeEvalTrust(
+export async function checkAddCodeTrust(
   projectId: string,
 ): Promise<{ trusted: boolean }> {
   const { data, error } = await client.GET(
-    "/api/projects/{project_id}/code_eval_trust",
+    "/api/projects/{project_id}/add_code_trust",
     {
       params: {
         path: {
@@ -208,20 +208,20 @@ export async function checkCodeEvalTrust(
   )
   if (error) {
     throw new Error(
-      `code_eval_trust check failed: ${extractErrorMessage(error)}`,
+      `add_code_trust check failed: ${extractErrorMessage(error)}`,
     )
   }
   return data
 }
 
 /**
- * Grant code_eval trust for a project in the current session.
+ * Add code trust for a project in the current session.
  */
-export async function grantCodeEvalTrust(
+export async function addCodeTrust(
   projectId: string,
 ): Promise<{ trusted: boolean }> {
   const { data, error } = await client.POST(
-    "/api/projects/{project_id}/grant_code_eval_trust",
+    "/api/projects/{project_id}/add_code_trust",
     {
       params: {
         path: {
@@ -231,9 +231,7 @@ export async function grantCodeEvalTrust(
     },
   )
   if (error) {
-    throw new Error(
-      `grant_code_eval_trust failed: ${extractErrorMessage(error)}`,
-    )
+    throw new Error(`add_code_trust failed: ${extractErrorMessage(error)}`)
   }
   return data
 }

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -2155,34 +2155,18 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/projects/{project_id}/grant_code_eval_trust": {
+    "/api/projects/{project_id}/add_code_trust": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** Check code trust for a project */
+        get: operations["check_add_code_trust_endpoint_api_projects__project_id__add_code_trust_get"];
         put?: never;
-        /** Grant code eval trust for a project */
-        post: operations["grant_code_eval_trust_endpoint_api_projects__project_id__grant_code_eval_trust_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/projects/{project_id}/code_eval_trust": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Check code eval trust for a project */
-        get: operations["check_code_eval_trust_endpoint_api_projects__project_id__code_eval_trust_get"];
-        put?: never;
-        post?: never;
+        /** Add code trust for a project */
+        post: operations["add_code_trust_endpoint_api_projects__project_id__add_code_trust_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4544,14 +4528,6 @@ export interface components {
              */
             timeout_seconds: number;
         };
-        /**
-         * CodeEvalTrustResponse
-         * @description Response indicating whether code eval is trusted for a project.
-         */
-        CodeEvalTrustResponse: {
-            /** Trusted */
-            trusted: boolean;
-        };
         /** CodeToolArchiveRequest */
         CodeToolArchiveRequest: {
             /**
@@ -4687,6 +4663,14 @@ export interface components {
              * @description User-facing notes shown in the UI.
              */
             description?: string | null;
+        };
+        /**
+         * CodeTrustResponse
+         * @description Response indicating whether code is trusted for a project in this session.
+         */
+        CodeTrustResponse: {
+            /** Trusted */
+            trusted: boolean;
         };
         /** CohereCompatibleProperties */
         CohereCompatibleProperties: {
@@ -16909,7 +16893,7 @@ export interface operations {
             };
         };
     };
-    grant_code_eval_trust_endpoint_api_projects__project_id__grant_code_eval_trust_post: {
+    check_add_code_trust_endpoint_api_projects__project_id__add_code_trust_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -16927,7 +16911,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CodeEvalTrustResponse"];
+                    "application/json": components["schemas"]["CodeTrustResponse"];
                 };
             };
             /** @description Validation Error */
@@ -16941,7 +16925,7 @@ export interface operations {
             };
         };
     };
-    check_code_eval_trust_endpoint_api_projects__project_id__code_eval_trust_get: {
+    add_code_trust_endpoint_api_projects__project_id__add_code_trust_post: {
         parameters: {
             query?: never;
             header?: never;
@@ -16959,7 +16943,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CodeEvalTrustResponse"];
+                    "application/json": components["schemas"]["CodeTrustResponse"];
                 };
             };
             /** @description Validation Error */

--- a/app/web_ui/src/lib/components/code_tools/code_trust_dialog.svelte
+++ b/app/web_ui/src/lib/components/code_tools/code_trust_dialog.svelte
@@ -2,7 +2,7 @@
   import Dialog from "$lib/ui/dialog.svelte"
   import Warning from "$lib/ui/warning.svelte"
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
-  import { grantCodeEvalTrust } from "$lib/api/v2_eval_api"
+  import { addCodeTrust } from "$lib/api/v2_eval_api"
 
   export let project_id: string
   export let on_trust_granted: () => void
@@ -17,7 +17,7 @@
 
   async function grant_trust_and_proceed(): Promise<boolean> {
     try {
-      await grantCodeEvalTrust(project_id)
+      await addCodeTrust(project_id)
     } catch (e) {
       trust_error = createKilnError(e)
       return false

--- a/app/web_ui/src/lib/components/eval_types/eval_config_builder.svelte
+++ b/app/web_ui/src/lib/components/eval_types/eval_config_builder.svelte
@@ -26,8 +26,8 @@
     testV2Eval,
     testV2EvalLlmJudge,
     fetchTaskRuns,
-    checkCodeEvalTrust,
-    grantCodeEvalTrust,
+    checkAddCodeTrust,
+    addCodeTrust,
     type EvalTaskInput,
     type TestV2EvalResponse,
   } from "$lib/api/v2_eval_api"
@@ -431,7 +431,7 @@
 
   async function grant_trust_and_retry(): Promise<boolean> {
     try {
-      await grantCodeEvalTrust(project_id)
+      await addCodeTrust(project_id)
     } catch (e) {
       test_error = createKilnError(e)
       return false
@@ -452,7 +452,7 @@
 
     if (metadata?.requiresTrust) {
       try {
-        const trust_response = await checkCodeEvalTrust(project_id)
+        const trust_response = await checkAddCodeTrust(project_id)
         if (!trust_response.trusted) {
           pending_trust_action = "save"
           create_evaluator_loading = false

--- a/app/web_ui/src/lib/components/eval_types/eval_config_builder_form_scope.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/eval_config_builder_form_scope.test.ts
@@ -101,8 +101,8 @@ vi.mock("$lib/api/v2_eval_api", async (importOriginal) => {
     testV2EvalLlmJudge: vi.fn(),
     createEvalConfig: vi.fn(),
     createLlmJudgeConfig: vi.fn(),
-    checkCodeEvalTrust: vi.fn(),
-    grantCodeEvalTrust: vi.fn(),
+    checkAddCodeTrust: vi.fn(),
+    addCodeTrust: vi.fn(),
     fetchTaskRuns: vi.fn().mockResolvedValue([]),
   }
 })

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/create_eval_config/page.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/create_eval_config/page.test.ts
@@ -183,8 +183,8 @@ vi.mock("$lib/utils/eval_types/registry", async (importOriginal) => {
 const mockTestV2Eval = vi.fn()
 const mockCreateEvalConfig = vi.fn()
 const mockCreateLlmJudgeConfig = vi.fn()
-const mockCheckCodeEvalTrust = vi.fn()
-const mockGrantCodeEvalTrust = vi.fn()
+const mockCheckAddCodeTrust = vi.fn()
+const mockAddCodeTrust = vi.fn()
 const mockFetchTaskRuns = vi.fn()
 const mockTestV2EvalLlmJudge = vi.fn()
 
@@ -206,8 +206,8 @@ vi.mock("$lib/api/v2_eval_api", async (importOriginal) => {
     createEvalConfig: (...args: unknown[]) => mockCreateEvalConfig(...args),
     createLlmJudgeConfig: (...args: unknown[]) =>
       mockCreateLlmJudgeConfig(...args),
-    checkCodeEvalTrust: (...args: unknown[]) => mockCheckCodeEvalTrust(...args),
-    grantCodeEvalTrust: (...args: unknown[]) => mockGrantCodeEvalTrust(...args),
+    checkAddCodeTrust: (...args: unknown[]) => mockCheckAddCodeTrust(...args),
+    addCodeTrust: (...args: unknown[]) => mockAddCodeTrust(...args),
     fetchTaskRuns: (...args: unknown[]) => mockFetchTaskRuns(...args),
   }
 })
@@ -528,8 +528,8 @@ describe("EvalConfigBuilder", () => {
     mockTestV2EvalLlmJudge.mockReset()
     mockCreateEvalConfig.mockReset()
     mockCreateLlmJudgeConfig.mockReset()
-    mockCheckCodeEvalTrust.mockReset()
-    mockGrantCodeEvalTrust.mockReset()
+    mockCheckAddCodeTrust.mockReset()
+    mockAddCodeTrust.mockReset()
     mockFetchTaskRuns.mockReset()
     mockFetchTaskRuns.mockResolvedValue([sampleTaskRun])
   })
@@ -569,7 +569,7 @@ describe("EvalConfigBuilder", () => {
     it("shows trust dialog when saving a code_eval without trust", async () => {
       const { container } = await renderBuilder("code_eval")
 
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: false })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: false })
 
       const submitBtn = container.querySelector(
         '[data-testid="column-save-button"]',
@@ -599,7 +599,7 @@ describe("EvalConfigBuilder", () => {
       await tick()
 
       expect(showCalls).not.toContain("Trust Code and Project?")
-      expect(mockCheckCodeEvalTrust).not.toHaveBeenCalled()
+      expect(mockCheckAddCodeTrust).not.toHaveBeenCalled()
       expect(showCalls).toContain("Save Without Testing?")
     })
   })
@@ -668,7 +668,7 @@ describe("EvalConfigBuilder", () => {
     it("shows confirm dialog for code_eval after trust is already granted", async () => {
       const { container } = await renderBuilder("code_eval")
 
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
 
       const submitBtn = container.querySelector(
         '[data-testid="column-save-button"]',
@@ -841,7 +841,7 @@ describe("EvalConfigBuilder — Phase 3: container shell + intro", () => {
 
   it("B7: Save button still gates via handle_submit (trust check for code_eval)", async () => {
     const { container } = await renderBuilder("code_eval")
-    mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: false })
+    mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: false })
 
     const saveBtn = container.querySelector(
       "[data-testid='column-save-button']",
@@ -908,8 +908,8 @@ describe("EvalConfigBuilder — Phase 4: trust modal + bugs", () => {
     mockTestV2EvalLlmJudge.mockReset()
     mockCreateEvalConfig.mockReset()
     mockCreateLlmJudgeConfig.mockReset()
-    mockCheckCodeEvalTrust.mockReset()
-    mockGrantCodeEvalTrust.mockReset()
+    mockCheckAddCodeTrust.mockReset()
+    mockAddCodeTrust.mockReset()
     mockFetchTaskRuns.mockReset()
     mockFetchTaskRuns.mockResolvedValue([sampleTaskRun])
   })
@@ -1011,7 +1011,7 @@ describe("EvalConfigBuilder — Phase 4: trust modal + bugs", () => {
       const trustPromise = new Promise((resolve) => {
         trustResolve = resolve
       })
-      mockCheckCodeEvalTrust.mockImplementationOnce(() => trustPromise)
+      mockCheckAddCodeTrust.mockImplementationOnce(() => trustPromise)
 
       const { container } = await renderBuilder("code_eval")
 
@@ -1063,12 +1063,12 @@ describe("EvalConfigBuilder — Phase 4: trust modal + bugs", () => {
       expect(saveBtn.disabled).toBe(false)
     })
 
-    it("resets loading when checkCodeEvalTrust throws an error", async () => {
+    it("resets loading when checkAddCodeTrust throws an error", async () => {
       let trustReject: (e: Error) => void
       const trustPromise = new Promise((_resolve, reject) => {
         trustReject = reject
       })
-      mockCheckCodeEvalTrust.mockImplementationOnce(() => trustPromise)
+      mockCheckAddCodeTrust.mockImplementationOnce(() => trustPromise)
 
       const { container } = await renderBuilder("code_eval")
 
@@ -1132,14 +1132,14 @@ describe("EvalConfigBuilder — Phase 4: trust modal + bugs", () => {
       const testPromise = new Promise((resolve) => {
         testResolve = resolve
       })
-      mockGrantCodeEvalTrust.mockResolvedValueOnce({})
+      mockAddCodeTrust.mockResolvedValueOnce({})
       mockTestV2Eval.mockImplementationOnce(() => testPromise)
 
       const asyncAction = trustAction!.asyncAction as () => Promise<boolean>
       const result = await asyncAction()
 
       expect(result).toBe(true)
-      expect(mockGrantCodeEvalTrust).toHaveBeenCalled()
+      expect(mockAddCodeTrust).toHaveBeenCalled()
 
       testResolve!({
         scores: { accuracy: 1.0 },
@@ -1154,7 +1154,7 @@ describe("EvalConfigBuilder — Phase 4: trust modal + bugs", () => {
     it("grant_trust fires do_save without awaiting it", async () => {
       const { container } = await renderBuilder("code_eval")
 
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: false })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: false })
 
       const submitBtn = container.querySelector(
         '[data-testid="column-save-button"]',
@@ -1178,14 +1178,14 @@ describe("EvalConfigBuilder — Phase 4: trust modal + bugs", () => {
       const savePromise = new Promise((resolve) => {
         saveResolve = resolve
       })
-      mockGrantCodeEvalTrust.mockResolvedValueOnce({})
+      mockAddCodeTrust.mockResolvedValueOnce({})
       mockCreateEvalConfig.mockImplementationOnce(() => savePromise)
 
       const asyncAction = trustAction!.asyncAction as () => Promise<boolean>
       const result = await asyncAction()
 
       expect(result).toBe(true)
-      expect(mockGrantCodeEvalTrust).toHaveBeenCalled()
+      expect(mockAddCodeTrust).toHaveBeenCalled()
 
       saveResolve!({
         id: "config123",
@@ -1403,8 +1403,8 @@ describe("Reference data save gate", () => {
     mockTestV2EvalLlmJudge.mockReset()
     mockCreateEvalConfig.mockReset()
     mockCreateLlmJudgeConfig.mockReset()
-    mockCheckCodeEvalTrust.mockReset()
-    mockGrantCodeEvalTrust.mockReset()
+    mockCheckAddCodeTrust.mockReset()
+    mockAddCodeTrust.mockReset()
     mockFetchTaskRuns.mockReset()
     mockFetchTaskRuns.mockResolvedValue([sampleTaskRun])
   })
@@ -1420,7 +1420,7 @@ describe("Reference data save gate", () => {
       setInitialCode(
         'def score(output, reference_data=None):\n  val = reference_data["key"]\n  return {"score": 1.0}',
       )
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
 
       const { container } = await renderBuilder("code_eval")
 
@@ -1448,7 +1448,7 @@ describe("Reference data save gate", () => {
       setInitialCode(
         "def score(output, reference_data=None):\n  return {'score': 1.0}",
       )
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
 
       const { container } = await renderBuilder("code_eval")
 
@@ -1468,7 +1468,7 @@ describe("Reference data save gate", () => {
       setInitialCode(
         'def score(output, reference_data=None):\n  val = reference_data["key"]\n  return {"score": 1.0}',
       )
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
 
       const { container } = await renderBuilder("code_eval")
 
@@ -1493,7 +1493,7 @@ describe("Reference data save gate", () => {
       await tick()
 
       resetCalls()
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
       mockCreateEvalConfig.mockResolvedValueOnce({
         id: "config123",
         type: "v2",
@@ -1530,7 +1530,7 @@ describe("Reference data save gate", () => {
         return {"no_dark_humour": 0.0}
     return {"no_dark_humour": 1.0}`
       setInitialCode(starterCode)
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
 
       const { container } = await renderBuilder("code_eval")
 
@@ -1725,7 +1725,7 @@ describe("Reference data save gate", () => {
 
       // Save
       resetCalls()
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
       mockCreateEvalConfig.mockResolvedValueOnce({
         id: "config123",
         type: "v2",
@@ -1836,7 +1836,7 @@ describe("Reference data save gate", () => {
 
       // Save
       resetCalls()
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
       mockCreateEvalConfig.mockResolvedValueOnce({
         id: "config123",
         type: "v2",
@@ -1858,7 +1858,7 @@ describe("Reference data save gate", () => {
     })
 
     it("code_eval: reference_keys are empty when config does not use reference_data", async () => {
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
       mockCreateEvalConfig.mockResolvedValueOnce({
         id: "config123",
         type: "v2",
@@ -1889,7 +1889,7 @@ describe("Reference data save gate", () => {
       await tick()
 
       resetCalls()
-      mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+      mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
       mockCreateEvalConfig.mockResolvedValueOnce({
         id: "config123",
         type: "v2",
@@ -1921,8 +1921,8 @@ describe("Save flow — handle_submit logic", () => {
     mockTestV2EvalLlmJudge.mockReset()
     mockCreateEvalConfig.mockReset()
     mockCreateLlmJudgeConfig.mockReset()
-    mockCheckCodeEvalTrust.mockReset()
-    mockGrantCodeEvalTrust.mockReset()
+    mockCheckAddCodeTrust.mockReset()
+    mockAddCodeTrust.mockReset()
     mockFetchTaskRuns.mockReset()
     mockFetchTaskRuns.mockResolvedValue([sampleTaskRun])
   })
@@ -2005,7 +2005,7 @@ describe("Save flow — handle_submit logic", () => {
 
     // Now save (trust granted)
     resetCalls()
-    mockCheckCodeEvalTrust.mockResolvedValueOnce({ trusted: true })
+    mockCheckAddCodeTrust.mockResolvedValueOnce({ trusted: true })
     mockCreateEvalConfig.mockResolvedValueOnce({
       id: "config_code",
       type: "v2",

--- a/libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py
+++ b/libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py
@@ -16,11 +16,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from kiln_ai.adapters.eval.v2_eval_code_eval import (
-    CodeEvalAdapter,
-    _trusted_projects,
-    grant_code_eval_trust,
-)
+from kiln_ai.adapters.eval.v2_eval_code_eval import CodeEvalAdapter
 from kiln_ai.datamodel.datamodel_enums import TaskOutputRatingType
 from kiln_ai.datamodel.eval import (
     CodeEvalProperties,
@@ -29,18 +25,6 @@ from kiln_ai.datamodel.eval import (
     EvalOutputScore,
     EvalTaskInput,
 )
-
-# ---------------------------------------------------------------------------
-# Trust cleanup (prevent leakage between tests)
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-def _clear_trust():
-    _trusted_projects.clear()
-    yield
-    _trusted_projects.clear()
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -328,8 +312,6 @@ class TestParseJsonExample:
     async def test_valid_json_with_required_fields(self):
         cfg = _make_config(PARSE_JSON_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         inp = _inp(final_message='{"name": "Alice", "description": "A person"}')
         result = await adapter.evaluate(inp)
         scores = result.scores
@@ -343,8 +325,6 @@ class TestParseJsonExample:
     async def test_valid_json_missing_fields(self):
         cfg = _make_config(PARSE_JSON_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         inp = _inp(final_message='{"name": "Alice"}')
         result = await adapter.evaluate(inp)
         scores = result.scores
@@ -358,8 +338,6 @@ class TestParseJsonExample:
     async def test_invalid_json(self):
         cfg = _make_config(PARSE_JSON_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         inp = _inp(final_message="not json at all")
         result = await adapter.evaluate(inp)
         scores = result.scores
@@ -374,8 +352,6 @@ class TestParseJsonExample:
         """A valid JSON array is not a dict -- passed should be False."""
         cfg = _make_config(PARSE_JSON_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         inp = _inp(final_message="[1, 2, 3]")
         result = await adapter.evaluate(inp)
         scores = result.scores
@@ -396,8 +372,6 @@ class TestCheckToolUsageExample:
     async def test_trace_with_search_calls(self):
         cfg = _make_config(CHECK_TOOL_USAGE_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         trace = [
             {
                 "role": "assistant",
@@ -435,8 +409,6 @@ class TestCheckToolUsageExample:
         """Regression: zero search calls must not raise -- five_star clamped to 1."""
         cfg = _make_config(CHECK_TOOL_USAGE_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         trace = [
             {
                 "role": "assistant",
@@ -464,8 +436,6 @@ class TestCheckToolUsageExample:
         """None trace should not raise -- get_tool_calls returns []."""
         cfg = _make_config(CHECK_TOOL_USAGE_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         inp = _inp(final_message="result", trace=None)
         result = await adapter.evaluate(inp)
         scores = result.scores
@@ -479,8 +449,6 @@ class TestCheckToolUsageExample:
     async def test_many_search_calls_capped_at_five(self):
         cfg = _make_config(CHECK_TOOL_USAGE_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         trace = [
             {
                 "role": "assistant",
@@ -515,8 +483,6 @@ class TestDomainGradingExample:
     async def test_output_contains_expected_answer(self):
         cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         output = "The answer is 42 and here is some additional context to pad it out a bit more words"
         inp = _inp(
             final_message=output,
@@ -535,8 +501,6 @@ class TestDomainGradingExample:
     async def test_output_missing_expected_answer(self):
         cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         output = " ".join(["word"] * 20)
         inp = _inp(
             final_message=output,
@@ -555,8 +519,6 @@ class TestDomainGradingExample:
         """Empty/missing reference_data should not raise -- expected defaults to ''."""
         cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         output = " ".join(["word"] * 30)
         inp = _inp(final_message=output, reference_data=None)
         result = await adapter.evaluate(inp)
@@ -572,8 +534,6 @@ class TestDomainGradingExample:
         """reference_data={} (no expected_answer key) should not raise."""
         cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         output = " ".join(["word"] * 30)
         inp = _inp(final_message=output, reference_data={})
         result = await adapter.evaluate(inp)
@@ -589,8 +549,6 @@ class TestDomainGradingExample:
         """Output with fewer than 50 words gets rating of 5."""
         cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         output = "short"
         inp = _inp(final_message=output, reference_data=None)
         result = await adapter.evaluate(inp)
@@ -605,8 +563,6 @@ class TestDomainGradingExample:
         """Output with 150+ words gets rating of 1."""
         cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         output = " ".join(["word"] * 160)
         inp = _inp(final_message=output, reference_data=None)
         result = await adapter.evaluate(inp)
@@ -621,8 +577,6 @@ class TestDomainGradingExample:
         """Output with 50-149 words gets rating of 3."""
         cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         output = " ".join(["word"] * 80)
         inp = _inp(final_message=output, reference_data=None)
         result = await adapter.evaluate(inp)
@@ -648,8 +602,6 @@ class TestParseJsonExampleSingleScore:
     async def test_valid_json_with_required_fields(self):
         cfg = _make_config(PARSE_JSON_CODE_SINGLE, SINGLE_SCORE)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         inp = _inp(final_message='{"name": "Alice", "description": "A person"}')
         result = await adapter.evaluate(inp)
         scores = result.scores
@@ -662,8 +614,6 @@ class TestParseJsonExampleSingleScore:
     async def test_invalid_json(self):
         cfg = _make_config(PARSE_JSON_CODE_SINGLE, SINGLE_SCORE)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         inp = _inp(final_message="not json at all")
         result = await adapter.evaluate(inp)
         scores = result.scores
@@ -680,8 +630,6 @@ class TestCheckToolUsageExampleSingleScore:
     async def test_search_tool_used(self):
         cfg = _make_config(CHECK_TOOL_USAGE_CODE_SINGLE, SINGLE_SCORE)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         trace = [
             {
                 "role": "assistant",
@@ -706,8 +654,6 @@ class TestCheckToolUsageExampleSingleScore:
     async def test_no_tool_calls(self):
         cfg = _make_config(CHECK_TOOL_USAGE_CODE_SINGLE, SINGLE_SCORE)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         result = await adapter.evaluate(_inp(final_message="result", trace=None))
         scores = result.scores
 
@@ -723,8 +669,6 @@ class TestDomainGradingExampleSingleScore:
     async def test_output_contains_expected(self):
         cfg = _make_config(DOMAIN_GRADING_CODE_SINGLE, SINGLE_SCORE)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         inp = _inp(
             final_message="The answer is 42",
             reference_data={"expected_answer": "42"},
@@ -740,8 +684,6 @@ class TestDomainGradingExampleSingleScore:
     async def test_output_missing_expected(self):
         cfg = _make_config(DOMAIN_GRADING_CODE_SINGLE, SINGLE_SCORE)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         inp = _inp(
             final_message="nothing relevant here",
             reference_data={"expected_answer": "UNICORN_NOT_PRESENT"},
@@ -769,8 +711,6 @@ class TestDefaultCodePassFail:
     async def test_non_empty_output_passes(self):
         cfg = _make_config(DEFAULT_PASS_FAIL_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         result = await adapter.evaluate(_inp(final_message="some output"))
         scores = result.scores
         assert result.skipped_reason is None
@@ -781,8 +721,6 @@ class TestDefaultCodePassFail:
     async def test_empty_output_low(self):
         cfg = _make_config(DEFAULT_PASS_FAIL_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         result = await adapter.evaluate(_inp(final_message=""))
         scores = result.scores
         assert result.skipped_reason is None
@@ -800,8 +738,6 @@ class TestDefaultCodeFiveStar:
     async def test_non_empty_output_passes(self):
         cfg = _make_config(DEFAULT_FIVE_STAR_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         result = await adapter.evaluate(_inp(final_message="some output"))
         scores = result.scores
         assert result.skipped_reason is None
@@ -813,8 +749,6 @@ class TestDefaultCodeFiveStar:
         """Regression guard: five_star low value must be 1.0, not 0.0."""
         cfg = _make_config(DEFAULT_FIVE_STAR_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         result = await adapter.evaluate(_inp(final_message=""))
         scores = result.scores
         assert result.skipped_reason is None
@@ -832,8 +766,6 @@ class TestDefaultCodePassFailCritical:
     async def test_non_empty_output_passes(self):
         cfg = _make_config(DEFAULT_PASS_FAIL_CRITICAL_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         result = await adapter.evaluate(_inp(final_message="some output"))
         scores = result.scores
         assert result.skipped_reason is None
@@ -844,8 +776,6 @@ class TestDefaultCodePassFailCritical:
     async def test_empty_output_low(self):
         cfg = _make_config(DEFAULT_PASS_FAIL_CRITICAL_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         result = await adapter.evaluate(_inp(final_message=""))
         scores = result.scores
         assert result.skipped_reason is None
@@ -867,8 +797,6 @@ class TestDefaultCodeMultiOutput:
     async def test_non_empty_output_passes(self):
         cfg = _make_config(DEFAULT_MULTI_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         result = await adapter.evaluate(_inp(final_message="some output"))
         scores = result.scores
         assert result.skipped_reason is None
@@ -882,8 +810,6 @@ class TestDefaultCodeMultiOutput:
         """Regression guard: five_star low is 1.0, pass_fail/pfc low is 0.0."""
         cfg = _make_config(DEFAULT_MULTI_CODE, self.SCORES)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust(PROJECT_PATH)
-
         result = await adapter.evaluate(_inp(final_message=""))
         scores = result.scores
         assert result.skipped_reason is None

--- a/libs/core/kiln_ai/adapters/eval/test_v2_eval_code_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_eval_code_eval.py
@@ -3,16 +3,15 @@
 import asyncio
 import threading
 import time
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
 from kiln_ai.adapters.eval.v2_eval_code_eval import (
     CodeEvalAdapter,
-    _trusted_projects,
-    grant_code_eval_trust,
-    is_code_eval_trusted,
-    revoke_code_eval_trust,
+    _reset_add_code_trust,
+    add_code_trust,
+    has_add_code_trust,
 )
 from kiln_ai.datamodel.datamodel_enums import TaskOutputRatingType
 from kiln_ai.datamodel.eval import (
@@ -21,15 +20,14 @@ from kiln_ai.datamodel.eval import (
     EvalConfigType,
     EvalOutputScore,
     EvalTaskInput,
-    SkippedReason,
 )
 
 
 @pytest.fixture(autouse=True)
 def _clear_trust():
-    _trusted_projects.clear()
+    _reset_add_code_trust()
     yield
-    _trusted_projects.clear()
+    _reset_add_code_trust()
 
 
 def _make_config(
@@ -71,27 +69,29 @@ def _inp(**overrides) -> EvalTaskInput:
 
 
 class TestTrustGate:
-    def test_grant_and_check(self):
-        assert not is_code_eval_trusted("proj-1")
-        grant_code_eval_trust("proj-1")
-        assert is_code_eval_trusted("proj-1")
+    def test_add_and_check(self):
+        assert not has_add_code_trust("proj-1")
+        add_code_trust("proj-1")
+        assert has_add_code_trust("proj-1")
 
-    def test_revoke(self):
-        grant_code_eval_trust("proj-1")
-        revoke_code_eval_trust("proj-1")
-        assert not is_code_eval_trusted("proj-1")
+    def test_add_is_idempotent(self):
+        add_code_trust("proj-1")
+        add_code_trust("proj-1")
+        assert has_add_code_trust("proj-1")
 
-    def test_revoke_nonexistent_is_noop(self):
-        revoke_code_eval_trust("proj-never-added")
+    def test_reset_clears_all(self):
+        add_code_trust("proj-a")
+        add_code_trust("proj-b")
+        _reset_add_code_trust()
+        assert not has_add_code_trust("proj-a")
+        assert not has_add_code_trust("proj-b")
 
     def test_multiple_projects(self):
-        grant_code_eval_trust("proj-a")
-        grant_code_eval_trust("proj-b")
-        assert is_code_eval_trusted("proj-a")
-        assert is_code_eval_trusted("proj-b")
-        revoke_code_eval_trust("proj-a")
-        assert not is_code_eval_trusted("proj-a")
-        assert is_code_eval_trusted("proj-b")
+        add_code_trust("proj-a")
+        add_code_trust("proj-b")
+        assert has_add_code_trust("proj-a")
+        assert has_add_code_trust("proj-b")
+        assert not has_add_code_trust("proj-c")
 
 
 class TestCodeEvalAdapterInit:
@@ -110,19 +110,9 @@ class TestCodeEvalAdapterInit:
 
 class TestCodeEvalAdapterEvaluate:
     @pytest.mark.asyncio
-    async def test_untrusted_project_skips(self):
-        cfg = _make_config()
-        adapter = CodeEvalAdapter(cfg)
-        result = await adapter.evaluate(_inp())
-        assert result.scores == {}
-        assert result.skipped_reason == SkippedReason.code_eval_not_trusted
-        assert result.skipped_detail is not None
-
-    @pytest.mark.asyncio
     async def test_successful_evaluation(self):
         cfg = _make_config()
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
 
         with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
             mock_run.return_value = {"ok": {"accuracy": 0.95}}
@@ -136,8 +126,6 @@ class TestCodeEvalAdapterEvaluate:
     async def test_timeout_raises_runtime_error(self):
         cfg = _make_config()
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
-
         with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
             mock_run.side_effect = RuntimeError("Code eval scorer timed out after 30s")
             with pytest.raises(RuntimeError, match="timed out"):
@@ -147,8 +135,6 @@ class TestCodeEvalAdapterEvaluate:
     async def test_scorer_error_raises_runtime_error(self):
         cfg = _make_config()
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
-
         with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
             mock_run.return_value = {
                 "error": "NameError: undefined",
@@ -161,8 +147,6 @@ class TestCodeEvalAdapterEvaluate:
     async def test_non_dict_result_raises(self):
         cfg = _make_config()
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
-
         with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
             mock_run.return_value = {"ok": "not a dict"}
             with pytest.raises(RuntimeError, match="Scorer must return a dict"):
@@ -172,8 +156,6 @@ class TestCodeEvalAdapterEvaluate:
     async def test_inputs_passed_correctly(self):
         cfg = _make_config()
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
-
         with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
             mock_run.return_value = {"ok": {"accuracy": 1.0}}
             await adapter.evaluate(
@@ -198,8 +180,6 @@ class TestScoreValidation:
     async def test_bool_rejected(self):
         cfg = _make_config()
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
-
         with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
             mock_run.return_value = {"ok": {"accuracy": True}}
             with pytest.raises(RuntimeError, match="returned a bool"):
@@ -209,8 +189,6 @@ class TestScoreValidation:
     async def test_int_converted_to_float(self):
         cfg = _make_config()
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
-
         with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
             mock_run.return_value = {"ok": {"accuracy": 1}}
             result = await adapter.evaluate(_inp())
@@ -223,8 +201,6 @@ class TestScoreValidation:
     async def test_key_mismatch_raises(self):
         cfg = _make_config()
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
-
         with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
             mock_run.return_value = {"ok": {"wrong_key": 0.5}}
             with pytest.raises(RuntimeError, match="Score key mismatch"):
@@ -234,8 +210,6 @@ class TestScoreValidation:
     async def test_string_score_rejected(self):
         cfg = _make_config()
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
-
         with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
             mock_run.return_value = {"ok": {"accuracy": "high"}}
             with pytest.raises(RuntimeError, match="must be a float"):
@@ -257,38 +231,10 @@ class TestAsyncScorerEndToEnd:
         )
         cfg = _make_config(code=code)
         adapter = CodeEvalAdapter(cfg)
-        grant_code_eval_trust("/fake/project/path")
-
         result = await adapter.evaluate(_inp(final_message="test"))
         assert result.scores == {"accuracy": 0.75}
         assert result.skipped_reason is None
         assert result.skipped_detail is None
-
-
-class TestResolveProjectPath:
-    def test_no_project_returns_none(self):
-        cfg = _make_config()
-        adapter = CodeEvalAdapter(cfg)
-        adapter.target_task.parent = None
-        assert adapter._resolve_project_path() is None
-
-    def test_no_path_returns_none(self):
-        cfg = _make_config()
-        adapter = CodeEvalAdapter(cfg)
-        adapter.target_task.parent.path = None
-        assert adapter._resolve_project_path() is None
-
-    def test_valid_chain_returns_path(self):
-        cfg = _make_config()
-        adapter = CodeEvalAdapter(cfg)
-        assert adapter._resolve_project_path() == "/fake/project/path"
-
-    def test_exception_returns_none(self):
-        cfg = _make_config()
-        adapter = CodeEvalAdapter(cfg)
-        broken_parent = PropertyMock(side_effect=RuntimeError("broken"))
-        type(adapter.target_task).parent = broken_parent
-        assert adapter._resolve_project_path() is None
 
 
 class TestExecutionSerialization:
@@ -305,8 +251,6 @@ class TestExecutionSerialization:
         cfg2 = _make_config()
         adapter1 = CodeEvalAdapter(cfg1)
         adapter2 = CodeEvalAdapter(cfg2)
-        grant_code_eval_trust("/fake/project/path")
-
         counter_lock = threading.Lock()
         concurrency_counter = 0
         max_concurrency = 0

--- a/libs/core/kiln_ai/adapters/eval/v2_eval_code_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/v2_eval_code_eval.py
@@ -15,7 +15,6 @@ from kiln_ai.datamodel.eval import (
     EvalConfig,
     EvalScores,
     EvalTaskInput,
-    SkippedReason,
     V2EvalResult,
 )
 
@@ -25,19 +24,26 @@ _trusted_projects: set[str] = set()
 _code_eval_execution_lock = asyncio.Lock()
 
 
-def grant_code_eval_trust(project_path: str) -> None:
+def add_code_trust(project_path: str) -> None:
+    """Confer code trust on a project for the current session.
+
+    Called when NEW/not-yet-saved code is admitted or executed (saving a code
+    tool/eval, running not-yet-saved code in a test pane). Saved code is
+    trusted to run without this — the flag governs the authoring session only.
+    """
     with _trust_lock:
         _trusted_projects.add(project_path)
 
 
-def revoke_code_eval_trust(project_path: str) -> None:
-    with _trust_lock:
-        _trusted_projects.discard(project_path)
-
-
-def is_code_eval_trusted(project_path: str) -> bool:
+def has_add_code_trust(project_path: str) -> bool:
     with _trust_lock:
         return project_path in _trusted_projects
+
+
+def _reset_add_code_trust() -> None:
+    """Test-only reset of the in-memory trust set. Not part of the product API."""
+    with _trust_lock:
+        _trusted_projects.clear()
 
 
 class CodeEvalAdapter(BaseV2EvalBridge):
@@ -55,13 +61,6 @@ class CodeEvalAdapter(BaseV2EvalBridge):
     async def evaluate(self, eval_input: EvalTaskInput) -> V2EvalResult:
         props = self.properties
         assert isinstance(props, CodeEvalProperties)
-
-        project_path = self._resolve_project_path()
-        if project_path is None or not is_code_eval_trusted(project_path):
-            return V2EvalResult(
-                skipped_reason=SkippedReason.code_eval_not_trusted,
-                skipped_detail="Project not trusted for code eval execution.",
-            )
 
         inputs: dict[str, Any] = {
             "output": eval_input.final_message,
@@ -90,15 +89,6 @@ class CodeEvalAdapter(BaseV2EvalBridge):
 
         scores = self._validate_scores(raw_scores)
         return V2EvalResult(scores=scores)
-
-    def _resolve_project_path(self) -> str | None:
-        try:
-            project = self.target_task.parent
-            if project is None:
-                return None
-            return str(project.path) if project.path else None
-        except Exception:
-            return None
 
     def _validate_scores(self, raw: dict[str, Any]) -> EvalScores:
         expected_keys = {score.json_key() for score in self._output_scores}

--- a/libs/core/kiln_ai/sandbox/test_code_tool_execution.py
+++ b/libs/core/kiln_ai/sandbox/test_code_tool_execution.py
@@ -11,10 +11,6 @@ from unittest.mock import patch
 
 import pytest
 
-from kiln_ai.adapters.eval.v2_eval_code_eval import (
-    grant_code_eval_trust,
-    revoke_code_eval_trust,
-)
 from kiln_ai.datamodel.code_tool import CodeTool
 from kiln_ai.datamodel.project import Project
 from kiln_ai.sandbox.spawn import _spawn_lock
@@ -134,15 +130,6 @@ class FakeTool(KilnToolInterface):
 # ---------------------------------------------------------------------------
 # Child / protocol tests (real spawns)
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-def _trust_all_projects(tmp_path):
-    """Grant trust for tests so the trust gate doesn't block execution."""
-    path = str(tmp_path / "project")
-    grant_code_eval_trust(path)
-    yield
-    revoke_code_eval_trust(path)
 
 
 class TestChildSyncRun:
@@ -352,7 +339,6 @@ class TestMissingRun:
         )
         object.__setattr__(ct, "__pydantic_fields_set__", set())
         pct = PythonCodeTool(ct, project)
-        grant_code_eval_trust(str(project.path))
         result = await pct.run(None)
         assert result.is_error
         assert "run" in result.output.lower()
@@ -760,20 +746,6 @@ class TestSemaphore:
         await asyncio.gather(*(run_nested(i) for i in range(CODE_TOOL_MAX_CONCURRENCY)))
         assert len(results) == CODE_TOOL_MAX_CONCURRENCY
         assert all(not r.is_error for r in results)
-
-
-class TestTrustRefusal:
-    @pytest.mark.asyncio
-    async def test_trust_refusal_no_spawn(self, tmp_path):
-        project = Project(name="untrusted", path=tmp_path / "untrusted")
-        project.save_to_file()
-        revoke_code_eval_trust(str(project.path))
-        ct = _make_code_tool('def run(x):\n    return "should_not_run"\n')
-        ct.parent = project
-        pct = PythonCodeTool(ct, project)
-        result = await pct.run(None, x="test")
-        assert result.is_error
-        assert "not trusted" in result.error_message.lower()
 
 
 class TestToolCallRecorder:

--- a/libs/core/kiln_ai/tools/code_tool.py
+++ b/libs/core/kiln_ai/tools/code_tool.py
@@ -117,15 +117,6 @@ class PythonCodeTool(KilnToolInterface):
     async def run(
         self, context: ToolCallContext | None = None, **kwargs: Any
     ) -> ToolCallResult:
-        from kiln_ai.adapters.eval.v2_eval_code_eval import is_code_eval_trusted
-
-        if not is_code_eval_trusted(str(self._project.path)):
-            return ToolCallResult(
-                output="Code tools are disabled until the project is trusted in Kiln.",
-                is_error=True,
-                error_message="Project not trusted",
-            )
-
         outcome = await self._invoke(context, kwargs)
 
         tool_name = self._code_tool.tool_function_name

--- a/libs/server/kiln_server/utils/agent_checks/annotations/get_api_projects_project_id_add_code_trust.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/get_api_projects_project_id_add_code_trust.json
@@ -1,0 +1,8 @@
+{
+  "method": "get",
+  "path": "/api/projects/{project_id}/add_code_trust",
+  "agent_policy": {
+    "permission": "deny",
+    "requires_approval": false
+  }
+}

--- a/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_add_code_trust.json
+++ b/libs/server/kiln_server/utils/agent_checks/annotations/post_api_projects_project_id_add_code_trust.json
@@ -1,0 +1,8 @@
+{
+  "method": "post",
+  "path": "/api/projects/{project_id}/add_code_trust",
+  "agent_policy": {
+    "permission": "deny",
+    "requires_approval": false
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Refactors code-eval / code-tool "trust" so it stops gating the running of already-saved code.

**Problem:** the per-session trust flag (`_trusted_projects`, an in-memory set) was checked on *run* paths — `CodeEvalAdapter.evaluate` and `PythonCodeTool.run`. Because the set is process-local and empty on every server restart, running an **existing** code eval or invoking an **existing** code tool after a restart was blocked/skipped as `code_eval_not_trusted` until a human re-clicked the UI trust dialog.

**Model:** *saved == trusted.* Code saved into a Kiln project is trusted to run — it arrived via project import/sync (you trusted the source, not a point-in-time snapshot) or was added locally with explicit consent. So the per-session flag should gate only the **introduction of new/unsaved code**, never the running of saved code.

**Changes:**
- Rename `grant_code_eval_trust → add_code_trust` and `is_code_eval_trusted → has_add_code_trust`; drop the public `revoke_*` (replaced with a test-only reset).
- **Remove** the trust gate from both run paths (`CodeEvalAdapter.evaluate`, `PythonCodeTool.run`) — this is the restart-bug fix.
- Keep the gate on the code-tool **create/test** endpoints, and add the equivalent for code evals: the **test pane** (`test_v2_eval`, returns the existing `code_eval_not_trusted` skip) and **save** (`create_eval_config`, `403` raised before anything is persisted). Saving is the moment untrusted code becomes trusted-forever, so it's the conferral boundary.
- Rename the `/add_code_trust` GET/POST endpoints and `CodeEvalTrustResponse → CodeTrustResponse`, regenerate the TS schema, update the frontend clients/callers, and add the `add_code_trust` agent-policy annotations (retaining the old annotation files per the `agent_checks` retention convention).
- `SkippedReason.code_eval_not_trusted` wire value is left unchanged (persisted enum value / frontend-matched string).

**Trust surface after this change:**
- Run saved code (batch evals, saved code tools): no gate.
- Confer trust — save new code (`create_code_tool`, `create_eval_config` code type) and run not-yet-saved code (`test_code_tool`, `test_v2_eval` code type): gated by `has_add_code_trust`.

**Verification notes (please re-run in CI):** touched Python suites pass (core eval/sandbox/code-tool APIs, `test_dump_annotations`), frontend vitest + `npm run check` pass, and `ruff`/`ty` are clean. Two steps could not run in the dev sandbox due to pre-existing dependency version drift and were worked around: `test_eval_api.py` was run through an in-process starlette shim (112 passed) rather than the pinned starlette, and the OpenAPI schema regen (`generate_schema.sh`/`check_schema.sh`) could not execute, so `api_schema.d.ts` was hand-edited and byte-verified against `openapi-typescript` output — **CI's `check_schema.sh` should confirm it is byte-identical.**

## Related Issues

<!-- none -->

## Checklists

- [x] Tests have been run locally and passed (see verification notes re: two sandboxed workarounds)
- [x] New tests have been added to any work in /lib


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjTLJqkwC9o7QFGurookmA)_