### PR TITLE
fix(evals): V2 LLM judges persist no reasoning — ask for it in the schema

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/base_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/base_eval.py
@@ -27,6 +27,16 @@ from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 DEFAULT_SYSTEM_PROMPT = "You are an evaluator."
 _DEFAULT_THINKING_INSTRUCTION = "Think step by step, explaining your reasoning."
 
+# Schema key the LLM judge writes its rationale into. Lifted out of the judge's
+# structured output into EvalRun.intermediate_outputs, so it must never collide
+# with an output score's json_key. Matches the key the web UI's "View reasoning"
+# control reads.
+REASONING_SCHEMA_KEY = "reasoning"
+
+# Fallback slot used only when a reasoning-capable provider already deposited
+# native reasoning under REASONING_SCHEMA_KEY, so neither record is lost.
+JUDGE_RATIONALE_KEY = "judge_rationale"
+
 _JINJA_OPENERS = ("{{", "{%", "{#")
 
 
@@ -350,7 +360,12 @@ class BaseEval:
         pass
 
     @classmethod
-    def build_score_schema(cls, eval: Eval, allow_float_scores: bool = False) -> str:
+    def build_score_schema(
+        cls,
+        eval: Eval,
+        allow_float_scores: bool = False,
+        reasoning_instruction: str | None = None,
+    ) -> str:
         """
         Build a JSON schema for the scoring output of the task requirements
 
@@ -358,6 +373,10 @@ class BaseEval:
 
         allow_float_scores=False is used for the call to the model, and forces the model into selecting into discrete rating options (int 1-5, pass-fail, etc).
         allow_float_scores=True is used for final score output (for example, after we take a g-eval weighting of the model's logprobs). A pass/fail rating might return 0.75 for likely pass (as opposed to 0.99 for near certain pass), or a 1-5 score might return 3.75.
+
+        When *reasoning_instruction* is set, a leading string field is added so the
+        judge states its rationale in the same structured response as the scores.
+        It is NOT an output score — the caller must strip it before scoring.
         """
 
         # Note: python maintains order, which is good as we want the user defined order, and overall last
@@ -425,6 +444,19 @@ class BaseEval:
                     raise_exhaustive_enum_error(output_score.type)
 
             properties[output_score_json_key] = property
