### PR TITLE
Return JSON 404s for API paths instead of web app HTML

### DIFF
--- a/app/desktop/studio_server/test_webhost.py
+++ b/app/desktop/studio_server/test_webhost.py
@@ -6,12 +6,19 @@ import pytest
 from app.desktop.studio_server.webhost import connect_webhost
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from kiln_server.custom_errors import connect_custom_errors
+
+WEB_APP_404_BODY = "<html><body>custom not found</body></html>"
 
 
 @pytest.fixture
 def temp_studio():
     with tempfile.TemporaryDirectory() as d:
         os.makedirs(d, exist_ok=True)
+        # The compiled web app always ships a 404.html: StaticFiles in html mode
+        # will serve it for any miss unless we prevent it on API paths.
+        with open(os.path.join(d, "404.html"), "w", encoding="utf-8") as f:
+            f.write(WEB_APP_404_BODY)
         with patch("app.desktop.studio_server.webhost.studio_path", lambda: d):
             yield d
 
@@ -24,25 +31,122 @@ def app_with_webhost(temp_studio):
     def forced_not_found():
         raise HTTPException(status_code=404, detail="test missing resource")
 
+    @app.get("/api/get-only")
+    def get_only():
+        return {"ok": True}
+
     connect_webhost(app)
     return app
 
 
-def test_not_found_handler_returns_json_for_api_http_exception(app_with_webhost):
-    client = TestClient(app_with_webhost)
-    response = client.get("/api/forced-not-found")
+@pytest.fixture
+def client(app_with_webhost):
+    return TestClient(app_with_webhost)
+
+
+def assert_json_404(response, message="Not Found"):
     assert response.status_code == 404
-    assert response.json() == {"detail": "test missing resource"}
+    assert response.headers.get("content-type", "").startswith("application/json")
+    assert response.json() == {"message": message}
+
+
+def assert_json_405(response):
+    assert response.status_code == 405
     assert response.headers.get("content-type", "").startswith("application/json")
 
 
-def test_not_found_handler_serves_404_html_for_non_api_paths(temp_studio):
-    with open(os.path.join(temp_studio, "404.html"), "w", encoding="utf-8") as f:
-        f.write("<html><body>custom not found</body></html>")
+def test_not_found_handler_returns_json_for_api_http_exception(client):
+    assert_json_404(client.get("/api/forced-not-found"), "test missing resource")
 
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api",
+        "/api/",
+        "/api/some-unmatched-path",
+        "/api/nested/unmatched/path",
+        "/api/unmatched.html",
+    ],
+)
+def test_unmatched_api_paths_return_json_not_web_app_404(client, path):
+    response = client.get(path)
+    assert_json_404(response)
+    assert WEB_APP_404_BODY not in response.text
+
+
+def test_api_head_request_returns_json_404(client):
+    # HEAD responses carry no body, so the JSON shape can't be asserted here.
+    response = client.head("/api/some-unmatched-path")
+    assert response.status_code == 404
+    assert response.headers.get("content-type", "").startswith("application/json")
+    assert response.text == ""
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE", "OPTIONS"])
+@pytest.mark.parametrize("path", ["/api/some-unmatched-path", "/api/get-only"])
+def test_non_get_method_on_api_path_keeps_405(client, method, path):
+    # The web host mount matches every path, so any method the static file
+    # server doesn't serve reaches it and gets its 405 (which, unlike a
+    # router-generated one, carries no Allow header). All of this predates the
+    # JSON 404 handling and is left as-is: 405 is right for a wrong verb on a
+    # real route, and for a path that doesn't exist at all it's arguably wrong
+    # (404 would be more defensible) but not something this change touches.
+    assert_json_405(client.request(method, path))
+
+
+def test_matched_api_route_still_works(client):
+    response = client.get("/api/get-only")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/route-that-does-not-exist",
+        # Paths that merely start with the letters "api" are web app paths
+        "/apiary",
+        "/api-keys",
+    ],
+)
+def test_non_api_paths_serve_web_app_404(client, path):
+    response = client.get(path)
+    assert response.status_code == 404
+    assert response.headers.get("content-type", "").startswith("text/html")
+    assert WEB_APP_404_BODY in response.text
+
+
+def test_non_get_method_on_non_api_path_keeps_405(client):
+    assert_json_405(client.post("/route-that-does-not-exist"))
+
+
+def test_api_404s_with_custom_error_handlers(temp_studio):
+    # The real server registers the shared error handlers before the web host.
+    # This 404 status handler must keep winning over their HTTPException class
+    # handler, and neither may reintroduce the HTML 404.
     app = FastAPI()
+
+    @app.get("/api/forced-not-found")
+    def forced_not_found():
+        raise HTTPException(status_code=404, detail="test missing resource")
+
+    connect_custom_errors(app)
     connect_webhost(app)
     client = TestClient(app)
