### PR TITLE
Raise memory caps to 280/4000 and harden write-side validation

### DIFF
--- a/libs/core/kiln_ai/datamodel/memory.py
+++ b/libs/core/kiln_ai/datamodel/memory.py
@@ -9,8 +9,11 @@ from kiln_ai.datamodel.basemodel import KilnParentedModel
 from kiln_ai.datamodel.model_cache import ModelCache
 from kiln_ai.utils.validation import validate_tags
 
-MAX_OVERVIEW_LENGTH = 140
-MAX_CONTENT_LENGTH = 2000
+# These caps are enforced at write time AND re-applied by pydantic when loading
+# stored rows, so any row exceeding them (e.g. from an out-of-band writer)
+# breaks every listing for its project. Raising them is safe; never lower them.
+MAX_OVERVIEW_LENGTH = 280
+MAX_CONTENT_LENGTH = 4000
 MAX_SCOPE_LENGTH = 255
 
 

--- a/libs/core/kiln_ai/datamodel/test_memory.py
+++ b/libs/core/kiln_ai/datamodel/test_memory.py
@@ -5,6 +5,11 @@ import pytest
 from pydantic import ValidationError
 
 from kiln_ai.datamodel import Memory, Project
+from kiln_ai.datamodel.memory import (
+    MAX_CONTENT_LENGTH,
+    MAX_OVERVIEW_LENGTH,
+    MAX_SCOPE_LENGTH,
+)
 
 
 @pytest.fixture
@@ -24,19 +29,19 @@ def make_memory(**overrides) -> Memory:
 
 
 def test_overview_accepts_max_length():
-    m = make_memory(overview="a" * 140)
-    assert len(m.overview) == 140
+    m = make_memory(overview="a" * MAX_OVERVIEW_LENGTH)
+    assert len(m.overview) == MAX_OVERVIEW_LENGTH
 
 
 def test_overview_rejects_over_length():
     with pytest.raises(ValidationError):
-        make_memory(overview="a" * 141)
+        make_memory(overview="a" * (MAX_OVERVIEW_LENGTH + 1))
 
 
 def test_overview_rejects_over_length_only_after_strip():
-    # 140 real chars plus surrounding whitespace should be accepted (stripped first).
-    m = make_memory(overview="  " + "a" * 140 + "  ")
-    assert m.overview == "a" * 140
+    # Max-length real chars plus surrounding whitespace: accepted (stripped first).
+    m = make_memory(overview="  " + "a" * MAX_OVERVIEW_LENGTH + "  ")
+    assert m.overview == "a" * MAX_OVERVIEW_LENGTH
 
 
 @pytest.mark.parametrize("bad", ["line1\nline2", "line1\r\nline2", "a\rb"])
@@ -68,13 +73,13 @@ def test_content_defaults_none():
 
 
 def test_content_accepts_max_length():
-    m = make_memory(content="a" * 2000)
-    assert len(m.content) == 2000
+    m = make_memory(content="a" * MAX_CONTENT_LENGTH)
+    assert len(m.content) == MAX_CONTENT_LENGTH
 
 
 def test_content_rejects_over_length():
     with pytest.raises(ValidationError):
-        make_memory(content="a" * 2001)
+        make_memory(content="a" * (MAX_CONTENT_LENGTH + 1))
 
 
 @pytest.mark.parametrize("empty", ["", "   ", "\n"])
@@ -122,13 +127,13 @@ def test_scope_required():
 
 
 def test_scope_accepts_max_length():
-    m = make_memory(scope="s" * 255)
-    assert len(m.scope) == 255
+    m = make_memory(scope="s" * MAX_SCOPE_LENGTH)
+    assert len(m.scope) == MAX_SCOPE_LENGTH
 
 
 def test_scope_rejects_over_length():
     with pytest.raises(ValidationError):
-        make_memory(scope="s" * 256)
+        make_memory(scope="s" * (MAX_SCOPE_LENGTH + 1))
 
 
 @pytest.mark.parametrize("bad", ["a\nb", "a\r\nb"])
