### PR TITLE
Add 5 new Qwen models and update DeepSeek V4 Flash to the 0731 checkpoint (OpenRouter)

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -5619,7 +5619,7 @@ built_in_models: List[KilnModel] = [
         providers=[
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
-                model_id="deepseek/deepseek-v4-flash",
+                model_id="deepseek/deepseek-v4-flash-0731",
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_data_gen=True,
                 available_thinking_levels=DEEPSEEK_V4_OPENROUTER_THINKING_LEVELS,

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -209,16 +209,21 @@ class ModelName(str, Enum):
     grok_4_1_fast = "grok_4_1_fast"
     grok_4 = "grok_4"
     qwen_3p5_flash = "qwen_3p5_flash"
+    qwen_3p5_9b = "qwen_3p5_9b"
     qwen_3p5_122b_a10b = "qwen_3p5_122b_a10b"
     qwen_3p5_27b = "qwen_3p5_27b"
     qwen_3p5_35b_a3b = "qwen_3p5_35b_a3b"
+    qwen_3p7_flash = "qwen_3p7_flash"
     qwen_3p7_plus = "qwen_3p7_plus"
     qwen_3p7_max = "qwen_3p7_max"
+    qwen_3p6_flash = "qwen_3p6_flash"
+    qwen_3p6_35b_a3b = "qwen_3p6_35b_a3b"
     qwen_3p6_plus = "qwen_3p6_plus"
     qwen_3p5_plus = "qwen_3p5_plus"
     qwen_3p5_397b_a17b = "qwen_3p5_397b_a17b"
     qwen_3_next_80b_a3b = "qwen_3_next_80b_a3b"
     qwen_3_next_80b_a3b_thinking = "qwen_3_next_80b_a3b_thinking"
+    qwen_3_max_thinking = "qwen_3_max_thinking"
     qwen_3_max = "qwen_3_max"
     qwen_3_0p6b = "qwen_3_0p6b"
     qwen_3_0p6b_no_thinking = "qwen_3_0p6b_no_thinking"
@@ -6422,6 +6427,35 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
+    # Qwen 3.7 Flash
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3p7_flash,
+        friendly_name="Qwen 3.7 Flash",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3.7-flash",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_function_calling=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+        ],
+    ),
     # Qwen 3.7 Max
     KilnModel(
         family=ModelFamily.qwen,
@@ -6474,6 +6508,64 @@ built_in_models: List[KilnModel] = [
             ),
         ],
     ),
+    # Qwen 3.6 Flash
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3p6_flash,
+        friendly_name="Qwen 3.6 Flash",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3.6-flash",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_function_calling=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+        ],
+    ),
+    # Qwen 3.6 35B A3B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3p6_35b_a3b,
+        friendly_name="Qwen 3.6 35B A3B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3.6-35b-a3b",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_function_calling=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+        ],
+    ),
     # Qwen 3.6 Plus
     KilnModel(
         family=ModelFamily.qwen,
@@ -6520,6 +6612,35 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.openrouter,
                 model_id="qwen/qwen3.5-plus-02-15",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_function_calling=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
+                ],
+                multimodal_requires_pdf_as_image=True,
+            ),
+        ],
+    ),
+    # Qwen 3.5 9B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3p5_9b,
+        friendly_name="Qwen 3.5 9B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3.5-9b",
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 supports_data_gen=True,
                 supports_function_calling=True,
@@ -6591,6 +6712,23 @@ built_in_models: List[KilnModel] = [
             # returns degenerate output -- it rambles to the 4096 token cap with
             # unrelated word lists, failing even the plaintext test. Not a config
             # issue; the served weights appear broken.
+        ],
+    ),
+    # Qwen 3 Max Thinking
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3_max_thinking,
+        friendly_name="Qwen 3 Max Thinking",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3-max-thinking",
+                structured_output_mode=StructuredOutputMode.json_instructions,
+                supports_data_gen=True,
+                supports_function_calling=True,
+                # Adaptive reasoning: does not always emit reasoning, so keep
+                # reasoning_capable=False to avoid "no reasoning returned" errors.
+            ),
         ],
     ),
     # Qwen 3 Max


### PR DESCRIPTION
## What does this PR do?

Adds five new Qwen models on OpenRouter and repoints DeepSeek V4 Flash at its new `0731` checkpoint. Each was verified against real inference.

- **Qwen 3.7 Flash**, **Qwen 3.6 Flash**, **Qwen 3.6 35B A3B**, **Qwen 3.5 9B** — multimodal (image + video, PDF-as-image), `json_instruction_and_object`.
- **Qwen 3 Max Thinking** — text-only, `json_instructions`. `reasoning_capable` left `False` (see below).
- **DeepSeek V4 Flash** — OpenRouter slug updated `deepseek/deepseek-v4-flash` → `deepseek/deepseek-v4-flash-0731`, keeping `json_schema` and the existing thinking levels. Fireworks provider unchanged.

### Test Results

