### PR TITLE
Pre-bash runner papercuts + save/run guards (6.8B)

### DIFF
--- a/app/desktop/studio_server/copilot_api.py
+++ b/app/desktop/studio_server/copilot_api.py
@@ -85,7 +85,10 @@ from app.desktop.studio_server.utils.copilot_utils import (
     untag_multi_turn_chains_for_eval,
     write_eval_slice_multi_turn,
 )
-from app.desktop.studio_server.api_models.eval_builder_models import JudgeConfig
+from app.desktop.studio_server.api_models.eval_builder_models import (
+    JudgeConfig,
+    spec_name_must_have_a_json_key,
+)
 from app.desktop.studio_server.utils.eval_builder_utils import (
     build_judge_prompt_template,
 )
@@ -102,6 +105,7 @@ from kiln_ai.datamodel.eval import (
     Eval,
     EvalConfig,
     EvalConfigType,
+    EvalDataType,
     EvalInput,
     LlmJudgeProperties,
     MultiTurnDriveConfig,
@@ -134,7 +138,7 @@ from kiln_server.utils.agent_checks.policy import (
     ALLOW_AGENT,
     agent_policy_require_approval,
 )
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
@@ -233,6 +237,10 @@ class CreateSpecWithCopilotRequest(BaseModel):
     # Short limit: the name becomes the eval's EvalOutputScore.name (max 32)
     # — a longer name would fail deep inside Eval construction, not here.
     name: FilenameStringShort
+    # Same up-front rule as the review requests: the judge's score key derives
+    # from this name, and an empty key would persist an eval that can never
+    # run (every job would fail inside the judge).
+    _name_has_json_key = field_validator("name")(spec_name_must_have_a_json_key)
     definition: str = Field(
         description="The spec definition string, built by client using buildSpecDefinition()"
     )
@@ -974,18 +982,21 @@ def connect_copilot_api(app: FastAPI):
         task = task_from_id(project_id, task_id)
 
         # Idempotency guard against re-submits after a completed save (the
-        # save is slow, so users retry). Case-insensitive because the eval
-        # tags and rating keys are derived from the lowercased name — two
-        # specs differing only by case would share a tag namespace. Two
-        # requests in flight at once can still race past this check —
-        # acceptable for a single-user studio.
+        # save is slow, so users retry). Compared via the derived eval tags,
+        # not the raw name: tags come from the lowercased, space-normalized
+        # name, so "My Spec" and "my_spec" would silently share a tag
+        # namespace (and each other's datasets) if only exact names were
+        # rejected. Two requests in flight at once can still race past this
+        # check — acceptable for a single-user studio.
+        requested_tags = generate_spec_eval_tags(request.name)
         if any(
-            spec.name.lower() == request.name.lower()
+            generate_spec_eval_tags(spec.name) == requested_tags
             for spec in task.specs(readonly=True)
         ):
             raise HTTPException(
                 status_code=409,
-                detail=f"A spec named '{request.name}' already exists for this task.",
+                detail=f"A spec named '{request.name}' (or one differing only "
+                "by case or spacing) already exists for this task.",
             )
 
         # Generate tags and filter IDs
@@ -1003,6 +1014,18 @@ def connect_copilot_api(app: FastAPI):
         evaluation_data_type = spec_eval_data_type(
             spec_type, request.evaluate_full_trace
         )
+
+        # The builder's judge template never renders a reference answer, so a
+        # reference_answer eval would save fine and then mis-score every run.
+        # Unreachable from the UI (spec classification stubs everything to
+        # Issue) — this guards direct API/agent clients.
+        if evaluation_data_type == EvalDataType.reference_answer:
+            raise HTTPException(
+                status_code=400,
+                detail="Reference-answer specs are not supported by the spec "
+                "builder yet: the saved judge would never see the reference "
+                "answer. Create this eval from the Evals tab instead.",
+            )
 
         # Multi-turn path: find existing chain leaves up front so we 404 before
         # creating any models if the batch_tag matches nothing. The reviewed

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -1309,6 +1309,20 @@ def connect_evals_api(app: FastAPI):
             save_context=build_save_context(request),
         )
 
