### PR TITLE
Fix sub-agent tabs sometimes never appearing (event-carried lineage)

### DIFF
--- a/app/desktop/studio_server/chat/runtime/sse.py
+++ b/app/desktop/studio_server/chat/runtime/sse.py
@@ -88,8 +88,16 @@ def format_conversation_state(record: ConversationRecord) -> bytes:
         payload["idle_reason"] = record.idle_reason
     if record.name is not None:
         payload["name"] = record.name
+    # Lineage rides the event so a firehose observer can attribute an unknown
+    # child to its parent directly, without a racy list-fetch round trip.
+    if record.parent_session_id is not None:
+        payload["parent_session_id"] = record.parent_session_id
     if record.kind == "subagent":
         payload["report_available"] = record.final_report is not None
+        # Identity rides along too, so a directly-attributed child renders its
+        # type badge/tooltip immediately instead of waiting for a list fetch.
+        if record.agent_type is not None:
+            payload["agent_type"] = record.agent_type
     return _encode(payload)
 
 

--- a/app/desktop/studio_server/chat/runtime/test_api.py
+++ b/app/desktop/studio_server/chat/runtime/test_api.py
@@ -293,6 +293,9 @@ async def test_observer_events_replay_and_terminal(supervisor, hang_engine, clie
     assert states[-1]["state"] == "stopped"
     assert states[-1]["kind"] == "subagent"
     assert states[-1]["report_available"] is True
+    # Identity rides subagent state events so an event-attributed tab renders
+    # its type immediately.
+    assert states[-1]["agent_type"] == "general"
 
     r = await client.get("/api/conversations/cv_missing/events")
     assert r.status_code == 404
@@ -314,6 +317,10 @@ async def test_state_firehose_snapshot_then_live(supervisor, hang_engine):
         assert b"conversation-state" in snapshot
         assert record.session_id.encode() in snapshot
         assert b'"running"' in snapshot
+        # The snapshot replay carries lineage, so a firehose subscriber can
+        # attribute a child it has never seen without a list fetch.
+        snapshot_event = json.loads(snapshot.decode().removeprefix("data: "))
+        assert snapshot_event["parent_session_id"] == record.parent_session_id
 
         # Live tail: a state change publishes to attached firehose observers.
         stop_task = asyncio.create_task(supervisor.stop(record.session_id))

--- a/app/desktop/studio_server/chat/runtime/test_supervisor.py
+++ b/app/desktop/studio_server/chat/runtime/test_supervisor.py
@@ -26,6 +26,7 @@ from app.desktop.studio_server.chat.test_fakes import (
 from .engine import ConversationEngine
 from .interceptors import DISABLE_AUTO_MODE_STALE_RESULT
 from .models import InboundMessage, RunState, SubAgentSeed
+from .sse import format_conversation_state
 from .supervisor import ConversationCapError, ConversationSupervisor
 
 URL = "https://example.test/v1/chat"
@@ -140,6 +141,35 @@ async def test_spawn_subagent_runs_to_completed_and_settles():
     assert states[-1]["state"] == "completed"
     assert states[-1]["kind"] == "subagent"
     assert states[-1]["report_available"] is True
+    # Lineage and identity ride the on-subscribe marker so a late observer can
+    # attribute and render the child without a list fetch.
+    assert states[-1]["parent_session_id"] == "cv_parent"
+    assert states[-1]["agent_type"] == "general"
+
+
+async def test_conversation_state_payload_carries_parent_lineage(hang_engine):
+    sup = _sup()
+    parent = sup.create_conversation("interactive", upstream_url=URL, headers={})
+    child = sup.spawn_subagent(
+        _seed(), parent_session_id=parent.session_id, upstream_url=URL, headers={}
+    )
+
+    child_payload = json.loads(
+        format_conversation_state(child).decode().removeprefix("data: ")
+    )
+    assert child_payload["parent_session_id"] == parent.session_id
+    assert child_payload["agent_type"] == "general"
+
+    # Parents (no lineage, no sub-agent identity) omit the fields entirely —
+    # optional fields ride only when meaningful, matching the rest of the
+    # payload.
+    parent_payload = json.loads(
+        format_conversation_state(parent).decode().removeprefix("data: ")
+    )
+    assert "parent_session_id" not in parent_payload
+    assert "agent_type" not in parent_payload
+
+    await sup.stop(child.session_id)
 
 
 async def test_settle_publishes_state_transitions_to_live_observer():

--- a/app/web_ui/src/lib/chat/conversation_store.test.ts
+++ b/app/web_ui/src/lib/chat/conversation_store.test.ts
@@ -254,7 +254,104 @@ describe("conversation_store", () => {
       expect(get(store.children).map((c) => c.session_id)).toEqual(["cv_1"])
     })
 
-    it("re-fetches the list when a state event arrives for an unknown child", async () => {
+    it("adds an unknown child directly from a lineage-carrying event, with no fetch", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse([]))
+      vi.stubGlobal("fetch", fetchMock)
+      await store.syncForConversation("cv_parent")
+
+      store.connect()
+      FakeEventSource.latest().message({
+        type: "conversation-state",
+        session_id: "cv_new",
+        kind: "subagent",
+        state: "running",
+        auto_flag: false,
+        name: "Agent cv_new",
+        agent_type: "general",
+        parent_session_id: "cv_parent",
+      })
+      await flush()
+
+      // Attributed straight from the event: only the initial sync fetched —
+      // no list re-fetch competing for connection-pool slots.
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(get(store.children)).toMatchObject([
+        {
+          session_id: "cv_new",
+          kind: "subagent",
+          state: "running",
+          name: "Agent cv_new",
+          agent_type: "general",
+          parent_session_id: "cv_parent",
+          report_available: false,
+        },
+      ])
+    })
+
+    it("backfills a null agent_type from a later state event, never overwriting a known one", async () => {
+      // A child added from an event predating the agent_type field carries
+      // null identity; the next state event patches it in. Identity is
+      // immutable, so an established value is never replaced.
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse([]))
+      vi.stubGlobal("fetch", fetchMock)
+      await store.syncForConversation("cv_parent")
+
+      store.connect()
+      const source = FakeEventSource.latest()
+      source.message({
+        type: "conversation-state",
+        session_id: "cv_new",
+        kind: "subagent",
+        state: "running",
+        auto_flag: false,
+        parent_session_id: "cv_parent",
+      })
+      expect(get(store.children)[0].agent_type).toBeNull()
+
+      source.message({
+        type: "conversation-state",
+        session_id: "cv_new",
+        kind: "subagent",
+        state: "running",
+        auto_flag: false,
+        agent_type: "general",
+        parent_session_id: "cv_parent",
+      })
+      expect(get(store.children)[0].agent_type).toBe("general")
+
+      source.message({
+        type: "conversation-state",
+        session_id: "cv_new",
+        kind: "subagent",
+        state: "completed",
+        auto_flag: false,
+        agent_type: "other",
+        parent_session_id: "cv_parent",
+      })
+      expect(get(store.children)[0].agent_type).toBe("general")
+    })
+
+    it("ignores a lineage-carrying event for another conversation's child (no fetch)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse([]))
+      vi.stubGlobal("fetch", fetchMock)
+      await store.syncForConversation("cv_parent")
+
+      store.connect()
+      FakeEventSource.latest().message({
+        type: "conversation-state",
+        session_id: "cv_foreign",
+        kind: "subagent",
+        state: "running",
+        auto_flag: false,
+        parent_session_id: "cv_other_parent",
+      })
+      await flush()
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(get(store.children)).toEqual([])
+    })
+
+    it("falls back to a list re-fetch for an unknown child WITHOUT lineage (older desktop)", async () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(jsonResponse([]))
@@ -313,10 +410,11 @@ describe("conversation_store", () => {
     })
 
     it("reconciles children on a timer so a missed running child appears", async () => {
-      // The safety net for a missed single-shot running-child event: while the
-      // firehose is connected and a parent is set, a periodic reconcile
-      // re-fetches the list, so a child whose "running" event never arrived
-      // converges within seconds instead of only on a manual refresh.
+      // Old-desktop-compat / freak-loss safety net: direct attribution from
+      // lineage-carrying events is the primary path now, but while the
+      // firehose is connected and a parent is set a low-frequency reconcile
+      // still re-fetches the list, so a child that slipped through every
+      // event path converges without a manual refresh.
       vi.useFakeTimers()
       try {
         const fetchMock = vi
@@ -329,7 +427,7 @@ describe("conversation_store", () => {
         store.connect()
         expect(get(store.children)).toEqual([])
 
-        await vi.advanceTimersByTimeAsync(3500)
+        await vi.advanceTimersByTimeAsync(20_000)
 
         expect(get(store.children).map((c) => c.session_id)).toEqual([
           "cv_late",
@@ -347,12 +445,12 @@ describe("conversation_store", () => {
 
         await store.syncForConversation("trace-leaf")
         store.connect()
-        await vi.advanceTimersByTimeAsync(3500) // one reconcile fetch
+        await vi.advanceTimersByTimeAsync(20_000) // one reconcile fetch
         const callsAfterOneTick = fetchMock.mock.calls.length
         expect(callsAfterOneTick).toBeGreaterThan(1)
 
         store.disconnect()
-        await vi.advanceTimersByTimeAsync(14000) // several intervals
+        await vi.advanceTimersByTimeAsync(80_000) // several intervals
 
         // No further reconcile fetches once the firehose is disconnected.
         expect(fetchMock.mock.calls.length).toBe(callsAfterOneTick)
@@ -370,7 +468,7 @@ describe("conversation_store", () => {
         vi.stubGlobal("fetch", fetchMock)
 
         store.connect()
-        await vi.advanceTimersByTimeAsync(14000)
+        await vi.advanceTimersByTimeAsync(80_000)
 
         expect(fetchMock).not.toHaveBeenCalled()
       } finally {
@@ -393,7 +491,7 @@ describe("conversation_store", () => {
         store.connect()
         expect(get(store.children).map((c) => c.session_id)).toEqual(["cv_1"])
 
-        await vi.advanceTimersByTimeAsync(3500) // reconcile tick fails
+        await vi.advanceTimersByTimeAsync(20_000) // reconcile tick fails
 
         // A timeout/blip must not yank running tabs away.
         expect(get(store.children).map((c) => c.session_id)).toEqual(["cv_1"])
@@ -419,14 +517,193 @@ describe("conversation_store", () => {
         await store.syncForConversation("trace-leaf")
         store.connect()
 
-        await vi.advanceTimersByTimeAsync(3500) // tick 1: times out
+        await vi.advanceTimersByTimeAsync(20_000) // tick 1: times out
         expect(get(store.children)).toEqual([])
-        await vi.advanceTimersByTimeAsync(3500) // tick 2: recovers
+        await vi.advanceTimersByTimeAsync(20_000) // tick 2: recovers
 
         expect(get(store.children).map((c) => c.session_id)).toEqual([
           "cv_recovered",
         ])
         expect(fetchMock.mock.calls.length).toBe(3)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it("a stale in-flight list fetch does not clobber a child added meanwhile from a state event", async () => {
+      // Direct attribution doesn't supersede an in-flight fetch: a list
+      // computed BEFORE a spawn can land AFTER the spawn's event already
+      // added the tab. The success path must merge the event-added child in —
+      // clobbering would blank its tab until the next reconcile and, if
+      // selected, abort its observation and yank the selection.
+      let resolveList!: (r: Response) => void
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        if (String(url).includes("/api/conversations?")) {
+          return new Promise<Response>((resolve) => (resolveList = resolve))
+        }
+        // The selected child's hydration/events: hang, irrelevant here.
+        return new Promise<never>(() => {})
+      })
+      vi.stubGlobal("fetch", fetchMock)
+
+      const sync = store.syncForConversation("cv_parent")
+      store.connect()
+      FakeEventSource.latest().message({
+        type: "conversation-state",
+        session_id: "cv_new",
+        kind: "subagent",
+        state: "running",
+        auto_flag: false,
+        parent_session_id: "cv_parent",
+      })
+      expect(get(store.children).map((c) => c.session_id)).toEqual(["cv_new"])
+      store.select("cv_new")
+
+      // The pre-spawn list (fetched before cv_new existed) lands late.
+      resolveList(
+        jsonResponse([child("cv_old", { parent_session_id: "cv_parent" })]),
+      )
+      await sync
+
+      expect(get(store.children).map((c) => c.session_id)).toEqual([
+        "cv_old",
+        "cv_new",
+      ])
+      // The event-added tab kept its selection (and thus its observation).
+      expect(get(store.selectedId)).toBe("cv_new")
+    })
+
+    it("a child that settles inside the stale-fetch window survives the fetch with selection intact", async () => {
+      // The shield deliberately ignores terminal state: this child was added
+      // AFTER the stale fetch started, so the fetch's answer says nothing
+      // about it — settling meanwhile must not let the stale fetch yank the
+      // transcript and selection while the user reads the failure output.
+      let resolveList!: (r: Response) => void
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        if (String(url).includes("/api/conversations?")) {
+          return new Promise<Response>((resolve) => (resolveList = resolve))
+        }
+        // The selected child's hydration/events: hang, irrelevant here.
+        return new Promise<never>(() => {})
+      })
+      vi.stubGlobal("fetch", fetchMock)
+
+      const sync = store.syncForConversation("cv_parent")
+      store.connect()
+      FakeEventSource.latest().message({
+        type: "conversation-state",
+        session_id: "cv_flash",
+        kind: "subagent",
+        state: "running",
+        auto_flag: false,
+        parent_session_id: "cv_parent",
+      })
+      store.select("cv_flash")
+      // The child settles (terminal) before the pre-spawn list lands.
+      FakeEventSource.latest().message({
+        type: "conversation-state",
+        session_id: "cv_flash",
+        kind: "subagent",
+        state: "failed",
+        auto_flag: false,
+        parent_session_id: "cv_parent",
+      })
+      expect(get(store.children)[0]?.state).toBe("failed")
+
+      // The pre-spawn list (computed before cv_flash existed) lands late.
+      resolveList(jsonResponse([]))
+      await sync
+
+      expect(get(store.children).map((c) => c.session_id)).toEqual(["cv_flash"])
+      expect(get(store.children)[0]?.state).toBe("failed")
+      expect(get(store.selectedId)).toBe("cv_flash")
+    })
+
+    it("a stale successful fetch does not revert a terminal child to running", async () => {
+      // Terminal is monotone: a reconcile row computed before the child
+      // settled still says "running" — applying it verbatim would resurrect
+      // the tab's live state (and drop the report affordance) for up to a
+      // reconcile interval. The event-carried fields must win.
+      vi.useFakeTimers()
+      try {
+        let resolveList!: (r: Response) => void
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(
+            jsonResponse([child("cv_1", { parent_session_id: "cv_parent" })]),
+          )
+          .mockImplementationOnce(
+            () => new Promise<Response>((resolve) => (resolveList = resolve)),
+          )
+        vi.stubGlobal("fetch", fetchMock)
+
+        await store.syncForConversation("cv_parent")
+        store.connect()
+        expect(get(store.children)[0]?.state).toBe("running")
+
+        // Reconcile tick starts the (soon-stale) fetch…
+        await vi.advanceTimersByTimeAsync(20_000)
+        // …then the child settles via a live state event while it's pending.
+        FakeEventSource.latest().message({
+          type: "conversation-state",
+          session_id: "cv_1",
+          kind: "subagent",
+          state: "completed",
+          auto_flag: false,
+          parent_session_id: "cv_parent",
+          report_available: true,
+        })
+        expect(get(store.children)[0]?.state).toBe("completed")
+
+        // The stale row (computed before the settle) lands: still "running".
+        resolveList(
+          jsonResponse([child("cv_1", { parent_session_id: "cv_parent" })]),
+        )
+        await vi.advanceTimersByTimeAsync(1)
+
+        const merged = get(store.children)[0]
+        expect(merged?.state).toBe("completed")
+        expect(merged?.report_available).toBe(true)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it("a fetch started AFTER the event-add that lacks the child drops it (no ghost tab)", async () => {
+      // Counterpart to the stale-fetch shield above: the shield is scoped to
+      // fetches that started BEFORE the child was added (they couldn't have
+      // known it). A fetch that started after the add and still lacks the
+      // child is authoritative absence — e.g. a desktop restart emptied the
+      // in-memory registry, so no terminal event will ever arrive. Without
+      // the started-at check every reconcile would re-shield the ghost
+      // "running" tab forever.
+      vi.useFakeTimers()
+      try {
+        const fetchMock = vi.fn().mockResolvedValue(jsonResponse([]))
+        vi.stubGlobal("fetch", fetchMock)
+        await store.syncForConversation("cv_parent")
+
+        store.connect()
+        FakeEventSource.latest().message({
+          type: "conversation-state",
+          session_id: "cv_ghost",
+          kind: "subagent",
+          state: "running",
+          auto_flag: false,
+          parent_session_id: "cv_parent",
+        })
+        expect(get(store.children).map((c) => c.session_id)).toEqual([
+          "cv_ghost",
+        ])
+
+        // Reconcile tick: this fetch starts 20s after the add and the server
+        // (restarted, registry empty) doesn't know the child.
+        await vi.advanceTimersByTimeAsync(20_000)
+        expect(get(store.children)).toEqual([])
+
+        // And it STAYS gone on subsequent ticks (no re-shield loop).
+        await vi.advanceTimersByTimeAsync(20_000)
+        expect(get(store.children)).toEqual([])
       } finally {
         vi.useRealTimers()
       }
@@ -446,6 +723,41 @@ describe("conversation_store", () => {
 
       // Another conversation's children must never linger under this one.
       expect(get(store.children)).toEqual([])
+    })
+
+    it("a failed cross-parent fetch keeps the NEW parent's children added from events meanwhile", async () => {
+      // Switch A→B whose first fetch fails: A's children must clear, but a
+      // B-child attributed from a state event during the fetch window is
+      // event-proven — a fetch FAILURE is not authoritative and must not
+      // wipe it.
+      let rejectList!: (e: Error) => void
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse([child("cv_a", { parent_session_id: "parent-a" })]),
+        )
+        .mockImplementationOnce(
+          () => new Promise<Response>((_, reject) => (rejectList = reject)),
+        )
+      vi.stubGlobal("fetch", fetchMock)
+
+      await store.syncForConversation("parent-a")
+      expect(get(store.children).map((c) => c.session_id)).toEqual(["cv_a"])
+
+      const sync = store.syncForConversation("parent-b")
+      store.connect()
+      FakeEventSource.latest().message({
+        type: "conversation-state",
+        session_id: "cv_b",
+        kind: "subagent",
+        state: "running",
+        auto_flag: false,
+        parent_session_id: "parent-b",
+      })
+      rejectList(new Error("unreachable"))
+      await sync
+
+      expect(get(store.children).map((c) => c.session_id)).toEqual(["cv_b"])
     })
 
     it("reconnects when the firehose connect wedges before open", async () => {
@@ -596,6 +908,73 @@ describe("conversation_store", () => {
         .map((c) => String(c[0]))
         .filter((u) => u.endsWith("/api/conversations/cv_1"))
       expect(itemCalls).toEqual([])
+    })
+
+    it("a failed re-hydration on re-select keeps the transcript from the previous observation", async () => {
+      // select() keeps a deselected child's transcript for instant repaint
+      // and re-hydrates on re-select; a hydration blip (network throw or a
+      // non-404 error status) must not blank what was deliberately kept.
+      let hydrationResult: "ok" | "network" | "http500" = "ok"
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        const u = String(url)
+        if (u.includes("/api/conversations?")) {
+          return Promise.resolve(jsonResponse([child("cv_1")]))
+        }
+        if (u.includes("/api/conversations/cv_1/events")) {
+          return Promise.resolve(sseResponse([]))
+        }
+        if (u.includes("/api/chat/sessions/cv_1")) {
+          if (hydrationResult === "network") {
+            return Promise.reject(new Error("network down"))
+          }
+          if (hydrationResult === "http500") {
+            return Promise.resolve({
+              ok: false,
+              status: 500,
+            } as unknown as Response)
+          }
+          return Promise.resolve(
+            jsonResponse({
+              id: "trace-cv_1",
+              task_run: {
+                trace: [
+                  { role: "user", content: "briefing" },
+                  { role: "assistant", content: "persisted turn" },
+                ],
+              },
+            }),
+          )
+        }
+        return Promise.reject(new Error(`Unmatched fetch: ${u}`))
+      })
+      vi.stubGlobal("fetch", fetchMock)
+      await store.syncForConversation("trace-leaf")
+
+      store.select("cv_1")
+      await flush()
+      expect(
+        (get(store.transcripts).get("cv_1") ?? []).map((m) => m.role),
+      ).toEqual(["user", "assistant"])
+
+      // Switch away (stream torn down, transcript kept), then back with the
+      // hydration endpoint throwing.
+      store.select(null)
+      hydrationResult = "network"
+      store.select("cv_1")
+      await flush()
+      expect(
+        (get(store.transcripts).get("cv_1") ?? []).map((m) => m.role),
+      ).toEqual(["user", "assistant"])
+
+      // Same for an error status (a 404 stays authoritative: not covered
+      // here — "nothing persisted" makes the empty transcript the truth).
+      store.select(null)
+      hydrationResult = "http500"
+      store.select("cv_1")
+      await flush()
+      expect(
+        (get(store.transcripts).get("cv_1") ?? []).map((m) => m.role),
+      ).toEqual(["user", "assistant"])
     })
 
     it("strips steer framing from replayed user-message echoes", async () => {
@@ -878,6 +1257,90 @@ describe("conversation_store", () => {
 
       store.select(null)
       expect(get(store.selectedId)).toBeNull()
+    })
+
+    // A never-ending events body + per-child signal capture, so observer
+    // stream lifetime can be asserted across tab switches.
+    function hangingObserverRoutes(signals: Map<string, AbortSignal>) {
+      const hangingBody = {
+        getReader: () => ({
+          read: () => new Promise<never>(() => {}),
+        }),
+      }
+      const fetchMock = vi
+        .fn()
+        .mockImplementation((url: string, init?: RequestInit) => {
+          const u = String(url)
+          if (u.includes("/api/conversations?")) {
+            return Promise.resolve(jsonResponse([child("cv_1"), child("cv_2")]))
+          }
+          const events = u.match(/\/api\/conversations\/(cv_\d+)\/events/)
+          if (events) {
+            signals.set(events[1], init?.signal as AbortSignal)
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              body: hangingBody,
+            } as unknown as Response)
+          }
+          if (u.includes("/api/chat/sessions/")) {
+            return Promise.resolve(
+              jsonResponse({ id: "trace", task_run: { trace: [] } }),
+            )
+          }
+          return Promise.reject(new Error(`Unmatched fetch: ${u}`))
+        })
+      vi.stubGlobal("fetch", fetchMock)
+      return fetchMock
+    }
+
+    it("only the selected child keeps a live observer stream (switch tears the old one down)", async () => {
+      // Every open child stream holds one of the browser's few per-origin
+      // connections; the firehose covers status for unselected tabs, so a
+      // deselected child's stream must close.
+      const signals = new Map<string, AbortSignal>()
+      hangingObserverRoutes(signals)
+      await store.syncForConversation("trace-leaf")
+
+      store.select("cv_1")
+      await flush()
+      expect(signals.get("cv_1")?.aborted).toBe(false)
+
+      store.select("cv_2")
+      await flush()
+      expect(signals.get("cv_1")?.aborted).toBe(true)
+      expect(signals.get("cv_2")?.aborted).toBe(false)
+      // The deselected child's transcript survives for an instant repaint.
+      expect(get(store.transcripts).has("cv_1")).toBe(true)
+    })
+
+    it("selecting back to the main agent (null) closes the child's observer", async () => {
+      const signals = new Map<string, AbortSignal>()
+      hangingObserverRoutes(signals)
+      await store.syncForConversation("trace-leaf")
+
+      store.select("cv_1")
+      await flush()
+      expect(signals.get("cv_1")?.aborted).toBe(false)
+
+      store.select(null)
+      expect(signals.get("cv_1")?.aborted).toBe(true)
+    })
+
+    it("re-selecting the same child does not tear down its stream", async () => {
+      const signals = new Map<string, AbortSignal>()
+      const fetchMock = hangingObserverRoutes(signals)
+      await store.syncForConversation("trace-leaf")
+
+      store.select("cv_1")
+      await flush()
+      const callsAfterFirst = fetchMock.mock.calls.length
+
+      store.select("cv_1")
+      await flush()
+      expect(signals.get("cv_1")?.aborted).toBe(false)
+      // observe() is idempotent while active: no re-hydration, no new stream.
+      expect(fetchMock.mock.calls.length).toBe(callsAfterFirst)
     })
   })
 

--- a/app/web_ui/src/lib/chat/conversation_store.ts
+++ b/app/web_ui/src/lib/chat/conversation_store.ts
@@ -77,18 +77,16 @@ const CHILDREN_FETCH_TIMEOUT_MS = 10_000
 // nor onerror, so without a bound it never reconnects.
 const FIREHOSE_CONNECT_TIMEOUT_MS = 15_000
 // Low-frequency safety-net re-fetch of the children list while the firehose is
-// connected and a parent is set (see `updateReconcileTimer`). WHY: the children
-// strip is populated only when a child's firehose `conversation-state` event
-// triggers a fetch, and a running child publishes that event exactly ONCE (at
-// spawn) — nothing more until it settles. If that single event is missed (a
-// firehose micro-drop, a server snapshot/subscribe race on (re)connect, or a
-// fetch-race edge), a RUNNING child is absent from the strip with no further
-// trigger until it COMPLETES (whose terminal tab is dropped by design) or the
-// user refreshes. This periodic reconcile re-fetches the authoritative list
-// (`children_of` always returns the complete current set) so any missed child
-// converges within a few seconds instead of never. Cheap: localhost, and the
-// server fix closes the snapshot gap so this rarely has anything to correct.
-const RECONCILE_INTERVAL_MS = 3500
+// connected and a parent is set (see `updateReconcileTimer`). Since
+// `conversation-state` events carry `parent_session_id`, an unknown child is
+// attributed to the current parent DIRECTLY from the event (no fetch), so this
+// reconcile is no longer load-bearing for tab appearance. It survives only as
+// a cheap safety net for two residual cases: an older desktop whose events
+// lack the lineage field (there the fetch fallback can lose a race), and a
+// freak loss where both the live event and the reconnect snapshot were
+// missed. Hence the long interval — frequent ticks would just compete for the
+// connection-pool slots the page's SSE streams already strain.
+const RECONCILE_INTERVAL_MS = 20_000
 
 // Lifecycle of the state-firehose EventSource, surfaced for tests / debugging.
 // A pure observer: this only reports the connection, it never mutates a run.
@@ -110,7 +108,20 @@ interface ConversationStateEvent {
   auto_flag?: boolean
   idle_reason?: string
   name?: string
+  /**
+   * Sub-agent lineage: the parent conversation's session id. Rides every
+   * sub-agent state event (live publish and snapshot replay) so an unknown
+   * child can be attributed to the current parent straight from the event.
+   * Absent on events from desktops predating the field — those fall back to
+   * the list fetch.
+   */
+  parent_session_id?: string
   report_available?: boolean
+  /**
+   * Sub-agent identity (rides subagent state events), so a directly-attributed
+   * child renders its type badge/tooltip without waiting for a list fetch.
+   */
+  agent_type?: string
 }
 
 // Terminal = the run can never advance again (one-shot kinds only). Same
@@ -180,7 +191,11 @@ export interface ConversationStore {
    * it is safe to call reactively.
    */
   syncForConversation(parentId: string | null): Promise<void>
-  /** Select a tab; selecting a child starts observing it. */
+  /**
+   * Select a tab; selecting a child starts observing it, and the previously
+   * selected child's observer stream is torn down (only the selected child
+   * holds a live per-child SSE connection).
+   */
   select(sessionId: string | null): void
   /**
    * Observe one child: hydrate its persisted history, then attach the live
@@ -238,6 +253,13 @@ export function createConversationStore(): ConversationStore {
   let firehoseActive = false
 
   const observations = new Map<string, ChildObservation>()
+
+  // When each event-attributed child was appended (Date.now()), keyed by
+  // session id. Lets a landing list fetch decide whether a child it lacks is
+  // one it could not have known about (added after the fetch STARTED → shield
+  // it) or one the server authoritatively no longer knows (added before →
+  // drop it). Entries are pruned alongside the child (see pruneToChildren).
+  const eventAddedAt = new Map<string, number>()
 
   // --- Transcript bookkeeping ------------------------------------------------
 
@@ -318,6 +340,10 @@ export function createConversationStore(): ConversationStore {
               ...child,
               name: event.name ?? child.name,
               state: (event.state ?? child.state) as RunState,
+              // Identity backfill for an event-attributed child added before
+              // its agent_type was known; an established value is never
+              // overwritten (identity is immutable).
+              agent_type: child.agent_type ?? event.agent_type ?? null,
               report_available:
                 event.report_available ?? child.report_available,
             }
@@ -326,10 +352,59 @@ export function createConversationStore(): ConversationStore {
     )
   }
 
+  // An unknown sub-agent attributed to the current parent straight from a
+  // lineage-carrying state event: append it from the fields the event carries
+  // (everything the tab strip renders). The remaining ConversationItem fields
+  // take their schema defaults; the initial-hydration fetch or later state
+  // events fill them in.
+  function addChildFromStateEvent(event: ConversationStateEvent): void {
+    if (!event.session_id) return
+    if (get(children).some((c) => c.session_id === event.session_id)) return
+    eventAddedAt.set(event.session_id, Date.now())
+    const item: ConversationItem = {
+      session_id: event.session_id,
+      kind: "subagent",
+      state: (event.state ?? "running") as RunState,
+      name: event.name ?? null,
+      agent_type: event.agent_type ?? null,
+      parent_session_id: event.parent_session_id ?? null,
+      auto_flag: event.auto_flag ?? false,
+      rounds_used: 0,
+      report_available: event.report_available ?? false,
+      report_delivered: false,
+    }
+    children.update((list) => [...list, item])
+  }
+
+  // The event-added children a list fetch that started at `startedAt` must not
+  // drop: same parent and appended AFTER the fetch started — so the server's
+  // answer (or failure) predates their existence and says nothing about them.
+  // Deliberately NOT filtered by terminal state: a child that spawns AND
+  // settles inside the fetch window stays shielded, so the transcript and
+  // selection aren't yanked while the user reads its failure output. The
+  // startedAt check alone removes ghosts — a fetch started after the add is
+  // authoritative about the child's absence. `>=` on the timestamp: a
+  // same-millisecond tie is unresolvable, and shielding errs toward keeping a
+  // live tab (a real ghost still dies on the next fetch, whose start strictly
+  // postdates the add).
+  function shieldedEventChildren(
+    parentId: string,
+    startedAt: number,
+  ): ConversationItem[] {
+    return get(children).filter(
+      (c) =>
+        c.parent_session_id === parentId &&
+        (eventAddedAt.get(c.session_id) ?? -Infinity) >= startedAt,
+    )
+  }
+
   // Drop observations/transcripts for children no longer in the list, and clear
   // the selection if the selected child disappeared (conversation switch).
   function pruneToChildren(list: ConversationItem[]): void {
     const ids = new Set(list.map((c) => c.session_id))
+    for (const id of eventAddedAt.keys()) {
+      if (!ids.has(id)) eventAddedAt.delete(id)
+    }
     for (const [id, obs] of observations) {
       if (!ids.has(id)) {
         obs.abort.abort()
@@ -366,6 +441,9 @@ export function createConversationStore(): ConversationStore {
 
   async function fetchChildren(parentId: string): Promise<void> {
     const thisGeneration = ++syncGeneration
+    // Anchors the shield decision on landing (see shieldedEventChildren): the
+    // server computed its answer no earlier than this instant.
+    const startedAt = Date.now()
     let list: ConversationItem[] = []
     let failed = false
     try {
@@ -396,18 +474,66 @@ export function createConversationStore(): ConversationStore {
       // Failure handling depends on WHOSE children are currently shown:
       // - same parent → keep them. Clearing on a blip/timeout would flicker
       //   running tabs away; the reconcile loop retries in a few seconds.
-      // - different parent (a switch whose first fetch failed) → clear, so
-      //   another conversation's children never linger under this one.
+      // - different parent (a switch whose first fetch failed) → clear the old
+      //   parent's children, so another conversation's tabs never linger under
+      //   this one — but keep any child of THIS parent attributed from a state
+      //   event while the fetch was in flight (a failure is not authoritative,
+      //   and dropping it would blank a live tab the events already proved).
       if (renderedParentId !== parentId) {
         renderedParentId = parentId
-        children.set([])
-        pruneToChildren([])
+        const kept = shieldedEventChildren(parentId, startedAt)
+        children.set(kept)
+        pruneToChildren(kept)
       }
       return
     }
     renderedParentId = parentId
-    children.set(list)
-    pruneToChildren(list)
+    // Merge, don't clobber: a fetch computed BEFORE a spawn can land AFTER the
+    // spawn's state event already added the child directly (the fetch isn't
+    // generation-bumped by direct attribution). Shield ONLY children added
+    // after this fetch started — the server's answer predates them, so their
+    // absence proves nothing. A child the fetch SHOULD have known (added
+    // before it started) yet lacks is authoritatively gone and gets dropped:
+    // this is what removes a ghost whose terminal event will never arrive
+    // (e.g. a desktop restart emptied the in-memory registry), instead of
+    // every fetch re-shielding it forever.
+    const fetchedIds = new Set(list.map((c) => c.session_id))
+    const eventAdded = shieldedEventChildren(parentId, startedAt).filter(
+      (c) => !fetchedIds.has(c.session_id),
+    )
+    // For ids the fetch DOES know, the fetched fields normally win (the
+    // reconcile heals events the firehose missed) — with one exception:
+    // terminal is monotone, so if the store already saw a child settle (via a
+    // state event) and the fetched row still says non-terminal, the row is
+    // provably stale (computed before the settle) and must not revert the tab
+    // to running for up to a reconcile interval. In that one case the
+    // event-carried fields (state / name / agent_type / report_available)
+    // keep the in-store values; everything else still comes from the fetch.
+    // Chosen over "in-store always wins on state" because that would stop the
+    // reconcile from healing a missed transition; terminal-wins is the only
+    // ordering that is always provable.
+    const storedById = new Map(get(children).map((c) => [c.session_id, c]))
+    const reconciled = list.map((fetched) => {
+      const stored = storedById.get(fetched.session_id)
+      if (
+        !stored ||
+        !isTerminalState(stored.state) ||
+        isTerminalState(fetched.state)
+      ) {
+        return fetched
+      }
+      return {
+        ...fetched,
+        state: stored.state,
+        name: stored.name ?? fetched.name,
+        agent_type: stored.agent_type ?? fetched.agent_type,
+        report_available: stored.report_available || fetched.report_available,
+      }
+    })
+    const merged =
+      eventAdded.length > 0 ? [...reconciled, ...eventAdded] : reconciled
+    children.set(merged)
+    pruneToChildren(merged)
   }
 
   async function syncForConversation(parentId: string | null): Promise<void> {
@@ -440,8 +566,20 @@ export function createConversationStore(): ConversationStore {
       updateChildFromStateEvent(event)
       return
     }
-    // Unknown child: we can't tell whether it belongs to this conversation from
-    // the event alone, so re-fetch the list for the current parent (cheap).
+    // Unknown child carrying lineage: attribute it directly from the event —
+    // no list fetch. The fetch fallback used to compete with the page's
+    // long-lived SSE streams for the browser's small per-origin connection
+    // budget and could starve indefinitely, leaving the tab strip blind.
+    if (event.parent_session_id !== undefined) {
+      if (event.parent_session_id === syncedParentId) {
+        addChildFromStateEvent(event)
+      }
+      // Another conversation's child: not ours, nothing to fetch.
+      return
+    }
+    // No lineage on the event (older desktop): we can't tell whether the child
+    // belongs to this conversation, so re-fetch the list for the current
+    // parent.
     if (syncedParentId) {
       void fetchChildren(syncedParentId)
     }
@@ -673,9 +811,13 @@ export function createConversationStore(): ConversationStore {
     // desktop resolves the record's CURRENT leaf per request, so hydration
     // is always fresh — this replaces the deleted current_trace_id field
     // AND the pre-hydration item re-fetch that kept it fresh. Best effort:
-    // a failure (including 404 for a child with nothing persisted yet)
-    // still attaches the live tail on an empty transcript.
+    // a failure still attaches the live tail below.
     let messages: ChatMessage[] = []
+    // Only an authoritative answer may overwrite a kept transcript: 2xx (the
+    // persisted history) or 404 (nothing persisted — empty IS the truth). A
+    // network throw or other error status on a RE-select must not blank the
+    // transcript select() deliberately kept for instant repaint.
+    let authoritative = false
     try {
       const response = await fetch(
         `${base_url}/api/chat/sessions/${encodeURIComponent(sessionId)}`,
@@ -685,15 +827,20 @@ export function createConversationStore(): ConversationStore {
         const snapshot = (await response.json()) as ChatSessionSnapshot
         const hydrated = hydrateSessionFromSnapshot(snapshot)
         messages = hydrated.messages
+        authoritative = true
         if (hydrated.contextUsage) {
           updateRuntime(sessionId, { contextUsage: hydrated.contextUsage })
         }
+      } else if (response.status === 404) {
+        authoritative = true
       }
     } catch {
       /* aborted or unreachable — live tail below still attaches */
     }
     if (abort.signal.aborted) return
-    setTranscript(sessionId, messages)
+    if (authoritative || transcriptFor(sessionId).length === 0) {
+      setTranscript(sessionId, messages)
+    }
 
     // 2. Attach the live tail: buffer replay (current turn) + state marker +
     // live events. For terminal runs the stream ends after the marker.
@@ -731,8 +878,23 @@ export function createConversationStore(): ConversationStore {
 
   // --- Actions ----------------------------------------------------------------
 
+  function stopObservation(id: string): void {
+    const obs = observations.get(id)
+    if (!obs) return
+    obs.abort.abort()
+    observations.delete(id)
+    clearRuntime(id)
+  }
+
   function select(sessionId: string | null): void {
+    const previous = get(selectedId)
     selectedId.set(sessionId)
+    // Only the SELECTED child keeps a live observer stream: each stream holds
+    // one of the browser's few per-origin connections, and the firehose
+    // already carries status for unselected tabs. The transcript is kept for
+    // an instant repaint on re-select; re-selecting re-hydrates and
+    // re-attaches the live tail.
+    if (previous && previous !== sessionId) stopObservation(previous)
     if (sessionId) void observe(sessionId)
   }
 
@@ -798,6 +960,9 @@ export function createConversationStore(): ConversationStore {
       obs.abort.abort()
     }
     observations.clear()
+    // Invariant: eventAddedAt only holds entries for current children —
+    // children.set([]) below bypasses pruneToChildren, so clear it here.
+    eventAddedAt.clear()
     syncGeneration++
     syncedParentId = undefined
     renderedParentId = null


### PR DESCRIPTION
Stacked on #1614. Fixes the intermittently-missing sub-agent tabs by removing the fetch dependency from the spawn→tab hot path — root-cause fix, no symptom patches.

## Root cause

The firehose `conversation-state` event carried no `parent_session_id`, so the browser could not attribute an unknown child from the event and was forced through `GET /api/conversations?parent=...`. That fetch competes with the page's long-lived SSE streams (firehose + main observer + one per previously-selected child — which leaked) for the browser's ~6 per-origin connection budget, and can starve past its 10s timeout indefinitely. The 3.5s reconcile used the same starved fetch, so it couldn't self-heal — and a running child publishes state exactly once, so a missed window meant no tab, ever.

## Fix

- `conversation-state` events carry `parent_session_id` (+ `agent_type` for children) on all three delivery paths (live, on-subscribe marker, snapshot replay) — the browser adds tabs directly from events, zero fetch.
- Only the currently-selected child holds a live `/events` observer stream (deselect tears down; transcript kept for instant repaint, preserved across hydration blips).
- The `?parent=` fetch survives for initial hydration + old-desktop compat; its merge shields event-added children a stale in-flight fetch couldn't have known about (`startedAt` anchor), drops genuine ghosts (desktop restart), and never reverts a terminal child to running (terminal is provably monotone for subagent records).
- Reconcile demoted from 3.5s load-bearing poll to a 20s safety net.

## Review

4 rounds. Notable catches fixed along the way: stale in-flight fetch clobbering an event-added child (with selection yank); permanent ghost tab after desktop restart from the first merge attempt; re-select hydration failure blanking the kept transcript. Known accepted edge: a hydration blip on re-select during an in-flight turn can transiently duplicate that turn's partial content (self-heals on next successful hydration).