Every provider slug was verified with an actual inference call, not just the catalog listing, and the catalogs overstated availability. That's why the new Qwen models ship OpenRouter-only: **Fireworks** lists the Qwen slugs but the API 404s (not deployed — the known Fireworks-lag quirk); **Together** hosts the Plus variants as streaming-only (unusable in Kiln, same as the existing Qwen 3.7 Max note) and the 35B FP8 as dedicated-only; **Featherless** serves the small Qwen deployments but they ignore JSON-instruction prompting and return reasoning prose (`Qwen/Qwen3.5-9B` failed 8/15 structured tests, `Qwen/Qwen3.6-*` returned empty), so all were dropped. **Qwen 3.6 27B** was dropped entirely — it returns empty/degenerate output on every provider.

Two config notes. **Qwen 3 Max Thinking** first failed `RuntimeError: Reasoning is required for this model, but no reasoning was returned` — it uses adaptive reasoning and does not always emit a reasoning block, so `reasoning_capable=False` (reasoning is still parsed/displayed when present); it passed cleanly afterward. **Qwen 3.5 9B** on OpenRouter flaked once on `test_data_gen_sample_all_models_providers` under parallel load (appended extra keys to structured output) but passed that test on three isolated reruns — a content-quality flake, not a config issue. **DeepSeek V4 Flash 0731** had no live OpenRouter endpoints at the start of this work and came online partway through; its first parallel test run hit transient HTTP 429 "temporarily rate-limited upstream" on the just-launched shared pool, but a serial re-run once capacity ramped passed all 11 OpenRouter tests cleanly, so it ships green.

Qwen 3.7 Flash (openrouter): 19 passed, 0 failed
Qwen 3.6 Flash (openrouter): 19 passed, 0 failed
Qwen 3.6 35B A3B (openrouter): 19 passed, 0 failed
Qwen 3.5 9B (openrouter): 18 passed, 1 flake (data-gen sample; passed on retry)
Qwen 3 Max Thinking (openrouter): 11 passed, 0 failed (text-only)
DeepSeek V4 Flash (fireworks_ai): full suite passed
DeepSeek V4 Flash (openrouter, 0731): 11 passed, 0 failed (initial parallel run hit transient upstream 429s; all passed on a serial re-run)

