### PR TITLE
fix: CI broken on main

### DIFF
--- a/app/web_ui/tests/e2e/act/discover/data-generation.spec.ts
+++ b/app/web_ui/tests/e2e/act/discover/data-generation.spec.ts
@@ -149,8 +149,9 @@ test.describe("Synthetic data generation", () => {
   ## Goals
   On a fresh task with no saved data guide, the synth page first shows the
   "Create a Data Guide" intro (KIL-485). Clicking "Continue Without Data
-  Guide" falls through to the DataGenIntro with "Add Topics" and "Generate
-  Model Inputs" buttons.
+  Guide" advances to the batch chooser; picking "Create Manually" then falls
+  through to the DataGenIntro with "Add Topics" and "Generate Model Inputs"
+  buttons.
 
   ## Fixtures
   - registeredUser
@@ -159,13 +160,14 @@ test.describe("Synthetic data generation", () => {
   ## Hints
   - Route is /generate/{project_id}/{task_id}/synth?reason=fine_tune&template_id=fine_tuning&splits=fine_tune_data%3A1
   - First-time users see the "Create a Data Guide" intro card. Clicking
-    "Continue Without Data Guide" sets skip_data_guide=true and reveals the
-    underlying DataGenIntro.
+    "Continue Without Data Guide" sets skip_data_guide=true and advances to the
+    SynthBatchChooser (manual vs Kiln Pro). Clicking "Create Manually" sets
+    batch_mode=manual and reveals the underlying DataGenIntro.
 
   ## Assertions
   - Page heading "Synthetic Data Generation" is visible.
-  - After clicking "Continue Without Data Guide", "Add Topics" and "Generate
-    Model Inputs" buttons are visible.
+  - After clicking "Continue Without Data Guide" then "Create Manually", the
+    "Add Topics" and "Generate Model Inputs" buttons are visible.
   */
   test("synth page shows intro with add topics and generate inputs buttons", async ({
     page,
@@ -186,6 +188,10 @@ test.describe("Synthetic data generation", () => {
     await page
       .getByRole("button", { name: "Continue Without Data Guide" })
       .click()
+
+    // Skipping the data guide advances to the batch chooser; pick manual
+    // generation to reach the DataGenIntro.
+    await page.getByRole("button", { name: "Create Manually" }).click()
 
     await expect(page.getByRole("button", { name: "Add Topics" })).toBeVisible()
 

--- a/app/web_ui/tests/e2e/act/discover/extractors.spec.ts
+++ b/app/web_ui/tests/e2e/act/discover/extractors.spec.ts
@@ -155,12 +155,19 @@ test.describe("Create extractor page", () => {
       page.getByRole("heading", { name: "Create Document Extractor" }),
     ).toBeVisible()
 
-    const advancedToggle = page.getByText("Advanced Options")
-    await expect(advancedToggle).toBeVisible()
-    await advancedToggle
-      .locator("xpath=ancestor::div[contains(@class,'collapse')]")
-      .locator("input[type='checkbox']")
-      .check({ force: true })
+    await expect(page.getByText("Advanced Options")).toBeVisible()
+
+    // Toggle the DaisyUI collapse by clicking its overlay checkbox. Use a normal
+    // (actionability-checked) click rather than `check({ force: true })`: the
+    // app's global loading overlay (+layout.svelte, z-[1000]) can still be
+    // covering the page here, and `force` clicks straight through it onto the
+    // overlay, so the checkbox never toggles ("did not change its state"). A
+    // normal click auto-waits for that overlay to clear before hitting the
+    // checkbox.
+    await page
+      .locator(".collapse", { hasText: "Advanced Options" })
+      .locator('input[type="checkbox"]')
+      .click()
 
     await expect(page.getByText("Document Extraction Prompt")).toBeVisible()
     await expect(page.getByText("Image Extraction Prompt")).toBeVisible()


### PR DESCRIPTION
## Summary

Fixes two preexisting failures in the **Playwright Tests** workflow on `main` (both under `app/web_ui/tests/e2e/act/discover/`). Both are **test-level** fixes — no product code changed. Independent of the KIL-771 prompt-caching work.

## Failure 1 (hard failure): `data-generation.spec.ts:170` — "synth page shows intro with add topics and generate inputs buttons"

**Symptom:** After clicking "Continue Without Data Guide", `expect(getByRole("button", { name: "Add Topics" })).toBeVisible()` timed out ("element(s) not found").

**Root cause:** The synth flow gained an intermediate `SynthBatchChooser` step (manual vs Kiln Pro), added in commit `7b4645dee` on 2026-07-11. Skipping the data guide now advances to that chooser, not directly to the `DataGenIntro`. The test was last updated 2026-05-07 and still expected the old direct flow. The intermediate step is intended product behavior (documented in `synth/+page.svelte`: "The post-intro flow (skip-guide → chooser → manual/pro) is encoded in URL search params...").

**Fix (test):** After "Continue Without Data Guide", click "Create Manually" in the chooser before asserting the `DataGenIntro` buttons. Also updated the test's doc comment.

## Failure 2 (flaky): `extractors.spec.ts:144` — "advanced options section shows prompt and detail fields"

**Symptom:** `check({ force: true })` on the Advanced Options collapse checkbox reported "Clicking the checkbox did not change its state"; the subsequent "Document Extraction Prompt" assertion then failed. Passed on retry in CI; reproduced 5/5 locally with `--retries=0`.

**Root cause:** Confirmed via a DOM probe (`elementFromPoint` at the checkbox center) that the app's **global loading overlay** (`+layout.svelte`, `div.fixed ... z-[1000]`, shown while projects load) was still covering the page. `force: true` bypasses actionability and clicks straight through onto that overlay, so the DaisyUI collapse checkbox never toggled. `toBeVisible()` still passed on the (obscured) heading because Playwright's visibility check ignores obscuring elements. Once the overlay detaches, the checkbox is the top element and a normal click toggles it.

**Fix (test):** Replaced `check({ force: true })` with a normal, actionability-checked `.click()` (via a cleaner `.collapse` + checkbox locator). A normal click auto-waits for the overlay to clear before hitting the checkbox.

## Verification

From `app/web_ui`:
- `data-generation.spec.ts` target test: **5/5 passed** (`--retries=0`)
- `extractors.spec.ts` target test: was **0/5** before, now **5/5 passed** (`--retries=0`)
- Full `extractors.spec.ts` + `data-generation.spec.ts`: **14 passed**
- `npm run format_check`: pass
- `npm run lint`: pass
- `npm run check`: 0 errors (4 pre-existing warnings in untouched `run.svelte`)