### PR TITLE
eval v2: derive EvalRun.task_run_usage from the evaluated trace

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from dataclasses import dataclass
-from typing import AsyncGenerator, Dict, List, Literal, Set
+from typing import Any, AsyncGenerator, Dict, List, Literal, Set
 
 import litellm
 
@@ -30,6 +30,7 @@ from kiln_ai.datamodel.eval import (
 )
 from kiln_ai.datamodel.task import TaskRunConfig
 from kiln_ai.datamodel.task_run import TaskRun, Usage
+from kiln_ai.datamodel.usage import MessageUsage
 from kiln_ai.utils.async_job_runner import AsyncJobRunner, Progress, RetryableError
 from kiln_ai.utils.git_sync_protocols import SaveContext, default_save_context
 
@@ -485,6 +486,7 @@ class EvalRunner:
                     else None,
                     skipped_detail=result.skipped_detail,
                     intermediate_outputs=result.intermediate_outputs,
+                    task_run_usage=_usage_from_trace(eval_task_input.trace),
                 )
                 eval_run.save_to_file()
             return True
@@ -515,6 +517,7 @@ class EvalRunner:
                     else None,
                     skipped_detail=result.skipped_detail,
                     intermediate_outputs=result.intermediate_outputs,
+                    task_run_usage=_usage_from_trace(eval_task_input.trace),
                 )
                 eval_run.save_to_file()
             return True
@@ -547,6 +550,32 @@ class EvalRunner:
                 )
                 eval_run.save_to_file()
             return True
+
+
+def _usage_from_trace(trace: list[dict[str, Any]] | None) -> Usage | None:
+    """Aggregate per-message usage and latency into run-level Usage.
+
+    The v2 lanes score traces (fresh generations from run_task, or a golden
+    TaskRun's stored conversation) rather than persisted TaskRuns, so
+    run-level usage must be derived from the trace itself. Latency is the
+    sum of per-call latency_ms: calls within one conversation run
+    sequentially, so the sum is the real time spent waiting on the model."""
+    if not trace:
+        return None
+    message_usage = MessageUsage()
+    latency = 0
+    for message in trace:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        raw_usage = message.get("usage")
+        if isinstance(raw_usage, MessageUsage):
+            message_usage = message_usage + raw_usage
+        elif isinstance(raw_usage, dict):
+            message_usage = message_usage + MessageUsage.model_validate(raw_usage)
+        latency += message.get("latency_ms") or 0
+    if message_usage == MessageUsage() and not latency:
+        return None
+    return Usage(**message_usage.model_dump(), total_llm_latency_ms=latency or None)
 
 
 def _unwrap_kiln_run_error(e: BaseException) -> BaseException:

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -1661,6 +1661,81 @@ class TestV2FreshGeneration:
         assert saved.skipped_reason is None
 
     @pytest.mark.asyncio