+
+        if reasoning_instruction:
+            # Prepended, not appended: the model states its rationale BEFORE
+            # committing to scores, so the scores are conditioned on the
+            # reasoning rather than rationalised after the fact.
+            properties = {
+                REASONING_SCHEMA_KEY: {
+                    "type": "string",
+                    "title": "Reasoning",
+                    "description": reasoning_instruction,
+                },
+                **properties,
+            }
 
         schema = {
             "type": "object",

--- a/libs/core/kiln_ai/adapters/eval/test_v2_eval_llm_judge.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_eval_llm_judge.py
@@ -96,6 +96,125 @@ class TestLlmJudgeTask:
         assert task.output_json_schema == _VALID_SCHEMA
 
 
+class TestLlmJudgeReasoningCapture:
+    """A judge with no persisted reasoning cannot be audited: EvalRun
+    intermediate_outputs is the only record of WHY a verdict was reached, and
+    the web UI's "View reasoning" control reads it."""
+
+    @staticmethod
+    def _mock(mock_adapter_for_task, output=None, intermediate_outputs=None):
+        mock_adapter = AsyncMock()
+        mock_adapter.invoke_returning_run_output.return_value = (
+            Mock(),
+            RunOutput(
+                output=output if output is not None else {"quality": "4"},
+                intermediate_outputs=intermediate_outputs,
+            ),
+        )
+        mock_adapter_for_task.return_value = mock_adapter
+        return mock_adapter
+
+    @staticmethod
+    def _judge_schema(mock_adapter_for_task):
+        return json.loads(mock_adapter_for_task.call_args.args[0].output_json_schema)
+
+    @pytest.mark.asyncio
+    @patch("kiln_ai.adapters.eval.v2_eval_llm_judge.adapter_for_task")
+    async def test_judge_asked_for_reasoning_first(self, mock_adapter_for_task):
+        """The rationale field leads the schema so scores are conditioned on it
+        rather than rationalised after the fact."""
+        self._mock(
+            mock_adapter_for_task,
+            output={"reasoning": "Fails: it invented an assignee.", "quality": "1"},
+        )
+
+        cfg = _make_config(_make_props(thinking_instruction="Explain your reasoning."))
+        result = await LlmJudgeEval(cfg).evaluate(_inp())
+
+        schema = self._judge_schema(mock_adapter_for_task)
+        assert list(schema["properties"]) == ["reasoning", "quality"]
+        assert schema["properties"]["reasoning"]["description"] == (
+            "Explain your reasoning."
+        )
+        assert "reasoning" in schema["required"]
+
+        # reasoning is persisted, and never leaks into scores
+        assert result.intermediate_outputs == {
+            "reasoning": "Fails: it invented an assignee."
+        }
+        assert result.scores == {"quality": 1.0}
+
+    @pytest.mark.asyncio
+    @patch("kiln_ai.adapters.eval.v2_eval_llm_judge.adapter_for_task")
+    async def test_no_thinking_instruction_means_no_reasoning_field(
+        self, mock_adapter_for_task
+    ):
+        self._mock(mock_adapter_for_task)
+
+        cfg = _make_config(_make_props(thinking_instruction=None))
+        result = await LlmJudgeEval(cfg).evaluate(_inp())
+
+        assert list(self._judge_schema(mock_adapter_for_task)["properties"]) == [
+            "quality"
+        ]
+        assert result.scores == {"quality": 4.0}
+        assert result.intermediate_outputs is None
+
+    @pytest.mark.asyncio
+    @patch("kiln_ai.adapters.eval.v2_eval_llm_judge.adapter_for_task")
+    async def test_native_provider_reasoning_is_not_clobbered(
+        self, mock_adapter_for_task
+    ):
+        """Reasoning-capable providers already deposit native reasoning under
+        the same key — keep both records."""
+        self._mock(
+            mock_adapter_for_task,
+            output={"reasoning": "Stated rationale.", "quality": "4"},
+            intermediate_outputs={"reasoning": "Native model thinking."},
+        )
+
+        cfg = _make_config(_make_props(thinking_instruction="Explain your reasoning."))
+        result = await LlmJudgeEval(cfg).evaluate(_inp())
+
+        assert result.intermediate_outputs == {
+            "reasoning": "Native model thinking.",
+            "judge_rationale": "Stated rationale.",
+        }
+        assert result.scores == {"quality": 4.0}
+
+    @pytest.mark.asyncio
+    @patch("kiln_ai.adapters.eval.v2_eval_llm_judge.adapter_for_task")
+    async def test_g_eval_keeps_schema_free_of_reasoning(self, mock_adapter_for_task):
+        """g_eval rebuilds raw JSON from logprobs and needs each metric name to
+        appear exactly once — a free-text rationale quoting a score name would
+        turn a missing rationale into a hard scoring failure."""
+        self._mock(mock_adapter_for_task, output={"quality": "5"})
+
+        cfg = _make_config(
+            _make_props(g_eval=True, thinking_instruction="Explain your reasoning.")
+        )
+        with patch(
+            "kiln_ai.adapters.eval.v2_eval_llm_judge.build_g_eval_score"
+        ) as mock_g_eval_score:
+            mock_g_eval_score.return_value = {"quality": 4.3}
+            await LlmJudgeEval(cfg).evaluate(_inp())
+
+        assert list(self._judge_schema(mock_adapter_for_task)["properties"]) == [
+            "quality"
+        ]
+
+    @pytest.mark.asyncio
+    @patch("kiln_ai.adapters.eval.v2_eval_llm_judge.adapter_for_task")
+    async def test_blank_reasoning_is_not_persisted(self, mock_adapter_for_task):
+        self._mock(mock_adapter_for_task, output={"reasoning": "   ", "quality": "4"})
+
+        cfg = _make_config(_make_props(thinking_instruction="Explain your reasoning."))
+        result = await LlmJudgeEval(cfg).evaluate(_inp())
+
+        assert result.scores == {"quality": 4.0}
+        assert result.intermediate_outputs is None
+
+
 class TestLlmJudgeEvalLlmAsJudge:
     @pytest.mark.asyncio
     @patch("kiln_ai.adapters.eval.v2_eval_llm_judge.adapter_for_task")

--- a/libs/core/kiln_ai/adapters/eval/v2_eval_llm_judge.py
+++ b/libs/core/kiln_ai/adapters/eval/v2_eval_llm_judge.py
@@ -13,7 +13,12 @@ from typing import TYPE_CHECKING
 from jinja2 import UndefinedError
 
 from kiln_ai.adapters.adapter_registry import adapter_for_task
-from kiln_ai.adapters.eval.base_eval import BaseEval, BaseV2EvalBridge
+from kiln_ai.adapters.eval.base_eval import (
+    JUDGE_RATIONALE_KEY,
+    REASONING_SCHEMA_KEY,
+    BaseEval,
+    BaseV2EvalBridge,
+)
 
 if TYPE_CHECKING:
     from kiln_ai.adapters.model_adapters.base_adapter import SkillsDict
@@ -116,8 +121,22 @@ class LlmJudgeEval(BaseV2EvalBridge):
                 skipped_detail=f"Template references missing data: {e}",
             )
 