---
Qwen 3.7 Flash (openrouter):
✅ test_data_gen_all_models_providers[qwen_3p7_flash-openrouter]
✅ test_data_gen_sample_all_models_providers[qwen_3p7_flash-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[qwen_3p7_flash-openrouter]
✅ test_all_built_in_models_llm_as_judge[qwen_3p7_flash-openrouter]
✅ test_all_built_in_models_structured_output[qwen_3p7_flash-openrouter]
✅ test_all_built_in_models_structured_input[qwen_3p7_flash-openrouter]
✅ test_structured_output_cot_prompt_builder[qwen_3p7_flash-openrouter]
✅ test_structured_input_cot_prompt_builder[qwen_3p7_flash-openrouter]
✅ test_all_models_providers_plaintext[qwen_3p7_flash-openrouter]
✅ test_cot_prompt_builder[qwen_3p7_flash-openrouter]
✅ test_tools_all_built_in_models[qwen_3p7_flash-openrouter]
✅ test_supports_vision_is_coherent[qwen_3p7_flash-openrouter]
✅ test_provider_bad_request[qwen_3p7_flash-openrouter]
✅ test_extract_document_success[...-qwen_3p7_flash-openrouter] (6/6 MIME probes)

Qwen 3.6 Flash (openrouter):
✅ test_data_gen_all_models_providers[qwen_3p6_flash-openrouter]
✅ test_data_gen_sample_all_models_providers[qwen_3p6_flash-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[qwen_3p6_flash-openrouter]
✅ test_all_built_in_models_llm_as_judge[qwen_3p6_flash-openrouter]
✅ test_all_built_in_models_structured_output[qwen_3p6_flash-openrouter]
✅ test_all_built_in_models_structured_input[qwen_3p6_flash-openrouter]
✅ test_structured_output_cot_prompt_builder[qwen_3p6_flash-openrouter]
✅ test_structured_input_cot_prompt_builder[qwen_3p6_flash-openrouter]
✅ test_all_models_providers_plaintext[qwen_3p6_flash-openrouter]
✅ test_cot_prompt_builder[qwen_3p6_flash-openrouter]
✅ test_tools_all_built_in_models[qwen_3p6_flash-openrouter]
✅ test_supports_vision_is_coherent[qwen_3p6_flash-openrouter]
✅ test_provider_bad_request[qwen_3p6_flash-openrouter]
✅ test_extract_document_success[...-qwen_3p6_flash-openrouter] (6/6 MIME probes)

Qwen 3.6 35B A3B (openrouter):
✅ test_data_gen_all_models_providers[qwen_3p6_35b_a3b-openrouter]
✅ test_data_gen_sample_all_models_providers[qwen_3p6_35b_a3b-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[qwen_3p6_35b_a3b-openrouter]
✅ test_all_built_in_models_llm_as_judge[qwen_3p6_35b_a3b-openrouter]
✅ test_all_built_in_models_structured_output[qwen_3p6_35b_a3b-openrouter]
✅ test_all_built_in_models_structured_input[qwen_3p6_35b_a3b-openrouter]
✅ test_structured_output_cot_prompt_builder[qwen_3p6_35b_a3b-openrouter]
✅ test_structured_input_cot_prompt_builder[qwen_3p6_35b_a3b-openrouter]
✅ test_all_models_providers_plaintext[qwen_3p6_35b_a3b-openrouter]
✅ test_cot_prompt_builder[qwen_3p6_35b_a3b-openrouter]
✅ test_tools_all_built_in_models[qwen_3p6_35b_a3b-openrouter]
✅ test_supports_vision_is_coherent[qwen_3p6_35b_a3b-openrouter]
✅ test_provider_bad_request[qwen_3p6_35b_a3b-openrouter]
✅ test_extract_document_success[...-qwen_3p6_35b_a3b-openrouter] (6/6 MIME probes)

Qwen 3.5 9B (openrouter):
✅ test_data_gen_all_models_providers[qwen_3p5_9b-openrouter]
⚠️ test_data_gen_sample_all_models_providers[qwen_3p5_9b-openrouter] — small model added extra keys under parallel load; passed on 3 isolated reruns
✅ test_data_gen_sample_all_models_providers_with_structured_output[qwen_3p5_9b-openrouter]
✅ test_all_built_in_models_llm_as_judge[qwen_3p5_9b-openrouter]
✅ test_all_built_in_models_structured_output[qwen_3p5_9b-openrouter]
✅ test_all_built_in_models_structured_input[qwen_3p5_9b-openrouter]
✅ test_structured_output_cot_prompt_builder[qwen_3p5_9b-openrouter]
✅ test_structured_input_cot_prompt_builder[qwen_3p5_9b-openrouter]
✅ test_all_models_providers_plaintext[qwen_3p5_9b-openrouter]
✅ test_cot_prompt_builder[qwen_3p5_9b-openrouter]
✅ test_tools_all_built_in_models[qwen_3p5_9b-openrouter]
✅ test_supports_vision_is_coherent[qwen_3p5_9b-openrouter]
✅ test_provider_bad_request[qwen_3p5_9b-openrouter]
✅ test_extract_document_success[...-qwen_3p5_9b-openrouter] (6/6 MIME probes)

Qwen 3 Max Thinking (openrouter):
✅ test_data_gen_all_models_providers[qwen_3_max_thinking-openrouter]
✅ test_data_gen_sample_all_models_providers[qwen_3_max_thinking-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[qwen_3_max_thinking-openrouter]
✅ test_all_built_in_models_llm_as_judge[qwen_3_max_thinking-openrouter]
✅ test_all_built_in_models_structured_output[qwen_3_max_thinking-openrouter]
✅ test_all_built_in_models_structured_input[qwen_3_max_thinking-openrouter]
✅ test_structured_output_cot_prompt_builder[qwen_3_max_thinking-openrouter]
✅ test_structured_input_cot_prompt_builder[qwen_3_max_thinking-openrouter]
✅ test_all_models_providers_plaintext[qwen_3_max_thinking-openrouter]
✅ test_cot_prompt_builder[qwen_3_max_thinking-openrouter]
✅ test_tools_all_built_in_models[qwen_3_max_thinking-openrouter]

DeepSeek V4 Flash (fireworks_ai — unchanged, re-confirmed):
✅ test_data_gen_all_models_providers[deepseek_4_flash-fireworks_ai]
✅ test_data_gen_sample_all_models_providers[deepseek_4_flash-fireworks_ai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[deepseek_4_flash-fireworks_ai]
✅ test_all_built_in_models_llm_as_judge[deepseek_4_flash-fireworks_ai]
✅ test_all_built_in_models_structured_output[deepseek_4_flash-fireworks_ai]
✅ test_all_built_in_models_structured_input[deepseek_4_flash-fireworks_ai]
✅ test_structured_output_cot_prompt_builder[deepseek_4_flash-fireworks_ai]
✅ test_structured_input_cot_prompt_builder[deepseek_4_flash-fireworks_ai]
✅ test_tools_all_built_in_models[deepseek_4_flash-fireworks_ai]

DeepSeek V4 Flash (openrouter — 0731 checkpoint, serial re-run):
✅ test_data_gen_all_models_providers[deepseek_4_flash-openrouter]
✅ test_data_gen_sample_all_models_providers[deepseek_4_flash-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[deepseek_4_flash-openrouter]
✅ test_all_built_in_models_llm_as_judge[deepseek_4_flash-openrouter]
✅ test_all_built_in_models_structured_output[deepseek_4_flash-openrouter]
✅ test_all_built_in_models_structured_input[deepseek_4_flash-openrouter]
✅ test_structured_output_cot_prompt_builder[deepseek_4_flash-openrouter]
✅ test_structured_input_cot_prompt_builder[deepseek_4_flash-openrouter]
✅ test_all_models_providers_plaintext[deepseek_4_flash-openrouter]
✅ test_cot_prompt_builder[deepseek_4_flash-openrouter]
✅ test_tools_all_built_in_models[deepseek_4_flash-openrouter]

## Related Issues

N/A

## Contributor License Agreement

I, @tawnymanticore, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)