+        # Surface drive-config/run-config incompatibilities as one 400 before
+        # the SSE stream opens — otherwise each job fails individually and
+        # clients only see an anonymous error count. (EventSource consumers
+        # can't read a 400 body, but an up-front error state still beats N
+        # silent job errors; API clients get the full message.) Run-config
+        # strictness only applies to a hand-picked list — with
+        # all_run_configs, one incompatible config shouldn't block the rest.
+        try:
+            eval_runner.validate_multi_turn_drive_readiness(
+                check_run_configs=not all_run_configs
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
         return await run_eval_runner_with_status(eval_runner)
 
     @app.post(
@@ -1379,6 +1393,20 @@ def connect_evals_api(app: FastAPI):
     ) -> StreamingResponse:
         """Run all eval configs against each other for calibration and stream progress via SSE. Used to check that eval configs produce consistent scores."""
         eval = eval_from_id(project_id, task_id, eval_id)
+
+        # An empty golden set would "complete" instantly with zero scores — a
+        # vacuous calibration the UI reads as success. Refuse it up front.
+        task = task_from_id(project_id, task_id)
+        if eval.eval_configs_filter_id is None or not dataset_ids_in_filter(
+            task, eval.eval_configs_filter_id, readonly=True
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="This eval's golden dataset is empty, so there is "
+                "nothing to calibrate the judge against. Add human-rated "
+                "examples to the golden set first.",
+            )
+
         eval_configs = eval.configs()
         eval_runner = EvalRunner(
             eval_configs=eval_configs,

--- a/app/desktop/studio_server/test_copilot_api.py
+++ b/app/desktop/studio_server/test_copilot_api.py
@@ -925,6 +925,92 @@ class TestCreateSpecWithCopilotMultiTurn:
         assert "already exists" in response.json()["message"]
         assert len(task.evals()) == 0
 
+    def test_tag_normalized_spec_name_collision_is_409(
+        self, client, project_and_task, multi_turn_request_data
+    ):
+        """ "Multi_Turn_Spec" and "Multi Turn Spec" differ as names but produce
+        identical eval tags (lowercase, spaces→underscores) — saving the
+        second would silently share the first's datasets."""
+        from kiln_ai.datamodel.spec import Spec, SpecStatus
+
+        project, task = project_and_task
+        existing = Spec(
+            parent=task,
+            name="Multi_Turn_Spec",
+            definition="already here",
+            properties={
+                "spec_type": SpecType.issue.value,
+                "issue_description": "existing",
+            },
+            status=SpecStatus.active,
+            tags=[],
+            eval_id="unused_eval_id",
+        )
+        existing.save_to_file()
+
+        with patch(
+            "app.desktop.studio_server.copilot_api.task_from_id",
+            return_value=task,
+        ):
+            response = client.post(
+                f"/api/projects/{project.id}/tasks/{task.id}/spec_with_copilot",
+                json=multi_turn_request_data,
+            )
+
+        assert response.status_code == 409
+        assert len(task.evals()) == 0
+
+    def test_spec_name_without_json_key_chars_is_422(
+        self, client, project_and_task, multi_turn_request_data
+    ):
+        """A name with no [a-z0-9_] characters (e.g. fully non-ASCII) yields
+        an empty judge score key — the save would persist an eval that can
+        never run."""
+        project, task = project_and_task
+        multi_turn_request_data["name"] = "中文规格"
+
+        with patch(
+            "app.desktop.studio_server.copilot_api.task_from_id",
+            return_value=task,
+        ):
+            response = client.post(
+                f"/api/projects/{project.id}/tasks/{task.id}/spec_with_copilot",
+                json=multi_turn_request_data,
+            )
+
+        assert response.status_code == 422
+        assert "score key" in response.json()["message"]
+        assert len(task.evals()) == 0
+        assert len(task.specs()) == 0
+
+    def test_reference_answer_spec_type_is_400(
+        self, client, project_and_task, multi_turn_request_data
+    ):
+        """The builder's judge template never renders a reference answer;
+        saving one would mis-score every run. Guarded until supported."""
+        project, task = project_and_task
+        multi_turn_request_data["properties"] = {
+            "spec_type": SpecType.reference_answer_accuracy.value,
+            "core_requirement": "Answers must match the reference.",
+            "reference_answer_accuracy_description": "Compare to reference.",
+            "accurate_examples": "example a",
+            "inaccurate_examples": "example b",
+        }
+
+        with patch(
+            "app.desktop.studio_server.copilot_api.task_from_id",
+            return_value=task,
+        ):
+            response = client.post(
+                f"/api/projects/{project.id}/tasks/{task.id}/spec_with_copilot",
+                json=multi_turn_request_data,
+            )
+
+        assert response.status_code == 400
+        assert "Reference-answer" in response.json()["message"]
+        assert len(task.evals()) == 0
+        assert len(task.specs()) == 0
+
     def test_spec_name_over_short_limit_is_422(
         self, client, project_and_task, multi_turn_request_data
     ):

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -18,6 +18,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
 from kiln_server.custom_errors import connect_custom_errors
+from kiln_ai.adapters.eval.eval_runner import EvalRunner
 from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.datamodel import (
     DataSource,
@@ -1806,11 +1807,43 @@ async def test_get_eval_config_compare_summary_skips_custom_scores(
     assert data["partially_rated_count"] == 0
 
 
+def _seed_golden_run(mock_task) -> TaskRun:
+    """One human-rated TaskRun in the golden set (tag::golden), so
+    calibration has something to run against."""
+    task_run = TaskRun(
+        input="golden input",
+        input_source=DataSource(
+            type=DataSourceType.synthetic,
+            properties={
+                "model_name": "gpt-4",
+                "model_provider": "openai",
+                "adapter_name": "langchain_adapter",
+            },
+        ),
+        output=TaskOutput(
+            output="golden output",
+            source=DataSource(
+                type=DataSourceType.synthetic,
+                properties={
+                    "model_name": "gpt-4",
+                    "model_provider": "openai",
+                    "adapter_name": "langchain_adapter",
+                },
+            ),
+        ),
+        tags=["golden"],
+        parent=mock_task,
+    )
+    task_run.save_to_file()
+    return task_run
+
+
 @pytest.mark.asyncio
 async def test_run_eval_config_eval(
     client, mock_task_from_id, mock_task, mock_eval, mock_eval_config
 ):
     mock_task_from_id.return_value = mock_task
+    _seed_golden_run(mock_task)
 
     # Create a mock response for run_eval_runner_with_status
     mock_response = StreamingResponse(
@@ -5025,3 +5058,47 @@ class TestTestV2EvalOverrides:
             == "Custom {{ task_input }} {{ final_message }}"
         )
         assert call_kwargs.kwargs["system_prompt"] == "Be strict."
+
+
+@pytest.mark.asyncio
+async def test_run_calibration_empty_golden_set_400(
+    client, mock_task_from_id, mock_task, mock_eval, mock_eval_config
+):
+    """No runs match the golden filter: calibration would complete vacuously
+    (zero jobs, zero scores) and read as success — refuse it up front."""
+    mock_task_from_id.return_value = mock_task
+
+    response = client.get(
+        "/api/projects/project1/tasks/task1/evals/eval1/run_calibration"
+    )
+
+    assert response.status_code == 400
+    assert "golden dataset is empty" in response.json()["message"]
+
+
+@pytest.mark.asyncio
+async def test_run_comparison_multi_turn_drive_problems_400(
+    client, mock_task_from_id, mock_task, mock_eval, mock_eval_config, mock_run_config
+):
+    """Drive-config/run-config incompatibilities surface as one 400 before
+    the SSE stream opens, not as N anonymous per-job errors."""
+    mock_task_from_id.return_value = mock_task
+
+    with (
+        patch(
+            "app.desktop.studio_server.eval_api.task_run_config_from_id"
+        ) as mock_run_config_from_id,
+        patch.object(
+            EvalRunner,
+            "validate_multi_turn_drive_readiness",
+            side_effect=ValueError("run config 'MCP one' is not a Kiln agent config"),
+        ),
+    ):
+        mock_run_config_from_id.return_value = mock_run_config
+        response = client.get(
+            "/api/projects/project1/tasks/task1/evals/eval1/eval_config/eval_config1/run_comparison",
+            params={"run_config_ids": ["run_config1"]},
+        )
+
+    assert response.status_code == 400
+    assert "MCP one" in response.json()["message"]

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/builder/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/builder/+page.svelte
@@ -1105,12 +1105,33 @@
       },
     )
     // Refine failed — ship the original judge rather than block the save.
-    if (error || !data) return judge
+    // The fallback is invisible to the user by design, so leave a telemetry
+    // trail: silent fallbacks would otherwise read as "refinement works".
+    if (error || !data) {
+      console.warn(
+        "Judge refinement failed at save; keeping the reviewed judge.",
+        error,
+      )
+      posthog.capture("eval_v2_judge_refine_fallback", {
+        reason: "request_failed",
+      })
+      return judge
+    }
     const proposal = data as RefineJudgeProposal
     // Only ship a mechanically-valid refined prompt (it renders into the judge
     // harness verbatim); otherwise fall back to the original.
-    if (validate_refined_judge_prompt(proposal.refined_judge_prompt))
+    const validation_error = validate_refined_judge_prompt(
+      proposal.refined_judge_prompt,
+    )
+    if (validation_error) {
+      console.warn(
+        `Refined judge prompt rejected (${validation_error}); keeping the reviewed judge.`,
+      )
+      posthog.capture("eval_v2_judge_refine_fallback", {
+        reason: "invalid_refined_prompt",
+      })
       return judge
+    }
     return { ...judge, prompt: proposal.refined_judge_prompt }
   }
 

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, AsyncGenerator, Dict, List, Literal, Set, Tuple
 
 import litellm
@@ -9,7 +9,10 @@ from kiln_ai.adapters.adapter_registry import load_skills_for_task
 from kiln_ai.adapters.errors import KilnRunError
 from kiln_ai.adapters.eval.base_eval import BaseEval, BaseV2EvalBridge
 from kiln_ai.adapters.eval.drive_fingerprint import compute_drive_fingerprint
-from kiln_ai.adapters.eval.registry import legacy_eval_adapter_from_type
+from kiln_ai.adapters.eval.registry import (
+    legacy_eval_adapter_from_type,
+    v2_eval_type_available,
+)
 from kiln_ai.adapters.model_adapters.base_adapter import SkillsDict
 from kiln_ai.datamodel.basemodel import ID_TYPE
 from kiln_ai.datamodel.datamodel_enums import ModelProviderName
@@ -48,6 +51,10 @@ class EvalJob:
     type: Literal["task_run_eval", "eval_config_eval"]
     eval_config: EvalConfig
     task_run_config: TaskRunConfig | None = None
+    # Recoverable-skip records this job replaces (their blocking condition
+    # has lifted). Deleted after the job persists its record — leaving them
+    # would put two records on one item and read paths take the first found.
+    superseded_tombstones: List[EvalRun] = field(default_factory=list)
 
 
 @dataclass
@@ -167,16 +174,23 @@ class EvalRunner:
 
         # already_run[eval_config_id][dataset_id]
         already_run: Dict[ID_TYPE, Set[ID_TYPE]] = {}
+        superseded: Dict[Tuple[ID_TYPE, ID_TYPE], List[EvalRun]] = {}
         for eval_config in self.eval_configs:
             already_run[eval_config.id] = set()
             for run in eval_config.runs(readonly=True):
-                already_run[eval_config.id].add(run.dataset_id)
+                if self._counts_as_already_run(run, eval_config):
+                    already_run[eval_config.id].add(run.dataset_id)
+                else:
+                    superseded.setdefault((eval_config.id, run.dataset_id), []).append(
+                        run
+                    )
 
         return [
             EvalJob(
                 item=task_run,
                 eval_config=eval_config,
                 type="eval_config_eval",
+                superseded_tombstones=superseded.get((eval_config.id, task_run.id), []),
             )
             for task_run in self.task.runs(readonly=True)
             if filter(task_run)
@@ -204,19 +218,27 @@ class EvalRunner:
         input_filter = eval_input_filter_from_id(filter_id)
 
         already_run: Dict[ID_TYPE, Dict[ID_TYPE, Set[ID_TYPE]]] = {}
+        superseded: Dict[Tuple[ID_TYPE, ID_TYPE, ID_TYPE], List[EvalRun]] = {}
         for eval_config in self.eval_configs:
             already_run[eval_config.id] = {}
             for run_config in self.run_configs or []:
                 already_run[eval_config.id][run_config.id] = set()
             for run in eval_config.runs(readonly=True):
                 if (
-                    run.eval_input_id is not None
-                    and run.task_run_config_id is not None
-                    and run.task_run_config_id in already_run[eval_config.id]
+                    run.eval_input_id is None
+                    or run.task_run_config_id is None
+                    or run.task_run_config_id not in already_run[eval_config.id]
                 ):
+                    continue
+                if self._counts_as_already_run(run, eval_config):
                     already_run[eval_config.id][run.task_run_config_id].add(
                         run.eval_input_id
                     )
+                else:
+                    superseded.setdefault(
+                        (eval_config.id, run.task_run_config_id, run.eval_input_id),
+                        [],
+                    ).append(run)
 
         jobs: List[EvalJob] = []
         for eval_input in self.task.eval_inputs(readonly=True):
@@ -232,6 +254,9 @@ class EvalRunner:
                             eval_config=eval_config,
                             type="task_run_eval",
                             task_run_config=run_config,
+                            superseded_tombstones=superseded.get(
+                                (eval_config.id, run_config.id, eval_input.id), []
+                            ),
                         )
                     )
         return jobs
