### PR TITLE
Teach the root-first protocol in the skill tool description

### DIFF
--- a/libs/core/kiln_ai/tools/skill_tool.py
+++ b/libs/core/kiln_ai/tools/skill_tool.py
@@ -35,10 +35,14 @@ class SkillTool(KilnToolInterface):
     async def description(self) -> str:
         return (
             "Load an agent skill by name. Use this tool when a specialized skill "
-            "may help solve the user's task. Calling the tool with a skill name loads that skill's "
-            "full instructions. If the skill references additional files "
-            "relevant to the task, load them by passing a 'resource' path "
-            "(e.g. 'references/guide.md', 'references/subdir/notes.txt', or 'assets/template.csv')."
+            "may help solve the user's task. Skills use progressive disclosure: "
+            "call skill(name) first to load the skill's instruction page. That "
+            "page is the only place a skill's resource files are listed. If it "
+            "points at a file you need, call skill(name, resource) and copy the "
+            "path exactly as the instructions wrote it. Resource paths always "
+            "start with references/ or assets/, but never guess or assemble one: "
+            "a path the instructions do not list does not exist, and many skills "
+            "ship no resource files at all."
         )
 
     async def toolcall_definition(self) -> ToolCallDefinition:
@@ -52,11 +56,11 @@ class SkillTool(KilnToolInterface):
                     "properties": {
                         "name": {
                             "type": "string",
-                            "description": "The name of the skill to load.",
+                            "description": "The name of the skill to load, exactly as listed in the system prompt.",
                         },
                         "resource": {
                             "type": "string",
-                            "description": "Optional. Path to a specific resource file within the skill (e.g. 'references/guide.md', 'assets/data.csv'). If omitted, returns the skill's main instructions.",
+                            "description": "Optional. Leave unset on the first call: that returns the skill's instructions, which list its resource files if it has any. Set this only to a path those instructions listed, copied verbatim (paths start with references/ or assets/). Never guess a path; unlisted paths do not exist.",
                         },
                     },
                     "required": ["name"],

--- a/libs/core/kiln_ai/tools/test_skill_tool.py
+++ b/libs/core/kiln_ai/tools/test_skill_tool.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import MagicMock
 
 import pytest
@@ -78,6 +79,35 @@ class TestSkillToolDefinition:
         assert "resource" in desc
         assert "assets/" in desc
         assert len(desc) <= 1024
+
+    async def test_description_teaches_root_first_protocol(self, skill_tool: SkillTool):
+        desc = await skill_tool.description()
+        assert "skill(name)" in desc
+        assert "skill(name, resource)" in desc
+        assert "never guess" in desc
+
+    async def test_schema_contains_no_concrete_resource_path(
+        self, skill_tool: SkillTool
+    ):
+        """The schema must describe the shape of a resource path, never spell one out.
+
+        A concrete-looking path in a tool schema gets copied verbatim as a real
+        request. The previous description's `references/guide.md` example was
+        issued as an actual resource request 32 times on an external agent-port
+        corpus, including at skills that ship no resource files at all.
+        """
+        concrete_path = re.compile(r"(?:references|assets)/\S*\.\w+")
+        defn = await skill_tool.toolcall_definition()
+        properties = defn["function"]["parameters"]["properties"]
+        texts = [
+            await skill_tool.description(),
+            properties["name"]["description"],
+            properties["resource"]["description"],
+        ]
+        for text in texts:
+            assert concrete_path.search(text) is None, (
+                f"schema text spells out a resource path: {text!r}"
+            )
 
     async def test_toolcall_definition_schema(self, skill_tool: SkillTool):
         defn = await skill_tool.toolcall_definition()


### PR DESCRIPTION
## Problem

The `skill` tool's description is the text a model reads at its decision point, and it was teaching the wrong protocol.

**It spelled out three concrete resource paths:**

```
"...load them by passing a 'resource' path (e.g. 'references/guide.md',
 'references/subdir/notes.txt', or 'assets/template.csv')."
```

plus a fourth and fifth in the `resource` parameter description (`references/guide.md`, `assets/data.csv`).

**And it never said where real resource paths come from.** It described `skill(name)` and `skill(name, resource)` as two independent ways to call the tool, with nothing establishing that a skill's instruction page is the only place its resource files are listed — so nothing told the model to load the root first.

### Measured impact

From an out-of-tree agent port (an UpKeep assistant ported onto Kiln), audited over **187 stored runs**. These figures come from that external corpus, not from anything in this repo:

- The literal example path **`references/guide.md` was requested as a real resource 32 times**, including at skills that ship no resource files at all. The model was not inventing a plausible path — it was copying the one in the schema.
- **91% of resource reads (227/250) were issued with no prior skill-root load.** The model guessed a path before ever reading the instructions that list the real ones.
- **161 laundered skill-tool errors across 54 of 187 runs** (36% of runs on one lane).

Repo-side mitigations on the port — rewriting each skill's own description to say "load the root first", then inlining a full path index into one skill's description — took that lane 35.7% → 6.4%. The residual is structural: no amount of per-skill text fixes a tool whose own schema advertises a made-up path, because the tool description sits closer to the decision than any distant instruction.

## What changed

