### PR TITLE
Flag skill tool failures with is_error / error_message

### DIFF
--- a/libs/core/kiln_ai/tools/skill_tool.py
+++ b/libs/core/kiln_ai/tools/skill_tool.py
@@ -71,14 +71,16 @@ class SkillTool(KilnToolInterface):
         resource = kwargs.get("resource")
 
         if not isinstance(skill_name, str) or not skill_name:
-            return ToolCallResult(output="Error: 'name' parameter is required.")
+            msg = "Error: 'name' parameter is required."
+            return ToolCallResult(output=msg, is_error=True, error_message=msg)
 
         skill = self._skills.get(skill_name)
         if skill is None:
             available = ", ".join(self._skills.keys())
-            return ToolCallResult(
-                output=f"Error: Skill '{skill_name}' not found. Available skills: {available}"
+            msg = (
+                f"Error: Skill '{skill_name}' not found. Available skills: {available}"
             )
+            return ToolCallResult(output=msg, is_error=True, error_message=msg)
 
         if resource:
             return self._load_resource(skill, resource)
@@ -86,23 +88,20 @@ class SkillTool(KilnToolInterface):
         try:
             body = skill.body()
         except Exception as e:
-            return ToolCallResult(
-                output=f"Error: Failed to load skill '{skill_name}': {e}"
-            )
+            msg = f"Error: Failed to load skill '{skill_name}': {e}"
+            return ToolCallResult(output=msg, is_error=True, error_message=msg)
         return ToolCallResult(output=body)
 
     def _load_resource(self, skill: Skill, resource: str) -> ToolCallResult:
         """Load a resource file from an allowed subdirectory (references/ or assets/)."""
         if not any(resource.startswith(p) for p in ALLOWED_RESOURCE_PREFIXES):
-            return ToolCallResult(
-                output=f"Error: Resource path must start with one of: {', '.join(ALLOWED_RESOURCE_PREFIXES)}"
-            )
+            msg = f"Error: Resource path must start with one of: {', '.join(ALLOWED_RESOURCE_PREFIXES)}"
+            return ToolCallResult(output=msg, is_error=True, error_message=msg)
 
         parts = resource.split("/", 1)
         if len(parts) != 2 or not parts[1]:
-            return ToolCallResult(
-                output="Error: Resource path must include a filename after the directory prefix."
-            )
+            msg = "Error: Resource path must include a filename after the directory prefix."
+            return ToolCallResult(output=msg, is_error=True, error_message=msg)
 
         prefix, relative_path = parts
 
@@ -112,11 +111,12 @@ class SkillTool(KilnToolInterface):
             elif prefix == "assets":
                 content = skill.read_asset(relative_path)
             else:
-                return ToolCallResult(
-                    output=f"Error: Unknown resource directory: {prefix}"
-                )
+                msg = f"Error: Unknown resource directory: {prefix}"
+                return ToolCallResult(output=msg, is_error=True, error_message=msg)
             return ToolCallResult(output=content)
         except FileNotFoundError:
-            return ToolCallResult(output=f"Error: Resource not found: {resource}")
+            msg = f"Error: Resource not found: {resource}"
+            return ToolCallResult(output=msg, is_error=True, error_message=msg)
         except ValueError as e:
-            return ToolCallResult(output=f"Error: {e}")
+            msg = f"Error: {e}"
+            return ToolCallResult(output=msg, is_error=True, error_message=msg)

--- a/libs/core/kiln_ai/tools/test_skill_tool.py
+++ b/libs/core/kiln_ai/tools/test_skill_tool.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import kiln_ai.tools.skill_tool as skill_tool_module
 from kiln_ai.datamodel.project import Project
 from kiln_ai.datamodel.skill import Skill
 from kiln_ai.datamodel.tool_id import _check_tool_id
@@ -98,21 +99,29 @@ class TestSkillToolRun:
         result = await tool.run()
         assert "Error" in result.output
         assert "'name' parameter is required" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
 
     async def test_empty_name_parameter(self, tool):
         result = await tool.run(name="")
         assert "'name' parameter is required" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
 
     async def test_unknown_skill(self, tool):
         result = await tool.run(name="nonexistent")
         assert "not found" in result.output
         assert "code-review" in result.output
         assert "test-writing" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
 
     async def test_successful_skill_load(self, tool, skills):
         skills[0].body.return_value = "# Code Review\nReview all code."
         result = await tool.run(name="code-review")
         assert result.output == "# Code Review\nReview all code."
+        assert result.is_error is False
+        assert result.error_message is None
 
     async def test_body_io_error_is_caught(self, tool, skills):
         skills[0].body.side_effect = FileNotFoundError(
@@ -121,6 +130,8 @@ class TestSkillToolRun:
         result = await tool.run(name="code-review")
         assert "Error" in result.output
         assert "code-review" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
 
     async def test_body_value_error_is_caught(self, tool, skills):
         skills[0].body.side_effect = ValueError(
@@ -129,12 +140,16 @@ class TestSkillToolRun:
         result = await tool.run(name="code-review")
         assert "Error" in result.output
         assert "Failed to load skill" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
 
     async def test_body_parse_error_is_caught(self, tool, skills):
         skills[0].body.side_effect = Exception("frontmatter parse error")
         result = await tool.run(name="code-review")
         assert "Error" in result.output
         assert "frontmatter parse error" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
 
 
 class TestSkillToolResource:
@@ -187,12 +202,16 @@ class TestSkillToolResource:
         assert "Error" in result.output
         assert "references/" in result.output
         assert "assets/" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
 
     async def test_path_traversal_blocked(self, skill_tool: SkillTool):
         result = await skill_tool.run(
             name="code-review", resource="references/../../etc/passwd"
         )
         assert "Error" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
 
     async def test_missing_reference(self, skill_tool: SkillTool):
         result = await skill_tool.run(
@@ -200,14 +219,48 @@ class TestSkillToolResource:
         )
         assert "Error" in result.output
         assert "not found" in result.output.lower()
+        assert result.is_error is True
+        assert result.error_message == result.output
 
     async def test_no_filename_after_prefix(self, skill_tool: SkillTool):
         result = await skill_tool.run(name="code-review", resource="references/")
         assert "Error" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
+
+    async def test_unknown_resource_directory(
+        self, skill_tool: SkillTool, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The prefix allowlist normally makes this branch unreachable; widen it
+        # so the "unknown resource directory" failure shape can be exercised.
+        monkeypatch.setattr(
+            skill_tool_module,
+            "ALLOWED_RESOURCE_PREFIXES",
+            ("references/", "assets/", "templates/"),
+        )
+        result = await skill_tool.run(
+            name="code-review", resource="templates/report.md"
+        )
+        assert result.output == "Error: Unknown resource directory: templates"
+        assert result.is_error is True
+        assert result.error_message == result.output
 
     async def test_without_resource_returns_body(self, skill_tool: SkillTool):
         result = await skill_tool.run(name="code-review")
         assert result.output == "## Code Review\nCheck for bugs."
+        assert result.is_error is False
+        assert result.error_message is None
+
+    async def test_successful_resource_load_is_not_flagged(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        ref_dir = sample_skills[0].references_dir()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        (ref_dir / "ok.md").write_text("fine", encoding="utf-8")
+        result = await skill_tool.run(name="code-review", resource="references/ok.md")
+        assert result.output == "fine"
+        assert result.is_error is False
+        assert result.error_message is None
 
     async def test_binary_resource_rejected(
         self, sample_skills: list[Skill], skill_tool: SkillTool
@@ -220,6 +273,62 @@ class TestSkillToolResource:
         )
         assert "Error" in result.output
         assert "not a readable text file" in result.output
+        assert result.is_error is True
+        assert result.error_message == result.output
+
+
+class TestSkillToolErrorOutputIsStable:
+    """The ``output`` text of each failure is a stable contract.
+
+    Downstream consumers match on these exact strings, so flagging a failure
+    with ``is_error``/``error_message`` must never reword the output.
+    """
+
+    async def test_missing_name_output_unchanged(self, tool):
+        result = await tool.run()
+        assert result.output == "Error: 'name' parameter is required."
+
+    async def test_unknown_skill_output_unchanged(self, tool):
+        result = await tool.run(name="nonexistent")
+        assert result.output == (
+            "Error: Skill 'nonexistent' not found. "
+            "Available skills: code-review, test-writing"
+        )
+
+    async def test_body_failure_output_unchanged(self, tool, skills):
+        skills[0].body.side_effect = ValueError("boom")
+        result = await tool.run(name="code-review")
+        assert result.output == "Error: Failed to load skill 'code-review': boom"
+
+    async def test_invalid_prefix_output_unchanged(self, skill_tool: SkillTool):
+        result = await skill_tool.run(name="code-review", resource="secrets/key.txt")
+        assert result.output == (
+            "Error: Resource path must start with one of: references/, assets/"
+        )
+
+    async def test_no_filename_output_unchanged(self, skill_tool: SkillTool):
+        result = await skill_tool.run(name="code-review", resource="references/")
+        assert result.output == (
+            "Error: Resource path must include a filename after the directory prefix."
+        )
+
+    async def test_resource_not_found_output_unchanged(self, skill_tool: SkillTool):
+        result = await skill_tool.run(
+            name="code-review", resource="references/nonexistent.md"
+        )
+        assert result.output == "Error: Resource not found: references/nonexistent.md"
+
+    async def test_value_error_output_unchanged(
+        self, sample_skills: list[Skill], skill_tool: SkillTool
+    ):
+        ref_dir = sample_skills[0].references_dir()
+        ref_dir.mkdir(parents=True, exist_ok=True)
+        (ref_dir / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n\x00")
+        result = await skill_tool.run(
+            name="code-review", resource="references/image.png"
+        )
+        assert result.output.startswith("Error: ")
+        assert "Error: Error:" not in result.output
 
 
 class TestSkillToolId:


### PR DESCRIPTION
## Problem

`libs/core/kiln_ai/tools/skill_tool.py` has **eight distinct failure returns** — missing `name` argument, unknown skill, skill body load failure, disallowed resource prefix, malformed resource path, unknown resource directory, resource not found, and resource `ValueError` (path traversal / binary file). Every one of them was a bare `ToolCallResult(output="Error: …")`, leaving `is_error` at its `False` default and `error_message` at `None`.

`ToolCallResult` documents these fields as the way a tool reports failure (`base_tool.py:36-42`), and the rest of Kiln reads them. The `skill` tool — a Kiln **built-in**, whose failures a user cannot control or work around — did not set them.

## Why this matters

**1. Internal inconsistency with a sibling tool.** `libs/core/kiln_ai/tools/mcp_server_tool.py:55-69` maps an MCP `isError` result to `ToolCallResult(output=…, is_error=True, error_message=…)`. That is the same class of failure — a tool call that ran and came back unusable — handled the opposite way. On this branch `mcp_server_tool.py:66` is the *only* non-test `is_error=True` in `libs/core/kiln_ai`.

**2. It never reaches the trace.** `libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py:915` serializes the field as `is_error=result.is_error if result.is_error else None`, and `adapters/chat/chat_formatter.py:68` only writes the key when it is not `None`. A `False` flag is therefore dropped entirely — so no downstream consumer can distinguish a skill error from a successful skill load.

**3. It defeats Kiln's own UI.** `app/web_ui/src/lib/ui/trace/trace.svelte:90-107` derives `is_tool_error()` from `message.is_error`, with a `JSON.parse(content).isError` fallback that the skill tool also never emits. That value drives the label and styling at lines 266-289 (`"Tool Error"` vs `"Tool Result"`, `text-error`, `border-error/20`) and the summary line at :39-42. Net effect: **skill errors render as successful tool results in the trace viewer.**

**4. Measured impact on a real corpus.** On an agent port (711 distinct multi-turn traces): **3,427 skill-tool error results across 86 of 711 traces**, with `is_error` unset on **189,310 / 189,310** tool messages. Any error-rate metric built on the documented Kiln field reads exactly zero.

## What changed

Each failure return now binds its message once and passes it to both fields:

```python
msg = f"Error: Resource not found: {resource}"
return ToolCallResult(output=msg, is_error=True, error_message=msg)
```

Applied to all eight failure paths. No control flow, no message text, and no successful-path behavior changed.

## `output` strings are unchanged — deliberately

The `output` text of every failure is **byte-identical** to before; only the two flags are added. Consumers that match on the error text — including out-of-tree content-aware detectors keying on `Error: Resource not found:`, `Error: Skill '<x>' not found`, and `Error: Resource path must …` — are unaffected. A dedicated test class (`TestSkillToolErrorOutputIsStable`) pins the exact string of each sentinel so a future reword cannot land silently.

## Test evidence

`libs/core/kiln_ai/tools/test_skill_tool.py`: flag assertions on every failure path, `is_error is False` / `error_message is None` assertions on both success paths, a new `test_unknown_resource_directory` case, and the seven output-text regression tests.

```
$ uv run pytest libs/core/kiln_ai/tools/test_skill_tool.py -q
34 passed, 30 warnings in 4.22s

$ uv run pytest libs/core/kiln_ai/tools/ -q
347 passed, 5 skipped, 44 warnings in 21.32s
```

Verified the new assertions are meaningful — reverting `skill_tool.py` alone while keeping the tests:

```
12 failed, 22 passed
```

covering all eight failure shapes. The seven `TestSkillToolErrorOutputIsStable` tests pass **both** with and without the fix, which is the proof that `output` did not change.

`uv run ruff format --check` and `uv run ruff check` clean on both touched files; the pre-commit hook passed.

## Note on the unreachable branch

The `else: Error: Unknown resource directory` branch is unreachable through `run()` — the prefix allowlist above it already constrains `parts[0]` to `references` or `assets`. It is flagged anyway for consistency, and the new test reaches it by monkeypatching `ALLOWED_RESOURCE_PREFIXES`. Left in place rather than deleted, as removing dead code is out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