@@ -260,6 +285,7 @@ class EvalRunner:
                 if (
                     run.task_run_config_id is not None
                     and run.task_run_config_id in already_run[eval_config.id]
+                    and self._counts_as_already_run(run, eval_config)
                 ):
                     already_run[eval_config.id][run.task_run_config_id].add(
                         run.dataset_id
@@ -278,6 +304,72 @@ class EvalRunner:
             for run_config in self.run_configs or []
             if task_run.id not in already_run[eval_config.id][run_config.id]
         ]
+
+    def _counts_as_already_run(self, run: EvalRun, eval_config: EvalConfig) -> bool:
+        """Whether a persisted record makes its item "done" for dedup.
+
+        Most records do — including skips, which are terminal verdicts about
+        the input itself (missing_trace, incompatible_input_shape, ...). The
+        recoverable skips mark a blocked PRECONDITION instead: once the
+        condition is lifted, treating the tombstone as done would freeze the
+        item out forever, so it stops counting and the item is collected
+        again. A still-blocked item keeps deduping, so re-triggering never
+        piles up duplicate tombstones.
+        """
+        if run.skipped_reason == SkippedReason.missing_drive_config.value:
+            return self.eval.multi_turn_drive_config is None
+        if run.skipped_reason == SkippedReason.type_not_available.value:
+            return not v2_eval_type_available(eval_config)
+        return True
+
+    def validate_multi_turn_drive_readiness(
+        self, check_run_configs: bool = True
+    ) -> None:
+        """Fail fast on config problems every multi-turn re-drive job would
+        hit: a drive config with an unknown model provider, or run configs
+        that aren't Kiln agent configs. Callers can invoke this before
+        starting a batch so the user gets one clear error up front instead
+        of one opaque error per job. The per-job checks stay as the backstop
+        for standalone runner use.
+
+        `check_run_configs=False` limits validation to the drive config —
+        for callers running a fleet the user didn't hand-pick, where one
+        incompatible run config shouldn't block every other config's jobs.
+
+        Raises ValueError listing every problem; no-op unless re-drive jobs
+        can actually occur (task_run_eval over an EvalInput source with a
+        multi_turn_drive_config — stored-TaskRun sources never re-drive).
+        """
+        drive_config = self.eval.multi_turn_drive_config
+        if (
+            drive_config is None
+            or self.eval_run_type != "task_run_eval"
+            or self._source_mode != "eval_input"
+        ):
+            return
+        problems: list[str] = []
+        try:
+            ModelProviderName(drive_config.model_provider)
+        except ValueError:
+            problems.append(
+                "the eval's synthetic-user drive config has unknown model "
+                f"provider '{drive_config.model_provider}'"
+            )
+        if check_run_configs:
+            for run_config in self.run_configs or []:
+                try:
+                    as_kiln_agent_run_config(run_config.run_config_properties)
+                except ValueError:
+                    problems.append(
+                        f"run config '{run_config.name}' is not a Kiln agent "
+                        "config, so it can't hold a multi-turn conversation"
+                    )
+        if problems:
+            raise ValueError(
+                "Cannot re-drive this eval's multi-turn conversations: "
+                + "; ".join(problems)
+                + "."
+            )
 
     def _preload_skills(self) -> SkillsDict:
         """Collect all skill IDs from run configs and bulk-load them once."""
