### PR TITLE
Add val_set_filter_id to Eval: three-way train/val/test dataset splits

### DIFF
--- a/app/desktop/studio_server/copilot_api.py
+++ b/app/desktop/studio_server/copilot_api.py
@@ -738,10 +738,13 @@ def connect_copilot_api(app: FastAPI):
         task = task_from_id(project_id, task_id)
 
         # Generate tags and filter IDs
-        eval_tag, train_tag, golden_tag = generate_spec_eval_tags(request.name)
-        eval_set_filter_id, train_set_filter_id, eval_configs_filter_id = (
-            generate_spec_eval_filter_ids(eval_tag, train_tag, golden_tag)
-        )
+        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags(request.name)
+        (
+            eval_set_filter_id,
+            train_set_filter_id,
+            val_set_filter_id,
+            eval_configs_filter_id,
+        ) = generate_spec_eval_filter_ids(eval_tag, train_tag, val_tag, golden_tag)
 
         # Extract spec_type from properties (discriminated union)
         spec_type = request.properties["spec_type"]
@@ -765,6 +768,7 @@ def connect_copilot_api(app: FastAPI):
             output_scores=output_scores,
             eval_set_filter_id=eval_set_filter_id,
             train_set_filter_id=train_set_filter_id,
+            val_set_filter_id=val_set_filter_id,
             eval_configs_filter_id=eval_configs_filter_id,
             template_properties=None,
             evaluation_data_type=evaluation_data_type,
@@ -807,12 +811,13 @@ def connect_copilot_api(app: FastAPI):
             spec_definition=request.definition,
         )
 
-        # 4. Create TaskRuns for eval, train, and golden datasets
+        # 4. Create TaskRuns for eval, train, val, and golden datasets
         dataset_runs = create_dataset_task_runs(
             all_examples=all_examples,
             reviewed_examples=request.reviewed_examples,
             eval_tag=eval_tag,
             train_tag=train_tag,
+            val_tag=val_tag,
             golden_tag=golden_tag,
             spec_name=request.name,
         )