Description text only. No behavior, no control flow, no error `output` strings, no function signature.

**Before:**

> Load an agent skill by name. Use this tool when a specialized skill may help solve the user's task. Calling the tool with a skill name loads that skill's full instructions. If the skill references additional files relevant to the task, load them by passing a 'resource' path (e.g. 'references/guide.md', 'references/subdir/notes.txt', or 'assets/template.csv').

**After:**

> Load an agent skill by name. Use this tool when a specialized skill may help solve the user's task. Skills use progressive disclosure: call skill(name) first to load the skill's instruction page. That page is the only place a skill's resource files are listed. If it points at a file you need, call skill(name, resource) and copy the path exactly as the instructions wrote it. Resource paths always start with references/ or assets/, but never guess or assemble one: a path the instructions do not list does not exist, and many skills ship no resource files at all.

The `resource` parameter description now carries the same contract at the argument itself ("Leave unset on the first call… Set this only to a path those instructions listed, copied verbatim… Never guess a path; unlisted paths do not exist"), and `name` gains "exactly as listed in the system prompt".

### Why the example path is the crux

Everything else here is advice; the example path was an instruction. A path that looks real in a JSON schema *is* real to the model — it is the single most concrete, most copyable token in the whole description, and it appeared at exactly the moment the model was choosing an argument value. The 32 verbatim copies are the direct evidence. The fix is not to pick a better example but to have none: the description now specifies the *shape* of a legal path (the `references/` / `assets/` prefixes, which are the actual allowlist in `ALLOWED_RESOURCE_PREFIXES`) and says explicitly that concrete paths only ever come from the skill's own instructions.

### Alignment with the existing skill format

The wording follows the progressive-disclosure convention Kiln's skills already implement, and matches the prior art in the repo:

- `libs/core/kiln_ai/datamodel/skill.py:20-29` — "A Skill represents reusable agent instructions following the **agentskills.io** specification… The agent discovers available skills via the skill tool description, then loads a skill's body on demand."
- `libs/core/kiln_ai/adapters/prompt_builders.py:33-38` — the system-prompt section already states root-first ordering: "When a Skill is relevant, load it with `skill(name)` and follow its instructions. Load additional Skill resources only if needed with `skill(name, resource)`." The tool description now agrees with it instead of undercutting it. **No change needed there** — it was already correct and carries no example path.
- Skill-body UI copy (`skills/skill_form.svelte:143-164`): "This is only loaded into context when the agent chooses to use the skill."

### Length

The description grew 361 → 565 chars. It is read on every request, so it was kept to one paragraph. Repo convention: `Skill.description` is `max_length=1024` (`datamodel/skill.py:34-38`) and the existing test asserts `len(desc) <= 1024`; this is comfortably inside it, and is the only tool-description budget the repo defines.

## Tests

`test_description_mentions_resource` still passes unchanged — the rewrite deliberately preserves the `"Load an agent skill by name"` opening, the word `resource`, and the `assets/` token it asserts on.

Two new tests in `TestSkillToolDefinition`:

- `test_description_teaches_root_first_protocol` — pins `skill(name)`, `skill(name, resource)`, and `never guess`.
- `test_schema_contains_no_concrete_resource_path` — regex-asserts that **no** concrete path (`references/…​.ext` or `assets/…​.ext`) appears in the description or in either parameter description. Verified meaningful: the same regex finds all three paths in the old description and both in the old `resource` parameter description.

```
$ uv run python3 -m pytest libs/core/kiln_ai/tools/test_skill_tool.py -q
27 passed, 30 warnings in 3.88s

$ uv run python3 -m pytest libs/core/kiln_ai/tools/ \
    libs/core/kiln_ai/adapters/test_prompt_builders.py \
    libs/core/kiln_ai/adapters/fine_tune/test_dataset_formatter.py -q
403 passed, 5 skipped, 44 warnings in 21.38s
```

The wider set covers the two other consumers of the skill toolcall definition (the fine-tune dataset formatter and the prompt builder). `uv run ruff format --check`, `uv run ruff check`, and `uv run ty check` are clean on both touched files.

## Note on PR #1634

**#1634 (`fix/skill-tool-is-error`) is outstanding against `main` and touches both of these same two files** — it adds `is_error=True` / `error_message` to the eight failure returns in `skill_tool.py` and appends a `TestSkillToolErrorOutputIsStable` class to the test file. The two changes are disjoint in the file: #1634 is entirely inside `run()` / `_load_resource()`, this PR is entirely inside `description()` / `toolcall_definition()`. Verified mechanically — `git merge-tree` against this branch and `origin/fix/skill-tool-is-error` auto-merges both files with no conflict. Either can land first.

They are also complementary: #1634 makes these failures *visible* in the trace, and this PR reduces how often they happen.

## Pre-commit hook note (unrelated, worth knowing)

The committed `.git/hooks/pre-commit` template does `cd "$(dirname "$0")"` then `uv run ../../checks.sh`. In a **git worktree**, `.git` is a file and hooks resolve to the *main* checkout's hook dir, so the hook lints the main checkout's working tree rather than the worktree being committed from. Not addressed here, but it means `--no-verify` is currently required when committing from a worktree. Checks were run manually against the worktree instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