@@ -307,9 +399,12 @@ class EvalRunner:
     async def run_job(self, job: EvalJob) -> bool:
         try:
             if job.eval_config.config_type == EvalConfigType.v2:
-                return await self._run_v2_job(job)
+                done = await self._run_v2_job(job)
             else:
-                return await self._run_legacy_job(job)
+                done = await self._run_legacy_job(job)
+            if done:
+                await self._delete_superseded_tombstones(job)
+            return done
         except Exception as e:
             if _is_retryable_error(e):
                 logger.error(
@@ -324,6 +419,26 @@ class EvalRunner:
                 exc_info=True,
             )
             raise
+
+    async def _delete_superseded_tombstones(self, job: EvalJob) -> None:
+        """Remove the recoverable-skip records this job just replaced. Runs
+        only after the replacement record persisted, so an errored job leaves
+        the tombstone in place (the item stays re-collectable). Deletion
+        failures are logged, never raised: the fresh record is already the
+        one read paths should prefer, a leftover duplicate is the lesser
+        problem."""
+        if not job.superseded_tombstones:
+            return
+        async with self._save_context():
+            for run in job.superseded_tombstones:
+                try:
+                    run.delete()
+                except Exception:
+                    logger.warning(
+                        f"Failed to delete superseded skip record {run.id} for "
+                        f"dataset item {job.item.id}",
+                        exc_info=True,
+                    )
 
     async def _run_legacy_job(self, job: EvalJob) -> bool:
         if not isinstance(job.item, TaskRun):
@@ -561,8 +676,9 @@ class EvalRunner:
                     skipped_detail=result.skipped_detail,
                     intermediate_outputs=result.intermediate_outputs,
                     # Fresh generations are transient — the record is the only
-                    # place the evaluated conversation survives.
+                    # place the evaluated conversation (and its spend) survives.
                     task_run_trace=_serialize_trace(eval_task_input.trace),
+                    task_run_usage=run_output.usage,
                 )
                 eval_run.save_to_file()
             return True
@@ -573,7 +689,10 @@ class EvalRunner:
             result = await evaluator.evaluate(eval_task_input)
             task_output = run_output.output.output
             task_input_str = run_output.input
-            dataset_id = run_output.id
+            # Key on the dataset item, not the fresh generation: run_output is
+            # never persisted so its id is None (EvalRun would fail validation),
+            # and dedup compares this field against the item's id.
+            dataset_id = job.item.id
 
             async with self._save_context():
                 eval_run = EvalRun(
@@ -596,6 +715,7 @@ class EvalRunner:
                     # The fresh run's conversation, when the adapter produced
                     # one — kept regardless of scoring outcome.
                     task_run_trace=_serialize_trace(eval_task_input.trace),
+                    task_run_usage=run_output.usage,
                 )
                 eval_run.save_to_file()
             return True
@@ -714,6 +834,10 @@ class EvalRunner:
         fingerprint = compute_drive_fingerprint(
             drive_config, job.task_run_config.run_config_properties, data
         )
+        # Generation spend for THIS record: stays None on reuse — the drive
+        # cost was already recorded on the record that drove the conversation,
+        # and counting it again would double-book the spend.
+        drive_usage: Usage | None = None
         reused_trace = self._find_reusable_trace(fingerprint, job.task_run_config.id)
         if reused_trace is not None:
             # Another v2 config (this eval's or a task sibling's) already
@@ -723,7 +847,7 @@ class EvalRunner:
                 eval_input, reused_trace
             )
         else:
-            leaf = await drive_case_for_eval(
+            drive_result = await drive_case_for_eval(
                 seed_prompt=seed,
                 synthetic_user_info=data.synthetic_user_info,
                 target_task=self.task,
@@ -735,6 +859,8 @@ class EvalRunner:
                 turns=drive_config.turns,
                 skills=self._skills,
             )
+            leaf = drive_result.chain[-1]
+            drive_usage = _drive_usage(leaf, drive_result.su_total_cost)
             eval_task_input = EvalTaskInput.from_eval_input(eval_input, leaf)
             # Publish the fresh trace so same-invocation sibling jobs reuse
             # it without waiting for this record to hit disk.
@@ -769,6 +895,7 @@ class EvalRunner:
                 # of the sibling that originally drove them.
                 task_run_trace=_serialize_trace(eval_task_input.trace),
                 drive_fingerprint=fingerprint,
+                task_run_usage=drive_usage,
             )
             eval_run.save_to_file()
         return True
@@ -848,6 +975,22 @@ class EvalRunner:
                     if existing is None or sort_key < existing.sort_key:
                         index[key] = _ReusableTrace(trace=trace, sort_key=sort_key)
         return index
+
+
+def _drive_usage(leaf: TaskRun, su_total_cost: float) -> Usage | None:
+    """Total generation spend of one eval-time drive: the agent side's
+    cumulative usage plus the synthetic user's LLM cost (which surfaces
+    nowhere else — SU turns aren't persisted). Token counts are agent-side
+    only; cost covers both sides. None when neither side reported anything.
+    """
+    total = (leaf.cumulative_usage or MessageUsage()) + MessageUsage(
+        cost=su_total_cost if su_total_cost > 0 else None
+    )
+    # Field-level check (not ==) so a Usage subclass instance in
+    # cumulative_usage can't defeat pydantic's class-sensitive equality.
+    if all(v is None for v in total.model_dump().values()):
+        return None
+    return Usage(**total.model_dump())
 
 
 def _trace_json_default(obj: object) -> object:

--- a/libs/core/kiln_ai/adapters/eval/registry.py
+++ b/libs/core/kiln_ai/adapters/eval/registry.py
@@ -34,6 +34,17 @@ _V2_ADAPTER_MAP: dict[V2EvalType, type[BaseV2EvalBridge]] = {
 }
 
 