-    response = client.get("/route-that-does-not-exist")
-    assert response.status_code == 404
-    assert "custom not found" in response.text
+
+    assert_json_404(client.get("/api/some-unmatched-path"))
+    assert_json_404(client.get("/api/forced-not-found"), "test missing resource")
+
+    web_app_response = client.get("/route-that-does-not-exist")
+    assert web_app_response.status_code == 404
+    assert WEB_APP_404_BODY in web_app_response.text
+
+
+def test_non_api_static_file_still_served(temp_studio, client):
+    with open(os.path.join(temp_studio, "page.html"), "w", encoding="utf-8") as f:
+        f.write("<html><body>real page</body></html>")
+
+    response = client.get("/page")
+    assert response.status_code == 200
+    assert "real page" in response.text

--- a/app/desktop/studio_server/webhost.py
+++ b/app/desktop/studio_server/webhost.py
@@ -26,6 +26,13 @@ def studio_path():
         return os.path.join(base_path, "../../app/web_ui/build")
 
 
+API_PATH_PREFIX = "/api"
+
+
+def is_api_path(url_path: str) -> bool:
+    return url_path == API_PATH_PREFIX or url_path.startswith(f"{API_PATH_PREFIX}/")
+
+
 def add_no_cache_headers(response: Response):
     # This is already local, disable browser caching to prevent issues of old web-app trying to load old APIs and out of date web-ui
     response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
@@ -36,6 +43,17 @@ def add_no_cache_headers(response: Response):
 # File server that maps /foo/bar to /foo/bar.html (Starlette StaticFiles only does index.html)
 class HTMLStaticFiles(StaticFiles):
     async def get_response(self, path: str, scope):
+        # API paths must never be served web app content: StaticFiles in html mode
+        # answers any miss with the web app's 404.html instead of raising, which
+        # would bypass the JSON 404 handler below. Only guard the methods
+        # StaticFiles serves, so other methods keep falling through to its 405.
+        # Like the 404 handler below, this assumes an empty ASGI root_path (the
+        # desktop server sets none); under a prefix it would need get_route_path.
+        request_method = scope.get("method")
+        request_path = scope.get("path", "")
+        if request_method in ("GET", "HEAD") and is_api_path(request_path):
+            raise StarletteHTTPException(status_code=404)
+
         try:
             response = await super().get_response(path, scope)
             if response.status_code != 404:
@@ -62,11 +80,13 @@ def connect_webhost(app: FastAPI):
     @app.exception_handler(404)
     def not_found_exception_handler(request, exc):
         # don't handle /api routes, which return JSON errors
-        if request.url.path.startswith("/api"):
+        if is_api_path(request.url.path):
             if isinstance(exc, StarletteHTTPException):
+                # "message" matches every other Kiln API error (custom_errors.py), and
+                # is the key the web UI reads.
                 return JSONResponse(
                     status_code=exc.status_code,
-                    content={"detail": exc.detail},
+                    content={"message": exc.detail},
                 )
             raise exc
         return FileResponse(os.path.join(studio_path(), "404.html"), status_code=404)

--- a/app/web_ui/src/lib/utils/task_sample_example.ts
+++ b/app/web_ui/src/lib/utils/task_sample_example.ts
@@ -79,7 +79,7 @@ export async function fetch_task_sample_candidates(
     throw new Error(
       typeof error === "string"
         ? error
-        : (error as { detail?: string }).detail ?? "Failed to fetch runs",
+        : (error as { message?: string }).message ?? "Failed to fetch runs",
     )
   }
 
@@ -143,7 +143,7 @@ export async function build_prompt_with_task_sample(
     throw new Error(
       typeof error === "string"
         ? error
-        : (error as { detail?: string }).detail ?? "Failed to build prompt",
+        : (error as { message?: string }).message ?? "Failed to build prompt",
     )
   }
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes API error responses to consistently return JSON instead of the web app's HTML 404 page. The changes ensure that:

1. **API paths (`/api/*`) always return JSON 404 responses** with a `message` field (matching other Kiln API errors) instead of HTML
2. **Non-API paths continue to serve the web app's 404.html** for proper SPA routing
3. **The JSON 404 handler takes precedence** over custom error handlers registered by the shared error handling middleware

### Key Changes

**webhost.py:**
- Added `is_api_path()` helper to identify API routes (`/api` or `/api/*`)
- Modified `HTMLStaticFiles.get_response()` to raise a 404 exception for GET/HEAD requests to API paths, preventing the static file server from serving the web app's 404.html
- Updated the 404 exception handler to return JSON with a `message` field (instead of `detail`) for API paths, matching the format used by other Kiln API errors
- The handler now properly distinguishes between API and non-API paths

**task_sample_example.ts:**
- Updated error handling to read the `message` field instead of `detail` from API error responses

**test_webhost.py:**
- Significantly expanded test coverage with comprehensive scenarios:
  - Unmatched API paths return JSON 404s
  - HEAD requests to API paths return JSON 404s
  - Non-GET methods on API paths return 405s (existing behavior preserved)
  - Matched API routes continue to work
  - Non-API paths serve the web app's 404.html
  - Custom error handlers don't interfere with API 404 handling
  - Static files outside `/api` are still served correctly

## Related Issues

<!-- Link to related issues if applicable -->

## Contributor License Agreement

I confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

https://claude.ai/code/session_01Pf6BHCk1YW3JF993WZPxsi