+    async def test_task_run_eval_derives_usage_from_trace(
+        self,
+        mock_v2_task_run_eval_runner,
+        mock_v2_task_run_eval_config,
+        mock_run_config,
+        data_source,
+    ):
+        stale_task_run = TaskRun(
+            input="test input",
+            output=TaskOutput(output="stale output", source=data_source),
+            parent=mock_v2_task_run_eval_runner.task,
+        )
+        stale_task_run.save_to_file()
+
+        fresh_task_run = TaskRun(
+            input="test input",
+            output=TaskOutput(output="hello", source=data_source),
+            parent=mock_v2_task_run_eval_runner.task,
+            trace=[
+                {"role": "user", "content": "test input"},
+                {
+                    "role": "assistant",
+                    "content": "thinking...",
+                    "usage": {
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "total_tokens": 15,
+                        "cost": 0.01,
+                    },
+                    "latency_ms": 100,
+                },
+                {
+                    "role": "assistant",
+                    "content": "hello",
+                    "usage": {
+                        "input_tokens": 20,
+                        "output_tokens": 7,
+                        "total_tokens": 27,
+                        "cost": 0.02,
+                    },
+                    "latency_ms": 250,
+                },
+            ],
+        )
+        fresh_task_run.save_to_file()
+
+        job = EvalJob(
+            item=stale_task_run,
+            eval_config=mock_v2_task_run_eval_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+
+        stub = StubV2Eval(mock_v2_task_run_eval_config)
+        with (
+            patch.object(stub, "run_task", return_value=fresh_task_run),
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+        ):
+            result = await mock_v2_task_run_eval_runner.run_job(job)
+
+        assert result is True
+        runs = mock_v2_task_run_eval_config.runs(readonly=True)
+        assert len(runs) == 1
+        saved = runs[0]
+        assert saved.task_run_usage is not None
+        assert saved.task_run_usage.input_tokens == 30
+        assert saved.task_run_usage.output_tokens == 12
+        assert saved.task_run_usage.total_tokens == 42
+        assert saved.task_run_usage.cost == pytest.approx(0.03)
+        assert saved.task_run_usage.total_llm_latency_ms == 350
+
+    @pytest.mark.asyncio
     async def test_task_run_eval_persists_fresh_output_not_stale(
         self,
         mock_v2_task_run_eval_runner,


### PR DESCRIPTION
## The gap

The v2 eval lanes score **traces**, not persisted TaskRuns — the only writer of `EvalRun.task_run_usage` was the legacy path (`_run_legacy_job`, eval_runner.py:328-370), which copies usage off the TaskRun it ran or scored. Every v2 EvalRun was saved with `task_run_usage=None`, so the UI's usage panel showed "not calculated" for every v2 eval — even though every assistant message in the evaluated trace already carries `usage` (MessageUsage) and `latency_ms`.

## The fix

- `_usage_from_trace()` in `eval_runner.py`: walks the trace, sums per-assistant-message `usage` (accepting both `MessageUsage` instances and plain dicts from JSON round-trips) plus per-call `latency_ms`, and returns a `Usage` with `total_llm_latency_ms` (calls in one conversation run sequentially, so the sum is real wall time spent on the model). Returns `None` for empty/usage-less traces so records without data stay honestly unset.
- Wired `task_run_usage=_usage_from_trace(eval_task_input.trace)` into the two trace-carrying v2 EvalRun constructions on this branch: the **single-turn EvalInput job** and the **fresh task_run_eval job**. `eval_config_eval` (golden calibration) records stay scores-only — their usage already lives on the golden TaskRun itself.

The aggregation is inlined rather than delegating to `MessageUsage.from_trace` because that signature takes `list[ChatCompletionMessageParam]` while `EvalTaskInput.trace` is `list[dict[str, Any]]` — bridging it would need `typing.cast`, which ruff bans (TID251).

## Reused-trace / multi-turn coverage

This branch still skips multi-turn inputs, so there's nothing to wire there yet — but this is exactly the branch where trace-derived usage becomes the **only** option: the multi-turn drive lane produces transient conversations (no leaf TaskRun is ever persisted), and reused-trace records (drive-fingerprint reuse) have no fresh run at all. When that lane lands, its EvalRun construction(s) should get the same `_usage_from_trace(eval_task_input.trace)` wiring; the helper is already shape-agnostic.

## Reporting caveat

Once the multi-turn reuse index exists, N evals score the **same** driven conversation via the drive fingerprint index — each of those N EvalRuns will carry the same trace-derived usage. Naive cost totals summed over EvalRuns therefore multiply-count conversations; per-conversation reporting should dedupe on the drive fingerprint.

## Testing

- `libs/core/kiln_ai/adapters/eval/test_eval_runner.py`: 67 passed (66 existing + 1 new: fresh task_run_eval with a two-assistant-message trace carrying usage dicts + latency_ms asserts the summed `Usage` incl. `total_llm_latency_ms` lands on the EvalRun).
- `ruff format` + `ruff check` clean on both touched files; pyright reports no new errors (the 2 on this file are pre-existing on the base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)