--- a/app/desktop/studio_server/test_copilot_api.py
+++ b/app/desktop/studio_server/test_copilot_api.py
@@ -1,3 +1,4 @@
+import json
 from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -443,7 +444,7 @@ class TestCreateSpecWithCopilot:
             patch(
                 "app.desktop.studio_server.copilot_api.create_dataset_task_runs",
                 return_value=DatasetTaskRuns(),
-            ),
+            ) as mock_create_dataset_task_runs,
             patch(
                 "app.desktop.studio_server.copilot_api.generate_memorable_name",
                 return_value="test-config-name",
@@ -460,11 +461,24 @@ class TestCreateSpecWithCopilot:
         assert res["definition"] == "The system should respond politely"
         assert res["eval_id"] is not None
 
+        # Verify the dataset runs were dealt with the spec's split tags
+        dataset_run_kwargs = mock_create_dataset_task_runs.call_args.kwargs
+        assert dataset_run_kwargs["eval_tag"] == "eval_test_spec"
+        assert dataset_run_kwargs["train_tag"] == "train_test_spec"
+        assert dataset_run_kwargs["val_tag"] == "val_test_spec"
+        assert dataset_run_kwargs["golden_tag"] == "eval_golden_test_spec"
+
         # Verify models were saved
         evals = task.evals()
         assert len(evals) == 1
         assert evals[0].name == "Test Spec"
         assert evals[0].current_config_id is not None
+
+        # Check the raw saved eval file: the lazy train/val migrations run on load and
+        # would synthesize these same values, masking missing wiring in the create path
+        saved_eval = json.loads(evals[0].path.read_text())
+        assert saved_eval["train_set_filter_id"] == "tag::train_test_spec"
+        assert saved_eval["val_set_filter_id"] == "tag::val_test_spec"
 
         specs = task.specs()
         assert len(specs) == 1

--- a/app/desktop/studio_server/utils/copilot_utils.py
+++ b/app/desktop/studio_server/utils/copilot_utils.py
@@ -248,15 +248,17 @@ def create_dataset_task_runs(
     reviewed_examples: list[ReviewedExample],
     eval_tag: str,
     train_tag: str,
+    val_tag: str,
     golden_tag: str,
     spec_name: str,
 ) -> DatasetTaskRuns:
-    """Create TaskRuns for eval, train, and golden datasets.
+    """Create TaskRuns for eval, train, val, and golden datasets.
 
     Samples from all_examples (mutating it) and creates TaskRuns for:
-    - Eval dataset
-    - Train dataset
     - Golden dataset (reviewed examples + unrated examples to reach MIN_GOLDEN_EXAMPLES)
+    - Eval dataset (half of the remaining examples)
+    - Val dataset (one third of the other half)
+    - Train dataset (the rest)
 
     Returns DatasetTaskRuns without parent set - caller must set parent and call
     save_pending_feedback after saving each run.
@@ -282,16 +284,24 @@ def create_dataset_task_runs(
         for example in unrated_golden_examples:
             result.add_run(create_task_run_from_sample(example, golden_tag, extra_tags))
 
-    # Sample half the remaining examples for eval vs train datasets
+    # Sample half the remaining examples for the eval dataset, then split the
+    # other half between val (one third) and train (two thirds)
     example_count = len(all_examples)
     eval_count = example_count // 2
-    train_count = example_count - eval_count
+    remaining_count = example_count - eval_count
+    val_count = remaining_count // 3
+    train_count = remaining_count - val_count
     eval_examples = sample_and_remove(all_examples, eval_count)
+    val_examples = sample_and_remove(all_examples, val_count)
     train_examples = sample_and_remove(all_examples, train_count)
 
     # Create TaskRuns for eval examples
     for example in eval_examples:
         result.add_run(create_task_run_from_sample(example, eval_tag, extra_tags))
+
+    # Create TaskRuns for val examples
+    for example in val_examples:
+        result.add_run(create_task_run_from_sample(example, val_tag, extra_tags))
 
     # Create TaskRuns for train examples
     for example in train_examples:

--- a/app/desktop/studio_server/utils/test_copilot_utils.py
+++ b/app/desktop/studio_server/utils/test_copilot_utils.py
@@ -265,6 +265,7 @@ class TestCreateDatasetTaskRuns:
             reviewed_examples,
             "eval_tag",
             "train_tag",
+            "val_tag",
             "golden_tag",
             "Test Spec",
         ).task_runs
@@ -293,6 +294,7 @@ class TestCreateDatasetTaskRuns:
             reviewed_examples,
             "eval_tag",
             "train_tag",
+            "val_tag",
             "golden_tag",
             "Test Spec",
         ).task_runs
@@ -316,6 +318,7 @@ class TestCreateDatasetTaskRuns:
             reviewed_examples,
             "eval_tag",
             "train_tag",
+            "val_tag",
             "golden_tag",
             "Test Spec",
         ).task_runs
@@ -339,6 +342,7 @@ class TestCreateDatasetTaskRuns:
             reviewed_examples,
             "eval_tag",
             "train_tag",
+            "val_tag",
             "golden_tag",
             "Test Spec",
         ).task_runs
@@ -364,6 +368,7 @@ class TestCreateDatasetTaskRuns:
             reviewed_examples,
             "eval_tag",
             "train_tag",
+            "val_tag",
             "golden_tag",
             "Test Spec",
         ).task_runs
@@ -385,6 +390,7 @@ class TestCreateDatasetTaskRuns:
             reviewed_examples,
             "eval_tag",
             "train_tag",
+            "val_tag",
             "golden_tag",
             "Test Spec",
         ).task_runs
@@ -392,8 +398,34 @@ class TestCreateDatasetTaskRuns:
         train_runs = [tr for tr in task_runs if "train_tag" in tr.tags]
         num_runs = NUM_SAMPLES_PER_TOPIC * NUM_TOPICS
         num_eval_runs = (num_runs - MIN_GOLDEN_EXAMPLES) // 2