+        # Ask the judge to state WHY in the same structured response as the
+        # scores. Without this the judge leaves no rationale behind: V2 runs a
+        # single SIMPLE call (no chain-of-thought turn), so unless the provider
+        # happens to return native reasoning content, EvalRun
+        # intermediate_outputs is empty and no verdict can be audited.
+        #
+        # Not in g_eval mode: that path rebuilds raw JSON from logprobs and
+        # requires each metric name to appear EXACTLY once in it, so a free-text
+        # rationale that happens to quote a score name would turn a missing
+        # rationale into a hard scoring failure. g_eval keeps native provider
+        # reasoning only.
+        reasoning_instruction = None if props.g_eval else props.thinking_instruction
         output_json_schema = BaseEval.build_score_schema(
-            self.eval, allow_float_scores=False
+            self.eval,
+            allow_float_scores=False,
+            reasoning_instruction=reasoning_instruction,
         )
 
         system_prompt = props.system_prompt or _DEFAULT_SYSTEM_PROMPT
@@ -167,6 +186,15 @@ class LlmJudgeEval(BaseV2EvalBridge):
 
         _, run_output = await adapter.invoke_returning_run_output(rendered_prompt)
 
+        # Lift the rationale out of the scored output. Both scoring paths derive
+        # their metric list from output.keys(), so leaving it in would fail as
+        # "No score found for metric: reasoning".
+        judge_reasoning: str | None = None
+        if reasoning_instruction and isinstance(run_output.output, dict):
+            popped = run_output.output.pop(REASONING_SCHEMA_KEY, None)
+            if isinstance(popped, str) and popped.strip():
+                judge_reasoning = popped.strip()
+
         if props.g_eval:
             scores = build_g_eval_score(
                 run_output,
@@ -180,7 +208,17 @@ class LlmJudgeEval(BaseV2EvalBridge):
                 score_from_token_string,
             )
 
+        # Reasoning-capable providers already deposit native reasoning under the
+        # same key. Keep both rather than clobbering either: the web UI reads
+        # `reasoning` first, so whichever is present still surfaces.
+        intermediate_outputs = dict(run_output.intermediate_outputs or {})
+        if judge_reasoning:
+            if intermediate_outputs.get(REASONING_SCHEMA_KEY):
+                intermediate_outputs[JUDGE_RATIONALE_KEY] = judge_reasoning
+            else:
+                intermediate_outputs[REASONING_SCHEMA_KEY] = judge_reasoning
+
         return V2EvalResult(
             scores=scores,
-            intermediate_outputs=run_output.intermediate_outputs,
+            intermediate_outputs=intermediate_outputs or None,
         )


### PR DESCRIPTION
## The bug

Judge EvalRuns are meant to record **why** a verdict was reached: `intermediate_outputs` is persisted on the EvalRun, and `llm_judge_result.svelte` has a **"View reasoning"** control that reads it (`intermediate_outputs?.reasoning || ?.chain_of_thought`).

For **V2 `llm_judge` configs that record is empty**, so no verdict can be audited. The control never appears.

### Cause

The V2 judge invokes the adapter with `prompt_id=PromptGenerators.SIMPLE` — a single call, no chain-of-thought turn — so nothing ever populates `intermediate_outputs`. The sole exception is a reasoning-capable provider returning native `reasoning_content` (`litellm_adapter._extract_reasoning_to_intermediate_outputs`), which is strategy-independent.