@@ -204,16 +209,16 @@ def test_load_leniency_boundary_values(project: Project):
     # Max-length values that once saved must always load without error.
     memory = Memory(
         parent=project,
-        overview="o" * 140,
-        scope="s" * 255,
-        content="c" * 2000,
+        overview="o" * MAX_OVERVIEW_LENGTH,
+        scope="s" * MAX_SCOPE_LENGTH,
+        content="c" * MAX_CONTENT_LENGTH,
     )
     memory.save_to_file()
 
     loaded = Memory.load_from_file(memory.path)
-    assert len(loaded.overview) == 140
-    assert len(loaded.scope) == 255
-    assert len(loaded.content) == 2000
+    assert len(loaded.overview) == MAX_OVERVIEW_LENGTH
+    assert len(loaded.scope) == MAX_SCOPE_LENGTH
+    assert len(loaded.content) == MAX_CONTENT_LENGTH
 
 
 def test_on_disk_shape(project: Project):

--- a/libs/core/kiln_ai/memory/test_memory_store.py
+++ b/libs/core/kiln_ai/memory/test_memory_store.py
@@ -2,8 +2,10 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from kiln_ai.datamodel import Memory, Project
+from kiln_ai.datamodel.memory import MAX_OVERVIEW_LENGTH
 from kiln_ai.memory import (
     InvalidContentMatchError,
     MemoryNotFoundError,
@@ -176,8 +178,8 @@ def test_update_partial_replace_only_provided(project: Project, store: MemorySto
 
 def test_update_revalidates_provided_field(project: Project, store: MemoryStore):
     memory = add(project, "orig", "project", minutes=0)
-    with pytest.raises(Exception):
-        store.update_memory(memory.id, overview="a" * 141)
+    with pytest.raises(ValidationError):
+        store.update_memory(memory.id, overview="a" * (MAX_OVERVIEW_LENGTH + 1))
 
 
 def test_update_content_empty_clears_to_none(project: Project, store: MemoryStore):

--- a/libs/core/kiln_ai/tools/memory_tools.py
+++ b/libs/core/kiln_ai/tools/memory_tools.py
@@ -18,7 +18,11 @@ from typing import Any, ClassVar
 
 from pydantic import ValidationError
 
-from kiln_ai.datamodel.memory import Memory
+from kiln_ai.datamodel.memory import (
+    MAX_CONTENT_LENGTH,
+    MAX_OVERVIEW_LENGTH,
+    Memory,
+)
 from kiln_ai.datamodel.project import Project
 from kiln_ai.datamodel.tool_id import ToolId, memory_operation_from_tool_id
 from kiln_ai.memory import MemoryListResult, MemoryStore
@@ -118,18 +122,19 @@ class SaveMemoryTool(_MemoryTool):
             "overview": {
                 "type": "string",
                 "description": (
-                    "One-line summary (<=140 chars, no newlines) written so a future "
-                    "reader can decide whether to fetch the full content."
+                    f"One-line summary (<={MAX_OVERVIEW_LENGTH} chars, no newlines) "
+                    "written so a future reader can decide whether to fetch the "
+                    "full content."
                 ),
             },
             "scope": _SCOPE_SCHEMA,
             "content": {
                 "type": "string",
                 "description": (
-                    "The memory body (<=2000 chars): the finding/fact/decision with "
-                    "its conditions and evidence level, citing related Kiln records as "
-                    "prose IDs (e.g. 'run_config 184623901234'). Omit when the overview "
-                    "says everything."
+                    f"The memory body (<={MAX_CONTENT_LENGTH} chars): the finding/"
+                    "fact/decision with its conditions and evidence level, citing "
+                    "related Kiln records as prose IDs (e.g. 'run_config "
+                    "184623901234'). Omit when the overview says everything."
                 ),
             },
             "tags": _TAGS_SCHEMA,
@@ -251,11 +256,15 @@ class UpdateMemoryTool(_MemoryTool):
             "id": {"type": "string", "description": "The memory id to update."},
             "overview": {
                 "type": "string",
-                "description": "New one-line summary (<=140 chars, no newlines).",
+                "description": (
+                    f"New one-line summary (<={MAX_OVERVIEW_LENGTH} chars, no newlines)."
+                ),
             },
             "content": {
                 "type": "string",
-                "description": "New body (<=2000 chars). Empty string clears it.",
+                "description": (
+                    f"New body (<={MAX_CONTENT_LENGTH} chars). Empty string clears it."
+                ),
             },
             "tags": _TAGS_SCHEMA,
             "scope": _SCOPE_SCHEMA,

--- a/libs/core/kiln_ai/tools/test_memory_tools.py
+++ b/libs/core/kiln_ai/tools/test_memory_tools.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from kiln_ai.datamodel import Project, Task
+from kiln_ai.datamodel.memory import MAX_OVERVIEW_LENGTH
 from kiln_ai.datamodel.tool_id import (
     build_memory_tool_id,
     memory_operation_from_tool_id,
@@ -154,7 +155,9 @@ async def test_update_clears_content_with_empty_string(project):
 
 
 async def test_save_over_length_overview_is_tool_error(project):
-    result = await tool(project, "save").run(overview="a" * 141, scope="project")
+    result = await tool(project, "save").run(
+        overview="a" * (MAX_OVERVIEW_LENGTH + 1), scope="project"
+    )
     assert result.is_error
     assert result.error_message
 

--- a/libs/server/kiln_server/test_memory_api.py
+++ b/libs/server/kiln_server/test_memory_api.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
@@ -5,6 +6,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from kiln_ai.datamodel import Memory, Project
+from kiln_ai.datamodel.memory import MAX_CONTENT_LENGTH, MAX_OVERVIEW_LENGTH
 
 from kiln_server.custom_errors import connect_custom_errors
 from kiln_server.memory_api import connect_memory_api
@@ -80,9 +82,46 @@ def test_save_over_length_overview_is_422(client, project):
     with _patch(project):
         resp = client.post(
             f"/api/projects/{project.id}/memories",
-            json={"overview": "a" * 141, "scope": "project"},
+            json={"overview": "a" * (MAX_OVERVIEW_LENGTH + 1), "scope": "project"},
         )
     assert resp.status_code == 422
+    error = resp.json()["source_errors"][0]
+    assert error["type"] == "string_too_long"
+    assert error["ctx"]["max_length"] == str(MAX_OVERVIEW_LENGTH)
+    assert len(project.memories()) == 0
+
+
+def test_save_over_length_content_is_422(client, project):
+    with _patch(project):
+        resp = client.post(
+            f"/api/projects/{project.id}/memories",
+            json={
+                "overview": "x",
+                "scope": "project",
+                "content": "a" * (MAX_CONTENT_LENGTH + 1),
+            },
+        )
+    assert resp.status_code == 422
+    error = resp.json()["source_errors"][0]
+    assert error["type"] == "string_too_long"
+    assert error["ctx"]["max_length"] == str(MAX_CONTENT_LENGTH)
+    assert len(project.memories()) == 0
+
+
+def test_save_accepts_exactly_max_lengths(client, project):
+    with _patch(project):
+        resp = client.post(
+            f"/api/projects/{project.id}/memories",
+            json={
+                "overview": "a" * MAX_OVERVIEW_LENGTH,
+                "scope": "project",
+                "content": "b" * MAX_CONTENT_LENGTH,
+            },
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["overview"]) == MAX_OVERVIEW_LENGTH
+    assert len(data["content"]) == MAX_CONTENT_LENGTH
 
 
 def test_save_newline_overview_is_422(client, project):
@@ -164,6 +203,43 @@ def test_list_rejects_out_of_range_paging(client, project, params):
     assert resp.status_code == 422
 
 
+def test_list_includes_stored_178_char_overview_row(client, project):
+    """Regression: a stored row with a 178-char overview (written when the write
+    path didn't stop it) used to fail load validation under the old 140 cap and
+    422 every listing. Plant the row raw on disk — bypassing write validation,
+    like the original writer — and verify it now lists and fetches fine."""
+    long_overview = "x" * 178
+    memory_dir = project.path.parent / "assistant_memory" / "999888777666"
+    memory_dir.mkdir(parents=True)
+    (memory_dir / "memory.kiln").write_text(
+        json.dumps(
+            {
+                "v": 1,
+                "id": "999888777666",
+                "created_at": BASE.isoformat(),
+                "created_by": "agent",
+                "model_type": "memory",
+                "overview": long_overview,
+                "content": None,
+                "tags": [],
+                "scope": "project",
+            },
+            ensure_ascii=False,
+        )
+    )
+
+    with _patch(project):
+        listed = client.get(f"/api/projects/{project.id}/memories")
+        fetched = client.get(
+            f"/api/projects/{project.id}/memories/by_ids",
+            params={"ids": ["999888777666"]},
+        )
+    assert listed.status_code == 200
+    assert [r["overview"] for r in listed.json()["listings"]] == [long_overview]
+    assert fetched.status_code == 200
+    assert fetched.json()[0]["overview"] == long_overview
+
+
 # --- summary ---
 
 
@@ -230,14 +306,48 @@ def test_update_unknown_id_is_404(client, project):
     assert resp.status_code == 404
 
 
-def test_update_over_length_is_422(client, project):
+def test_update_over_length_overview_is_422(client, project):
     m = add(project, "orig", "project", 0)
     with _patch(project):
         resp = client.patch(
             f"/api/projects/{project.id}/memories/{m.id}",
-            json={"overview": "a" * 141},
+            json={"overview": "a" * (MAX_OVERVIEW_LENGTH + 1)},
         )
     assert resp.status_code == 422
+    error = resp.json()["source_errors"][0]
+    assert error["type"] == "string_too_long"
+    assert error["ctx"]["max_length"] == str(MAX_OVERVIEW_LENGTH)
+    assert project.memories()[0].overview == "orig"
+
+
+def test_update_over_length_content_is_422(client, project):
+    m = add(project, "orig", "project", 0)
+    with _patch(project):
+        resp = client.patch(
+            f"/api/projects/{project.id}/memories/{m.id}",
+            json={"content": "a" * (MAX_CONTENT_LENGTH + 1)},
+        )
+    assert resp.status_code == 422
+    error = resp.json()["source_errors"][0]
+    assert error["type"] == "string_too_long"
+    assert error["ctx"]["max_length"] == str(MAX_CONTENT_LENGTH)
+    assert project.memories()[0].content is None
+
+
+def test_update_accepts_exactly_max_lengths(client, project):
+    m = add(project, "orig", "project", 0)
+    with _patch(project):
+        resp = client.patch(
+            f"/api/projects/{project.id}/memories/{m.id}",
+            json={
+                "overview": "a" * MAX_OVERVIEW_LENGTH,
+                "content": "b" * MAX_CONTENT_LENGTH,
+            },
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["overview"]) == MAX_OVERVIEW_LENGTH
+    assert len(data["content"]) == MAX_CONTENT_LENGTH
 
 
 # --- delete ---


### PR DESCRIPTION
## What does this PR do?

Fixes a live incident: a 178-char memory `overview` reached disk via an out-of-band writer, and because pydantic re-applies `Field(max_length=...)` caps at load time, that single row 422'd every memory listing for its project.

- Raise the caps at the single authoritative place (`MAX_OVERVIEW_LENGTH` 140 → 280, `MAX_CONTENT_LENGTH` 2000 → 4000 in the memory datamodel) — both observed organic overruns were high-quality writes that now fit. Everything else (REST request models, store, MCP tool descriptions) derives from these constants; tool descriptions are now f-string-interpolated so they can't drift.
- Verify + test write-side enforcement: POST and PATCH 422 over-cap fields (`string_too_long`, `ctx.max_length`) with no state mutation; boundary accepts at exactly 280/4000.
- Regression test reproducing the incident: a raw 178-char-overview row planted on disk (bypassing write validation) now lists fine under the new cap — mutation-verified (fails under the old cap).
- Document the accepted risk at the constants: caps also apply at load; never lower them.

## Related Issues

Stacks on the memory-feature branch (`claude/kiln-new-project-mtncvl`).

## Contributor License Agreement

I, @scosman, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135zWTBh8MRPwCXiWvuE597

---
_Generated by [Claude Code](https://claude.ai/code/session_0135zWTBh8MRPwCXiWvuE597)_