-        num_train_runs = (num_runs - MIN_GOLDEN_EXAMPLES) - num_eval_runs
+        num_remaining = (num_runs - MIN_GOLDEN_EXAMPLES) - num_eval_runs
+        num_val_runs = num_remaining // 3
+        num_train_runs = num_remaining - num_val_runs
         assert len(train_runs) == num_train_runs
+
+    def test_val_examples_have_val_tag(self):
+        all_examples = [
+            SampleApi(input=f"input_{i}", output=f"output_{i}")
+            for i in range(NUM_SAMPLES_PER_TOPIC * NUM_TOPICS)
+        ]
+        reviewed_examples: list[ReviewedExample] = []
+
+        task_runs = create_dataset_task_runs(
+            all_examples,
+            reviewed_examples,
+            "eval_tag",
+            "train_tag",
+            "val_tag",
+            "golden_tag",
+            "Test Spec",
+        ).task_runs
+
+        val_runs = [tr for tr in task_runs if "val_tag" in tr.tags]
+        num_runs = NUM_SAMPLES_PER_TOPIC * NUM_TOPICS
+        num_eval_runs = (num_runs - MIN_GOLDEN_EXAMPLES) // 2
+        num_remaining = (num_runs - MIN_GOLDEN_EXAMPLES) - num_eval_runs
+        num_val_runs = num_remaining // 3
+        assert len(val_runs) == num_val_runs
 
     def test_handles_insufficient_examples(self):
         # Fewer examples than needed
@@ -407,6 +439,7 @@ class TestCreateDatasetTaskRuns:
             reviewed_examples,
             "eval_tag",
             "train_tag",