The V1 G-Eval / LLM-as-Judge lane hardcodes `SIMPLE_CHAIN_OF_THOUGHT` ("We always use Simple COT for G-Eval and LLM as Judge") and therefore always records a `chain_of_thought`.

`d1209663e` wired `intermediate_outputs` from the judge through `V2EvalResult` to `EvalRun` persistence (D31). The plumbing is correct — it's just connected to a source that produces nothing.

### Scope: which judges are actually affected

Native reasoning capture (`litellm_adapter._extract_reasoning_to_intermediate_outputs`) is **strategy-independent** — it fires whenever the provider returns `reasoning_content`, SIMPLE call or not. So:

| Judge model | `intermediate_outputs` today |
|---|---|
| **Reasoning-native** (e.g. deepseek) | populated — native `reasoning_content` is captured regardless of prompt strategy |
| **Non-reasoning** (gpt-5.4, gpt-4o, sonnet w/o thinking) | **empty** — no COT turn, no native reasoning, nothing to record |

The gap is the second row, and it is a total absence rather than a degradation.

Evidence, stated precisely:

- A V1 `llm_as_judge` project on `gpt_5_4`: **19,030 / 19,030** EvalRuns carry `chain_of_thought`. The same model on the V2 path has no mechanism to produce one — the only difference is that V1 runs Simple COT.
- A V2 judge run on `deepseek_4_pro` **did** record reasoning (1/1), via native capture — consistent with the table above.
- I have no on-disk V2-judge-plus-non-reasoning-model run to show the empty case directly; that combination has not been run here. The claim for that row rests on the code path: `SIMPLE` → no cot_prompt → `single_turn` strategy → `chat_formatter` never sets `chain_of_thought`, and no native reasoning arrives.

### Compounding: a dead field

`materialize_llm_judge_properties` — the shared create+test path — **always** sets `thinking_instruction` to `"Think step by step, explaining your reasoning."`. Nothing in the V2 path ever read it (`grep thinking_instruction v2_eval_llm_judge.py` → no hits). It was stored, surfaced in the config, and silently ignored.

## The fix

Keeps the single `SIMPLE` call — no chain-of-thought turn, nothing added to the deprecated CoT path.

- `build_score_schema()` takes an optional `reasoning_instruction`. When set, it **prepends** a `reasoning` string field, so the judge states its rationale *before* committing to scores rather than rationalising after the fact.
- The V2 judge passes `thinking_instruction` as that instruction — giving the dead field a real job — then pops `reasoning` out of the output before scoring and files it under `intermediate_outputs["reasoning"]`, the key the web UI already reads. **No frontend change needed.**
- Native provider reasoning is preserved: if it already occupies `reasoning`, the judge's stated rationale lands in `judge_rationale` rather than clobbering it.
- **Skipped in `g_eval` mode.** That path rebuilds raw JSON from logprobs and `metric_offsets` requires each metric name to appear *exactly once*; a free-text rationale that quoted a score name would turn a missing rationale into a hard scoring failure. g_eval keeps native provider reasoning only.

Scores are unaffected — `build_llm_as_judge_score` and `build_g_eval_score` both derive their metric list from `output.keys()`, and `reasoning` is removed before either runs.

## Why the existing test didn't catch it

`test_intermediate_outputs_propagated` mocks the adapter's return value, so it proves the plumbing while the source stays empty. The new tests assert the **schema the judge is actually handed** and that the rationale never leaks into scores.

## Tests (run on this base)

- 5 new tests: reasoning field leads the schema and carries the instruction; rationale persisted and kept out of scores; no instruction → no field; native reasoning not clobbered; g_eval schema stays clean; blank rationale not persisted.
- `libs/core/kiln_ai/adapters/eval/`: 546 passed.
- `libs/core/kiln_ai/adapters/` + `datamodel/` + `test_eval_api.py`: 3898 passed.
- `ruff format --check` + `ruff check`: clean.

## Note for existing data

Capture-forward only. V2 judge EvalRuns already on disk have no rationale and would need re-scoring to gain one.

## Related

`dchiang/multiturn-eval-megabranch` and `agi-anyting_goes_into` carry the identical bug and will pick this up when they next merge from evals_v2. (Supersedes #1612, which targeted the megabranch — closed in favour of this one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
