### PR TITLE
CI: run Build Desktop Apps on dependency PRs

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -7,6 +7,15 @@ on:
   push:
     branches:
       - main
+  # Also run on PRs that change dependencies, so a packaging break (e.g. a lockfile
+  # bump that drops a module the desktop bundle needs) is caught pre-merge rather than
+  # only on the post-merge push-to-main run. Path-filtered to keep it off unrelated PRs.
+  pull_request:
+    paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
+      - 'app/web_ui/package-lock.json'
+      - 'app/web_ui/package.json'
 
 jobs:
   build:


### PR DESCRIPTION
The desktop packaging job (`Build Desktop Apps`) only ran on push-to-main / release / workflow_dispatch — never on PRs. So a dependency bump that breaks the bundle passes every PR check and only fails post-merge. This just happened: setuptools 83 dropped `pkg_resources`, which the desktop bundle imports, and it broke all 5 platforms on main (reverted in #1617).

This adds a path-filtered `pull_request` trigger so PRs that change dependency lockfiles run the same desktop build pre-merge. The path filter keeps it off unrelated PRs. The build uses no secrets (Sentry is currently disabled in the workflow), so Dependabot PRs — which get no secret access — run it fine.

Note: this is advisory unless added to branch protection's required checks. A path-filtered check can't be marked required without blocking PRs that don't touch those paths, so leaving it advisory for now.