### PR TITLE
Fix V2 evals crashing on every dataset item with dataset_id validation error

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -495,7 +495,9 @@ class EvalRunner:
             result = await evaluator.evaluate(eval_task_input)
             task_output = run_output.output.output
             task_input_str = run_output.input
-            dataset_id = run_output.id
+            # The source dataset item, not the fresh generation: run_task never
+            # persists its run, and dedupe/progress accounting key on the source id.
+            dataset_id = job.item.id
 
             async with self._save_context():
                 eval_run = EvalRun(

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -1630,7 +1630,6 @@ class TestV2FreshGeneration:
             output=TaskOutput(output="hello", source=data_source),
             parent=mock_v2_task_run_eval_runner.task,
         )
-        fresh_task_run.save_to_file()
 
         job = EvalJob(
             item=stale_task_run,
@@ -1655,7 +1654,7 @@ class TestV2FreshGeneration:
         assert len(runs) == 1
         saved = runs[0]
         assert saved.output == "hello"
-        assert saved.dataset_id == fresh_task_run.id
+        assert saved.dataset_id == stale_task_run.id
         assert saved.scores == {"accuracy": 1.0}
         assert saved.eval_config_eval is False
         assert saved.skipped_reason is None
@@ -1680,7 +1679,6 @@ class TestV2FreshGeneration:
             output=TaskOutput(output="new answer", source=data_source),
             parent=mock_v2_task_run_eval_runner.task,
         )
-        fresh_task_run.save_to_file()
 
         job = EvalJob(
             item=stale_task_run,
@@ -1707,7 +1705,7 @@ class TestV2FreshGeneration:
         saved = runs[0]
         assert saved.output == "new answer"
         assert saved.output != "old answer"
-        assert saved.dataset_id == fresh_task_run.id
+        assert saved.dataset_id == stale_task_run.id
 
     @pytest.mark.asyncio
     async def test_task_run_eval_skip_persists_skipped_eval_run(
@@ -1729,7 +1727,6 @@ class TestV2FreshGeneration:
             output=TaskOutput(output="fresh output", source=data_source),
             parent=mock_v2_task_run_eval_runner.task,
         )
-        fresh_task_run.save_to_file()
 
         job = EvalJob(
             item=stale_task_run,
@@ -1757,7 +1754,58 @@ class TestV2FreshGeneration:
         assert saved.output is None
         assert saved.scores == {}
         assert saved.eval_config_eval is False
-        assert saved.dataset_id == fresh_task_run.id
+        assert saved.dataset_id == stale_task_run.id
+
+    @pytest.mark.asyncio
+    async def test_task_run_eval_uses_source_id_when_fresh_run_unsaved(
+        self,
+        mock_v2_task_run_eval_runner,
+        mock_v2_task_run_eval_config,
+        mock_run_config,
+        data_source,
+    ):
+        """Production reproduction: run_task uses allow_saving=False, so the fresh
+        TaskRun comes back with id=None. The EvalRun must still record the source
+        dataset item's id."""
+        stale_task_run = TaskRun(
+            input="test input",
+            output=TaskOutput(output="stale output", source=data_source),
+            parent=mock_v2_task_run_eval_runner.task,
+        )
+        stale_task_run.save_to_file()
+
+        fresh_task_run = TaskRun(
+            input="test input",
+            output=TaskOutput(output="hello", source=data_source),
+            parent=mock_v2_task_run_eval_runner.task,
+        )
+        fresh_task_run.id = None
+
+        job = EvalJob(
+            item=stale_task_run,
+            eval_config=mock_v2_task_run_eval_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+
+        stub = StubV2Eval(mock_v2_task_run_eval_config)
+        with (
+            patch.object(stub, "run_task", return_value=fresh_task_run),
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+        ):
+            result = await mock_v2_task_run_eval_runner.run_job(job)
+
+        assert result is True
+        runs = mock_v2_task_run_eval_config.runs(readonly=True)
+        assert len(runs) == 1
+        saved = runs[0]
+        assert saved.dataset_id == stale_task_run.id
+        assert saved.eval_input_id is None
+        assert saved.output == "hello"
+        assert saved.scores == {"accuracy": 1.0}
 
     @pytest.mark.asyncio
     async def test_eval_config_eval_scores_existing_without_fresh_gen(


### PR DESCRIPTION
## What does this PR do?

Fixes V2 evals failing on **every** dataset item when run against a run config:

```
Error running eval job for dataset item 195481810082: 1 validation error for EvalRun
  Value error, Exactly one of dataset_id (V1 TaskRun source) or eval_input_id (V2 EvalInput source) must be set
```

**Root cause.** In the `task_run_eval` branch of `EvalRunner._run_v2_job`, `dataset_id` was taken from the freshly generated `TaskRun`. `BaseEval.run_task` builds its adapter with `AdapterConfig(allow_saving=False)`, and `base_adapter` clears `run.id` when saving is disabled — so that id is always `None` in production. With `eval_input_id` also `None`, `EvalRun.validate_input_source` rejected the model.

**Fix.** Use the source dataset item's id (`job.item.id`). That's the field's documented meaning ("The ID of the dataset item (TaskRun) that was used for this run") and what every other code path already passes. It also matters beyond dodging the `None`: dedupe compares `run.dataset_id` against the source `task_run.id` to skip already-run items, and the eval API's progress accounting maps `dataset_id` back into the dataset filter — the fresh run's id would have been wrong on both counts even if it existed.

**Scope.** Only the `task_run_eval` + TaskRun-item branch. The `eval_config_eval` path, EvalInput-sourced runs, multi-turn leaves, and all V1 evals are untouched.

**Why CI never caught this.** Three assertions in `TestV2FreshGeneration` encoded the wrong semantic and are flipped to the source item. They passed only because each stubbed `run_task` with a fresh `TaskRun` that had been explicitly `save_to_file()`'d, giving it an id that production never has; those `save_to_file()` calls are removed so the stubs match production. Adds `test_task_run_eval_uses_source_id_when_fresh_run_unsaved`, which stubs `run_task` with an unsaved fresh `TaskRun` (`id is None`) and asserts the `EvalRun` persists with `dataset_id` set to the source item's id.

Verified by reverting the one-line fix: the new test then fails with the exact production `ValidationError`, and all four `TestV2FreshGeneration` task_run_eval tests fail once the false-green stubs are gone.

## Related Issues

None linked.


## Checklists

- [x] Tests have been run locally and passed — `uv run --frozen python3 -m pytest -n auto libs/core/kiln_ai/adapters/eval` → 557 passed, 1069 skipped; `ruff check` and `ruff format --check` clean; `ty check` shows only two pre-existing diagnostics in the untouched `g_eval.py`.
- [x] New tests have been added to any work in /lib

Note: `app/desktop/studio_server/test_eval_api.py` could not be collected in this environment due to a pre-existing `ImportError: cannot import name 'collapse_excgroups' from 'starlette._utils'` (starlette/fastapi version mismatch in the venv), unrelated to this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_015fom1EurEw62dSXwZWk73t)_