### PR TITLE
Increase compare screen max run configs from 6 to 10

### DIFF
--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -511,7 +511,7 @@
     create_new_run_config_dialog?.show()
   }
 
-  const MAX_COLUMNS = 6
+  const MAX_COLUMNS = 10
   function addColumn() {
     if (columns < MAX_COLUMNS) {
       columns++


### PR DESCRIPTION
## What

Raises the maximum number of run configs that can be compared side-by-side on the run config comparison screen from **6 to 10**.

## Why

Users want to compare more than 6 run configs at once.

## Change

Single UI-only change: `MAX_COLUMNS` in `compare/+page.svelte` bumped from `6` → `10`. This constant already gates all three relevant paths (add-column button, URL param validation, and the add-column control), so no other edits are needed. The grid layout is already dynamic (`repeat({columns}, 1fr)`), so it adapts automatically.

## Testing

- `prettier --check` passes on the changed file.
- Change is a single numeric constant; no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)