+def v2_eval_type_available(eval_config: EvalConfig) -> bool:
+    """Whether this config's V2 type has a registered adapter — the pure
+    availability probe behind the type_not_available skip, safe to call
+    during job collection (no adapter is instantiated)."""
+    if eval_config.config_type != EvalConfigType.v2:
+        return False
+    if not isinstance(eval_config.properties, V2_PROPERTY_TYPES):
+        return False
+    return eval_config.properties.type in _V2_ADAPTER_MAP  # type: ignore[union-attr]
+
+
 def legacy_eval_adapter_from_type(eval_config: EvalConfig) -> type[BaseEval]:
     """Legacy dispatch -- returns a BaseEval subclass for g_eval/llm_as_judge.
 

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -14,6 +14,7 @@ from kiln_ai.adapters.eval.drive_fingerprint import compute_drive_fingerprint
 from kiln_ai.adapters.eval.eval_runner import (
     EvalJob,
     EvalRunner,
+    _drive_usage,
     _is_retryable_error,
 )
 from kiln_ai.adapters.ml_model_list import ModelProviderName
@@ -45,9 +46,15 @@ from kiln_ai.datamodel.eval import (
     UserMessage,
     V2EvalResult,
 )
-from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
+from kiln_ai.datamodel.run_config import (
+    KilnAgentRunConfigProperties,
+    McpRunConfigProperties,
+    MCPToolReference,
+)
 from kiln_ai.datamodel.task import StructuredOutputMode, TaskRunConfig
+from kiln_ai.datamodel.task_run import Usage
 from kiln_ai.datamodel.usage import MessageUsage
+from kiln_ai.synthetic_user.drive_loop import DriveCaseResult
 from kiln_ai.utils.async_job_runner import RetryableError
 from kiln_ai.utils.git_sync_protocols import default_save_context
 from kiln_ai.utils.open_ai_types import ChatCompletionMessageParam
@@ -1824,7 +1831,8 @@ class TestV2FreshGeneration:
         assert len(runs) == 1
         saved = runs[0]
         assert saved.output == "hello"
-        assert saved.dataset_id == fresh_task_run.id
+        # Keyed on the dataset item, not the transient fresh generation.
+        assert saved.dataset_id == stale_task_run.id
         assert saved.scores == {"accuracy": 1.0}
         assert saved.eval_config_eval is False
         assert saved.skipped_reason is None
@@ -1876,7 +1884,7 @@ class TestV2FreshGeneration:
         saved = runs[0]
         assert saved.output == "new answer"
         assert saved.output != "old answer"
-        assert saved.dataset_id == fresh_task_run.id
+        assert saved.dataset_id == stale_task_run.id
 
     @pytest.mark.asyncio
     async def test_task_run_eval_skip_persists_skipped_eval_run(
@@ -1926,7 +1934,7 @@ class TestV2FreshGeneration:
         assert saved.output is None
         assert saved.scores == {}
         assert saved.eval_config_eval is False
-        assert saved.dataset_id == fresh_task_run.id
+        assert saved.dataset_id == stale_task_run.id
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("stub_cls", [StubV2Eval, SkippingStubV2Eval])
@@ -2974,18 +2982,24 @@ def multi_turn_eval_input(mock_task):
     return ei
 
 
-def _fresh_leaf(task: Task, data_source: DataSource) -> TaskRun:
-    """The in-memory leaf drive_case_for_eval would return: id-less,
-    trace-carrying, never saved."""
+def _fresh_leaf(
+    task: Task,
+    data_source: DataSource,
+    su_total_cost: float = 0.0,
+    cumulative_usage: MessageUsage | None = None,
+) -> DriveCaseResult:
+    """The in-memory DriveCaseResult drive_case_for_eval would return:
+    an id-less, trace-carrying, never-saved leaf plus the SU-side spend."""
     leaf = TaskRun(
         input="opening message",
         input_source=data_source,
         output=TaskOutput(output="fresh reply", source=data_source),
         trace=MULTI_TURN_TRACE,
+        cumulative_usage=cumulative_usage,
         parent=task,
     )
     leaf.id = None
-    return leaf
+    return DriveCaseResult(chain=[leaf], su_total_cost=su_total_cost)
 
 
 class TestRunV2MultiTurnRedrive:
@@ -4030,3 +4044,582 @@ class TestTraceReuse:
 
         mock_drive.assert_not_awaited()
         assert stub.seen_inputs[0].trace == cross_trace
+
+
+# -------------------------------------------------------------------
+# Recoverable-skip re-collection tests
+# -------------------------------------------------------------------
+
+
+def _skip_run(
+    eval_config: EvalConfig,
+    run_config_id: str | None,
+    reason: SkippedReason,
+    eval_input_id: str | None = None,
+    dataset_id: str | None = None,
+) -> EvalRun:
+    run = EvalRun(
+        parent=eval_config,
+        eval_input_id=eval_input_id,
+        dataset_id=dataset_id,
+        task_run_config_id=run_config_id,
+        eval_config_eval=False,
+        scores={},
+        input="input",
+        output=None,
+        skipped_reason=reason.value,
+        skipped_detail="test tombstone",
+    )
+    run.save_to_file()
+    return run
+
+
+class TestRecoverableSkipRecollection:
+    """Recoverable skips (missing_drive_config / type_not_available) stop
+    deduping once their blocking condition is lifted; while still blocked
+    they keep deduping so re-triggers never write duplicate tombstones."""
+
+    def test_missing_drive_config_recollected_once_config_set(
+        self, mock_v2_redrive_config, mock_run_config, mock_eval_inputs
+    ):
+        # Tombstone written before the eval had a drive config; the redrive
+        # eval fixture HAS one now, so the item must be collected again.
+        _skip_run(
+            mock_v2_redrive_config,
+            mock_run_config.id,
+            SkippedReason.missing_drive_config,
+            eval_input_id="ei_1",
+        )
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        collected = {j.item.id for j in runner.collect_tasks()}
+        assert collected == {"ei_1", "ei_2"}
+
+    def test_missing_drive_config_still_deduped_while_condition_holds(
+        self, mock_v2_eval_config, mock_run_config, mock_eval_inputs
+    ):
+        # mock_v2_eval has NO drive config: the condition still holds, so the
+        # tombstone keeps deduping (no duplicate skip records per trigger).
+        _skip_run(
+            mock_v2_eval_config,
+            mock_run_config.id,
+            SkippedReason.missing_drive_config,
+            eval_input_id="ei_1",
+        )
+        runner = EvalRunner(
+            eval_configs=[mock_v2_eval_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        collected = {j.item.id for j in runner.collect_tasks()}
+        assert collected == {"ei_2"}
+
+    @pytest.mark.parametrize("available_now", [True, False])
+    def test_type_not_available_follows_adapter_availability(
+        self, mock_v2_eval_config, mock_run_config, mock_eval_inputs, available_now
+    ):
+        _skip_run(
+            mock_v2_eval_config,
+            mock_run_config.id,
+            SkippedReason.type_not_available,
+            eval_input_id="ei_1",
+        )
+        runner = EvalRunner(
+            eval_configs=[mock_v2_eval_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with patch(
+            "kiln_ai.adapters.eval.eval_runner.v2_eval_type_available",
+            return_value=available_now,
+        ):
+            collected = {j.item.id for j in runner.collect_tasks()}
+        assert collected == ({"ei_1", "ei_2"} if available_now else {"ei_2"})
+
+    def test_terminal_skips_still_dedupe(
+        self, mock_v2_redrive_config, mock_run_config, mock_eval_inputs
+    ):
+        # Non-recoverable skips are verdicts about the input itself — a lifted
+        # drive config must not resurrect them.
+        _skip_run(
+            mock_v2_redrive_config,
+            mock_run_config.id,
+            SkippedReason.incompatible_input_shape,
+            eval_input_id="ei_1",
+        )
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        collected = {j.item.id for j in runner.collect_tasks()}
+        assert collected == {"ei_2"}
+
+    def test_task_run_lane_recollects_recoverable_skips(
+        self, mock_task, mock_v2_task_run_eval_config, mock_run_config, data_source
+    ):
+        # Same semantics on the TaskRun-sourced lane (eval_set_filter_id).
+        task_run = TaskRun(
+            input="test input",
+            output=TaskOutput(output="out", source=data_source),
+            parent=mock_task,
+        )
+        task_run.save_to_file()
+        _skip_run(
+            mock_v2_task_run_eval_config,
+            mock_run_config.id,
+            SkippedReason.type_not_available,
+            dataset_id=task_run.id,
+        )
+        runner = EvalRunner(
+            eval_configs=[mock_v2_task_run_eval_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with patch(
+            "kiln_ai.adapters.eval.eval_runner.v2_eval_type_available",
+            return_value=True,
+        ):
+            jobs = runner.collect_tasks()
+        assert {j.item.id for j in jobs} == {task_run.id}
+
+
+# -------------------------------------------------------------------
+# KIL-749 regression: fresh generations are keyed on the dataset item
+# -------------------------------------------------------------------
+
+
+class TestFreshGenerationDatasetId:
+    @pytest.mark.asyncio
+    async def test_unsaved_fresh_run_does_not_crash_record_keys_on_item(
+        self,
+        mock_v2_task_run_eval_runner,
+        mock_v2_task_run_eval_config,
+        mock_run_config,
+        data_source,
+    ):
+        """KIL-749: run_task returns an UNSAVED TaskRun (id None). Keying the
+        record on it crashed EvalRun validation for every TaskRun-backed item;
+        the record must key on the dataset item instead."""
+        item = TaskRun(
+            input="test input",
+            output=TaskOutput(output="stored", source=data_source),
+            parent=mock_v2_task_run_eval_runner.task,
+        )
+        item.save_to_file()
+        fresh = TaskRun(
+            input="test input",
+            input_source=data_source,
+            output=TaskOutput(output="hello", source=data_source),
+        )
+        fresh.id = None
+
+        job = EvalJob(
+            item=item,
+            eval_config=mock_v2_task_run_eval_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+        stub = StubV2Eval(mock_v2_task_run_eval_config)
+        with (
+            patch.object(stub, "run_task", return_value=fresh),
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+        ):
+            assert await mock_v2_task_run_eval_runner.run_job(job) is True
+
+        runs = mock_v2_task_run_eval_config.runs(readonly=True)
+        assert len(runs) == 1
+        assert runs[0].dataset_id == item.id
+        # Dedup now recognizes the item as done.
+        assert mock_v2_task_run_eval_runner.collect_tasks() == []
+
+
+# -------------------------------------------------------------------
+# Cost recording tests
+# -------------------------------------------------------------------
+
+
+class TestEvalRunUsageRecording:
+    @pytest.mark.asyncio
+    async def test_drive_records_agent_usage_plus_su_cost(
+        self,
+        mock_task,
+        mock_run_config,
+        mock_v2_redrive_config,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        drive_result = _fresh_leaf(
+            mock_task,
+            data_source,
+            su_total_cost=0.25,
+            cumulative_usage=MessageUsage(
+                input_tokens=100, output_tokens=50, total_tokens=150, cost=1.0
+            ),
+        )
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        job = EvalJob(
+            item=multi_turn_eval_input,
+            eval_config=mock_v2_redrive_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=StubV2Eval(mock_v2_redrive_config),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=drive_result),
+            ),
+        ):
+            await runner.run_job(job)
+
+        saved = mock_v2_redrive_config.runs(readonly=True)[0]
+        assert saved.task_run_usage is not None
+        # Cost totals both sides; token counts are agent-side only.
+        assert saved.task_run_usage.cost == pytest.approx(1.25)
+        assert saved.task_run_usage.input_tokens == 100
+        assert saved.task_run_usage.total_tokens == 150
+
+    @pytest.mark.asyncio
+    async def test_reused_trace_records_no_usage(
+        self,
+        mock_task,
+        mock_run_config,
+        reuse_eval,
+        reuse_config_a,
+        reuse_config_b,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """A reuse hit pays nothing — recording the original drive's spend
+        again would double-book it."""
+        drive_result = _fresh_leaf(
+            mock_task,
+            data_source,
+            su_total_cost=0.25,
+            cumulative_usage=MessageUsage(cost=1.0),
+        )
+        runner = EvalRunner(
+            eval_configs=[reuse_config_a, reuse_config_b],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        # Config A's job drives (and records spend); config B's job reuses
+        # the in-memory trace.
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                side_effect=lambda config, *_: StubV2Eval(config),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=drive_result),
+            ) as mock_drive,
+        ):
+            for config in (reuse_config_a, reuse_config_b):
+                await runner.run_job(
+                    make_reuse_job(multi_turn_eval_input, config, mock_run_config)
+                )
+
+        assert mock_drive.await_count == 1
+        driven = reuse_config_a.runs(readonly=True)[0]
+        reused = reuse_config_b.runs(readonly=True)[0]
+        assert driven.task_run_usage is not None
+        assert driven.task_run_usage.cost == pytest.approx(1.25)
+        assert reused.task_run_usage is None
+
+    @pytest.mark.asyncio
+    async def test_eval_input_fresh_generation_records_usage(
+        self,
+        mock_v2_eval_config,
+        mock_run_config,
+        mock_eval_inputs,
+        data_source,
+    ):
+        fresh = TaskRun(
+            input="What is 2+2?",
+            input_source=data_source,
+            output=TaskOutput(output="hello", source=data_source),
+            usage=Usage(cost=0.3, total_tokens=42),
+        )
+        fresh.id = None
+        runner = EvalRunner(
+            eval_configs=[mock_v2_eval_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        job = EvalJob(
+            item=mock_eval_inputs[0],
+            eval_config=mock_v2_eval_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+        stub = StubV2Eval(mock_v2_eval_config)
+        with (
+            patch.object(stub, "run_task", return_value=fresh),
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+        ):
+            await runner.run_job(job)
+
+        saved = mock_v2_eval_config.runs(readonly=True)[0]
+        assert saved.task_run_usage is not None
+        assert saved.task_run_usage.cost == pytest.approx(0.3)
+        assert saved.task_run_usage.total_tokens == 42
+
+
+class TestDriveUsage:
+    def test_none_when_nothing_reported(self, mock_task, data_source):
+        leaf = _fresh_leaf(mock_task, data_source).chain[-1]
+        assert _drive_usage(leaf, 0.0) is None
+
+    def test_su_cost_only(self, mock_task, data_source):
+        leaf = _fresh_leaf(mock_task, data_source).chain[-1]
+        usage = _drive_usage(leaf, 0.5)
+        assert usage is not None
+        assert usage.cost == pytest.approx(0.5)
+        assert usage.total_tokens is None
+
+    def test_agent_usage_only(self, mock_task, data_source):
+        leaf = _fresh_leaf(
+            mock_task,
+            data_source,
+            cumulative_usage=MessageUsage(cost=2.0, total_tokens=10),
+        ).chain[-1]
+        usage = _drive_usage(leaf, 0.0)
+        assert usage is not None
+        assert usage.cost == pytest.approx(2.0)
+        assert usage.total_tokens == 10
+
+
+# -------------------------------------------------------------------
+# Up-front multi-turn drive validation tests
+# -------------------------------------------------------------------
+
+
+class TestValidateMultiTurnDriveReadiness:
+    def test_no_drive_config_is_noop(self, mock_v2_eval_config, mock_run_config):
+        runner = EvalRunner(
+            eval_configs=[mock_v2_eval_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        runner.validate_multi_turn_drive_readiness()
+
+    def test_valid_setup_passes(self, mock_v2_redrive_config, mock_run_config):
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        runner.validate_multi_turn_drive_readiness()
+
+    def test_non_agent_run_config_rejected(self, mock_task, mock_v2_redrive_config):
+        mcp_rc = TaskRunConfig(
+            name="mcp config",
+            description="not an agent",
+            run_config_properties=McpRunConfigProperties(
+                tool_reference=MCPToolReference(
+                    tool_id="mcp::local::server1::tool1",
+                ),
+            ),
+            parent=mock_task,
+        )
+        mcp_rc.save_to_file()
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config],
+            run_configs=[mcp_rc],
+            eval_run_type="task_run_eval",
+        )
+        with pytest.raises(ValueError, match="mcp config"):
+            runner.validate_multi_turn_drive_readiness()
+
+    def test_bad_su_provider_rejected(self, mock_task, mock_run_config):
+        eval = Eval(
+            id="bad_provider_eval",
+            name="bad provider eval",
+            description="drive config with unknown provider",
+            eval_input_filter_id="all",
+            eval_configs_filter_id="all",
+            evaluation_data_type=EvalDataType.full_trace,
+            multi_turn_drive_config=MultiTurnDriveConfig(
+                model_name="claude_4_5_haiku",
+                model_provider="not_a_real_provider",
+                turns=3,
+            ),
+            output_scores=[
+                EvalOutputScore(
+                    name="Accuracy",
+                    instruction="Check",
+                    type=TaskOutputRatingType.pass_fail,
+                ),
+            ],
+            parent=mock_task,
+        )
+        eval.save_to_file()
+        config = EvalConfig(
+            name="bad provider cfg",
+            config_type=EvalConfigType.v2,
+            properties=ExactMatchProperties(expected_value="x"),
+            parent=eval,
+        )
+        config.save_to_file()
+        runner = EvalRunner(
+            eval_configs=[config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        with pytest.raises(ValueError, match="not_a_real_provider"):
+            runner.validate_multi_turn_drive_readiness()
+
+
+class TestSupersededTombstoneDeletion:
+    @pytest.mark.asyncio
+    async def test_replacement_run_deletes_tombstone(
+        self,
+        mock_task,
+        mock_run_config,
+        mock_v2_redrive_config,
+        multi_turn_eval_input,
+        data_source,
+    ):
+        """Once a re-collected item persists its fresh record, the old
+        tombstone is deleted — two records on one item would race in
+        first-found read paths (the fresh score could be masked)."""
+        tombstone = _skip_run(
+            mock_v2_redrive_config,
+            mock_run_config.id,
+            SkippedReason.missing_drive_config,
+            eval_input_id="ei_redrive",
+        )
+        tombstone_path = tombstone.path
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        jobs = runner.collect_tasks()
+        job = next(j for j in jobs if j.item.id == "ei_redrive")
+        assert [t.id for t in job.superseded_tombstones] == [tombstone.id]
+
+        with (
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=StubV2Eval(mock_v2_redrive_config),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.eval_runner.drive_case_for_eval",
+                new=AsyncMock(return_value=_fresh_leaf(mock_task, data_source)),
+            ),
+        ):
+            assert await runner.run_job(job) is True
+
+        assert not tombstone_path.exists()
+        runs = mock_v2_redrive_config.runs(readonly=True)
+        assert len(runs) == 1
+        assert runs[0].skipped_reason is None
+        assert runs[0].eval_input_id == "ei_redrive"
+
+    def test_still_blocked_tombstone_not_marked_superseded(
+        self, mock_v2_eval_config, mock_run_config, mock_eval_inputs
+    ):
+        """While the condition holds, the tombstone dedupes and no job
+        carries it for deletion."""
+        _skip_run(
+            mock_v2_eval_config,
+            mock_run_config.id,
+            SkippedReason.missing_drive_config,
+            eval_input_id="ei_1",
+        )
+        runner = EvalRunner(
+            eval_configs=[mock_v2_eval_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        jobs = runner.collect_tasks()
+        assert all(j.superseded_tombstones == [] for j in jobs)
+
+
+class TestValidateReadinessSourceGating:
+    def test_task_run_source_with_drive_config_is_noop(
+        self, mock_task, mock_run_config
+    ):
+        """A drive config on a stored-TaskRun-sourced eval never drives
+        (chain leaves judge their stored trace), so validation must not
+        block the run — even with problems it would otherwise flag."""
+        eval = Eval(
+            id="tr_drive_eval",
+            name="task run eval with drive cfg",
+            description="drive config is vestigial here",
+            eval_set_filter_id="all",
+            eval_configs_filter_id="all",
+            evaluation_data_type=EvalDataType.full_trace,
+            multi_turn_drive_config=MultiTurnDriveConfig(
+                model_name="claude_4_5_haiku",
+                model_provider="not_a_real_provider",
+                turns=3,
+            ),
+            output_scores=[
+                EvalOutputScore(
+                    name="Accuracy",
+                    instruction="Check",
+                    type=TaskOutputRatingType.pass_fail,
+                ),
+            ],
+            parent=mock_task,
+        )
+        eval.save_to_file()
+        config = EvalConfig(
+            name="tr drive cfg",
+            config_type=EvalConfigType.v2,
+            properties=ExactMatchProperties(expected_value="x"),
+            parent=eval,
+        )
+        config.save_to_file()
+        runner = EvalRunner(
+            eval_configs=[config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        runner.validate_multi_turn_drive_readiness()
+
+    def test_check_run_configs_false_skips_run_config_problems(
+        self, mock_task, mock_v2_redrive_config
+    ):
+        """With an un-hand-picked fleet (all_run_configs), one incompatible
+        run config must not block the others — only drive-config problems
+        (which block every job) still raise."""
+        mcp_rc = TaskRunConfig(
+            name="mcp fleet member",
+            description="not an agent",
+            run_config_properties=McpRunConfigProperties(
+                tool_reference=MCPToolReference(
+                    tool_id="mcp::local::server1::tool1",
+                ),
+            ),
+            parent=mock_task,
+        )
+        mcp_rc.save_to_file()
+        runner = EvalRunner(
+            eval_configs=[mock_v2_redrive_config],
+            run_configs=[mcp_rc],
+            eval_run_type="task_run_eval",
+        )
+        runner.validate_multi_turn_drive_readiness(check_run_configs=False)
+        with pytest.raises(ValueError, match="mcp fleet member"):
+            runner.validate_multi_turn_drive_readiness()

--- a/libs/core/kiln_ai/adapters/eval/test_registry.py
+++ b/libs/core/kiln_ai/adapters/eval/test_registry.py
@@ -7,6 +7,7 @@ from kiln_ai.adapters.eval.g_eval import GEval
 from kiln_ai.adapters.eval.registry import (
     legacy_eval_adapter_from_type,
     v2_eval_adapter_from_config,
+    v2_eval_type_available,
 )
 from kiln_ai.datamodel.eval import (
     CodeEvalProperties,
@@ -107,3 +108,21 @@ class TestV2EvalAdapterFromConfig:
         cfg = _mock_eval_config(EvalConfigType.g_eval)
         with pytest.raises(ValueError, match="only accepts V2 configs"):
             v2_eval_adapter_from_config(cfg)
+
+
+class TestV2EvalTypeAvailable:
+    """The pure availability probe: True exactly when dispatch would succeed."""
+
+    @pytest.mark.parametrize(
+        "v2_type", TestV2EvalAdapterFromConfig._IMPLEMENTED_V2_TYPES
+    )
+    def test_registered_types_available(self, v2_type: V2EvalType):
+        assert v2_eval_type_available(_mock_v2_eval_config(v2_type)) is True
+
+    def test_legacy_config_not_available(self):
+        assert v2_eval_type_available(_mock_eval_config(EvalConfigType.g_eval)) is False
+
+    def test_untyped_properties_not_available(self):
+        cfg = _mock_eval_config(EvalConfigType.v2)
+        cfg.properties = {"type": "llm_judge"}
+        assert v2_eval_type_available(cfg) is False

--- a/libs/core/kiln_ai/synthetic_user/eval_drive.py
+++ b/libs/core/kiln_ai/synthetic_user/eval_drive.py
@@ -17,7 +17,7 @@ from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.task import Task
 from kiln_ai.datamodel.task_output import DataSource, DataSourceType
 from kiln_ai.datamodel.task_run import TaskRun
-from kiln_ai.synthetic_user.drive_loop import drive_case
+from kiln_ai.synthetic_user.drive_loop import DriveCaseResult, drive_case
 from kiln_ai.synthetic_user.driver import SyntheticUserDriver
 from kiln_ai.synthetic_user.models import (
     SyntheticUserDriverConfig,
@@ -40,12 +40,14 @@ async def drive_case_for_eval(
     su_driver_config: SyntheticUserDriverConfig,
     turns: int,
     skills: SkillsDict,
-) -> TaskRun:
-    """Drive one case in memory and return the leaf TaskRun (never saved).
+) -> DriveCaseResult:
+    """Drive one case in memory and return the full DriveCaseResult (never saved).
 
-    The leaf's `.trace` holds the full cumulative conversation and its id is
-    None (nothing touches disk). `skills` must be preloaded by the caller —
-    the adapter raises on skill tools with no injected dict.
+    The result's leaf (`chain[-1]`) has `.trace` holding the full cumulative
+    conversation and its id is None (nothing touches disk). The result also
+    carries `su_total_cost` — the synthetic user's LLM spend, which surfaces
+    nowhere else since SU turns aren't persisted. `skills` must be preloaded
+    by the caller — the adapter raises on skill tools with no injected dict.
     """
     su_driver = SyntheticUserDriver(synthetic_user_info, su_driver_config)
     adapter = adapter_for_task(
@@ -77,10 +79,9 @@ async def drive_case_for_eval(
             prior_trace=prior_trace,
         )
 
-    result = await drive_case(
+    return await drive_case(
         seed_prompt=seed_prompt,
         target_invoker=_invoker,
         su_driver=su_driver,
         turns=turns,
     )
-    return result.chain[-1]

--- a/libs/core/kiln_ai/synthetic_user/test_eval_drive.py
+++ b/libs/core/kiln_ai/synthetic_user/test_eval_drive.py
@@ -115,7 +115,7 @@ async def test_drives_turns_and_returns_leaf(fake_adapter, fake_su_driver) -> No
     adapter, _ = fake_adapter
     task = Mock(spec=Task)
 
-    leaf = await drive_case_for_eval(
+    result = await drive_case_for_eval(
         seed_prompt="opening message",
         synthetic_user_info=_INFO,
         target_task=task,
@@ -133,9 +133,12 @@ async def test_drives_turns_and_returns_leaf(fake_adapter, fake_su_driver) -> No
     # Continuity rides prior_trace, growing turn over turn.
     assert adapter.calls[0]["prior_trace"] is None
     assert len(adapter.calls[2]["prior_trace"]) == 4
-    # The leaf is the last turn's run: unsaved, full cumulative trace.
+    # The leaf is the last turn's run: unsaved, full cumulative trace. The
+    # SU spend rides the result (each mocked respond() reports 0.0 cost).
+    leaf = result.chain[-1]
     assert leaf.id is None
     assert len(leaf.trace) == 6
+    assert result.su_total_cost == 0.0
 
     # The SU driver was built from the typed persona.
     assert fake_su_driver.ctor_args["info"] is _INFO


### PR DESCRIPTION
Phase 6.8 Session B: the self-contained pre-bug-bash items from the adoption audit, plus the KIL-749 fix. Full checks green; paid harness green against a local kiln_server (2 passed).

KIL-749 (bash-blocking, re-verified real): the TaskRun-lane task_run_eval branch keyed EvalRun.dataset_id on the unsaved fresh generation, whose id is None by adapter design, so every TaskRun-backed run_comparison item crashed EvalRun validation. Now keys on the dataset item, which also makes dedup recognize completed items. The old tests had the bug baked in (their mock fresh run was saved, so its id was non-None) — corrected, plus a regression test using an id-less fresh run.

Recoverable skips heal: missing_drive_config and type_not_available tombstones stop deduping once their blocking condition lifts (drive config set / adapter type registered, via the new registry.v2_eval_type_available probe). The replacing job deletes the superseded tombstone after its record persists, so an item never carries two records (first-found read paths could otherwise mask the fresh score). Still-blocked tombstones keep deduping, so re-triggers never write duplicates. Partial coverage of KIL-755; the general re-run story stays open.

Cost recording: drive_case_for_eval now returns the full DriveCaseResult instead of the bare leaf, and v2 records persist task_run_usage — drives record agent cumulative usage plus the SU driver's cost (which surfaces nowhere else), fresh single-turn generations record the run's usage, and reused traces record none since the driving record owns the spend.

Up-front validation: run_comparison returns one clean 400 before the SSE stream on an unknown SU provider or non-agent run configs, instead of N anonymous per-job errors. With all_run_configs, only drive-config problems block, so one incompatible config can't sink the whole fleet. run_calibration 400s on an empty golden set instead of vacuously succeeding.

Save guards in copilot_api: the duplicate-spec 409 now compares tag-normalized names ("My Spec" vs "My_Spec" previously shared a tag namespace silently); names with no score-key characters (e.g. fully non-ASCII) fail request validation instead of saving an eval that can never run; reference_answer spec types are rejected until the judge template can render the reference.

Builder UI: the refine-at-save fallback now logs the validator message and captures a posthog event instead of failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)