+            "val_tag",
             "golden_tag",
             "Test Spec",
         ).task_runs

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -5844,7 +5844,7 @@ export interface components {
             current_config_id?: string | null;
             /**
              * Eval Set Filter Id
-             * @description The id of the dataset filter which defines which dataset items are included when running this eval. Should be mutually exclusive with eval_configs_filter_id and train_set_filter_id.
+             * @description The id of the dataset filter which defines which dataset items are included when running this eval. This is the eval's test set; the 'eval set' name is legacy. Should be mutually exclusive with eval_configs_filter_id, train_set_filter_id and val_set_filter_id.
              */
             eval_set_filter_id: string;
             /**
@@ -5854,9 +5854,14 @@ export interface components {
             eval_configs_filter_id?: string | null;
             /**
              * Train Set Filter Id
-             * @description The id of the dataset filter which defines which dataset items are included in the training set for fine-tuning. Should be mutually exclusive with eval_set_filter_id.
+             * @description The id of the dataset filter which defines which dataset items are included in the training set for fine-tuning. Should be mutually exclusive with eval_set_filter_id and val_set_filter_id.
              */
             train_set_filter_id?: string | null;
+            /**
+             * Val Set Filter Id
+             * @description The id of the dataset filter which defines which dataset items are included in the validation set. Should be mutually exclusive with eval_set_filter_id and train_set_filter_id.
+             */
+            val_set_filter_id?: string | null;
             /**
              * Output Scores
              * @description The scores this evaluator should produce.

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -340,8 +340,10 @@ class Eval(KilnParentedModel, KilnParentModel, parent_of={"configs": EvalConfig}
         default=None,
         description="The id of the current config to use for this eval. This can be changed over time to run the same eval with different configs.",
     )
+    # Despite its name, eval_set_filter_id defines the eval's TEST set. The "eval set"
+    # name is legacy, kept for file-format compatibility.
     eval_set_filter_id: DatasetFilterId = Field(
-        description="The id of the dataset filter which defines which dataset items are included when running this eval. Should be mutually exclusive with eval_configs_filter_id and train_set_filter_id."
+        description="The id of the dataset filter which defines which dataset items are included when running this eval. This is the eval's test set; the 'eval set' name is legacy. Should be mutually exclusive with eval_configs_filter_id, train_set_filter_id and val_set_filter_id."
     )
     eval_configs_filter_id: DatasetFilterId | None = Field(
         default=None,
@@ -349,7 +351,11 @@ class Eval(KilnParentedModel, KilnParentModel, parent_of={"configs": EvalConfig}
     )
     train_set_filter_id: DatasetFilterId | None = Field(
         default=None,
-        description="The id of the dataset filter which defines which dataset items are included in the training set for fine-tuning. Should be mutually exclusive with eval_set_filter_id.",
+        description="The id of the dataset filter which defines which dataset items are included in the training set for fine-tuning. Should be mutually exclusive with eval_set_filter_id and val_set_filter_id.",
+    )
+    val_set_filter_id: DatasetFilterId | None = Field(
+        default=None,
+        description="The id of the dataset filter which defines which dataset items are included in the validation set. Should be mutually exclusive with eval_set_filter_id and train_set_filter_id.",
     )
     output_scores: List[EvalOutputScore] = Field(
         description="The scores this evaluator should produce."
@@ -437,6 +443,10 @@ class Eval(KilnParentedModel, KilnParentModel, parent_of={"configs": EvalConfig}
 
         return self
 
+    def _split_tag_suffix(self) -> str:
+        """The eval-name slug used to build split tag filter IDs (e.g., "My Eval" -> "my_eval")."""
+        return self.name.lower().replace(" ", "_")
+
     @model_validator(mode="after")
     def migrate_train_set_filter_id(self) -> Self:
         """
@@ -454,8 +464,27 @@ class Eval(KilnParentedModel, KilnParentModel, parent_of={"configs": EvalConfig}
         if self.train_set_filter_id is not None:
             return self
 
-        tag_suffix = self.name.lower().replace(" ", "_")
-        self.train_set_filter_id = f"tag::train_{tag_suffix}"
+        self.train_set_filter_id = f"tag::train_{self._split_tag_suffix()}"
+        return self
+
+    @model_validator(mode="after")
+    def migrate_val_set_filter_id(self) -> Self:
+        """
+        Migration: Auto-create a val_set_filter_id for evals that don't have one.
+
+        Generates a tag-based filter ID from the eval name following the convention
+        used by spec-based evals (e.g., "val_{name_slug}").
+        """
+        if self.id is None:
+            return self
+
+        if not self._loaded_from_file:
+            return self
+
+        if self.val_set_filter_id is not None:
+            return self
+
+        self.val_set_filter_id = f"tag::val_{self._split_tag_suffix()}"
         return self
 
     @model_validator(mode="after")

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -245,6 +245,145 @@ def test_migrate_train_set_filter_id_slugification(
     assert loaded_eval.train_set_filter_id == expected_tag
 
 
+def test_eval_with_val_set_filter_id():
+    """Test that Eval correctly stores val_set_filter_id."""
+    eval = Eval(
+        name="Test Eval",
+        eval_set_filter_id="tag::eval_test",
+        train_set_filter_id="tag::train_test",
+        val_set_filter_id="tag::val_test",
+        eval_configs_filter_id="tag::eval_golden_test",
+        output_scores=[
+            EvalOutputScore(
+                name="accuracy",
+                type=TaskOutputRatingType.pass_fail,
+            )
+        ],
+    )
+
+    assert eval.val_set_filter_id == "tag::val_test"
+
+
+def test_eval_val_set_filter_id_defaults_to_none():
+    """Test that val_set_filter_id defaults to None when not provided."""
+    eval = Eval(
+        name="Test Eval",
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        output_scores=[
+            EvalOutputScore(
+                name="score",
+                type=TaskOutputRatingType.pass_fail,
+            )
+        ],
+    )
+
+    assert eval.val_set_filter_id is None
+
+
+def test_migrate_val_set_filter_id_on_load(mock_task, tmp_path):
+    """Test that loading an eval from file auto-creates val_set_filter_id when missing."""
+    task_path = tmp_path / "task.kiln"
+    mock_task.path = task_path
+    mock_task.save_to_file()
+
+    eval = Eval(
+        name="My Eval Name",
+        parent=mock_task,
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        val_set_filter_id=None,
+        output_scores=[
+            EvalOutputScore(
+                name="score",
+                type=TaskOutputRatingType.pass_fail,
+            )
+        ],
+    )
+    eval.save_to_file()
+
+    loaded_eval = Eval.load_from_file(str(eval.path))
+    assert loaded_eval.val_set_filter_id == "tag::val_my_eval_name"
+
+
+def test_migrate_val_set_filter_id_preserves_existing(mock_task, tmp_path):
+    """Test that migration does not overwrite an existing val_set_filter_id."""
+    task_path = tmp_path / "task.kiln"
+    mock_task.path = task_path
+    mock_task.save_to_file()
+
+    eval = Eval(
+        name="My Eval",
+        parent=mock_task,
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        val_set_filter_id="tag::custom_val_tag",
+        output_scores=[
+            EvalOutputScore(
+                name="score",
+                type=TaskOutputRatingType.pass_fail,
+            )
+        ],
+    )
+    eval.save_to_file()
+
+    loaded_eval = Eval.load_from_file(str(eval.path))
+    assert loaded_eval.val_set_filter_id == "tag::custom_val_tag"
+
+
+def test_migrate_val_set_filter_id_not_on_new_eval():
+    """Test that migration does not trigger on newly created evals (not loaded from file)."""
+    eval = Eval(
+        name="New Eval",
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        val_set_filter_id=None,
+        output_scores=[
+            EvalOutputScore(
+                name="score",
+                type=TaskOutputRatingType.pass_fail,
+            )
+        ],
+    )
+    assert eval.val_set_filter_id is None
+
+
+@pytest.mark.parametrize(
+    "eval_name,expected_tag",
+    [
+        ("Simple", "tag::val_simple"),
+        ("Two Words", "tag::val_two_words"),
+        ("UPPER CASE", "tag::val_upper_case"),
+        ("mixed Case Name", "tag::val_mixed_case_name"),
+        ("already_underscored", "tag::val_already_underscored"),
+    ],
+)
+def test_migrate_val_set_filter_id_slugification(
+    mock_task, tmp_path, eval_name, expected_tag
+):
+    """Test that various eval names are correctly slugified into val_set_filter_id."""
+    task_path = tmp_path / "task.kiln"
+    mock_task.path = task_path
+    mock_task.save_to_file()
+
+    eval = Eval(
+        name=eval_name,
+        parent=mock_task,
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        output_scores=[
+            EvalOutputScore(
+                name="score",
+                type=TaskOutputRatingType.pass_fail,
+            )
+        ],
+    )
+    eval.save_to_file()
+
+    loaded_eval = Eval.load_from_file(str(eval.path))
+    assert loaded_eval.val_set_filter_id == expected_tag
+
+
 def test_eval_default_values():
     eval = Eval(
         name="Test Eval",

--- a/libs/server/kiln_server/spec_api.py
+++ b/libs/server/kiln_server/spec_api.py
@@ -101,10 +101,15 @@ def connect_spec_api(app: FastAPI):
 
         spec_type = spec_data.properties["spec_type"]
 
-        eval_tag, train_tag, golden_tag = generate_spec_eval_tags(spec_data.name)
-        eval_set_filter_id, train_set_filter_id, eval_configs_filter_id = (
-            generate_spec_eval_filter_ids(eval_tag, train_tag, golden_tag)
+        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags(
+            spec_data.name
         )
+        (
+            eval_set_filter_id,
+            train_set_filter_id,
+            val_set_filter_id,
+            eval_configs_filter_id,
+        ) = generate_spec_eval_filter_ids(eval_tag, train_tag, val_tag, golden_tag)
 
         template = spec_eval_template(spec_type)
         output_scores = [spec_eval_output_score(spec_data.name)]
@@ -120,6 +125,7 @@ def connect_spec_api(app: FastAPI):
             output_scores=output_scores,
             eval_set_filter_id=eval_set_filter_id,
             train_set_filter_id=train_set_filter_id,
+            val_set_filter_id=val_set_filter_id,
             eval_configs_filter_id=eval_configs_filter_id,
             template_properties=None,
             evaluation_data_type=evaluation_data_type,

--- a/libs/server/kiln_server/test_spec_api.py
+++ b/libs/server/kiln_server/test_spec_api.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from unittest.mock import patch
 
@@ -177,7 +178,14 @@ def test_create_spec_success(client, project_and_task):
     assert evals[0].id == res["eval_id"]
     assert evals[0].eval_set_filter_id == "tag::eval_test_spec"
     assert evals[0].train_set_filter_id == "tag::train_test_spec"
+    assert evals[0].val_set_filter_id == "tag::val_test_spec"
     assert evals[0].eval_configs_filter_id == "tag::eval_golden_test_spec"
+
+    # Check the raw saved file: the lazy train/val migrations run on load and would
+    # synthesize these same values, masking missing wiring in the create path
+    saved_eval = json.loads(evals[0].path.read_text())
+    assert saved_eval["train_set_filter_id"] == "tag::train_test_spec"
+    assert saved_eval["val_set_filter_id"] == "tag::val_test_spec"
 
 
 def test_create_spec_minimal(client, project_and_task):

--- a/libs/server/kiln_server/utils/spec_utils.py
+++ b/libs/server/kiln_server/utils/spec_utils.py
@@ -65,33 +65,40 @@ def spec_eval_template(spec_type: SpecType) -> EvalTemplateId | None:
             return None
 
 
-def generate_spec_eval_tags(spec_name: str) -> tuple[str, str, str]:
-    """Generate eval, train, and golden tags for a spec.
+def generate_spec_eval_tags(spec_name: str) -> tuple[str, str, str, str]:
+    """Generate eval, train, val, and golden tags for a spec.
 
     Args:
         spec_name: The name of the spec
 
     Returns:
-        Tuple of (eval_tag, train_tag, golden_tag)
+        Tuple of (eval_tag, train_tag, val_tag, golden_tag)
     """
     tag_suffix = spec_name.lower().replace(" ", "_")
     eval_tag = f"eval_{tag_suffix}"
     train_tag = f"train_{tag_suffix}"
+    val_tag = f"val_{tag_suffix}"
     golden_tag = f"eval_golden_{tag_suffix}"
-    return eval_tag, train_tag, golden_tag
+    return eval_tag, train_tag, val_tag, golden_tag
 
 
 def generate_spec_eval_filter_ids(
-    eval_tag: str, train_tag: str, golden_tag: str
-) -> tuple[str, str, str]:
-    """Generate filter IDs for eval set, train set, and eval configs.
+    eval_tag: str, train_tag: str, val_tag: str, golden_tag: str
+) -> tuple[str, str, str, str]:
+    """Generate filter IDs for eval set, train set, val set, and eval configs.
 
     Args:
         eval_tag: The eval dataset tag
         train_tag: The train dataset tag
+        val_tag: The val dataset tag
         golden_tag: The golden dataset tag
 
     Returns:
-        Tuple of (eval_set_filter_id, train_set_filter_id, eval_configs_filter_id)
+        Tuple of (eval_set_filter_id, train_set_filter_id, val_set_filter_id, eval_configs_filter_id)
     """
-    return f"tag::{eval_tag}", f"tag::{train_tag}", f"tag::{golden_tag}"
+    return (
+        f"tag::{eval_tag}",
+        f"tag::{train_tag}",
+        f"tag::{val_tag}",
+        f"tag::{golden_tag}",
+    )

--- a/libs/server/kiln_server/utils/test_spec_utils.py
+++ b/libs/server/kiln_server/utils/test_spec_utils.py
@@ -101,49 +101,65 @@ class TestSpecEvalTemplate:
 
 class TestGenerateSpecEvalTags:
     def test_generates_correct_tags_for_simple_name(self):
-        eval_tag, train_tag, golden_tag = generate_spec_eval_tags("Test Spec")
+        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("Test Spec")
         assert eval_tag == "eval_test_spec"
         assert train_tag == "train_test_spec"
+        assert val_tag == "val_test_spec"
         assert golden_tag == "eval_golden_test_spec"
 
     def test_handles_already_lowercase_name(self):
-        eval_tag, train_tag, golden_tag = generate_spec_eval_tags("my spec")
+        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("my spec")
         assert eval_tag == "eval_my_spec"
         assert train_tag == "train_my_spec"
+        assert val_tag == "val_my_spec"
         assert golden_tag == "eval_golden_my_spec"
 
     def test_handles_uppercase_name(self):
-        eval_tag, train_tag, golden_tag = generate_spec_eval_tags("MY SPEC")
+        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("MY SPEC")
         assert eval_tag == "eval_my_spec"
         assert train_tag == "train_my_spec"
+        assert val_tag == "val_my_spec"
         assert golden_tag == "eval_golden_my_spec"
 
     def test_handles_single_word_name(self):
-        eval_tag, train_tag, golden_tag = generate_spec_eval_tags("Toxicity")
+        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("Toxicity")
         assert eval_tag == "eval_toxicity"
         assert train_tag == "train_toxicity"
+        assert val_tag == "val_toxicity"
         assert golden_tag == "eval_golden_toxicity"
 
     def test_train_tag_uses_train_prefix(self):
         """Train tag should use 'train_' prefix, not 'eval_train_'."""
-        _, train_tag, _ = generate_spec_eval_tags("Test")
+        _, train_tag, _, _ = generate_spec_eval_tags("Test")
         assert train_tag.startswith("train_")
         assert not train_tag.startswith("eval_train_")
+
+    def test_val_tag_uses_val_prefix(self):
+        """Val tag should use 'val_' prefix, not 'eval_val_'."""
+        _, _, val_tag, _ = generate_spec_eval_tags("Test")
+        assert val_tag.startswith("val_")
+        assert not val_tag.startswith("eval_val_")
 
 
 class TestGenerateSpecEvalFilterIds:
     def test_generates_correct_filter_ids(self):
-        eval_filter, train_filter, golden_filter = generate_spec_eval_filter_ids(
-            "eval_test", "train_test", "golden_test"
+        eval_filter, train_filter, val_filter, golden_filter = (
+            generate_spec_eval_filter_ids(
+                "eval_test", "train_test", "val_test", "golden_test"
+            )
         )
         assert eval_filter == "tag::eval_test"
         assert train_filter == "tag::train_test"
+        assert val_filter == "tag::val_test"
         assert golden_filter == "tag::golden_test"
 
     def test_generates_filter_ids_with_tag_prefix(self):
-        eval_filter, train_filter, golden_filter = generate_spec_eval_filter_ids(
-            "my_tag", "other_tag", "third_tag"
+        eval_filter, train_filter, val_filter, golden_filter = (
+            generate_spec_eval_filter_ids(
+                "my_tag", "other_tag", "third_tag", "fourth_tag"
+            )
         )
         assert eval_filter.startswith("tag::")
         assert train_filter.startswith("tag::")
+        assert val_filter.startswith("tag::")
         assert golden_filter.startswith("tag::")


### PR DESCRIPTION
## What does this PR do?

Adds a validation split to evals, so run methods can be compared on held-out data without touching the test set. Evals previously carried only two split filters: `train_set_filter_id` and `eval_set_filter_id` (which is the test set — the name is legacy).

- Add `Eval.val_set_filter_id` with the same lazy migration as train: evals loaded without one get `tag::val_{name_slug}`
- Document on `eval_set_filter_id` that it is the test set and the name is legacy
- Mint `val_{name_slug}` tags/filter ids in spec eval creation (`generate_spec_eval_tags` / `generate_spec_eval_filter_ids` and both callers: `spec_api` and `copilot_api`)
- Deal a val split in copilot synthetic dataset creation: eval keeps half of the post-golden pool; the other half now splits 2/3 train, 1/3 val
- Regenerate the web client schema for the new Eval field

## Related Issues

None — approved eval-API improvement (val split groundwork).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135zWTBh8MRPwCXiWvuE597

---
_Generated by [Claude Code](https://claude.ai/code/session_0135zWTBh8MRPwCXiWvuE597)_