### PR TITLE
Add per-score direction flag to eval output scores

### DIFF
--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -45,6 +45,7 @@ from kiln_ai.datamodel.eval import (
     EvalOutputScore,
     EvalRun,
     EvalTemplateId,
+    ScoreDirection,
 )
 from kiln_ai.datamodel.prompt import BasePrompt
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
@@ -254,6 +255,53 @@ async def test_create_evaluator(
     assert saved_eval.template_properties is not None
     assert saved_eval.template_properties["test_property"] == "test_value"
     assert saved_eval.template_properties["numeric_property"] == 42
+    assert saved_eval.output_scores[0].direction == ScoreDirection.higher_is_better
+
+
+@pytest.mark.asyncio
+async def test_create_evaluator_with_direction(
+    client, mock_task_from_id, valid_evaluator_request, mock_task
+):
+    mock_task_from_id.return_value = mock_task
+    valid_evaluator_request.output_scores = [
+        EvalOutputScore(
+            name="score1",
+            type=TaskOutputRatingType.five_star,
+            direction=ScoreDirection.informational,
+        ),
+    ]
+
+    response = client.post(
+        "/api/projects/project1/tasks/task1/create_evaluator",
+        json=valid_evaluator_request.model_dump(),
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["output_scores"][0]["direction"] == "informational"
+
+    saved_eval = mock_task.evals()[0]
+    assert saved_eval.output_scores[0].direction == ScoreDirection.informational
+
+
+@pytest.mark.asyncio
+async def test_create_evaluator_direction_omitted_in_request(
+    client, mock_task_from_id, valid_evaluator_request, mock_task
+):
+    """Requests from clients that predate the direction field get the default."""
+    mock_task_from_id.return_value = mock_task
+    request_json = valid_evaluator_request.model_dump()
+    for score in request_json["output_scores"]:
+        del score["direction"]
+
+    response = client.post(
+        "/api/projects/project1/tasks/task1/create_evaluator",
+        json=request_json,
+    )
+
+    assert response.status_code == 200
+    saved_eval = mock_task.evals()[0]
+    assert saved_eval.output_scores[0].direction == ScoreDirection.higher_is_better
 
 
 @pytest.mark.asyncio

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -6044,6 +6044,11 @@ export interface components {
             instruction?: string | null;
             /** @description The type of rating to use ('five_star', 'pass_fail', 'pass_fail_critical'). */
             type: components["schemas"]["TaskOutputRatingType"];
+            /**
+             * @description The direction of improvement for this score: 'higher_is_better', 'lower_is_better', or 'informational' (context only, no preferred direction). Rating scales ('five_star', 'pass_fail', 'pass_fail_critical') are higher-is-better by definition, so they allow 'higher_is_better' and 'informational' but not 'lower_is_better'.
+             * @default higher_is_better
+             */
+            direction: components["schemas"]["ScoreDirection"];
         };
         /**
          * EvalProgress
@@ -9673,6 +9678,17 @@ export interface components {
              */
             projects: components["schemas"]["ProjectInfo"][];
         };
+        /**
+         * ScoreDirection
+         * @description The direction of improvement for an eval output score.
+         *
+         *     Tells consumers how to interpret a change in the score's value: 'higher_is_better'
+         *     means an increase is an improvement, 'lower_is_better' means a decrease is an
+         *     improvement, and 'informational' scores carry context only and should never drive
+         *     decisions in either direction.
+         * @enum {string}
+         */
+        ScoreDirection: "higher_is_better" | "lower_is_better" | "informational";
         /**
          * ScoreSummary
          * @description Summary of scores for an eval run.

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -55,6 +55,21 @@ class EvalConfigType(str, Enum):
     llm_as_judge = "llm_as_judge"
 
 
+class ScoreDirection(str, Enum):
+    """
+    The direction of improvement for an eval output score.
+
+    Tells consumers how to interpret a change in the score's value: 'higher_is_better'
+    means an increase is an improvement, 'lower_is_better' means a decrease is an
+    improvement, and 'informational' scores carry context only and should never drive
+    decisions in either direction.
+    """
+
+    higher_is_better = "higher_is_better"
+    lower_is_better = "lower_is_better"
+    informational = "informational"
+
+
 class EvalOutputScore(BaseModel):
     """
     A definition of a score that an evaluator will produce.
@@ -72,6 +87,10 @@ class EvalOutputScore(BaseModel):
     type: TaskOutputRatingType = Field(
         description="The type of rating to use ('five_star', 'pass_fail', 'pass_fail_critical').",
     )
+    direction: ScoreDirection = Field(
+        default=ScoreDirection.higher_is_better,
+        description="The direction of improvement for this score: 'higher_is_better', 'lower_is_better', or 'informational' (context only, no preferred direction). Rating scales ('five_star', 'pass_fail', 'pass_fail_critical') are higher-is-better by definition, so they allow 'higher_is_better' and 'informational' but not 'lower_is_better'.",
+    )
 
     def json_key(self) -> str:
         """
@@ -87,6 +106,25 @@ class EvalOutputScore(BaseModel):
             raise ValueError(
                 f"Custom scores are not supported in evaluators. Score '{self.name}' was set to a custom score."
             )
+        return self
+
+    @model_validator(mode="after")
+    def validate_direction(self) -> Self:
+        match self.type:
+            case (
+                TaskOutputRatingType.five_star
+                | TaskOutputRatingType.pass_fail
+                | TaskOutputRatingType.pass_fail_critical
+            ):
+                if self.direction == ScoreDirection.lower_is_better:
+                    raise ValueError(
+                        f"Score '{self.name}' has type '{self.type.value}', which is higher-is-better by definition. 'lower_is_better' is only valid for custom scores."
+                    )
+            case TaskOutputRatingType.custom:
+                # Any direction is valid for custom scores (unbounded numeric metrics).
+                pass
+            case _:
+                raise_exhaustive_enum_error(self.type)
         return self
 
 

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -10,6 +12,7 @@ from kiln_ai.datamodel.eval import (
     EvalOutputScore,
     EvalRun,
     EvalTemplateId,
+    ScoreDirection,
 )
 from kiln_ai.datamodel.task import Task
 from kiln_ai.datamodel.task_output import TaskOutputRatingType
@@ -577,6 +580,105 @@ def test_eval_output_score_name_validation():
         type=TaskOutputRatingType.five_star,
     )
     assert max_length_score.name == "a" * 32
+
+
+def test_eval_output_score_direction_default():
+    score = EvalOutputScore(
+        name="accuracy",
+        type=TaskOutputRatingType.five_star,
+    )
+    assert score.direction == ScoreDirection.higher_is_better
+
+
+def test_eval_output_score_direction_legacy_dict():
+    """Serialized scores that predate the direction field must still parse."""
+    score = EvalOutputScore.model_validate(
+        {
+            "name": "accuracy",
+            "type": "five_star",
+        }
+    )
+    assert score.direction == ScoreDirection.higher_is_better
+
+
+@pytest.mark.parametrize(
+    "score_type",
+    [
+        TaskOutputRatingType.five_star,
+        TaskOutputRatingType.pass_fail,
+        TaskOutputRatingType.pass_fail_critical,
+    ],
+)
+@pytest.mark.parametrize(
+    "direction",
+    [ScoreDirection.higher_is_better, ScoreDirection.informational],
+)
+def test_eval_output_score_direction_valid(score_type, direction):
+    score = EvalOutputScore(
+        name="my score",
+        type=score_type,
+        direction=direction,
+    )
+    assert score.direction == direction
+
+    round_tripped = EvalOutputScore.model_validate(score.model_dump())
+    assert round_tripped.direction == direction
+
+
+@pytest.mark.parametrize(
+    "score_type",
+    [
+        TaskOutputRatingType.five_star,
+        TaskOutputRatingType.pass_fail,
+        TaskOutputRatingType.pass_fail_critical,
+    ],
+)
+def test_eval_output_score_direction_lower_rejected(score_type):
+    with pytest.raises(
+        ValidationError,
+        match=r"'my score'.*higher-is-better by definition",
+    ):
+        EvalOutputScore(
+            name="my score",
+            type=score_type,
+            direction=ScoreDirection.lower_is_better,
+        )
+
+
+def test_eval_direction_legacy_file_load(mock_task, tmp_path):
+    """Eval files saved before the direction field existed must load with the default."""
+    task_path = tmp_path / "task.kiln"
+    mock_task.path = task_path
+    mock_task.save_to_file()
+
+    eval = Eval(
+        name="Legacy Eval",
+        parent=mock_task,
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        output_scores=[
+            EvalOutputScore(
+                name="score",
+                type=TaskOutputRatingType.pass_fail,
+            )
+        ],
+    )
+    eval.save_to_file()
+
+    # Rewrite the file without the direction key, simulating a pre-direction file
+    eval_path = eval.path
+    file_data = json.loads(eval_path.read_text())
+    for score in file_data["output_scores"]:
+        del score["direction"]
+    eval_path.write_text(json.dumps(file_data, ensure_ascii=False))
+
+    loaded_eval = Eval.load_from_file(str(eval_path))
+    assert loaded_eval.output_scores[0].direction == ScoreDirection.higher_is_better
+
+    # Re-saving persists the field explicitly
+    loaded_eval.save_to_file()
+    saved_data = json.loads(eval_path.read_text())
+    assert saved_data["output_scores"][0]["direction"] == "higher_is_better"
 
 
 @pytest.fixture


### PR DESCRIPTION
## What does this PR do?

Eval output scores had no way to declare which way is better. This adds `direction` on `EvalOutputScore` — `higher_is_better` (default), `lower_is_better`, or `informational` (context only, should never drive decisions) — so API consumers comparing results across runs can interpret score deltas without guessing.

- Rating scales (`five_star`, `pass_fail`, `pass_fail_critical`) are higher-is-better by definition: they accept `higher_is_better` and `informational`, and reject `lower_is_better`. `lower_is_better` is reserved for custom scores (unbounded numeric metrics), which evaluators do not support yet.
- Backward compatible: the field defaults to `higher_is_better`, so existing evals load unchanged; requests from clients that predate the field get the default.
- The field flows through the create_evaluator and read APIs automatically via `EvalOutputScore`; web client schema regenerated.

## Related Issues

Companion to #1620 and #1621 (eval-API improvements).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135zWTBh8MRPwCXiWvuE597

---
_Generated by [Claude Code](https://claude.ai/code/session_0135zWTBh8MRPwCXiWvuE597)_