### PR TITLE
Code judge LLM calls — llm / llm_judge tools for code evals

### DIFF
--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -54,6 +54,7 @@ from kiln_ai.datamodel.spec_properties import DesiredBehaviourProperties, SpecTy
 from kiln_ai.datamodel.task import TaskRunConfig
 from kiln_ai.adapters.run_output import RunOutput
 from kiln_ai.datamodel.task_run import Usage
+from kiln_ai.tools.sandbox_bridge import BridgeResult
 
 
 @pytest.fixture
@@ -3859,8 +3860,12 @@ class TestTestV2Eval:
                 return_value=True,
             ),
             patch(
-                "kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer",
-                return_value={"ok": {"accuracy": 0.75}},
+                "kiln_ai.adapters.eval.v2_eval_code_eval.run_bridged_child",
+                new=AsyncMock(
+                    return_value=BridgeResult(
+                        result_msg={"type": "result", "ok": {"accuracy": 0.75}}
+                    )
+                ),
             ),
         ):
             mock_eid.return_value = mock_v2_eval
@@ -4023,8 +4028,12 @@ class TestTestV2Eval:
                 return_value=True,
             ),
             patch(
-                "kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer",
-                return_value={"ok": {"accuracy": 5.0}},
+                "kiln_ai.adapters.eval.v2_eval_code_eval.run_bridged_child",
+                new=AsyncMock(
+                    return_value=BridgeResult(
+                        result_msg={"type": "result", "ok": {"accuracy": 5.0}}
+                    )
+                ),
             ),
         ):
             mock_eid.return_value = mock_v2_eval

--- a/app/desktop/studio_server/test_tool_api.py
+++ b/app/desktop/studio_server/test_tool_api.py
@@ -524,9 +524,21 @@ def test_get_tool_server_config_not_found(client, test_project):
         assert response.json()["message"] == "Tool server not found"
 
 
+def _builtin_ai_models_set(set_result):
+    """Return the always-present built-in AI Models tool set (or None)."""
+    return next(
+        (
+            s
+            for s in set_result
+            if s["type"] == "builtin" and s["set_name"] == "AI Models"
+        ),
+        None,
+    )
+
+
 def test_get_available_tools_empty(client, test_project):
-    """With no tool servers and the only built-in tool (Call Kiln API) being
-    not listed (it is an internal agent tool), no tool sets are returned."""
+    """With no tool servers, only the always-available built-in AI Models set
+    (llm + llm_judge) is returned. The Call Kiln API built-in stays hidden."""
     with patch(
         "app.desktop.studio_server.tool_api.project_from_id"
     ) as mock_project_from_id:
@@ -536,7 +548,13 @@ def test_get_available_tools_empty(client, test_project):
 
         assert response.status_code == 200
         result = response.json()
-        assert result == []
+        assert len(result) == 1
+        ai_models = _builtin_ai_models_set(result)
+        assert ai_models is not None
+        tool_ids = {t["id"] for t in ai_models["tools"]}
+        assert tool_ids == {"kiln_tool::llm", "kiln_tool::llm_judge"}
+        # Call Kiln API is intentionally not listed.
+        assert "kiln_tool::call_kiln_api" not in tool_ids
 
 
 async def test_get_available_tools_success_single_server(client, test_project):
@@ -580,8 +598,9 @@ async def test_get_available_tools_success_single_server(client, test_project):
 
             assert response.status_code == 200
             set_result = response.json()
-            # Just the MCP set — the Call Kiln API built-in tool is not listed.
-            assert len(set_result) == 1
+            # The built-in AI Models set plus the MCP set.
+            assert len(set_result) == 2
+            assert _builtin_ai_models_set(set_result) is not None
             mcp_set = next(
                 s
                 for s in set_result
@@ -721,9 +740,10 @@ async def test_get_available_tools_multiple_servers(client, test_project):
 
             assert response.status_code == 200
             set_result = response.json()
-            assert len(set_result) == 3  # 2 MCP servers + 1 kiln task set
-            # The Call Kiln API built-in tool is intentionally not listed.
-            assert not any(s["type"] == "builtin" for s in set_result)
+            # built-in AI Models + 2 MCP servers + 1 kiln task set
+            assert len(set_result) == 4
+            # The AI Models built-in set is always present; Call Kiln API is not.
+            assert _builtin_ai_models_set(set_result) is not None
 
             # Find sets by name instead of assuming order
             server1_set = next(
@@ -816,9 +836,10 @@ async def test_get_available_tools_mcp_error_handling(client, test_project):
             assert response.status_code == 200
             result = response.json()
 
-            # Failing server is skipped; the Call Kiln API built-in tool is not listed, so
-            # no tool sets remain.
-            assert result == []
+            # Failing MCP server is skipped; only the always-present built-in
+            # AI Models set remains (Call Kiln API is not listed).
+            assert len(result) == 1
+            assert _builtin_ai_models_set(result) is not None
 
 
 def test_get_available_tools_demo_tools_enabled(client, test_project):
@@ -842,13 +863,12 @@ def test_get_available_tools_demo_tools_enabled(client, test_project):
         assert response.status_code == 200
         result = response.json()
 
-        # The Call Kiln API built-in tool is not listed, so the
-        # built-in set is omitted and only the demo set remains.
-        assert len(result) == 1
-        assert not any(s["type"] == "builtin" for s in result)
+        # The always-present built-in AI Models set plus the demo set.
+        assert len(result) == 2
+        assert _builtin_ai_models_set(result) is not None
 
-        demo_set = result[0]
-        assert demo_set["set_name"] == "Kiln Demo Tools"
+        demo_set = next(s for s in result if s["set_name"] == "Kiln Demo Tools")
+        assert demo_set["type"] == "demo"
         assert len(demo_set["tools"]) == 4
 
         # Verify all demo tools are present with correct IDs and names
@@ -899,8 +919,38 @@ def test_get_available_tools_demo_tools_disabled(client, test_project):
         assert response.status_code == 200
         result = response.json()
 
-        # Demo tools disabled and the Call Kiln API built-in tool is not listed.
-        assert result == []
+        # Demo tools disabled: only the always-present built-in AI Models set
+        # remains (Call Kiln API is still not listed).
+        assert len(result) == 1
+        assert _builtin_ai_models_set(result) is not None
+
+
+def test_get_available_tools_builtin_ai_models_always_present(client, test_project):
+    """The AI Models built-in set (llm + llm_judge) is always available, and is
+    not demo-gated (present regardless of enable_demo_tools)."""
+    with (
+        patch(
+            "app.desktop.studio_server.tool_api.project_from_id"
+        ) as mock_project_from_id,
+        patch("app.desktop.studio_server.tool_api.Config.shared") as mock_config,
+    ):
+        mock_project_from_id.return_value = test_project
+        mock_config_instance = Mock()
+        mock_config_instance.enable_demo_tools = False
+        mock_config_instance.user_id = "test_user"
+        mock_config.return_value = mock_config_instance
+
+        response = client.get(f"/api/projects/{test_project.id}/available_tools")
+
+        assert response.status_code == 200
+        ai_models = _builtin_ai_models_set(response.json())
+        assert ai_models is not None
+        by_id = {t["id"]: t for t in ai_models["tools"]}
+        assert set(by_id) == {"kiln_tool::llm", "kiln_tool::llm_judge"}
+        assert by_id["kiln_tool::llm"]["name"] == "LLM"
+        assert by_id["kiln_tool::llm"]["function_name"] == "llm"
+        assert by_id["kiln_tool::llm_judge"]["name"] == "LLM Judge"
+        assert by_id["kiln_tool::llm_judge"]["function_name"] == "llm_judge"
 
 
 async def test_create_tool_server_whitespace_handling(
@@ -3522,8 +3572,9 @@ async def test_get_available_tools_with_rag_configs(client, test_project):
             assert response.status_code == 200
             result = response.json()
 
-            # RAG set only — the Call Kiln API built-in tool is not listed.
-            assert len(result) == 1
+            # Built-in AI Models set + RAG set.
+            assert len(result) == 2
+            assert _builtin_ai_models_set(result) is not None
             rag_set = next(s for s in result if s["set_name"] == "Search Tools (RAG)")
             assert len(rag_set["tools"]) == 2
 
@@ -3608,8 +3659,9 @@ async def test_get_available_tools_with_rag_and_mcp(client, test_project):
             assert response.status_code == 200
             result = response.json()
 
-            # RAG + MCP sets — the Call Kiln API built-in tool is not listed.
-            assert len(result) == 2
+            # Built-in AI Models + RAG + MCP sets.
+            assert len(result) == 3
+            assert _builtin_ai_models_set(result) is not None
 
             # Find both sets
             mcp_set = next(
@@ -3745,8 +3797,9 @@ async def test_available_tools_excludes_archived_rag_and_kiln_task_tools(
         assert response.status_code == 200
         result = response.json()
 
-        # RAG + Kiln task sets — the Call Kiln API built-in tool is not listed.
-        assert len(result) == 2
+        # Built-in AI Models + RAG + Kiln task sets.
+        assert len(result) == 3
+        assert _builtin_ai_models_set(result) is not None
 
         rag_set = next(
             (s for s in result if s["set_name"] == "Search Tools (RAG)"), None

--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -293,6 +293,32 @@ def connect_tool_servers_api(app: FastAPI):
 
         tool_sets = []
 
+        # Add built-in AI-model tools. These are always available (not demo-gated):
+        # `llm` calls a model from scorer/tool code, and `llm_judge` runs an
+        # LLM-as-judge call using a code judge's own score schema. `llm_judge` is
+        # only meaningful inside a code judge (it errors off-context), so the tool
+        # picker hides it outside the code-eval allowlist context.
+        tool_sets.append(
+            ToolSetApiDescription(
+                type=ToolSetType.BUILTIN,
+                set_name="AI Models",
+                tools=[
+                    ToolApiDescription(
+                        id=f"{KilnBuiltInToolId.LLM.value}",
+                        name="LLM",
+                        description="Call a language model with a rendered prompt. Optionally pass a JSON schema for structured output.",
+                        function_name="llm",
+                    ),
+                    ToolApiDescription(
+                        id=f"{KilnBuiltInToolId.LLM_JUDGE.value}",
+                        name="LLM Judge",
+                        description="Run an LLM-as-judge call using the code judge's own score schema. Only usable inside a code judge.",
+                        function_name="llm_judge",
+                    ),
+                ],
+            )
+        )
+
         # Add search tools (RAG)
         rag_configs = project.rag_configs(readonly=True)
         if rag_configs:

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -4540,9 +4540,14 @@ export interface components {
             reference_keys: string[];
             /**
              * Timeout Seconds
-             * @default 30
+             * @default 180
              */
             timeout_seconds: number;
+            /**
+             * Tool Allowlist
+             * @description Explicit per-tool allowlist of tools the scorer code may call.
+             */
+            tool_allowlist?: string[];
         };
         /**
          * CodeEvalTrustResponse

--- a/app/web_ui/src/lib/components/eval_types/__tests__/tools_selector_stub.svelte
+++ b/app/web_ui/src/lib/components/eval_types/__tests__/tools_selector_stub.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { ToolsSelectorSettings } from "$lib/ui/run_config_component/tools_selector_settings"
+
+  export let project_id: string = ""
+  export let label: string = ""
+  export let settings: Partial<ToolsSelectorSettings> = {}
+  export let tools: string[] = []
+</script>
+
+<div
+  data-testid="tools-selector-stub"
+  data-project-id={project_id}
+  data-label={label}
+  data-code-eval-context={settings.code_eval_context ? "true" : "false"}
+  data-tools={JSON.stringify(tools)}
+>
+  <button
+    type="button"
+    data-testid="tools-selector-add"
+    on:click={() => {
+      tools = [...tools, "kiln_tool::llm_judge"]
+    }}
+  >
+    add tool
+  </button>
+</div>

--- a/app/web_ui/src/lib/components/eval_types/code_eval_form.svelte
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_form.svelte
@@ -4,10 +4,12 @@
   import type { InlineAction } from "$lib/utils/form_element.svelte"
   import CodeEditor from "$lib/components/code_editor.svelte"
   import Dialog from "$lib/ui/dialog.svelte"
+  import ToolsSelector from "$lib/ui/run_config_component/tools_selector.svelte"
   import type { EvalOutputScore } from "$lib/types"
   import { generate_default_code, generate_examples } from "./code_eval_helpers"
 
   export let output_scores: EvalOutputScore[] | undefined = undefined
+  export let project_id: string = ""
 
   export let properties: components["schemas"]["CodeEvalProperties"] & {
     timeout_seconds?: number
@@ -15,7 +17,8 @@
     type: "code_eval",
     code: generate_default_code(output_scores),
     reference_keys: [],
-    timeout_seconds: 30,
+    timeout_seconds: 180,
+    tool_allowlist: [],
   }
 
   // Bindable code string so the parent can track code edits reactively.
@@ -30,9 +33,13 @@
     code_editor?.setValue(new_code)
   }
 
-  let timeout_seconds: number = properties.timeout_seconds ?? 30
+  let timeout_seconds: number = properties.timeout_seconds ?? 180
 
   $: properties.timeout_seconds = timeout_seconds
+
+  let tool_allowlist: string[] = properties.tool_allowlist ?? []
+
+  $: properties.tool_allowlist = tool_allowlist
 
   export function getProperties(): Omit<
     components["schemas"]["CodeEvalProperties"],
@@ -44,6 +51,7 @@
       type: "code_eval",
       code: properties.code,
       timeout_seconds,
+      tool_allowlist,
     }
   }
 
@@ -102,9 +110,24 @@
     description="Maximum time allowed for the score function to execute. Must be between 1 and 300 seconds."
     inputType="input_number"
     bind:value={timeout_seconds}
-    placeholder="30"
+    placeholder="180"
     min={1}
     max={300}
+  />
+
+  <ToolsSelector
+    {project_id}
+    label="Tools"
+    settings={{
+      description: "The score function can only call tools listed here.",
+      info_description:
+        "Select the tools this score function is allowed to call. Use them from `score()` via the kiln.tools or kiln.async_tools module. LLM Judge runs an LLM-as-judge call using this eval's own score schema.",
+      hide_create_kiln_task_tool_button: true,
+      optional: true,
+      empty_label: "None (no tool access)",
+      code_eval_context: true,
+    }}
+    bind:tools={tool_allowlist}
   />
 </div>
 

--- a/app/web_ui/src/lib/components/eval_types/code_eval_form.svelte
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_form.svelte
@@ -144,11 +144,13 @@
   ]}
 >
   <div class="flex flex-col gap-4">
-    <div class="tabs tabs-bordered">
+    <div class="tabs tabs-bordered flex-nowrap overflow-x-auto">
       {#each examples as example, i}
         <button
           type="button"
-          class="tab {active_example_tab === i ? 'tab-active' : ''}"
+          class="tab shrink-0 whitespace-nowrap {active_example_tab === i
+            ? 'tab-active'
+            : ''}"
           on:click={() => (active_example_tab = i)}
         >
           {example.label}

--- a/app/web_ui/src/lib/components/eval_types/code_eval_form.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_form.test.ts
@@ -18,6 +18,11 @@ vi.mock("$lib/utils/form_element.svelte", async () => {
   return { default: StubModule.default }
 })
 
+vi.mock("$lib/ui/run_config_component/tools_selector.svelte", async () => {
+  const StubModule = await import("./__tests__/tools_selector_stub.svelte")
+  return { default: StubModule.default }
+})
+
 const CodeEvalForm = (await import("./code_eval_form.svelte")).default
 
 beforeAll(() => {
@@ -117,7 +122,8 @@ describe("CodeEvalForm", () => {
     const props = component.getProperties()
     expect(props.type).toBe("code_eval")
     expect(props.code).toContain("def score(")
-    expect(props.timeout_seconds).toBe(30)
+    // Default raised to 180s to accommodate nested LLM tool latency.
+    expect(props.timeout_seconds).toBe(180)
   })
 
   it("produces CodeEvalProperties with updated timeout", async () => {
@@ -173,13 +179,15 @@ describe("CodeEvalForm", () => {
     expect(dialogStub?.getAttribute("data-title")).toBe("Code Judge Examples")
   })
 
-  it("renders example tabs (Parse JSON, Check tool usage, Domain-specific grading)", () => {
+  it("renders example tabs including the LLM tool examples", () => {
     const { container } = render(CodeEvalForm)
     const tabs = container.querySelectorAll(".tab")
-    expect(tabs.length).toBe(3)
+    expect(tabs.length).toBe(5)
     expect(tabs[0].textContent?.trim()).toBe("Parse JSON")
     expect(tabs[1].textContent?.trim()).toBe("Check tool usage")
     expect(tabs[2].textContent?.trim()).toBe("Domain-specific grading")
+    expect(tabs[3].textContent?.trim()).toBe("LLM judge")
+    expect(tabs[4].textContent?.trim()).toBe("Triage then LLM judge")
   })
 
   it("switches active example tab on click", async () => {
@@ -201,6 +209,50 @@ describe("CodeEvalForm", () => {
       '[data-testid="code-editor-stub"]',
     )
     expect(editorStub).not.toBeNull()
+  })
+})
+
+describe("tool allowlist picker", () => {
+  it("renders the ToolsSelector in code-eval context", () => {
+    const { container } = render(CodeEvalForm, {
+      props: { project_id: "proj_123" },
+    })
+    const selector = container.querySelector(
+      '[data-testid="tools-selector-stub"]',
+    )
+    expect(selector).not.toBeNull()
+    expect(selector?.getAttribute("data-project-id")).toBe("proj_123")
+    // code_eval_context must be true so llm_judge is offered here.
+    expect(selector?.getAttribute("data-code-eval-context")).toBe("true")
+  })
+
+  it("binds the picker to properties.tool_allowlist", () => {
+    const customProps = {
+      type: "code_eval" as const,
+      code: 'def score(output):\n    return {"quality": 1.0}\n',
+      reference_keys: [] as string[],
+      timeout_seconds: 180,
+      tool_allowlist: ["kiln_tool::llm"],
+    }
+    const { container } = render(CodeEvalForm, {
+      props: { properties: customProps },
+    })
+    const selector = container.querySelector(
+      '[data-testid="tools-selector-stub"]',
+    )
+    expect(JSON.parse(selector?.getAttribute("data-tools") ?? "[]")).toEqual([
+      "kiln_tool::llm",
+    ])
+  })
+
+  it("selecting a tool flows back into getProperties().tool_allowlist", async () => {
+    const { component, container } = render(CodeEvalForm)
+    const add_button = container.querySelector(
+      '[data-testid="tools-selector-add"]',
+    ) as HTMLButtonElement
+    await fireEvent.click(add_button)
+    const props = component.getProperties()
+    expect(props.tool_allowlist).toEqual(["kiln_tool::llm_judge"])
   })
 })
 

--- a/app/web_ui/src/lib/components/eval_types/code_eval_helpers.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_helpers.test.ts
@@ -152,24 +152,30 @@ describe("generate_default_code", () => {
 })
 
 describe("generate_examples", () => {
-  it("returns three examples with correct labels", () => {
+  // The first three examples are score-key-driven (built via the helper
+  // functions); the last two are hand-written LLM tool examples validated
+  // separately below.
+  const code_examples = (scores?: EvalOutputScore[]) =>
+    generate_examples(scores).slice(0, 3)
+
+  it("returns five examples with correct labels", () => {
     const examples = generate_examples(undefined)
-    expect(examples).toHaveLength(3)
+    expect(examples).toHaveLength(5)
     expect(examples[0].label).toBe("Parse JSON")
     expect(examples[1].label).toBe("Check tool usage")
     expect(examples[2].label).toBe("Domain-specific grading")
+    expect(examples[3].label).toBe("LLM judge")
+    expect(examples[4].label).toBe("Triage then LLM judge")
   })
 
   it("falls back to quality key when no output_scores", () => {
-    const examples = generate_examples(undefined)
-    for (const ex of examples) {
+    for (const ex of code_examples(undefined)) {
       expect(ex.code).toContain('"quality"')
     }
   })
 
   it("falls back to quality key when output_scores is empty", () => {
-    const examples = generate_examples([])
-    for (const ex of examples) {
+    for (const ex of code_examples([])) {
       expect(ex.code).toContain('"quality"')
     }
   })
@@ -179,11 +185,38 @@ describe("generate_examples", () => {
       make_score("Valid JSON", "pass_fail"),
       make_score("Overall Rating", "five_star"),
     ]
-    const examples = generate_examples(scores)
-    for (const ex of examples) {
+    for (const ex of code_examples(scores)) {
       expect(ex.code).toContain('"valid_json"')
       expect(ex.code).toContain('"overall_rating"')
     }
+  })
+
+  describe("LLM tool examples", () => {
+    it("LLM judge example calls tools.llm_judge and returns its scores", () => {
+      const example = generate_examples(undefined)[3]
+      expect(example.label).toBe("LLM judge")
+      expect(example.code).toContain("from kiln import tools")
+      expect(example.code).toContain("tools.llm_judge(")
+      expect(example.code).toContain("return json.loads(")
+    })
+
+    it("Triage example composes tools.llm and tools.llm_judge", () => {
+      const example = generate_examples(undefined)[4]
+      expect(example.label).toBe("Triage then LLM judge")
+      expect(example.code).toContain("tools.llm(")
+      expect(example.code).toContain("tools.llm_judge(")
+      // Safe branch threads the eval's score keys via build_return_dict.
+      expect(example.code).toContain('return {"quality": 1.0}')
+    })
+
+    it("Triage safe-branch uses real score keys from output_scores", () => {
+      const scores = [
+        make_score("Check", "pass_fail"),
+        make_score("Rating", "five_star"),
+      ]
+      const example = generate_examples(scores)[4]
+      expect(example.code).toContain('return {"check": 1.0, "rating": 5.0}')
+    })
   })
 
   describe("type-appropriate value mapping", () => {
@@ -193,23 +226,20 @@ describe("generate_examples", () => {
     ]
 
     it("uses KilnEvalHelpers.pass_fail for pass_fail scores", () => {
-      const examples = generate_examples(scores)
-      for (const ex of examples) {
+      for (const ex of code_examples(scores)) {
         expect(ex.code).toContain('"check": KilnEvalHelpers.pass_fail(')
       }
     })
 
     it("uses KilnEvalHelpers.five_star for five_star scores", () => {
-      const examples = generate_examples(scores)
-      for (const ex of examples) {
+      for (const ex of code_examples(scores)) {
         expect(ex.code).toContain('"rating": KilnEvalHelpers.five_star(')
       }
     })
 
     it("uses KilnEvalHelpers.pass_fail for pass_fail_critical scores", () => {
       const scores_pfc = [make_score("Safety", "pass_fail_critical")]
-      const examples = generate_examples(scores_pfc)
-      for (const ex of examples) {
+      for (const ex of code_examples(scores_pfc)) {
         expect(ex.code).toContain('"safety": KilnEvalHelpers.pass_fail(')
       }
     })
@@ -298,8 +328,7 @@ describe("generate_examples", () => {
         make_score("Check", "pass_fail"),
         make_score("Rating", "five_star"),
       ]
-      const examples = generate_examples(scores)
-      for (const ex of examples) {
+      for (const ex of code_examples(scores)) {
         expect(ex.code).toContain("# Adjust each score's logic for your eval")
       }
     })

--- a/app/web_ui/src/lib/components/eval_types/code_eval_helpers.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_helpers.test.ts
@@ -192,12 +192,15 @@ describe("generate_examples", () => {
   })
 
   describe("LLM tool examples", () => {
-    it("LLM judge example calls tools.llm_judge and returns its scores", () => {
+    it("LLM judge example judges the response itself", () => {
       const example = generate_examples(undefined)[3]
       expect(example.label).toBe("LLM judge")
       expect(example.code).toContain("from kiln import tools")
       expect(example.code).toContain("tools.llm_judge(")
       expect(example.code).toContain("return json.loads(")
+      // Judges the model's own output (not the user's messages).
+      expect(example.code).toContain("def score(output):")
+      expect(example.code).toContain('input={"response": output}')
     })
 
     it("Triage example composes tools.llm and tools.llm_judge", () => {
@@ -205,6 +208,9 @@ describe("generate_examples", () => {
       expect(example.label).toBe("Triage then LLM judge")
       expect(example.code).toContain("tools.llm(")
       expect(example.code).toContain("tools.llm_judge(")
+      // Cheap triage decides whether the careful judge is even needed.
+      expect(example.code).toContain('"needs_review"')
+      expect(example.code).toContain("if not triage[")
       // Safe branch threads the eval's score keys via build_return_dict.
       expect(example.code).toContain('return {"quality": 1.0}')
     })

--- a/app/web_ui/src/lib/components/eval_types/code_eval_helpers.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_helpers.ts
@@ -183,6 +183,7 @@ export function generate_examples(
     "contains",
     "5 if word_count < 50 else 3 if word_count < 150 else 1",
   )
+  const triage_safe_return = build_return_dict(scores, "passing")
 
   return [
     {
@@ -229,6 +230,86 @@ def score(output, reference_data):
     word_count = len(output.split())
 
     ${domain_return}
+`,
+    },
+    {
+      label: "LLM judge",
+      code: `import json
+from kiln import tools
+
+# llm_judge automatically uses this eval's own score schema, so its
+# returned keys already match what score() must return. Filter the
+# trace cheaply in Python first, then judge only the small slice.
+JUDGE_PROMPT = """Judge the assistant's behavior using only these user messages:
+
+{{ user_messages }}
+"""
+
+
+def relevant_user_messages(trace):
+    return [
+        message.get("content", "")
+        for message in (trace or [])
+        if message.get("role") == "user"
+    ]
+
+
+def score(trace):
+    user_messages = relevant_user_messages(trace)
+    return json.loads(
+        tools.llm_judge(
+            prompt=JUDGE_PROMPT,
+            input={"user_messages": user_messages},
+            model="gpt-4.1",
+            provider="openai",
+        )
+    )
+`,
+    },
+    {
+      label: "Triage then LLM judge",
+      code: `import json
+from kiln import tools
+
+# Cheap triage with a small model; only escalate to a careful judge
+# when the fast pass flags something worth a closer look.
+TRIAGE_SCHEMA = {
+    "type": "object",
+    "properties": {"verdict": {"type": "string", "enum": ["safe", "risky"]}},
+    "required": ["verdict"],
+    "additionalProperties": False,
+}
+
+
+def relevant_user_messages(trace):
+    return [
+        message.get("content", "")
+        for message in (trace or [])
+        if message.get("role") == "user"
+    ]
+
+
+def score(trace):
+    user_messages = relevant_user_messages(trace)
+    triage = json.loads(
+        tools.llm(
+            prompt="Obviously fine, or worth a closer look? {{ user_messages }}",
+            input={"user_messages": user_messages},
+            model="gpt-4.1-mini",
+            provider="openai",
+            schema=TRIAGE_SCHEMA,
+        )
+    )
+    if triage["verdict"] == "safe":
+        return ${triage_safe_return}
+    return json.loads(
+        tools.llm_judge(
+            prompt="Carefully judge the assistant's behavior. {{ user_messages }}",
+            input={"user_messages": user_messages},
+            model="gpt-4.1",
+            provider="openai",
+        )
+    )
 `,
     },
   ]

--- a/app/web_ui/src/lib/components/eval_types/code_eval_helpers.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_helpers.ts
@@ -238,28 +238,21 @@ def score(output, reference_data):
 from kiln import tools
 
 # llm_judge automatically uses this eval's own score schema, so its
-# returned keys already match what score() must return. Filter the
-# trace cheaply in Python first, then judge only the small slice.
-JUDGE_PROMPT = """Judge the assistant's behavior using only these user messages:
+# returned keys already match what score() must return. For long
+# conversations, filter the trace in Python first and judge just the slice.
+JUDGE_PROMPT = """Fail if the response contains profanity or aggressive language. Otherwise pass.
 
-{{ user_messages }}
+<response>
+{{ response }}
+</response>
 """
 
 
-def relevant_user_messages(trace):
-    return [
-        message.get("content", "")
-        for message in (trace or [])
-        if message.get("role") == "user"
-    ]
-
-
-def score(trace):
-    user_messages = relevant_user_messages(trace)
+def score(output):
     return json.loads(
         tools.llm_judge(
             prompt=JUDGE_PROMPT,
-            input={"user_messages": user_messages},
+            input={"response": output},
             model="gpt-4.1",
             provider="openai",
         )
@@ -271,41 +264,44 @@ def score(trace):
       code: `import json
 from kiln import tools
 
-# Cheap triage with a small model; only escalate to a careful judge
-# when the fast pass flags something worth a closer look.
+# A cheap model first decides whether a careful check is even needed;
+# escalate to a stronger judge only when it flags the response.
 TRIAGE_SCHEMA = {
     "type": "object",
-    "properties": {"verdict": {"type": "string", "enum": ["safe", "risky"]}},
-    "required": ["verdict"],
+    "properties": {"needs_review": {"type": "boolean"}},
+    "required": ["needs_review"],
     "additionalProperties": False,
 }
 
+TRIAGE_PROMPT = """Does this response give medical, legal, or financial advice? Answer needs_review true or false.
 
-def relevant_user_messages(trace):
-    return [
-        message.get("content", "")
-        for message in (trace or [])
-        if message.get("role") == "user"
-    ]
+{{ response }}
+"""
+
+JUDGE_PROMPT = """Fail if the response gives medical, legal, or financial advice without recommending a professional. Otherwise pass.
+
+<response>
+{{ response }}
+</response>
+"""
 
 
-def score(trace):
-    user_messages = relevant_user_messages(trace)
+def score(output):
     triage = json.loads(
         tools.llm(
-            prompt="Obviously fine, or worth a closer look? {{ user_messages }}",
-            input={"user_messages": user_messages},
+            prompt=TRIAGE_PROMPT,
+            input={"response": output},
             model="gpt-4.1-mini",
             provider="openai",
             schema=TRIAGE_SCHEMA,
         )
     )
-    if triage["verdict"] == "safe":
+    if not triage["needs_review"]:
         return ${triage_safe_return}
     return json.loads(
         tools.llm_judge(
-            prompt="Carefully judge the assistant's behavior. {{ user_messages }}",
-            input={"user_messages": user_messages},
+            prompt=JUDGE_PROMPT,
+            input={"response": output},
             model="gpt-4.1",
             provider="openai",
         )

--- a/app/web_ui/src/lib/components/eval_types/deterministic_forms.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/deterministic_forms.test.ts
@@ -2,10 +2,26 @@
 import { describe, it, expect, vi, beforeAll } from "vitest"
 import { render, fireEvent } from "@testing-library/svelte"
 import { tick } from "svelte"
+import { available_tools } from "$lib/stores"
+import type { ToolSetApiDescription } from "$lib/types"
 
 vi.mock("$lib/utils/form_element.svelte", async () => {
   const { default: Stub } = await import("./__tests__/form_element_stub.svelte")
   return { default: Stub }
+})
+
+// Keep the real CODE_EVAL_ONLY_TOOL_IDS; only stub the async function-name
+// resolver so build_tool_options runs without hitting the API.
+vi.mock("$lib/stores/tools_store", async () => {
+  const actual = await vi.importActual<
+    typeof import("$lib/stores/tools_store")
+  >("$lib/stores/tools_store")
+  return {
+    ...actual,
+    tool_id_to_function_name: vi.fn(
+      async (tool_id: string) => tool_id.split("::").pop() ?? tool_id,
+    ),
+  }
 })
 
 vi.mock("$lib/utils/form_list.svelte", async () => {
@@ -2915,5 +2931,56 @@ describe("required_reference_fields computation", () => {
     })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((component as any).required_reference_fields).toEqual([])
+  })
+})
+
+describe("ToolCallCheckForm tool option filtering", () => {
+  const ai_models_set: ToolSetApiDescription = {
+    type: "builtin",
+    set_name: "AI Models",
+    tools: [
+      {
+        id: "kiln_tool::llm",
+        name: "LLM",
+        description: "Call a model",
+        function_name: "llm",
+      },
+      {
+        id: "kiln_tool::llm_judge",
+        name: "LLM Judge",
+        description: "Judge with the eval schema",
+        function_name: "llm_judge",
+      },
+    ],
+  }
+
+  it("excludes code-eval-only tools (llm_judge) but keeps llm", async () => {
+    available_tools.set({ proj_tcc: [ai_models_set] })
+
+    const { container } = render(ToolCallCheckForm, {
+      props: {
+        project_id: "proj_tcc",
+        task_id: "task_tcc",
+        properties: {
+          type: "tool_call_check" as const,
+          expected_tools: [{ tool_name: "", expected_args: null }],
+          match_mode: "all" as const,
+          on_unexpected_tools: "ignore" as const,
+        },
+      },
+    })
+
+    // Let the async build_tool_options resolve, then flush reactivity.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await tick()
+
+    // llm is general-purpose and stays selectable.
+    expect(
+      container.querySelector('[data-testid="fancy-option-llm"]'),
+    ).not.toBeNull()
+    // llm_judge is code-eval-only and can never appear in a real trace.
+    expect(
+      container.querySelector('[data-testid="fancy-option-llm_judge"]'),
+    ).toBeNull()
   })
 })

--- a/app/web_ui/src/lib/components/eval_types/eval_config_builder.svelte
+++ b/app/web_ui/src/lib/components/eval_types/eval_config_builder.svelte
@@ -655,6 +655,7 @@
             bind:this={v2FormComponentRef}
             bind:code_string={code_eval_code}
             output_scores={evaluator?.output_scores}
+            {project_id}
           />
         {:else if (eval_config_type === "exact_match" || eval_config_type === "contains" || eval_config_type === "set_check") && metadata}
           <svelte:component

--- a/app/web_ui/src/lib/components/eval_types/tool_call_check_form.svelte
+++ b/app/web_ui/src/lib/components/eval_types/tool_call_check_form.svelte
@@ -6,7 +6,10 @@
   import CloseIcon from "$lib/ui/icons/close_icon.svelte"
   import { onMount } from "svelte"
   import { available_tools, load_available_tools } from "$lib/stores"
-  import { tool_id_to_function_name } from "$lib/stores/tools_store"
+  import {
+    tool_id_to_function_name,
+    CODE_EVAL_ONLY_TOOL_IDS,
+  } from "$lib/stores/tools_store"
   import type { OptionGroup, Option } from "$lib/ui/fancy_select_types"
   import type { ToolSetApiDescription } from "$lib/types"
 
@@ -51,8 +54,13 @@
     const groups: OptionGroup[] = []
     const fn_names = new Set<string>()
     for (const tool_set of tool_sets) {
+      // tool_call_check is never a code-eval context, so code-eval-only tools
+      // (e.g. llm_judge) can never appear in a real trace — exclude them.
+      const selectable_tools = tool_set.tools.filter(
+        (tool) => !CODE_EVAL_ONLY_TOOL_IDS.includes(tool.id),
+      )
       const resolved = await Promise.all(
-        tool_set.tools.map(async (tool): Promise<Option | null> => {
+        selectable_tools.map(async (tool): Promise<Option | null> => {
           try {
             const function_name = await tool_id_to_function_name(
               tool.id,

--- a/app/web_ui/src/lib/stores/tools_store.ts
+++ b/app/web_ui/src/lib/stores/tools_store.ts
@@ -11,6 +11,12 @@ type ToolsStore = {
   selected_tool_ids_by_task_id: Record<string, string[]>
 }
 
+// Built-in tools that are only meaningful inside a code judge. They resolve
+// through the normal tool path but error off-context (and can never appear in a
+// real agent trace), so tool pickers hide them everywhere except the code-eval
+// allowlist. Centralized here so every picker applies the same filter.
+export const CODE_EVAL_ONLY_TOOL_IDS = ["kiln_tool::llm_judge"]
+
 const tools_store_key = "tools_store"
 export const { store: tools_store, initialized: tools_store_initialized } =
   indexedDBStore<ToolsStore>(tools_store_key, {

--- a/app/web_ui/src/lib/ui/run_config_component/__tests__/form_element_options_stub.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/__tests__/form_element_options_stub.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { OptionGroup } from "$lib/ui/fancy_select_types"
+
+  export let fancy_select_options: OptionGroup[] = []
+  export let value: string[] = []
+</script>
+
+<div
+  data-testid="form-element-options"
+  data-option-values={JSON.stringify(
+    fancy_select_options.flatMap((group) =>
+      group.options.map((option) => option.value),
+    ),
+  )}
+  data-value={JSON.stringify(value)}
+></div>

--- a/app/web_ui/src/lib/ui/run_config_component/tools_selector.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/tools_selector.svelte
@@ -4,7 +4,11 @@
   import { available_tools, load_available_tools } from "$lib/stores"
   import { onMount } from "svelte"
   import type { ToolSetApiDescription, ToolSetType } from "$lib/types"
-  import { tools_store, tools_store_initialized } from "$lib/stores/tools_store"
+  import {
+    tools_store,
+    tools_store_initialized,
+    CODE_EVAL_ONLY_TOOL_IDS,
+  } from "$lib/stores/tools_store"
   import { goto } from "$app/navigation"
   import type { ToolsSelectorSettings } from "./tools_selector_settings"
 
@@ -29,6 +33,7 @@
     empty_label: "None",
     single_select: false,
     optional: true,
+    code_eval_context: false,
   }
   $: tools_selector_settings = {
     ...default_tools_selector_settings,
@@ -164,6 +169,7 @@
 
   function get_tool_options(
     available_tool_sets: ToolSetApiDescription[] | undefined,
+    code_eval_context: boolean,
   ): OptionGroup[] {
     if (!available_tool_sets || available_tool_sets.length === 0) {
       // When there are no available tools, we'll show the empty state "Add tools" button
@@ -193,7 +199,14 @@
 
       if (tool_sets.length > 0) {
         for (const tool_set of tool_sets) {
-          let tools = tool_set.tools
+          let tools = tool_set.tools.filter(
+            (tool) =>
+              code_eval_context || !CODE_EVAL_ONLY_TOOL_IDS.includes(tool.id),
+          )
+
+          if (tools.length === 0) {
+            continue
+          }
 
           let options = tools.map((tool) => ({
             value: tool.id,
@@ -232,7 +245,10 @@
     info_description: tools_selector_settings.hide_info_description
       ? undefined
       : tools_selector_settings.info_description,
-    fancy_select_options: get_tool_options($available_tools[project_id]),
+    fancy_select_options: get_tool_options(
+      $available_tools[project_id],
+      tools_selector_settings.code_eval_context,
+    ),
     empty_label:
       tools_selector_settings.empty_label ??
       default_tools_selector_settings.empty_label,

--- a/app/web_ui/src/lib/ui/run_config_component/tools_selector.test.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tools_selector.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll } from "vitest"
+import { render } from "@testing-library/svelte"
+import { tick } from "svelte"
+import { available_tools } from "$lib/stores"
+import type { ToolSetApiDescription } from "$lib/types"
+
+vi.mock("$app/navigation", () => ({ goto: vi.fn() }))
+
+vi.mock("$lib/utils/form_element.svelte", async () => {
+  const { default: Stub } = await import(
+    "./__tests__/form_element_options_stub.svelte"
+  )
+  return { default: Stub }
+})
+
+const ToolsSelector = (await import("./tools_selector.svelte")).default
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    ;(
+      globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }
+    ).ResizeObserver = ResizeObserverStub
+  }
+})
+
+const ai_models_set: ToolSetApiDescription = {
+  type: "builtin",
+  set_name: "AI Models",
+  tools: [
+    {
+      id: "kiln_tool::llm",
+      name: "LLM",
+      description: "Call a model",
+      function_name: "llm",
+    },
+    {
+      id: "kiln_tool::llm_judge",
+      name: "LLM Judge",
+      description: "Judge with the eval schema",
+      function_name: "llm_judge",
+    },
+  ],
+}
+
+async function option_values(
+  code_eval_context: boolean,
+  project_id: string,
+): Promise<string[]> {
+  available_tools.set({ [project_id]: [ai_models_set] })
+  const { container } = render(ToolsSelector, {
+    props: {
+      project_id,
+      settings: { code_eval_context },
+    },
+  })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await tick()
+  const el = container.querySelector('[data-testid="form-element-options"]')
+  return JSON.parse(el?.getAttribute("data-option-values") ?? "[]")
+}
+
+describe("ToolsSelector code-eval-only tool filtering", () => {
+  it("hides llm_judge outside a code-eval context (keeps llm)", async () => {
+    const values = await option_values(false, "proj_ts_off")
+    expect(values).toContain("kiln_tool::llm")
+    expect(values).not.toContain("kiln_tool::llm_judge")
+  })
+
+  it("shows llm_judge inside a code-eval context", async () => {
+    const values = await option_values(true, "proj_ts_on")
+    expect(values).toContain("kiln_tool::llm")
+    expect(values).toContain("kiln_tool::llm_judge")
+  })
+})

--- a/app/web_ui/src/lib/ui/run_config_component/tools_selector_settings.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tools_selector_settings.ts
@@ -8,4 +8,8 @@ export interface ToolsSelectorSettings {
   empty_label: string | undefined
   single_select: boolean
   optional: boolean
+  // When true, tools that are only meaningful inside a code judge (e.g. the
+  // llm_judge built-in) are offered in the picker. Off by default so those
+  // tools are hidden everywhere except the code-eval allowlist context.
+  code_eval_context: boolean
 }

--- a/libs/core/kiln_ai/adapters/eval/_heavy_main_bench.py
+++ b/libs/core/kiln_ai/adapters/eval/_heavy_main_bench.py
@@ -1,4 +1,4 @@
-"""Heavy-__main__ benchmark harness for run_scorer.
+"""Heavy-__main__ benchmark harness for the code-eval scorer spawn path.
 
 This script deliberately imports a heavy module at the top level,
 mimicking ``app/desktop/dev_server.py`` which has an unguarded
@@ -9,19 +9,22 @@ When invoked as ``python _heavy_main_bench.py``, *this file* is
 ``__main__``.  Under multiprocessing "spawn", the child process
 re-imports the parent's ``__main__`` module during bootstrap
 (``multiprocessing.spawn.get_preparation_data`` reads
-``sys.modules['__main__'].__file__``).  So if ``run_scorer`` does NOT
+``sys.modules['__main__'].__file__``).  So if the spawn path does NOT
 prevent the re-import, the child re-executes the heavy import chain
-(~1-3 s per call) -- the exact bug this benchmark catches.
+(~1-3 s per call) -- the exact bug this benchmark catches. The scorer now
+spawns through ``run_bridged_child``, which uses
+``start_process_with_light_main`` to keep the fix.
 
 Usage (from repo root):
     uv run python libs/core/kiln_ai/adapters/eval/_heavy_main_bench.py
 
-Prints one JSON line per run_scorer call:
+Prints one JSON line per scorer call:
     {"call": 1, "elapsed": 2.345}
 
 Exit code 0 on success.
 """
 
+import asyncio
 import json
 import multiprocessing
 import sys
@@ -36,7 +39,9 @@ import time
 # that the spawn child would re-execute.
 import litellm  # noqa: F401
 
-from kiln_ai.adapters.eval.sandbox_worker import run_scorer
+from kiln_ai.adapters.eval.sandbox_worker import execute_scorer_bridged
+from kiln_ai.datamodel.project import Project
+from kiln_ai.tools.sandbox_bridge import NestedToolServer, run_bridged_child
 
 _TRIVIAL_CODE = (
     "def score(output, trace, reference_data, task_input):\n    return {'x': 1.0}\n"
@@ -49,12 +54,29 @@ _INPUTS = {
 }
 _N = 2
 
+
+def _run_scorer(code: str, inputs: dict, timeout: float) -> dict:
+    async def _run() -> dict:
+        server = NestedToolServer(
+            allowlist=[], project=Project(name="heavy_bench"), task=None, context=None
+        )
+        res = await run_bridged_child(
+            target=execute_scorer_bridged,
+            args=(code, inputs),
+            timeout_s=float(timeout),
+            server=server,
+        )
+        return res.result_msg or {"error": "no result"}
+
+    return asyncio.run(_run())
+
+
 if __name__ == "__main__":
     multiprocessing.freeze_support()
 
     for i in range(1, _N + 1):
         t0 = time.perf_counter()
-        result = run_scorer(_TRIVIAL_CODE, _INPUTS, timeout=30)
+        result = _run_scorer(_TRIVIAL_CODE, _INPUTS, timeout=30)
         elapsed = time.perf_counter() - t0
 
         if "ok" not in result:

--- a/libs/core/kiln_ai/adapters/eval/sandbox_worker.py
+++ b/libs/core/kiln_ai/adapters/eval/sandbox_worker.py
@@ -1,37 +1,45 @@
-"""Multiprocessing worker for executing user-authored scorer functions.
+"""Child-process entry point for code-eval scorer execution.
 
-Thin module: only imports stdlib and kiln_ai.sandbox (which is itself
-stdlib-only). No Pydantic / Kiln-model / DB / UI imports.
+Stdlib only — no Pydantic / Kiln-model / DB / UI imports. Imports only from
+``kiln_ai.sandbox`` (itself stdlib-only).
+
+The parent spawns this via ``multiprocessing`` (spawn context) through
+:func:`kiln_ai.tools.sandbox_bridge.run_bridged_child`. Communication uses two
+queues (requests child->parent, responses parent->child), so the user ``score()``
+can call allowlisted tools (including ``tools.llm`` / ``tools.llm_judge``) via the
+synthetic ``kiln.tools`` / ``kiln.async_tools`` modules.
 """
 
 import inspect
 import io
-import multiprocessing
-import multiprocessing.queues
-import queue
 import sys
 import traceback
+from multiprocessing import Queue
 from typing import Any
 
 from kiln_ai.sandbox.entrypoint import call_entrypoint
-from kiln_ai.sandbox.spawn import start_process_with_light_main
+from kiln_ai.sandbox.tools_api import install_tools_modules
 
 
-def _execute_scorer(
+def execute_scorer_bridged(
     code: str,
     inputs: dict[str, Any],
-    result_queue: multiprocessing.Queue,  # type: ignore[type-arg]
+    requests: Queue,  # type: ignore[type-arg]
+    responses: Queue,  # type: ignore[type-arg]
 ) -> None:
-    """Target function for the child process.
+    """Entry point for the code-eval child process (two-queue bridge protocol).
 
-    Runs user scorer code in an isolated namespace. Both ``def score``
-    and ``async def score`` are supported -- if the call returns a
-    coroutine it is transparently awaited via ``asyncio.run()``.
+    Runs user scorer code in an isolated namespace. Both ``def score`` and
+    ``async def score`` are supported -- if the call returns a coroutine it is
+    transparently awaited via :func:`call_entrypoint`.
 
-    Puts exactly one JSON-serializable dict on *result_queue*:
-      - success:  {"ok": <result>, "stdout": ..., "stderr": ...}
-      - error:    {"error": str, "traceback": str, "stdout": ..., "stderr": ...}
-      - missing:  {"error": "...does not define score...", "stdout": ..., "stderr": ...}
+    Puts exactly one ``result`` message on *requests* and then returns:
+      - success:  {"type":"result","ok":<scores dict>,"stdout":...,"stderr":...}
+      - error:    {"type":"result","error":str,"traceback":str,"stdout":...,"stderr":...}
+      - missing:  {"type":"result","error":"...does not define score...","stdout":...,"stderr":...}
+
+    ``ok`` carries the scorer's returned scores **dict verbatim** (a code eval returns
+    a dict, not a passthrough string — no serialization step).
     """
     # Redirect stdout/stderr to capture user prints and avoid None-stdout
     # crashes in frozen (PyInstaller --windowed) builds.
@@ -40,29 +48,29 @@ def _execute_scorer(
     old_stdout = sys.stdout
     old_stderr = sys.stderr
     try:
-        sys.stdout = captured_stdout
-        sys.stderr = captured_stderr
+        sys.stdout = captured_stdout  # type: ignore[assignment]
+        sys.stderr = captured_stderr  # type: ignore[assignment]
+
+        install_tools_modules(requests, responses)
 
         namespace: dict[str, Any] = {}
-        exec(code, namespace)
+        exec(compile(code, "<code_eval>", "exec"), namespace)
 
         score_fn = namespace.get("score")
         if score_fn is None:
-            result_queue.put(
-                {
-                    "error": "User code does not define a 'score()' function",
-                    "stdout": captured_stdout.getvalue(),
-                    "stderr": captured_stderr.getvalue(),
-                }
+            _put_result_error(
+                requests,
+                "User code does not define a 'score()' function",
+                captured_stdout,
+                captured_stderr,
             )
             return
         if not callable(score_fn):
-            result_queue.put(
-                {
-                    "error": "'score' is defined but is not callable",
-                    "stdout": captured_stdout.getvalue(),
-                    "stderr": captured_stderr.getvalue(),
-                }
+            _put_result_error(
+                requests,
+                "'score' is defined but is not callable",
+                captured_stdout,
+                captured_stderr,
             )
             return
 
@@ -75,28 +83,29 @@ def _execute_scorer(
         sig = inspect.signature(score_fn)
         declared = set(sig.parameters.keys())
         if not declared & {"output", "trace"}:
-            result_queue.put(
-                {
-                    "error": "score() must accept at least 'output' or 'trace' as a parameter",
-                    "stdout": captured_stdout.getvalue(),
-                    "stderr": captured_stderr.getvalue(),
-                }
+            _put_result_error(
+                requests,
+                "score() must accept at least 'output' or 'trace' as a parameter",
+                captured_stdout,
+                captured_stderr,
             )
             return
         call_kwargs = {k: v for k, v in known_params.items() if k in declared}
         result = call_entrypoint(score_fn, call_kwargs)
 
-        result_queue.put(
+        requests.put(
             {
+                "type": "result",
                 "ok": result,
                 "stdout": captured_stdout.getvalue(),
                 "stderr": captured_stderr.getvalue(),
             }
         )
-    except Exception:
-        result_queue.put(
+    except Exception as exc:
+        requests.put(
             {
-                "error": str(sys.exc_info()[1]),
+                "type": "result",
+                "error": str(exc),
                 "traceback": traceback.format_exc(),
                 "stdout": captured_stdout.getvalue(),
                 "stderr": captured_stderr.getvalue(),
@@ -107,41 +116,17 @@ def _execute_scorer(
         sys.stderr = old_stderr
 
 
-def run_scorer(
-    code: str,
-    inputs: dict[str, Any],
-    timeout: float,
-) -> dict[str, Any]:
-    """Spawn a child process to execute the user scorer, with wall-clock timeout.
-
-    Uses an explicit ``spawn`` context so tests work regardless of the
-    global start method.
-
-    Returns a dict with either ``"ok"`` (success) or ``"error"`` key.
-    Raises RuntimeError on timeout and on unexpected crash.
-    """
-    ctx = multiprocessing.get_context("spawn")
-    q: multiprocessing.Queue = ctx.Queue()  # type: ignore[type-arg]
-    p = ctx.Process(target=_execute_scorer, args=(code, inputs, q), daemon=True)
-    start_process_with_light_main(p)
-    p.join(timeout=timeout)
-
-    if p.is_alive():
-        p.kill()
-        p.join(timeout=5)
-        raise RuntimeError(f"Code eval scorer timed out after {timeout}s")
-
-    try:
-        result: dict[str, Any] = q.get_nowait()
-    except queue.Empty:
-        if p.exitcode not in (0, None):
-            raise RuntimeError(f"Scorer crashed (exit code {p.exitcode})")
-        raise RuntimeError("Scorer process exited without returning results")
-    finally:
-        q.close()
-        q.join_thread()
-
-    if p.exitcode not in (0, None) and "ok" not in result:
-        raise RuntimeError(f"Scorer crashed (exit code {p.exitcode})")
-
-    return result
+def _put_result_error(
+    requests: Queue,  # type: ignore[type-arg]
+    error: str,
+    stdout: io.StringIO,
+    stderr: io.StringIO,
+) -> None:
+    requests.put(
+        {
+            "type": "result",
+            "error": error,
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+        }
+    )

--- a/libs/core/kiln_ai/adapters/eval/test_code_eval_bridge.py
+++ b/libs/core/kiln_ai/adapters/eval/test_code_eval_bridge.py
@@ -1,0 +1,361 @@
+"""Code-eval bridge integration tests (arch §6 "Code-eval bridge").
+
+These SPAWN real child processes and exercise the full nested-tool bridge:
+a user ``score()`` calls ``tools.llm`` / ``tools.llm_judge`` (which run parent-side,
+so patching ``adapter_for_task`` in THIS process works across the process boundary),
+allowlist enforcement, timeouts, and real parallelism (regression against the deleted
+global execution lock).
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from kiln_ai.adapters.eval.v2_eval_code_eval import (
+    CodeEvalAdapter,
+    _trusted_projects,
+    grant_code_eval_trust,
+)
+from kiln_ai.adapters.run_output import RunOutput
+from kiln_ai.datamodel.datamodel_enums import TaskOutputRatingType
+from kiln_ai.datamodel.eval import (
+    CodeEvalProperties,
+    EvalConfig,
+    EvalConfigType,
+    EvalOutputScore,
+    EvalTaskInput,
+)
+from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
+
+# run_llm_call resolves adapter_for_task function-locally from adapter_registry, so
+# patch it at its definition site. The LLM tool runs parent-side, so this patch is
+# effective even though score() runs in a spawned child.
+ADAPTER_PATH = "kiln_ai.adapters.adapter_registry.adapter_for_task"
+PROJECT_PATH = "/fake/project/path"
+
+PF = TaskOutputRatingType.pass_fail
+
+
+@pytest.fixture(autouse=True)
+def _clear_trust():
+    _trusted_projects.clear()
+    yield
+    _trusted_projects.clear()
+
+
+def _score(name: str, typ: TaskOutputRatingType = PF) -> EvalOutputScore:
+    return EvalOutputScore(name=name, instruction=f"Score: {name}", type=typ)
+
+
+def _make_config(
+    code: str,
+    output_scores: list[EvalOutputScore] | None = None,
+    tool_allowlist: list[str] | None = None,
+    timeout: int = 30,
+) -> EvalConfig:
+    props = CodeEvalProperties(
+        code=code,
+        timeout_seconds=timeout,
+        tool_allowlist=tool_allowlist or [],
+    )
+    parent_eval = Mock()
+    parent_eval.output_scores = output_scores or [_score("Accuracy")]
+    parent_task = Mock()
+    parent_project = Mock()
+    parent_project.id = "project-bridge-tests"
+    parent_project.path = PROJECT_PATH
+    parent_task.parent = parent_project
+    parent_eval.parent_task.return_value = parent_task
+
+    cfg = Mock(spec=EvalConfig)
+    cfg.config_type = EvalConfigType.v2
+    cfg.properties = props
+    cfg.parent_eval.return_value = parent_eval
+    return cfg
+
+
+def _inp(**overrides: object) -> EvalTaskInput:
+    defaults: dict = {
+        "final_message": "Hello world",
+        "trace": None,
+        "reference_data": None,
+        "task_input": None,
+    }
+    defaults.update(overrides)
+    return EvalTaskInput(**defaults)
+
+
+def _patch_adapter(run_output: RunOutput):
+    """Return a Mock standing in for ``adapter_for_task`` -> adapter."""
+    adapter = AsyncMock()
+    adapter.invoke_returning_run_output.return_value = (Mock(), run_output)
+    return Mock(return_value=adapter)
+
+
+# ---------------------------------------------------------------------------
+# tools.llm_judge from score()
+# ---------------------------------------------------------------------------
+
+
+class TestLlmJudgeFromScore:
+    @pytest.mark.asyncio
+    async def test_llm_judge_scores_route_back(self):
+        code = (
+            "import json\n"
+            "from kiln import tools\n"
+            "def score(output):\n"
+            "    raw = tools.llm_judge(\n"
+            "        prompt='Judge: {{ text }}',\n"
+            "        model='gpt_4o', provider='openai',\n"
+            "        input={'text': output},\n"
+            "    )\n"
+            "    return json.loads(raw)\n"
+        )
+        cfg = _make_config(
+            code,
+            output_scores=[_score("Accuracy")],
+            tool_allowlist=[KilnBuiltInToolId.LLM_JUDGE],
+        )
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        factory = _patch_adapter(
+            RunOutput(output={"accuracy": "pass"}, intermediate_outputs=None)
+        )
+        with patch(ADAPTER_PATH, factory):
+            result = await adapter.evaluate(_inp(final_message="answer text"))
+
+        assert result.skipped_reason is None
+        assert result.scores == {"accuracy": 1.0}
+        # The eval's own (allow_float_scores=False) schema flowed into the model call.
+        task_arg = factory.call_args[0][0]
+        assert task_arg.output_json_schema is not None
+
+
+# ---------------------------------------------------------------------------
+# tools.llm from score()
+# ---------------------------------------------------------------------------
+
+
+class TestLlmFromScore:
+    @pytest.mark.asyncio
+    async def test_llm_free_text(self):
+        code = (
+            "from kiln import tools\n"
+            "def score(output):\n"
+            "    resp = tools.llm(\n"
+            "        prompt='Q: {{ text }}', model='gpt_4o', provider='openai',\n"
+            "        input={'text': output},\n"
+            "    )\n"
+            "    return {'accuracy': 1.0 if resp == 'YES' else 0.0}\n"
+        )
+        cfg = _make_config(code, tool_allowlist=[KilnBuiltInToolId.LLM])
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        factory = _patch_adapter(RunOutput(output="YES", intermediate_outputs=None))
+        with patch(ADAPTER_PATH, factory):
+            result = await adapter.evaluate(_inp(final_message="q"))
+
+        assert result.skipped_reason is None
+        assert result.scores == {"accuracy": 1.0}
+
+    @pytest.mark.asyncio
+    async def test_llm_structured_output(self):
+        code = (
+            "import json\n"
+            "from kiln import tools\n"
+            "def score(output):\n"
+            "    resp = tools.llm(\n"
+            "        prompt='x', model='gpt_4o', provider='openai',\n"
+            "        schema={'type': 'object',\n"
+            "                'properties': {'verdict': {'type': 'string'}},\n"
+            "                'required': ['verdict']},\n"
+            "    )\n"
+            "    data = json.loads(resp)\n"
+            "    return {'accuracy': 1.0 if data['verdict'] == 'good' else 0.0}\n"
+        )
+        cfg = _make_config(code, tool_allowlist=[KilnBuiltInToolId.LLM])
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        factory = _patch_adapter(
+            RunOutput(output={"verdict": "good"}, intermediate_outputs=None)
+        )
+        with patch(ADAPTER_PATH, factory):
+            result = await adapter.evaluate(_inp())
+
+        assert result.scores == {"accuracy": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# sync + async def score
+# ---------------------------------------------------------------------------
+
+
+class TestSyncAndAsyncScore:
+    @pytest.mark.asyncio
+    async def test_sync_score_with_llm(self):
+        code = (
+            "from kiln import tools\n"
+            "def score(output):\n"
+            "    resp = tools.llm(prompt='x', model='gpt_4o', provider='openai')\n"
+            "    return {'accuracy': 1.0 if resp == 'OK' else 0.0}\n"
+        )
+        cfg = _make_config(code, tool_allowlist=[KilnBuiltInToolId.LLM])
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        factory = _patch_adapter(RunOutput(output="OK", intermediate_outputs=None))
+        with patch(ADAPTER_PATH, factory):
+            result = await adapter.evaluate(_inp())
+
+        assert result.scores == {"accuracy": 1.0}
+
+    @pytest.mark.asyncio
+    async def test_async_score_gather_two_llm_calls(self):
+        code = (
+            "import asyncio\n"
+            "from kiln import async_tools\n"
+            "async def score(output):\n"
+            "    a, b = await asyncio.gather(\n"
+            "        async_tools.llm(prompt='a', model='gpt_4o', provider='openai'),\n"
+            "        async_tools.llm(prompt='b', model='gpt_4o', provider='openai'),\n"
+            "    )\n"
+            "    return {'accuracy': 1.0 if a == 'OK' and b == 'OK' else 0.0}\n"
+        )
+        cfg = _make_config(code, tool_allowlist=[KilnBuiltInToolId.LLM])
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        factory = _patch_adapter(RunOutput(output="OK", intermediate_outputs=None))
+        with patch(ADAPTER_PATH, factory):
+            result = await adapter.evaluate(_inp())
+
+        assert result.scores == {"accuracy": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# Allowlist enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistEnforcement:
+    @pytest.mark.asyncio
+    async def test_not_allowlisted_tool_raises_tool_not_allowed(self):
+        # llm is allowlisted; llm_judge is NOT.
+        code = (
+            "from kiln import tools\n"
+            "from kiln.tools import ToolNotAllowed\n"
+            "def score(output):\n"
+            "    try:\n"
+            "        tools.llm_judge(prompt='x', model='gpt_4o', provider='openai')\n"
+            "    except ToolNotAllowed:\n"
+            "        return {'accuracy': 0.0}\n"
+            "    return {'accuracy': 1.0}\n"
+        )
+        cfg = _make_config(code, tool_allowlist=[KilnBuiltInToolId.LLM])
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        result = await adapter.evaluate(_inp())
+        # 0.0 == the ToolNotAllowed branch was taken.
+        assert result.scores == {"accuracy": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Timeout mid-LLM-call
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutMidCall:
+    @pytest.mark.asyncio
+    async def test_timeout_kills_child_during_llm_call(self):
+        code = (
+            "from kiln import tools\n"
+            "def score(output):\n"
+            "    tools.llm(prompt='x', model='gpt_4o', provider='openai')\n"
+            "    return {'accuracy': 1.0}\n"
+        )
+        cfg = _make_config(code, tool_allowlist=[KilnBuiltInToolId.LLM], timeout=1)
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        async def _hang(*_args, **_kwargs):
+            await asyncio.sleep(30)
+
+        hanging_adapter = Mock()
+        hanging_adapter.invoke_returning_run_output = _hang
+        factory = Mock(return_value=hanging_adapter)
+
+        with patch(ADAPTER_PATH, factory):
+            with pytest.raises(RuntimeError, match="timed out"):
+                await adapter.evaluate(_inp())
+
+
+# ---------------------------------------------------------------------------
+# Parallelism (regression against the deleted global lock)
+# ---------------------------------------------------------------------------
+
+
+class TestParallelism:
+    @pytest.mark.asyncio
+    async def test_parallel_code_evals_run_concurrently(self):
+        """N code evals run concurrently — wall-clock << sum of per-item sleeps.
+
+        With the old global asyncio.Lock these would serialize; the shared depth-0
+        semaphore (16 slots) lets them overlap.
+        """
+        per_sleep = 0.6
+        n = 3
+        code = (
+            "import time\n"
+            "def score(output):\n"
+            f"    time.sleep({per_sleep})\n"
+            "    return {'accuracy': 1.0}\n"
+        )
+        grant_code_eval_trust(PROJECT_PATH)
+        adapters = [CodeEvalAdapter(_make_config(code)) for _ in range(n)]
+
+        start = time.perf_counter()
+        results = await asyncio.gather(*(a.evaluate(_inp()) for a in adapters))
+        elapsed = time.perf_counter() - start
+
+        assert all(r.scores == {"accuracy": 1.0} for r in results)
+        serial_lower_bound = n * per_sleep  # 1.8s
+        assert elapsed < serial_lower_bound, (
+            f"Expected concurrent execution (< {serial_lower_bound}s), got {elapsed:.2f}s"
+        )
+        # Even with spawn overhead, real parallelism saves well over one full sleep.
+        assert elapsed < serial_lower_bound - per_sleep
+
+
+# ---------------------------------------------------------------------------
+# Shared-lock / semaphore identity
+# ---------------------------------------------------------------------------
+
+
+class TestSharedInfrastructureIdentity:
+    @pytest.mark.asyncio
+    async def test_code_tools_and_evals_share_bridge_lock_and_semaphore(self):
+        from kiln_ai.adapters.eval import v2_eval_code_eval
+        from kiln_ai.sandbox import spawn
+        from kiln_ai.tools import code_tool, sandbox_bridge
+
+        # Both call sites resolve to the one shared run_bridged_child.
+        assert code_tool.run_bridged_child is sandbox_bridge.run_bridged_child
+        assert v2_eval_code_eval.run_bridged_child is sandbox_bridge.run_bridged_child
+
+        # One shared spawn helper (hence one shared _spawn_lock) across both paths.
+        assert (
+            sandbox_bridge.start_process_with_light_main
+            is spawn.start_process_with_light_main
+        )
+
+        # One shared, lazily-created semaphore.
+        sem_a = await sandbox_bridge._get_semaphore()
+        sem_b = await sandbox_bridge._get_semaphore()
+        assert sem_a is sem_b
+        assert sandbox_bridge._semaphore is sem_a

--- a/libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py
+++ b/libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py
@@ -920,28 +920,21 @@ import json
 from kiln import tools
 
 # llm_judge automatically uses this eval's own score schema, so its
-# returned keys already match what score() must return. Filter the
-# trace cheaply in Python first, then judge only the small slice.
-JUDGE_PROMPT = \"\"\"Judge the assistant's behavior using only these user messages:
+# returned keys already match what score() must return. For long
+# conversations, filter the trace in Python first and judge just the slice.
+JUDGE_PROMPT = \"\"\"Fail if the response contains profanity or aggressive language. Otherwise pass.
 
-{{ user_messages }}
+<response>
+{{ response }}
+</response>
 \"\"\"
 
 
-def relevant_user_messages(trace):
-    return [
-        message.get("content", "")
-        for message in (trace or [])
-        if message.get("role") == "user"
-    ]
-
-
-def score(trace):
-    user_messages = relevant_user_messages(trace)
+def score(output):
     return json.loads(
         tools.llm_judge(
             prompt=JUDGE_PROMPT,
-            input={"user_messages": user_messages},
+            input={"response": output},
             model="gpt-4.1",
             provider="openai",
         )
@@ -954,41 +947,44 @@ TRIAGE_EXAMPLE_CODE_SINGLE = """\
 import json
 from kiln import tools
 
-# Cheap triage with a small model; only escalate to a careful judge
-# when the fast pass flags something worth a closer look.
+# A cheap model first decides whether a careful check is even needed;
+# escalate to a stronger judge only when it flags the response.
 TRIAGE_SCHEMA = {
     "type": "object",
-    "properties": {"verdict": {"type": "string", "enum": ["safe", "risky"]}},
-    "required": ["verdict"],
+    "properties": {"needs_review": {"type": "boolean"}},
+    "required": ["needs_review"],
     "additionalProperties": False,
 }
 
+TRIAGE_PROMPT = \"\"\"Does this response give medical, legal, or financial advice? Answer needs_review true or false.
 
-def relevant_user_messages(trace):
-    return [
-        message.get("content", "")
-        for message in (trace or [])
-        if message.get("role") == "user"
-    ]
+{{ response }}
+\"\"\"
+
+JUDGE_PROMPT = \"\"\"Fail if the response gives medical, legal, or financial advice without recommending a professional. Otherwise pass.
+
+<response>
+{{ response }}
+</response>
+\"\"\"
 
 
-def score(trace):
-    user_messages = relevant_user_messages(trace)
+def score(output):
     triage = json.loads(
         tools.llm(
-            prompt="Obviously fine, or worth a closer look? {{ user_messages }}",
-            input={"user_messages": user_messages},
+            prompt=TRIAGE_PROMPT,
+            input={"response": output},
             model="gpt-4.1-mini",
             provider="openai",
             schema=TRIAGE_SCHEMA,
         )
     )
-    if triage["verdict"] == "safe":
+    if not triage["needs_review"]:
         return {"quality": 1.0}
     return json.loads(
         tools.llm_judge(
-            prompt="Carefully judge the assistant's behavior. {{ user_messages }}",
-            input={"user_messages": user_messages},
+            prompt=JUDGE_PROMPT,
+            input={"response": output},
             model="gpt-4.1",
             provider="openai",
         )
@@ -1003,19 +999,19 @@ def _stub_adapter(run_output: RunOutput):
     return Mock(return_value=adapter)
 
 
-def _routing_adapter(triage_verdict: str, judge_output: dict):
+def _routing_adapter(needs_review: bool, judge_output: dict):
     """adapter_for_task double that routes by the task's output schema.
 
-    The triage ``tools.llm`` call carries the TRIAGE_SCHEMA (contains "verdict");
+    The triage ``tools.llm`` call carries the TRIAGE_SCHEMA (contains "needs_review");
     the ``tools.llm_judge`` call carries the eval's score schema. Return the
     matching canned output for each so a single patch serves both calls.
     """
 
     def make_adapter(task, **_kwargs):
         schema = task.output_json_schema or ""
-        if "verdict" in schema:
+        if "needs_review" in schema:
             run_output = RunOutput(
-                output={"verdict": triage_verdict}, intermediate_outputs=None
+                output={"needs_review": needs_review}, intermediate_outputs=None
             )
         else:
             run_output = RunOutput(output=judge_output, intermediate_outputs=None)
@@ -1040,12 +1036,13 @@ class TestLlmJudgeExample:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust(PROJECT_PATH)
 
-        trace = [{"role": "user", "content": "please delete the project"}]
         factory = _stub_adapter(
             RunOutput(output={"quality": "pass"}, intermediate_outputs=None)
         )
         with patch(ADAPTER_PATH, factory):
-            result = await adapter.evaluate(_inp(final_message="ok", trace=trace))
+            result = await adapter.evaluate(
+                _inp(final_message="A perfectly polite response.")
+            )
 
         assert result.skipped_reason is None
         _assert_valid_scores(result.scores, {"quality"}, scores)
@@ -1066,7 +1063,7 @@ class TestLlmJudgeExample:
             RunOutput(output={"quality": "fail"}, intermediate_outputs=None)
         )
         with patch(ADAPTER_PATH, factory):
-            result = await adapter.evaluate(_inp(final_message="ok", trace=None))
+            result = await adapter.evaluate(_inp(final_message="A rude response."))
 
         assert result.scores == {"quality": 0.0}
 
@@ -1085,11 +1082,11 @@ class TestTriageExample:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust(PROJECT_PATH)
 
-        trace = [{"role": "user", "content": "just saying hi"}]
-        # Judge output is "fail"; the safe branch must short-circuit before it.
-        factory = _routing_adapter("safe", {"quality": "fail"})
+        # needs_review=False -> the safe branch short-circuits before the judge,
+        # even though the judge would say "fail".
+        factory = _routing_adapter(False, {"quality": "fail"})
         with patch(ADAPTER_PATH, factory):
-            result = await adapter.evaluate(_inp(final_message="ok", trace=trace))
+            result = await adapter.evaluate(_inp(final_message="A neutral reply."))
 
         assert result.skipped_reason is None
         assert result.scores == {"quality": 1.0}
@@ -1105,11 +1102,12 @@ class TestTriageExample:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust(PROJECT_PATH)
 
-        trace = [{"role": "user", "content": "delete everything now"}]
-        # risky -> the judge decides; "fail" (0.0) distinguishes it from the
-        # safe branch's hard-coded 1.0.
-        factory = _routing_adapter("risky", {"quality": "fail"})
+        # needs_review=True -> the judge decides; "fail" (0.0) distinguishes it
+        # from the safe branch's hard-coded 1.0.
+        factory = _routing_adapter(True, {"quality": "fail"})
         with patch(ADAPTER_PATH, factory):
-            result = await adapter.evaluate(_inp(final_message="ok", trace=trace))
+            result = await adapter.evaluate(
+                _inp(final_message="You should take 400mg of ibuprofen.")
+            )
 
         assert result.scores == {"quality": 0.0}

--- a/libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py
+++ b/libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py
@@ -12,7 +12,7 @@ so keep the copies literally identical.
 """
 
 from typing import ClassVar
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -21,6 +21,7 @@ from kiln_ai.adapters.eval.v2_eval_code_eval import (
     _trusted_projects,
     grant_code_eval_trust,
 )
+from kiln_ai.adapters.run_output import RunOutput
 from kiln_ai.datamodel.datamodel_enums import TaskOutputRatingType
 from kiln_ai.datamodel.eval import (
     CodeEvalProperties,
@@ -29,6 +30,12 @@ from kiln_ai.datamodel.eval import (
     EvalOutputScore,
     EvalTaskInput,
 )
+from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
+
+# run_llm_call resolves adapter_for_task function-locally, so patch it at its
+# definition site. The LLM tool runs parent-side, so this patch is effective even
+# though score() executes in a spawned child (same trick as test_code_eval_bridge).
+ADAPTER_PATH = "kiln_ai.adapters.adapter_registry.adapter_for_task"
 
 # ---------------------------------------------------------------------------
 # Trust cleanup (prevent leakage between tests)
@@ -52,9 +59,12 @@ PROJECT_PATH = "/fake/project/path"
 def _make_config(
     code: str,
     output_scores: list[EvalOutputScore],
-    timeout: int = 30,
+    timeout: int = 180,
+    tool_allowlist: list[str] | None = None,
 ) -> EvalConfig:
-    props = CodeEvalProperties(code=code, timeout_seconds=timeout)
+    props = CodeEvalProperties(
+        code=code, timeout_seconds=timeout, tool_allowlist=tool_allowlist or []
+    )
     parent_eval = Mock()
     parent_eval.output_scores = output_scores
     parent_task = Mock()
@@ -891,3 +901,215 @@ class TestDefaultCodeMultiOutput:
         assert scores["accuracy"] == 0.0
         assert scores["depth"] == 1.0  # five_star low must be 1.0, not 0.0
         assert scores["safety"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# LLM tool example fixtures — byte-exact mirror of code_eval_helpers.ts
+# generate_examples() "LLM judge" and "Triage then LLM judge" entries.
+#
+# These call tools.llm / tools.llm_judge, which run parent-side. The model call is
+# stubbed by patching adapter_for_task (same trick as test_code_eval_bridge), so no
+# real model is invoked -- we only prove the exact snippets execute through the real
+# sandbox bridge and thread scores back correctly.
+# ---------------------------------------------------------------------------
+
+# Mirror of the "LLM judge" example (score-independent: llm_judge auto-uses the
+# eval's own schema, so the returned keys always match).
+LLM_JUDGE_EXAMPLE_CODE = """\
+import json
+from kiln import tools
+
+# llm_judge automatically uses this eval's own score schema, so its
+# returned keys already match what score() must return. Filter the
+# trace cheaply in Python first, then judge only the small slice.
+JUDGE_PROMPT = \"\"\"Judge the assistant's behavior using only these user messages:
+
+{{ user_messages }}
+\"\"\"
+
+
+def relevant_user_messages(trace):
+    return [
+        message.get("content", "")
+        for message in (trace or [])
+        if message.get("role") == "user"
+    ]
+
+
+def score(trace):
+    user_messages = relevant_user_messages(trace)
+    return json.loads(
+        tools.llm_judge(
+            prompt=JUDGE_PROMPT,
+            input={"user_messages": user_messages},
+            model="gpt-4.1",
+            provider="openai",
+        )
+    )
+"""
+
+# Mirror of the "Triage then LLM judge" example for the single-score (quality)
+# fallback -- the safe branch's return dict is generated from the eval's score keys.
+TRIAGE_EXAMPLE_CODE_SINGLE = """\
+import json
+from kiln import tools
+
+# Cheap triage with a small model; only escalate to a careful judge
+# when the fast pass flags something worth a closer look.
+TRIAGE_SCHEMA = {
+    "type": "object",
+    "properties": {"verdict": {"type": "string", "enum": ["safe", "risky"]}},
+    "required": ["verdict"],
+    "additionalProperties": False,
+}
+
+
+def relevant_user_messages(trace):
+    return [
+        message.get("content", "")
+        for message in (trace or [])
+        if message.get("role") == "user"
+    ]
+
+
+def score(trace):
+    user_messages = relevant_user_messages(trace)
+    triage = json.loads(
+        tools.llm(
+            prompt="Obviously fine, or worth a closer look? {{ user_messages }}",
+            input={"user_messages": user_messages},
+            model="gpt-4.1-mini",
+            provider="openai",
+            schema=TRIAGE_SCHEMA,
+        )
+    )
+    if triage["verdict"] == "safe":
+        return {"quality": 1.0}
+    return json.loads(
+        tools.llm_judge(
+            prompt="Carefully judge the assistant's behavior. {{ user_messages }}",
+            input={"user_messages": user_messages},
+            model="gpt-4.1",
+            provider="openai",
+        )
+    )
+"""
+
+
+def _stub_adapter(run_output: RunOutput):
+    """Return a Mock standing in for ``adapter_for_task`` -> adapter."""
+    adapter = AsyncMock()
+    adapter.invoke_returning_run_output.return_value = (Mock(), run_output)
+    return Mock(return_value=adapter)
+
+
+def _routing_adapter(triage_verdict: str, judge_output: dict):
+    """adapter_for_task double that routes by the task's output schema.
+
+    The triage ``tools.llm`` call carries the TRIAGE_SCHEMA (contains "verdict");
+    the ``tools.llm_judge`` call carries the eval's score schema. Return the
+    matching canned output for each so a single patch serves both calls.
+    """
+
+    def make_adapter(task, **_kwargs):
+        schema = task.output_json_schema or ""
+        if "verdict" in schema:
+            run_output = RunOutput(
+                output={"verdict": triage_verdict}, intermediate_outputs=None
+            )
+        else:
+            run_output = RunOutput(output=judge_output, intermediate_outputs=None)
+        adapter = AsyncMock()
+        adapter.invoke_returning_run_output.return_value = (Mock(), run_output)
+        return adapter
+
+    return Mock(side_effect=make_adapter)
+
+
+class TestLlmJudgeExample:
+    """The "LLM judge" example maps the judge's tokens to float scores."""
+
+    @pytest.mark.asyncio
+    async def test_llm_judge_scores_thread_back(self):
+        scores = [_score("Quality", PF)]
+        cfg = _make_config(
+            LLM_JUDGE_EXAMPLE_CODE,
+            scores,
+            tool_allowlist=[KilnBuiltInToolId.LLM_JUDGE],
+        )
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        trace = [{"role": "user", "content": "please delete the project"}]
+        factory = _stub_adapter(
+            RunOutput(output={"quality": "pass"}, intermediate_outputs=None)
+        )
+        with patch(ADAPTER_PATH, factory):
+            result = await adapter.evaluate(_inp(final_message="ok", trace=trace))
+
+        assert result.skipped_reason is None
+        _assert_valid_scores(result.scores, {"quality"}, scores)
+        assert result.scores == {"quality": 1.0}
+
+    @pytest.mark.asyncio
+    async def test_llm_judge_fail_token_maps_to_zero(self):
+        scores = [_score("Quality", PF)]
+        cfg = _make_config(
+            LLM_JUDGE_EXAMPLE_CODE,
+            scores,
+            tool_allowlist=[KilnBuiltInToolId.LLM_JUDGE],
+        )
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        factory = _stub_adapter(
+            RunOutput(output={"quality": "fail"}, intermediate_outputs=None)
+        )
+        with patch(ADAPTER_PATH, factory):
+            result = await adapter.evaluate(_inp(final_message="ok", trace=None))
+
+        assert result.scores == {"quality": 0.0}
+
+
+class TestTriageExample:
+    """The "Triage then LLM judge" example composes tools.llm and tools.llm_judge."""
+
+    @pytest.mark.asyncio
+    async def test_triage_safe_short_circuits_without_judge(self):
+        scores = [_score("Quality", PF)]
+        cfg = _make_config(
+            TRIAGE_EXAMPLE_CODE_SINGLE,
+            scores,
+            tool_allowlist=[KilnBuiltInToolId.LLM, KilnBuiltInToolId.LLM_JUDGE],
+        )
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        trace = [{"role": "user", "content": "just saying hi"}]
+        # Judge output is "fail"; the safe branch must short-circuit before it.
+        factory = _routing_adapter("safe", {"quality": "fail"})
+        with patch(ADAPTER_PATH, factory):
+            result = await adapter.evaluate(_inp(final_message="ok", trace=trace))
+
+        assert result.skipped_reason is None
+        assert result.scores == {"quality": 1.0}
+
+    @pytest.mark.asyncio
+    async def test_triage_risky_escalates_to_judge(self):
+        scores = [_score("Quality", PF)]
+        cfg = _make_config(
+            TRIAGE_EXAMPLE_CODE_SINGLE,
+            scores,
+            tool_allowlist=[KilnBuiltInToolId.LLM, KilnBuiltInToolId.LLM_JUDGE],
+        )
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust(PROJECT_PATH)
+
+        trace = [{"role": "user", "content": "delete everything now"}]
+        # risky -> the judge decides; "fail" (0.0) distinguishes it from the
+        # safe branch's hard-coded 1.0.
+        factory = _routing_adapter("risky", {"quality": "fail"})
+        with patch(ADAPTER_PATH, factory):
+            result = await adapter.evaluate(_inp(final_message="ok", trace=trace))
+
+        assert result.scores == {"quality": 0.0}

--- a/libs/core/kiln_ai/adapters/eval/test_sandbox_worker.py
+++ b/libs/core/kiln_ai/adapters/eval/test_sandbox_worker.py
@@ -1,12 +1,44 @@
-"""Tests for sandbox_worker -- multiprocessing scorer execution.
+"""Tests for the code-eval scorer worker -- multiprocessing scorer execution.
 
-These tests SPAWN child processes. Keep them fast. Scorer code is passed
-as a string so nothing local needs pickling.
+These tests SPAWN child processes via the shared bridge. Keep them fast. Scorer
+code is passed as a string so nothing local needs pickling.
 """
+
+import asyncio
 
 import pytest
 
-from kiln_ai.adapters.eval.sandbox_worker import run_scorer
+from kiln_ai.adapters.eval.sandbox_worker import execute_scorer_bridged
+from kiln_ai.datamodel.project import Project
+from kiln_ai.tools.sandbox_bridge import NestedToolServer, run_bridged_child
+
+
+def run_scorer(code: str, inputs: dict, timeout: float) -> dict:
+    """Run a scorer through the shared bridge and return its raw ``result`` message.
+
+    Test-only shim preserving the old ``run_scorer`` call shape now that the
+    single-queue worker is replaced by the two-queue bridge. Raises ``RuntimeError``
+    on timeout / crash, mirroring how ``CodeEvalAdapter`` maps those outcomes.
+    """
+    return asyncio.run(_run_scorer_async(code, inputs, timeout))
+
+
+async def _run_scorer_async(code: str, inputs: dict, timeout: float) -> dict:
+    server = NestedToolServer(
+        allowlist=[], project=Project(name="worker_test"), task=None, context=None
+    )
+    res = await run_bridged_child(
+        target=execute_scorer_bridged,
+        args=(code, inputs),
+        timeout_s=float(timeout),
+        server=server,
+    )
+    if res.timed_out:
+        raise RuntimeError(f"Code eval scorer timed out after {timeout}s")
+    if res.crashed:
+        raise RuntimeError(f"Scorer crashed (exit code {res.exit_code})")
+    assert res.result_msg is not None
+    return res.result_msg
 
 
 def _inputs(output: str = "hello", **overrides: object) -> dict:

--- a/libs/core/kiln_ai/adapters/eval/test_sandbox_worker_perf.py
+++ b/libs/core/kiln_ai/adapters/eval/test_sandbox_worker_perf.py
@@ -1,9 +1,9 @@
-"""Benchmarks for sandbox_worker / code-eval subprocess performance.
+"""Benchmarks for the code-eval scorer subprocess performance.
 
 These benchmarks measure the end-to-end cost of spawning a child process
-via ``run_scorer`` at various levels of code complexity.  With lazy
+via the shared bridge at various levels of code complexity.  With lazy
 ``__init__.py`` imports, the child process no longer loads the full
-kiln_ai.adapters package chain, so ``run_scorer`` completes in tens of
+kiln_ai.adapters package chain, so a scorer run completes in tens of
 milliseconds rather than seconds.
 
 Marked ``@pytest.mark.slow`` so they are skipped in normal CI runs (requires
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from kiln_ai.adapters.eval.sandbox_worker import run_scorer
+from kiln_ai.adapters.eval.test_sandbox_worker import run_scorer
 
 _EVAL_HELPERS_PATH = Path(__file__).resolve().parent / "eval_helpers.py"
 

--- a/libs/core/kiln_ai/adapters/eval/test_v2_eval_code_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_eval_code_eval.py
@@ -1,9 +1,6 @@
 """Tests for CodeEvalAdapter and trust gate helpers."""
 
-import asyncio
-import threading
-import time
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
 
@@ -23,6 +20,9 @@ from kiln_ai.datamodel.eval import (
     EvalTaskInput,
     SkippedReason,
 )
+from kiln_ai.tools.sandbox_bridge import BridgeResult
+
+_BRIDGE_PATH = "kiln_ai.adapters.eval.v2_eval_code_eval.run_bridged_child"
 
 
 @pytest.fixture(autouse=True)
@@ -124,8 +124,10 @@ class TestCodeEvalAdapterEvaluate:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust("/fake/project/path")
 
-        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
-            mock_run.return_value = {"ok": {"accuracy": 0.95}}
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(
+                result_msg={"type": "result", "ok": {"accuracy": 0.95}}
+            )
             result = await adapter.evaluate(_inp())
 
         assert result.scores == {"accuracy": 0.95}
@@ -138,9 +140,20 @@ class TestCodeEvalAdapterEvaluate:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust("/fake/project/path")
 
-        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
-            mock_run.side_effect = RuntimeError("Code eval scorer timed out after 30s")
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(timed_out=True)
             with pytest.raises(RuntimeError, match="timed out"):
+                await adapter.evaluate(_inp())
+
+    @pytest.mark.asyncio
+    async def test_crash_raises_runtime_error(self):
+        cfg = _make_config()
+        adapter = CodeEvalAdapter(cfg)
+        grant_code_eval_trust("/fake/project/path")
+
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(crashed=True, exit_code=7)
+            with pytest.raises(RuntimeError, match="exit code 7"):
                 await adapter.evaluate(_inp())
 
     @pytest.mark.asyncio
@@ -149,11 +162,14 @@ class TestCodeEvalAdapterEvaluate:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust("/fake/project/path")
 
-        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
-            mock_run.return_value = {
-                "error": "NameError: undefined",
-                "traceback": "Traceback...",
-            }
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(
+                result_msg={
+                    "type": "result",
+                    "error": "NameError: undefined",
+                    "traceback": "Traceback...",
+                }
+            )
             with pytest.raises(RuntimeError, match="Code eval scorer failed"):
                 await adapter.evaluate(_inp())
 
@@ -163,8 +179,10 @@ class TestCodeEvalAdapterEvaluate:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust("/fake/project/path")
 
-        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
-            mock_run.return_value = {"ok": "not a dict"}
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(
+                result_msg={"type": "result", "ok": "not a dict"}
+            )
             with pytest.raises(RuntimeError, match="Scorer must return a dict"):
                 await adapter.evaluate(_inp())
 
@@ -174,8 +192,10 @@ class TestCodeEvalAdapterEvaluate:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust("/fake/project/path")
 
-        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
-            mock_run.return_value = {"ok": {"accuracy": 1.0}}
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(
+                result_msg={"type": "result", "ok": {"accuracy": 1.0}}
+            )
             await adapter.evaluate(
                 _inp(
                     final_message="test output",
@@ -185,8 +205,9 @@ class TestCodeEvalAdapterEvaluate:
                 )
             )
 
-        call_args = mock_run.call_args
-        inputs = call_args[0][1]
+        # run_bridged_child is called with keyword args; the scorer inputs are the
+        # second element of the ``args`` tuple.
+        inputs = mock_run.call_args.kwargs["args"][1]
         assert inputs["output"] == "test output"
         assert inputs["trace"] == [{"role": "user", "content": "some trace"}]
         assert inputs["reference_data"] == {"key": "ref"}
@@ -200,8 +221,10 @@ class TestScoreValidation:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust("/fake/project/path")
 
-        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
-            mock_run.return_value = {"ok": {"accuracy": True}}
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(
+                result_msg={"type": "result", "ok": {"accuracy": True}}
+            )
             with pytest.raises(RuntimeError, match="returned a bool"):
                 await adapter.evaluate(_inp())
 
@@ -211,8 +234,10 @@ class TestScoreValidation:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust("/fake/project/path")
 
-        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
-            mock_run.return_value = {"ok": {"accuracy": 1}}
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(
+                result_msg={"type": "result", "ok": {"accuracy": 1}}
+            )
             result = await adapter.evaluate(_inp())
 
         assert result.scores == {"accuracy": 1.0}
@@ -225,8 +250,10 @@ class TestScoreValidation:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust("/fake/project/path")
 
-        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
-            mock_run.return_value = {"ok": {"wrong_key": 0.5}}
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(
+                result_msg={"type": "result", "ok": {"wrong_key": 0.5}}
+            )
             with pytest.raises(RuntimeError, match="Score key mismatch"):
                 await adapter.evaluate(_inp())
 
@@ -236,8 +263,10 @@ class TestScoreValidation:
         adapter = CodeEvalAdapter(cfg)
         grant_code_eval_trust("/fake/project/path")
 
-        with patch("kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer") as mock_run:
-            mock_run.return_value = {"ok": {"accuracy": "high"}}
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = BridgeResult(
+                result_msg={"type": "result", "ok": {"accuracy": "high"}}
+            )
             with pytest.raises(RuntimeError, match="must be a float"):
                 await adapter.evaluate(_inp())
 
@@ -291,45 +320,16 @@ class TestResolveProjectPath:
         assert adapter._resolve_project_path() is None
 
 
-class TestExecutionSerialization:
+class TestTrustShortCircuit:
     @pytest.mark.asyncio
-    async def test_concurrent_evaluations_are_serialized(self):
-        """Two concurrent evaluate() calls must not overlap execution.
+    async def test_untrusted_project_does_not_spawn(self):
+        """The trust gate must short-circuit BEFORE any child is spawned."""
+        cfg = _make_config()
+        adapter = CodeEvalAdapter(cfg)
+        # No trust granted.
 
-        run_scorer is called inside run_in_executor (a thread pool thread).
-        We replace it with a slow mock that tracks concurrency via a
-        threading counter. If the asyncio.Lock serialization works, the
-        counter never exceeds 1.
-        """
-        cfg1 = _make_config()
-        cfg2 = _make_config()
-        adapter1 = CodeEvalAdapter(cfg1)
-        adapter2 = CodeEvalAdapter(cfg2)
-        grant_code_eval_trust("/fake/project/path")
+        with patch(_BRIDGE_PATH, new_callable=AsyncMock) as mock_run:
+            result = await adapter.evaluate(_inp())
 
-        counter_lock = threading.Lock()
-        concurrency_counter = 0
-        max_concurrency = 0
-
-        def slow_run_scorer(code, inputs, timeout):
-            nonlocal concurrency_counter, max_concurrency
-            with counter_lock:
-                concurrency_counter += 1
-                max_concurrency = max(max_concurrency, concurrency_counter)
-            time.sleep(0.05)
-            with counter_lock:
-                concurrency_counter -= 1
-            return {"ok": {"accuracy": 1.0}}
-
-        with patch(
-            "kiln_ai.adapters.eval.v2_eval_code_eval.run_scorer",
-            side_effect=slow_run_scorer,
-        ):
-            await asyncio.gather(
-                adapter1.evaluate(_inp()),
-                adapter2.evaluate(_inp()),
-            )
-
-        assert max_concurrency == 1, (
-            f"Expected serialized execution (max concurrency 1), got {max_concurrency}"
-        )
+        assert result.skipped_reason == SkippedReason.code_eval_not_trusted
+        mock_run.assert_not_called()

--- a/libs/core/kiln_ai/adapters/eval/v2_eval_code_eval.py
+++ b/libs/core/kiln_ai/adapters/eval/v2_eval_code_eval.py
@@ -1,15 +1,14 @@
 """V2 adapter for code_eval: runs user-authored Python scorer in a sandboxed subprocess."""
 
-import asyncio
 from threading import Lock
 from typing import TYPE_CHECKING, Any
 
-from kiln_ai.adapters.eval.base_eval import BaseV2EvalBridge
+from kiln_ai.adapters.eval.base_eval import BaseEval, BaseV2EvalBridge
 
 if TYPE_CHECKING:
     from kiln_ai.adapters.model_adapters.base_adapter import SkillsDict
     from kiln_ai.datamodel.task import RunConfigProperties
-from kiln_ai.adapters.eval.sandbox_worker import run_scorer
+from kiln_ai.adapters.eval.sandbox_worker import execute_scorer_bridged
 from kiln_ai.datamodel.eval import (
     CodeEvalProperties,
     EvalConfig,
@@ -18,11 +17,11 @@ from kiln_ai.datamodel.eval import (
     SkippedReason,
     V2EvalResult,
 )
+from kiln_ai.tools.base_tool import ToolCallContext
+from kiln_ai.tools.sandbox_bridge import NestedToolServer, run_bridged_child
 
 _trust_lock = Lock()
 _trusted_projects: set[str] = set()
-
-_code_eval_execution_lock = asyncio.Lock()
 
 
 def grant_code_eval_trust(project_path: str) -> None:
@@ -70,19 +69,42 @@ class CodeEvalAdapter(BaseV2EvalBridge):
             "task_input": eval_input.task_input,
         }
 
-        async with _code_eval_execution_lock:
-            loop = asyncio.get_running_loop()
-            result = await loop.run_in_executor(
-                None, run_scorer, props.code, inputs, float(props.timeout_seconds)
+        server = NestedToolServer(
+            allowlist=props.tool_allowlist,
+            project=self.target_task.parent_project(),
+            task=self.target_task,
+            context=ToolCallContext(
+                allow_saving=False,
+                eval_output_schema=BaseEval.build_score_schema(
+                    self.eval, allow_float_scores=False
+                ),
+            ),
+            recorder=None,
+        )
+
+        res = await run_bridged_child(
+            target=execute_scorer_bridged,
+            args=(props.code, inputs),
+            timeout_s=float(props.timeout_seconds),
+            server=server,
+        )
+
+        if res.timed_out:
+            raise RuntimeError(
+                f"Code eval scorer timed out after {props.timeout_seconds}s"
+            )
+        if res.crashed:
+            raise RuntimeError(f"Scorer crashed (exit code {res.exit_code})")
+
+        result_msg = res.result_msg
+        assert result_msg is not None
+        if "error" in result_msg:
+            raise RuntimeError(
+                f"Code eval scorer failed: {result_msg['error']}\n"
+                f"{result_msg.get('traceback', '')}"
             )
 
-        if "error" in result:
-            tb = result.get("traceback", "")
-            msg = result["error"]
-            detail = f"{msg}\n{tb}".strip() if tb else msg
-            raise RuntimeError(f"Code eval scorer failed: {detail}")
-
-        raw_scores = result.get("ok")
+        raw_scores = result_msg["ok"]
         if not isinstance(raw_scores, dict):
             raise RuntimeError(
                 f"Scorer must return a dict, got {type(raw_scores).__name__}"

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -252,7 +252,7 @@ class CodeEvalProperties(BaseModel):
 
         tree = ast.parse(self.code)
         # Both sync and async score functions are accepted here.
-        # Async coroutines are transparently awaited in sandbox_worker._execute_scorer.
+        # Async coroutines are transparently awaited in sandbox_worker.execute_scorer_bridged.
         has_score_fn = any(
             isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
             and node.name == "score"

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -24,6 +24,11 @@ from kiln_ai.datamodel.datamodel_enums import TaskOutputRatingType
 from kiln_ai.datamodel.dataset_filters import DatasetFilterId, EvalInputFilterId
 from kiln_ai.datamodel.json_schema import string_to_json_key
 from kiln_ai.datamodel.task_run import Usage
+from kiln_ai.datamodel.tool_id import (
+    KILN_UNMANAGED_TOOL_ID_PREFIX,
+    SKILL_TOOL_ID_PREFIX,
+    ToolId,
+)
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 
 if TYPE_CHECKING:
@@ -204,7 +209,31 @@ class CodeEvalProperties(BaseModel):
     type: Literal[V2EvalType.code_eval] = V2EvalType.code_eval
     code: str
     reference_keys: list[str] = []
-    timeout_seconds: int = Field(default=30, ge=1, le=300)
+    timeout_seconds: int = Field(default=180, ge=1, le=300)
+    tool_allowlist: list[ToolId] = Field(
+        default_factory=list,
+        description="Explicit per-tool allowlist of tools the scorer code may call.",
+    )
+
+    @model_validator(mode="after")
+    def validate_allowlist(self) -> Self:
+        seen: set[str] = set()
+        for tool_id in self.tool_allowlist:
+            if tool_id.startswith(SKILL_TOOL_ID_PREFIX):
+                raise ValueError(
+                    f"Skill tool IDs cannot be used in tool_allowlist: {tool_id}. "
+                    "Skills are adapter-resolved and not callable from code evals."
+                )
+            if tool_id.startswith(KILN_UNMANAGED_TOOL_ID_PREFIX):
+                raise ValueError(
+                    f"Unmanaged tool IDs cannot be used in tool_allowlist: {tool_id}. "
+                    "Unmanaged tools are SDK-injected and not resolvable by the registry."
+                )
+            if tool_id in seen:
+                raise ValueError(f"Duplicate tool ID in tool_allowlist: {tool_id}")
+            seen.add(tool_id)
+
+        return self
 
     @model_validator(mode="after")
     def validate_code(self) -> Self:

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -2677,7 +2677,11 @@ class TestCodeEvalPropertiesValidation:
     def test_valid_code(self):
         props = CodeEvalProperties(code=self.VALID_CODE)
         assert props.code == self.VALID_CODE
-        assert props.timeout_seconds == 30
+        assert props.timeout_seconds == 180
+
+    def test_default_timeout_is_180(self):
+        props = CodeEvalProperties(code=self.VALID_CODE)
+        assert props.timeout_seconds == 180
 
     def test_custom_timeout(self):
         props = CodeEvalProperties(code=self.VALID_CODE, timeout_seconds=120)
@@ -2718,6 +2722,58 @@ class TestCodeEvalPropertiesValidation:
         code = "async def score(output, trace, reference_data, task_input):\n    return {'accuracy': 1.0}\n"
         props = CodeEvalProperties(code=code)
         assert props.code == code
+
+    def test_default_tool_allowlist_is_empty(self):
+        props = CodeEvalProperties(code=self.VALID_CODE)
+        assert props.tool_allowlist == []
+
+    def test_valid_tool_allowlist(self):
+        props = CodeEvalProperties(
+            code=self.VALID_CODE,
+            tool_allowlist=[
+                "kiln_tool::llm",
+                "kiln_tool::llm_judge",
+                "mcp::remote::server1::tool1",
+            ],
+        )
+        assert len(props.tool_allowlist) == 3
+
+    def test_tool_allowlist_rejects_skill_ids(self):
+        with pytest.raises(ValidationError, match="Skill tool IDs cannot"):
+            CodeEvalProperties(
+                code=self.VALID_CODE,
+                tool_allowlist=["kiln_tool::skill::some_skill"],
+            )
+
+    def test_tool_allowlist_rejects_unmanaged_ids(self):
+        with pytest.raises(ValidationError, match="Unmanaged tool IDs cannot"):
+            CodeEvalProperties(
+                code=self.VALID_CODE,
+                tool_allowlist=["kiln_unmanaged::some_tool"],
+            )
+
+    def test_tool_allowlist_rejects_duplicates(self):
+        with pytest.raises(ValidationError, match="Duplicate tool ID"):
+            CodeEvalProperties(
+                code=self.VALID_CODE,
+                tool_allowlist=["kiln_tool::llm", "kiln_tool::llm"],
+            )
+
+    def test_tool_allowlist_rejects_invalid_tool_id(self):
+        with pytest.raises(ValidationError, match="Invalid tool ID"):
+            CodeEvalProperties(
+                code=self.VALID_CODE,
+                tool_allowlist=["not_a_valid_tool_id"],
+            )
+
+    def test_tool_allowlist_allows_self_referential_code_tool_id(self):
+        # A code eval is not itself a tool, so the CodeTool self-reference check
+        # is intentionally omitted — any valid code tool ID is allowed.
+        props = CodeEvalProperties(
+            code=self.VALID_CODE,
+            tool_allowlist=["kiln_tool::code::123456789012"],
+        )
+        assert props.tool_allowlist == ["kiln_tool::code::123456789012"]
 
 
 # ── V1 Coexistence Regression Guards ─────────────────────────────────

--- a/libs/core/kiln_ai/datamodel/test_tool_id.py
+++ b/libs/core/kiln_ai/datamodel/test_tool_id.py
@@ -29,13 +29,27 @@ class TestKilnBuiltInToolId:
         assert KilnBuiltInToolId.MULTIPLY_NUMBERS == "kiln_tool::multiply_numbers"
         assert KilnBuiltInToolId.DIVIDE_NUMBERS == "kiln_tool::divide_numbers"
         assert KilnBuiltInToolId.CALL_KILN_API == "kiln_tool::call_kiln_api"
+        assert KilnBuiltInToolId.LLM == "kiln_tool::llm"
+        assert KilnBuiltInToolId.LLM_JUDGE == "kiln_tool::llm_judge"
         for enum_value in KilnBuiltInToolId.__members__.values():
             assert _check_tool_id(enum_value) == enum_value
+
+    def test_llm_tool_ids_round_trip_through_validator(self):
+        """The new LLM built-ins validate through the built-in membership branch."""
+        for tool_id in (KilnBuiltInToolId.LLM, KilnBuiltInToolId.LLM_JUDGE):
+            assert _check_tool_id(tool_id.value) == tool_id.value
+
+            class _M(BaseModel):
+                tool_id: ToolId
+
+            assert _M(tool_id=tool_id.value).tool_id == tool_id.value
 
     def test_enum_membership(self):
         """Test enum membership checks."""
         assert "kiln_tool::add_numbers" in KilnBuiltInToolId.__members__.values()
         assert "kiln_tool::call_kiln_api" in KilnBuiltInToolId.__members__.values()
+        assert "kiln_tool::llm" in KilnBuiltInToolId.__members__.values()
+        assert "kiln_tool::llm_judge" in KilnBuiltInToolId.__members__.values()
         assert "invalid_tool" not in KilnBuiltInToolId.__members__.values()
 
 

--- a/libs/core/kiln_ai/datamodel/tool_id.py
+++ b/libs/core/kiln_ai/datamodel/tool_id.py
@@ -30,6 +30,8 @@ class KilnBuiltInToolId(str, Enum):
     MULTIPLY_NUMBERS = "kiln_tool::multiply_numbers"
     DIVIDE_NUMBERS = "kiln_tool::divide_numbers"
     CALL_KILN_API = "kiln_tool::call_kiln_api"
+    LLM = "kiln_tool::llm"
+    LLM_JUDGE = "kiln_tool::llm_judge"
 
 
 MCP_REMOTE_TOOL_ID_PREFIX = "mcp::remote::"

--- a/libs/core/kiln_ai/sandbox/spawn.py
+++ b/libs/core/kiln_ai/sandbox/spawn.py
@@ -9,10 +9,12 @@ import threading
 import types
 
 _spawn_lock = threading.Lock()
-"""Process-global lock shared by code-evals (``run_scorer``) and code tools.
+"""Process-global lock shared by code-evals and code tools.
 
-Serializes the ``__main__`` stub-swap window around ``p.start()``,
-preventing the PyInstaller concurrent-spawn bug #7410.
+Both paths spawn through :func:`kiln_ai.tools.sandbox_bridge.run_bridged_child`,
+which calls :func:`start_process_with_light_main` below. Serializes the
+``__main__`` stub-swap window around ``p.start()``, preventing the PyInstaller
+concurrent-spawn bug #7410.
 """
 
 

--- a/libs/core/kiln_ai/sandbox/test_code_tool_execution.py
+++ b/libs/core/kiln_ai/sandbox/test_code_tool_execution.py
@@ -731,7 +731,7 @@ class TestDepthCap:
         finally:
             _depth.reset(token)
         assert result.is_error
-        assert "max code tool depth exceeded" in result.output
+        assert "maximum nested code execution depth exceeded" in result.output
 
 
 class TestSemaphore:
@@ -961,11 +961,11 @@ class TestUnicodePassthrough:
 
 class TestSpawnLockIdentity:
     def test_spawn_lock_shared(self):
-        """PythonCodeTool and run_scorer share the same _spawn_lock."""
-        from kiln_ai.adapters.eval import sandbox_worker
+        """Code tools and code evals spawn through the same bridge / _spawn_lock."""
+        from kiln_ai.tools import sandbox_bridge
 
         assert (
-            sandbox_worker.start_process_with_light_main.__module__
+            sandbox_bridge.start_process_with_light_main.__module__
             == "kiln_ai.sandbox.spawn"
         )
         from kiln_ai.sandbox.spawn import _spawn_lock as shared_lock

--- a/libs/core/kiln_ai/sandbox/test_code_tool_execution.py
+++ b/libs/core/kiln_ai/sandbox/test_code_tool_execution.py
@@ -24,10 +24,12 @@ from kiln_ai.tools.base_tool import (
     ToolCallResult,
 )
 from kiln_ai.tools.code_tool import (
-    CODE_TOOL_MAX_CONCURRENCY,
     PythonCodeTool,
     ToolCallLogEntry,
-    _code_tool_depth,
+)
+from kiln_ai.tools.sandbox_bridge import (
+    CODE_SANDBOX_MAX_CONCURRENCY,
+    _depth,
 )
 
 # ---------------------------------------------------------------------------
@@ -723,11 +725,11 @@ class TestDepthCap:
     async def test_depth_cap_at_10(self, tmp_path):
         """Depth >= 10 returns an error without spawning."""
         tool = _make_python_code_tool(tmp_path, 'def run(x):\n    return "ok"\n')
-        token = _code_tool_depth.set(10)
+        token = _depth.set(10)
         try:
             result = await tool.run(None, x="test")
         finally:
-            _code_tool_depth.reset(token)
+            _depth.reset(token)
         assert result.is_error
         assert "max code tool depth exceeded" in result.output
 
@@ -750,15 +752,17 @@ class TestSemaphore:
 
         async def run_nested(i: int):
             tool = _make_python_code_tool(tmp_path, code)
-            token = _code_tool_depth.set(1)
+            token = _depth.set(1)
             try:
                 r = await tool.run(None, x=str(i))
                 results.append(r)
             finally:
-                _code_tool_depth.reset(token)
+                _depth.reset(token)
 
-        await asyncio.gather(*(run_nested(i) for i in range(CODE_TOOL_MAX_CONCURRENCY)))
-        assert len(results) == CODE_TOOL_MAX_CONCURRENCY
+        await asyncio.gather(
+            *(run_nested(i) for i in range(CODE_SANDBOX_MAX_CONCURRENCY))
+        )
+        assert len(results) == CODE_SANDBOX_MAX_CONCURRENCY
         assert all(not r.is_error for r in results)
 
 

--- a/libs/core/kiln_ai/sandbox/test_sandbox_shared.py
+++ b/libs/core/kiln_ai/sandbox/test_sandbox_shared.py
@@ -4,38 +4,55 @@ import asyncio
 
 import pytest
 
-from kiln_ai.adapters.eval import sandbox_worker
-from kiln_ai.adapters.eval.sandbox_worker import run_scorer
+from kiln_ai.adapters.eval.sandbox_worker import execute_scorer_bridged
+from kiln_ai.datamodel.project import Project
 from kiln_ai.sandbox.entrypoint import call_entrypoint
 from kiln_ai.sandbox.spawn import _spawn_lock, start_process_with_light_main
+from kiln_ai.tools.sandbox_bridge import NestedToolServer, run_bridged_child
 
 
 class TestSpawnLockIdentity:
     def test_spawn_lock_shared_with_eval(self):
-        """run_scorer and code tools share the same _spawn_lock (PyInstaller #7410)."""
+        """Code evals and code tools share the same _spawn_lock (PyInstaller #7410)."""
         from kiln_ai.sandbox import spawn as spawn_mod
 
         assert spawn_mod._spawn_lock is _spawn_lock
 
-    def test_run_scorer_delegates_to_shared_helpers(self):
-        """sandbox_worker uses start_process_with_light_main from sandbox.spawn."""
+    def test_bridge_delegates_to_shared_spawn_helper(self):
+        """The shared bridge spawns via start_process_with_light_main from sandbox.spawn."""
+        from kiln_ai.tools import sandbox_bridge
+
         assert (
-            sandbox_worker.start_process_with_light_main
+            sandbox_bridge.start_process_with_light_main
             is start_process_with_light_main
         )
 
-    def test_run_scorer_still_works(self):
-        """Regression: run_scorer delegates to shared helpers and still works."""
+    @pytest.mark.asyncio
+    async def test_scorer_runs_through_bridge(self):
+        """Regression: a scorer executes through the shared bridge and returns its dict."""
         code = (
             "def score(output, trace, reference_data, task_input):\n"
             "    return {'ok': 1.0}\n"
         )
-        result = run_scorer(
-            code,
-            {"output": "x", "trace": None, "reference_data": None, "task_input": "y"},
-            timeout=10,
+        server = NestedToolServer(
+            allowlist=[], project=Project(name="shared_test"), task=None, context=None
         )
-        assert result["ok"] == {"ok": 1.0}
+        res = await run_bridged_child(
+            target=execute_scorer_bridged,
+            args=(
+                code,
+                {
+                    "output": "x",
+                    "trace": None,
+                    "reference_data": None,
+                    "task_input": "y",
+                },
+            ),
+            timeout_s=10,
+            server=server,
+        )
+        assert res.result_msg is not None
+        assert res.result_msg["ok"] == {"ok": 1.0}
 
 
 class TestCallEntrypoint:

--- a/libs/core/kiln_ai/tools/base_tool.py
+++ b/libs/core/kiln_ai/tools/base_tool.py
@@ -30,6 +30,13 @@ class ToolCallContext:
     """Used for Kiln Tasks as Tools, to know if the tool call should save the task run it invoked to that task's Dataset."""
     allow_saving: bool = True
 
+    """The code-eval judge score schema (allow_float_scores=False) as a JSON string.
+
+    Set only by the code-eval pump so the llm_judge tool can resolve through the
+    generic tool path yet still see the eval's schema at call time. Ignored by every
+    other caller and tool."""
+    eval_output_schema: str | None = None
+
 
 class ToolCallResult(BaseModel):
     output: str

--- a/libs/core/kiln_ai/tools/built_in_tools/llm_tools.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/llm_tools.py
@@ -1,0 +1,271 @@
+"""Built-in LLM tools: ``llm`` and ``llm_judge``.
+
+Both run entirely parent-side (the model call never happens in a sandbox
+child). They share :func:`run_llm_call`, which is extracted from the non-g-eval
+path of ``LlmJudgeEval.evaluate``.
+
+Imports of the adapter/eval stack are function-local: ``tools`` importing the
+adapter stack at module scope would cycle (``base_adapter`` imports
+``tool_registry``). ``RunOutput`` comes from the standalone
+``kiln_ai.adapters.run_output`` module (no cycle) so it can annotate the shared
+helper's return type.
+"""
+
+import json
+
+from jinja2 import TemplateSyntaxError, UndefinedError
+
+from kiln_ai.adapters.run_output import RunOutput
+from kiln_ai.datamodel.json_schema import validate_schema_dict
+from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
+from kiln_ai.tools.base_tool import KilnTool, ToolCallContext, ToolCallResult
+from kiln_ai.utils.jinja_engine import JinjaExtractionError, _template_env
+
+_DEFAULT_SYSTEM_PROMPT = (
+    "Your job is to evaluate a model's performance on a task. "
+    "Score the output according to the criteria provided."
+)
+
+
+async def run_llm_call(
+    *,
+    model: str,
+    provider: str,
+    system_prompt: str | None,
+    rendered_prompt: str,
+    output_json_schema: str | None,
+) -> RunOutput:
+    """Make a single parent-side model call and return its ``RunOutput``.
+
+    Mirrors the machinery ``LlmJudgeEval`` uses for its non-g-eval path: an
+    ephemeral judge Task invoked through ``adapter_for_task``.
+
+    When ``output_json_schema`` is None the call is free-text and
+    ``run_output.output`` is a ``str``; when set it is structured and
+    ``run_output.output`` is a ``dict``.
+    """
+    # Function-local imports to avoid the tools -> adapter -> tool_registry cycle.
+    from kiln_ai.adapters.adapter_registry import adapter_for_task
+    from kiln_ai.adapters.ml_model_list import (
+        ModelProviderName,
+        default_structured_output_mode_for_model_provider,
+    )
+    from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig
+    from kiln_ai.datamodel.project import Project
+    from kiln_ai.datamodel.prompt_id import PromptGenerators
+    from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
+    from kiln_ai.datamodel.task import StructuredOutputMode, Task
+
+    if provider not in ModelProviderName.__members__:
+        raise ValueError(f"Invalid model provider: {provider}")
+    provider_enum = ModelProviderName(provider)
+
+    tmp_project = Project(name="LlmTool")
+    judge_task = Task(
+        name="LlmTool Task",
+        parent=tmp_project,
+        instruction=system_prompt or _DEFAULT_SYSTEM_PROMPT,
+        output_json_schema=output_json_schema,
+    )
+
+    structured_output_mode = default_structured_output_mode_for_model_provider(
+        model,
+        provider_enum,
+        default=StructuredOutputMode.json_schema,
+        disallowed_modes=[
+            StructuredOutputMode.function_calling,
+            StructuredOutputMode.function_calling_weak,
+        ],
+    )
+
+    adapter = adapter_for_task(
+        judge_task,
+        run_config_properties=KilnAgentRunConfigProperties(
+            model_name=model,
+            model_provider_name=provider_enum,
+            prompt_id=PromptGenerators.SIMPLE,
+            structured_output_mode=structured_output_mode,
+        ),
+        base_adapter_config=AdapterConfig(
+            allow_saving=False,
+            top_logprobs=None,
+        ),
+    )
+
+    _, run_output = await adapter.invoke_returning_run_output(rendered_prompt)
+    return run_output
+
+
+def _render_prompt(prompt: str, input_data: dict) -> str:
+    """Render ``prompt`` as a Jinja2 template against ``input_data``.
+
+    Jinja errors (missing variables, invalid extraction) surface as a raised
+    ValueError, which the sandbox bridge maps to a tool call error.
+    """
+    try:
+        return _template_env.from_string(prompt).render(**input_data)
+    except TemplateSyntaxError as e:
+        raise ValueError(
+            f"Invalid prompt template: {e.message} (line {e.lineno})"
+        ) from e
+    except JinjaExtractionError as e:
+        raise ValueError(f"Prompt template rendering failed: {e}") from e
+    except UndefinedError as e:
+        raise ValueError(f"Prompt template references missing data: {e}") from e
+
+
+_LLM_TOOL_PARAMETERS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "prompt": {
+            "type": "string",
+            "description": "Jinja2 prompt template rendered against `input`.",
+        },
+        "model": {
+            "type": "string",
+            "description": "The model name to call.",
+        },
+        "provider": {
+            "type": "string",
+            "description": "The model provider name to call.",
+        },
+        "input": {
+            "type": "object",
+            "description": "Variables made available to the prompt template.",
+        },
+        "schema": {
+            "type": "object",
+            "description": "Optional JSON schema forcing structured output.",
+        },
+        "system_prompt": {
+            "type": "string",
+            "description": "Optional system prompt for the model call.",
+        },
+    },
+    "required": ["prompt", "model", "provider"],
+    "additionalProperties": False,
+}
+
+
+class LlmTool(KilnTool):
+    """Make a model call from within a code judge or agent.
+
+    Renders a Jinja2 prompt, optionally forces structured output via a JSON
+    schema, and returns the model's response (free text, or a JSON string when a
+    schema is supplied).
+    """
+
+    def __init__(self):
+        super().__init__(
+            tool_id=KilnBuiltInToolId.LLM,
+            name="llm",
+            description=(
+                "Call a language model with a rendered prompt. Provide an optional "
+                "JSON schema to force structured output."
+            ),
+            parameters_schema=_LLM_TOOL_PARAMETERS_SCHEMA,
+        )
+
+    async def run(
+        self, context: ToolCallContext | None = None, **kwargs
+    ) -> ToolCallResult:
+        rendered_prompt = _render_prompt(kwargs["prompt"], kwargs.get("input") or {})
+
+        schema = kwargs.get("schema")
+        if schema is not None:
+            validate_schema_dict(schema, require_object=True)
+            output_json_schema = json.dumps(schema, ensure_ascii=False)
+        else:
+            output_json_schema = None
+
+        run_output = await run_llm_call(
+            model=kwargs["model"],
+            provider=kwargs["provider"],
+            system_prompt=kwargs.get("system_prompt"),
+            rendered_prompt=rendered_prompt,
+            output_json_schema=output_json_schema,
+        )
+
+        output = (
+            run_output.output
+            if isinstance(run_output.output, str)
+            else json.dumps(run_output.output, ensure_ascii=False)
+        )
+        return ToolCallResult(output=output)
+
+
+_LLM_JUDGE_TOOL_PARAMETERS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "prompt": {
+            "type": "string",
+            "description": "Jinja2 prompt template rendered against `input`.",
+        },
+        "model": {
+            "type": "string",
+            "description": "The model name to call.",
+        },
+        "provider": {
+            "type": "string",
+            "description": "The model provider name to call.",
+        },
+        "input": {
+            "type": "object",
+            "description": "Variables made available to the prompt template.",
+        },
+        "system_prompt": {
+            "type": "string",
+            "description": "Optional system prompt for the model call.",
+        },
+    },
+    "required": ["prompt", "model", "provider"],
+    "additionalProperties": False,
+}
+
+
+class LlmJudgeTool(KilnTool):
+    """Run an LLM-as-judge scoring call using the enclosing code judge's schema.
+
+    Only available inside a code judge, where the eval's score schema is provided
+    via ``ToolCallContext.eval_output_schema``. Returns a JSON string mapping each
+    metric to its float score.
+    """
+
+    def __init__(self):
+        super().__init__(
+            tool_id=KilnBuiltInToolId.LLM_JUDGE,
+            name="llm_judge",
+            description=(
+                "Score an output with an LLM using the code judge's own scoring "
+                "schema. Returns a JSON object of metric scores."
+            ),
+            parameters_schema=_LLM_JUDGE_TOOL_PARAMETERS_SCHEMA,
+        )
+
+    async def run(
+        self, context: ToolCallContext | None = None, **kwargs
+    ) -> ToolCallResult:
+        if context is None or context.eval_output_schema is None:
+            raise ValueError(
+                "llm_judge is only available inside a code judge; use 'llm' with "
+                "an explicit schema elsewhere."
+            )
+
+        # Function-local import to avoid the tools -> adapter -> tool_registry cycle.
+        from kiln_ai.adapters.eval.eval_utils.scoring_utils import (
+            build_llm_as_judge_score,
+            score_from_token_string,
+        )
+
+        rendered_prompt = _render_prompt(kwargs["prompt"], kwargs.get("input") or {})
+
+        run_output = await run_llm_call(
+            model=kwargs["model"],
+            provider=kwargs["provider"],
+            system_prompt=kwargs.get("system_prompt"),
+            rendered_prompt=rendered_prompt,
+            output_json_schema=context.eval_output_schema,
+        )
+
+        scores = build_llm_as_judge_score(run_output, score_from_token_string)
+        return ToolCallResult(output=json.dumps(scores, ensure_ascii=False))

--- a/libs/core/kiln_ai/tools/built_in_tools/test_llm_tools.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_llm_tools.py
@@ -1,0 +1,341 @@
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from kiln_ai.adapters.eval.eval_utils.scoring_utils import (
+    build_llm_as_judge_score,
+    score_from_token_string,
+)
+from kiln_ai.adapters.run_output import RunOutput
+from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
+from kiln_ai.tools.base_tool import ToolCallContext, ToolCallResult
+from kiln_ai.tools.built_in_tools.llm_tools import (
+    _DEFAULT_SYSTEM_PROMPT,
+    LlmJudgeTool,
+    LlmTool,
+    run_llm_call,
+)
+
+# run_llm_call imports adapter_for_task function-locally from this module, so we
+# patch it at its definition site.
+ADAPTER_PATH = "kiln_ai.adapters.adapter_registry.adapter_for_task"
+
+VALID_SCORE_SCHEMA = json.dumps(
+    {
+        "type": "object",
+        "properties": {"score": {"type": "string"}},
+        "required": ["score"],
+    }
+)
+
+
+def _mock_adapter_for(run_output: RunOutput):
+    """Return (factory_mock, adapter_mock) doubling adapter_for_task -> adapter."""
+    adapter = AsyncMock()
+    adapter.invoke_returning_run_output.return_value = (Mock(), run_output)
+    factory = Mock(return_value=adapter)
+    return factory, adapter
+
+
+class TestToolDefinitions:
+    async def test_llm_tool_definition(self):
+        tool = LlmTool()
+        assert await tool.id() == KilnBuiltInToolId.LLM
+        assert await tool.name() == "llm"
+        defn = await tool.toolcall_definition()
+        params = defn["function"]["parameters"]
+        assert defn["function"]["name"] == "llm"
+        assert params["additionalProperties"] is False
+        assert set(params["required"]) == {"prompt", "model", "provider"}
+        assert "schema" in params["properties"]
+
+    async def test_llm_judge_tool_definition_has_no_schema_param(self):
+        tool = LlmJudgeTool()
+        assert await tool.id() == KilnBuiltInToolId.LLM_JUDGE
+        assert await tool.name() == "llm_judge"
+        defn = await tool.toolcall_definition()
+        params = defn["function"]["parameters"]
+        assert defn["function"]["name"] == "llm_judge"
+        assert params["additionalProperties"] is False
+        assert "schema" not in params["properties"]
+
+
+class TestLlmTool:
+    async def test_returns_text_without_schema(self):
+        run_output = RunOutput(output="hello world", intermediate_outputs=None)
+        factory, adapter = _mock_adapter_for(run_output)
+
+        with patch(ADAPTER_PATH, factory):
+            result = await LlmTool().run(
+                prompt="Say hi to {{ name }}",
+                model="gpt_4o",
+                provider="openai",
+                input={"name": "Bob"},
+            )
+
+        assert isinstance(result, ToolCallResult)
+        assert result.output == "hello world"
+        adapter.invoke_returning_run_output.assert_awaited_once_with("Say hi to Bob")
+        task_arg = factory.call_args[0][0]
+        assert task_arg.output_json_schema is None
+
+    async def test_returns_json_string_with_schema(self):
+        run_output = RunOutput(output={"rating": "5"}, intermediate_outputs=None)
+        factory, _ = _mock_adapter_for(run_output)
+        schema = {
+            "type": "object",
+            "properties": {"rating": {"type": "string"}},
+            "required": ["rating"],
+        }
+
+        with patch(ADAPTER_PATH, factory):
+            result = await LlmTool().run(
+                prompt="rate it",
+                model="gpt_4o",
+                provider="openai",
+                schema=schema,
+            )
+
+        assert json.loads(result.output) == {"rating": "5"}
+        task_arg = factory.call_args[0][0]
+        assert task_arg.output_json_schema is not None
+        assert "rating" in json.loads(task_arg.output_json_schema)["properties"]
+
+    async def test_system_prompt_passthrough(self):
+        run_output = RunOutput(output="ok", intermediate_outputs=None)
+        factory, _ = _mock_adapter_for(run_output)
+
+        with patch(ADAPTER_PATH, factory):
+            await LlmTool().run(
+                prompt="hi",
+                model="gpt_4o",
+                provider="openai",
+                system_prompt="Be terse.",
+            )
+
+        task_arg = factory.call_args[0][0]
+        assert task_arg.instruction == "Be terse."
+
+    async def test_invalid_schema_raises(self):
+        with pytest.raises(ValueError):
+            await LlmTool().run(
+                prompt="x",
+                model="gpt_4o",
+                provider="openai",
+                schema={"type": "string"},  # not an object schema
+            )
+
+    async def test_explicit_empty_schema_is_validated_and_rejected(self):
+        # An explicitly-passed {} is not None, so it is validated (and rejected
+        # by require_object) rather than silently treated as free-text.
+        factory, _ = _mock_adapter_for(RunOutput(output="", intermediate_outputs=None))
+        with patch(ADAPTER_PATH, factory):
+            with pytest.raises(ValueError):
+                await LlmTool().run(
+                    prompt="x",
+                    model="gpt_4o",
+                    provider="openai",
+                    schema={},
+                )
+        factory.assert_not_called()
+
+    async def test_template_syntax_error_raises(self):
+        with pytest.raises(ValueError, match="Invalid prompt template"):
+            await LlmTool().run(
+                prompt="Hi {{ unclosed",
+                model="gpt_4o",
+                provider="openai",
+            )
+
+    async def test_non_ascii_structured_output_preserved(self):
+        run_output = RunOutput(
+            output={"greeting": "héllo café ☕"}, intermediate_outputs=None
+        )
+        factory, _ = _mock_adapter_for(run_output)
+        schema = {
+            "type": "object",
+            "properties": {"greeting": {"type": "string"}},
+            "required": ["greeting"],
+        }
+
+        with patch(ADAPTER_PATH, factory):
+            result = await LlmTool().run(
+                prompt="hi",
+                model="gpt_4o",
+                provider="openai",
+                schema=schema,
+            )
+
+        # ensure_ascii=False keeps literal unicode instead of \uXXXX escapes.
+        assert "héllo café ☕" in result.output
+        assert "\\u" not in result.output
+        assert json.loads(result.output) == {"greeting": "héllo café ☕"}
+
+    async def test_invalid_provider_raises(self):
+        with pytest.raises(ValueError, match="Invalid model provider"):
+            await LlmTool().run(
+                prompt="hi",
+                model="gpt_4o",
+                provider="not_a_provider",
+            )
+
+    async def test_render_error_raises(self):
+        with pytest.raises(ValueError, match="missing data"):
+            await LlmTool().run(
+                prompt="Hi {{ missing }}",
+                model="gpt_4o",
+                provider="openai",
+                input={},
+            )
+
+
+class TestLlmJudgeTool:
+    async def test_off_context_none_raises(self):
+        factory, _ = _mock_adapter_for(RunOutput(output={}, intermediate_outputs=None))
+        with patch(ADAPTER_PATH, factory):
+            with pytest.raises(ValueError, match="only available inside a code judge"):
+                await LlmJudgeTool().run(
+                    None,
+                    prompt="x",
+                    model="gpt_4o",
+                    provider="openai",
+                )
+        factory.assert_not_called()
+
+    async def test_off_context_no_schema_raises(self):
+        factory, _ = _mock_adapter_for(RunOutput(output={}, intermediate_outputs=None))
+        ctx = ToolCallContext()  # eval_output_schema defaults to None
+        with patch(ADAPTER_PATH, factory):
+            with pytest.raises(ValueError, match="only available inside a code judge"):
+                await LlmJudgeTool().run(
+                    ctx,
+                    prompt="x",
+                    model="gpt_4o",
+                    provider="openai",
+                )
+        factory.assert_not_called()
+
+    async def test_maps_pass_fail_critical_and_stars(self):
+        run_output = RunOutput(
+            output={
+                "pass_metric": "pass",
+                "fail_metric": "fail",
+                "critical_metric": "critical",
+                "star_metric": "5",
+            },
+            intermediate_outputs=None,
+        )
+        factory, _ = _mock_adapter_for(run_output)
+        ctx = ToolCallContext(eval_output_schema=VALID_SCORE_SCHEMA)
+
+        with patch(ADAPTER_PATH, factory):
+            result = await LlmJudgeTool().run(
+                ctx,
+                prompt="judge {{ x }}",
+                model="gpt_4o",
+                provider="openai",
+                input={"x": "y"},
+            )
+
+        assert json.loads(result.output) == {
+            "pass_metric": 1.0,
+            "fail_metric": 0.0,
+            "critical_metric": -1.0,
+            "star_metric": 5.0,
+        }
+        # The eval's schema flows through to the judge model call.
+        task_arg = factory.call_args[0][0]
+        assert task_arg.output_json_schema == VALID_SCORE_SCHEMA
+
+    async def test_parity_with_build_llm_as_judge_score(self):
+        output = {"a": "3", "b": "pass", "c": "critical"}
+        factory, _ = _mock_adapter_for(
+            RunOutput(output=dict(output), intermediate_outputs=None)
+        )
+        ctx = ToolCallContext(eval_output_schema=VALID_SCORE_SCHEMA)
+
+        with patch(ADAPTER_PATH, factory):
+            result = await LlmJudgeTool().run(
+                ctx,
+                prompt="x",
+                model="gpt_4o",
+                provider="openai",
+            )
+
+        expected = build_llm_as_judge_score(
+            RunOutput(output=dict(output), intermediate_outputs=None),
+            score_from_token_string,
+        )
+        assert json.loads(result.output) == expected
+
+    async def test_invalid_provider_raises(self):
+        ctx = ToolCallContext(eval_output_schema=VALID_SCORE_SCHEMA)
+        with pytest.raises(ValueError, match="Invalid model provider"):
+            await LlmJudgeTool().run(
+                ctx,
+                prompt="hi",
+                model="gpt_4o",
+                provider="not_a_provider",
+            )
+
+    async def test_render_error_raises(self):
+        ctx = ToolCallContext(eval_output_schema=VALID_SCORE_SCHEMA)
+        with pytest.raises(ValueError, match="missing data"):
+            await LlmJudgeTool().run(
+                ctx,
+                prompt="Hi {{ missing }}",
+                model="gpt_4o",
+                provider="openai",
+            )
+
+
+class TestRunLlmCall:
+    async def test_returns_free_text_run_output(self):
+        run_output = RunOutput(output="free text", intermediate_outputs=None)
+        factory, adapter = _mock_adapter_for(run_output)
+
+        with patch(ADAPTER_PATH, factory):
+            out = await run_llm_call(
+                model="gpt_4o",
+                provider="openai",
+                system_prompt=None,
+                rendered_prompt="hi",
+                output_json_schema=None,
+            )
+
+        assert out is run_output
+        assert isinstance(out.output, str)
+        adapter.invoke_returning_run_output.assert_awaited_once_with("hi")
+        task_arg = factory.call_args[0][0]
+        assert task_arg.output_json_schema is None
+        # Default system prompt applied when none supplied.
+        assert task_arg.instruction == _DEFAULT_SYSTEM_PROMPT
+
+    async def test_returns_structured_run_output(self):
+        run_output = RunOutput(output={"k": "v"}, intermediate_outputs=None)
+        factory, _ = _mock_adapter_for(run_output)
+
+        with patch(ADAPTER_PATH, factory):
+            out = await run_llm_call(
+                model="gpt_4o",
+                provider="openai",
+                system_prompt="custom",
+                rendered_prompt="hi",
+                output_json_schema=VALID_SCORE_SCHEMA,
+            )
+
+        assert out.output == {"k": "v"}
+        task_arg = factory.call_args[0][0]
+        assert task_arg.output_json_schema == VALID_SCORE_SCHEMA
+        assert task_arg.instruction == "custom"
+
+    async def test_invalid_provider_raises(self):
+        with pytest.raises(ValueError, match="Invalid model provider"):
+            await run_llm_call(
+                model="gpt_4o",
+                provider="bogus",
+                system_prompt=None,
+                rendered_prompt="hi",
+                output_json_schema=None,
+            )

--- a/libs/core/kiln_ai/tools/code_tool.py
+++ b/libs/core/kiln_ai/tools/code_tool.py
@@ -1,29 +1,24 @@
 """PythonCodeTool — parent-side runtime for user-authored code tools.
 
-Spawns a child process per invocation, pumps nested tool-call IPC,
-enforces depth caps, concurrency bounds, and wall-clock timeouts.
+A thin caller over :mod:`kiln_ai.tools.sandbox_bridge`: builds a
+:class:`~kiln_ai.tools.sandbox_bridge.NestedToolServer`, runs one bridged child via
+:func:`~kiln_ai.tools.sandbox_bridge.run_bridged_child`, and maps the raw
+:class:`~kiln_ai.tools.sandbox_bridge.BridgeResult` into a :class:`ToolCallResult`.
+Depth caps, concurrency bounds, wall-clock timeouts, and nested-call IPC all live in
+the shared bridge.
 """
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
-import contextvars
-import json
 import logging
 import multiprocessing
-import queue
-import threading
 from dataclasses import dataclass
-from time import monotonic
 from typing import Any, Callable
 
 from kiln_ai.datamodel.code_tool import CodeTool
-from kiln_ai.datamodel.json_schema import validate_schema_with_value_error
 from kiln_ai.datamodel.project import Project
 from kiln_ai.datamodel.task import Task
 from kiln_ai.datamodel.tool_id import ToolId, build_code_tool_id
-from kiln_ai.sandbox.spawn import start_process_with_light_main
 from kiln_ai.sandbox.worker import child_main
 from kiln_ai.tools.base_tool import (
     KilnToolInterface,
@@ -31,30 +26,20 @@ from kiln_ai.tools.base_tool import (
     ToolCallDefinition,
     ToolCallResult,
 )
-
-logger = logging.getLogger(__name__)
-
-CODE_TOOL_MAX_CONCURRENCY = 8
-"""Maximum concurrent top-level code-tool invocations (process-wide)."""
-
-_code_tool_depth: contextvars.ContextVar[int] = contextvars.ContextVar(
-    "_code_tool_depth", default=0
+from kiln_ai.tools.sandbox_bridge import (
+    BridgeResult,
+    NestedToolServer,
+    ToolCallLogEntry,
+    run_bridged_child,
 )
 
-_semaphore: asyncio.Semaphore | None = None
-_semaphore_init_lock = threading.Lock()
+__all__ = [
+    "ChildOutcome",
+    "PythonCodeTool",
+    "ToolCallLogEntry",
+]
 
-
-async def _get_semaphore() -> asyncio.Semaphore:
-    """Lazily create the semaphore inside the running event loop."""
-    global _semaphore
-    if _semaphore is None:
-        with _semaphore_init_lock:
-            if _semaphore is None:
-                _semaphore = asyncio.Semaphore(CODE_TOOL_MAX_CONCURRENCY)
-    sem = _semaphore
-    assert sem is not None
-    return sem
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -68,15 +53,6 @@ class ChildOutcome:
     timed_out: bool = False
     crashed: bool = False
     exit_code: int | None = None
-
-
-@dataclass
-class ToolCallLogEntry:
-    tool_name: str
-    arguments: dict[str, Any]
-    output_preview: str
-    is_error: bool
-    duration_ms: int
 
 
 class PythonCodeTool(KilnToolInterface):
@@ -93,7 +69,6 @@ class PythonCodeTool(KilnToolInterface):
         self._project = project
         self._task = task
         self._tool_call_recorder = tool_call_recorder
-        self._name_map: dict[str, list[ToolId]] | None = None
 
     async def id(self) -> ToolId:
         return build_code_tool_id(self._code_tool.id)
@@ -149,422 +124,60 @@ class PythonCodeTool(KilnToolInterface):
         assert outcome.ok is not None
         return ToolCallResult(output=outcome.ok)
 
+    def _build_server(self, context: ToolCallContext | None) -> NestedToolServer:
+        return NestedToolServer(
+            allowlist=self._code_tool.tool_allowlist,
+            project=self._project,
+            task=self._task,
+            context=context,
+            recorder=self._tool_call_recorder,
+        )
+
     async def _invoke(
         self, context: ToolCallContext | None, kwargs: dict[str, Any]
     ) -> ChildOutcome:
-        depth = _code_tool_depth.get()
-        if depth >= 10:
-            return ChildOutcome(
-                error="max code tool depth exceeded — check for a cycle"
-            )
-
-        token = _code_tool_depth.set(depth + 1)
-        try:
-            if depth == 0:
-                cm = await _get_semaphore()
-            else:
-                cm = contextlib.nullcontext()  # type: ignore[assignment]
-
-            async with cm:
-                return await self._run_child(context, kwargs)
-        finally:
-            _code_tool_depth.reset(token)
-
-    async def _run_child(
-        self, context: ToolCallContext | None, kwargs: dict[str, Any]
-    ) -> ChildOutcome:
-        loop = asyncio.get_running_loop()
+        server = self._build_server(context)
         ctx = multiprocessing.get_context("spawn")
         requests: multiprocessing.Queue[dict[str, Any]] = ctx.Queue()
         responses: multiprocessing.Queue[dict[str, Any]] = ctx.Queue()
 
-        p = ctx.Process(
+        result = await run_bridged_child(
             target=child_main,
-            args=(
-                self._code_tool.code,
-                kwargs,
-                requests,
-                responses,
-            ),
-            daemon=True,
+            args=(self._code_tool.code, kwargs),
+            timeout_s=float(self._code_tool.timeout_seconds),
+            requests=requests,
+            responses=responses,
+            server=server,
         )
-
-        await loop.run_in_executor(None, start_process_with_light_main, p)
-
-        deadline = monotonic() + self._code_tool.timeout_seconds
-        pending_tasks: set[asyncio.Task[None]] = set()
-        start_time = monotonic()
-
-        try:
-            while True:
-                msg = await loop.run_in_executor(None, _poll_get, requests)
-
-                if monotonic() > deadline:
-                    elapsed = int((monotonic() - start_time) * 1000)
-                    p.kill()
-                    await loop.run_in_executor(None, p.join, 5)
-                    return ChildOutcome(timed_out=True, duration_ms=elapsed)
-
-                if msg is None:
-                    if not p.is_alive() and requests.empty():
-                        elapsed = int((monotonic() - start_time) * 1000)
-                        return ChildOutcome(
-                            crashed=True,
-                            exit_code=p.exitcode,
-                            duration_ms=elapsed,
-                        )
-                    continue
-
-                if msg["type"] in ("tool_call", "list_tools"):
-                    t = asyncio.create_task(self._serve(msg, context, responses))
-                    pending_tasks.add(t)
-                    t.add_done_callback(pending_tasks.discard)
-
-                elif msg["type"] == "result":
-                    elapsed = int((monotonic() - start_time) * 1000)
-                    await loop.run_in_executor(None, p.join, 5)
-                    if "ok" in msg:
-                        return ChildOutcome(
-                            ok=msg["ok"],
-                            stdout=msg.get("stdout", ""),
-                            stderr=msg.get("stderr", ""),
-                            duration_ms=elapsed,
-                        )
-                    else:
-                        return ChildOutcome(
-                            error=msg.get("error", "unknown error"),
-                            traceback_str=msg.get("traceback"),
-                            stdout=msg.get("stdout", ""),
-                            stderr=msg.get("stderr", ""),
-                            duration_ms=elapsed,
-                        )
-        finally:
-            for t in pending_tasks:
-                t.cancel()
-            if p.is_alive():
-                p.kill()
-                await loop.run_in_executor(None, p.join, 5)
-            _close_queues(requests, responses)
-
-    async def _serve(
-        self,
-        msg: dict[str, Any],
-        context: ToolCallContext | None,
-        responses: multiprocessing.Queue[dict[str, Any]],
-    ) -> None:
-        call_id = msg["call_id"]
-
-        if msg["type"] == "list_tools":
-            try:
-                tools_info = await self._get_tools_info()
-                responses.put(
-                    {"type": "tool_result", "call_id": call_id, "ok_list": tools_info}
-                )
-            except Exception as exc:
-                responses.put(
-                    {
-                        "type": "tool_result",
-                        "call_id": call_id,
-                        "error": {
-                            "kind": "call_error",
-                            "message": str(exc),
-                            "raw": None,
-                            "available": None,
-                        },
-                    }
-                )
-            return
-
-        tool_name = msg["tool_name"]
-        arguments = msg["arguments"]
-        positional_args: list[Any] = msg.get("positional_args", [])
-        start = monotonic()
-
-        try:
-            name_map = await self._build_name_map()
-            available_names = sorted(name_map.keys())
-
-            tool_ids = name_map.get(tool_name)
-            if tool_ids is None:
-                err_msg = (
-                    f"Tool '{tool_name}' is not available. "
-                    f"Available tools: {available_names}."
-                )
-                responses.put(
-                    {
-                        "type": "tool_result",
-                        "call_id": call_id,
-                        "error": {
-                            "kind": "not_allowed",
-                            "message": err_msg,
-                            "raw": None,
-                            "available": available_names,
-                        },
-                    }
-                )
-                self._record(tool_name, arguments, "not allowed", True, start)
-                return
-
-            if len(tool_ids) > 1:
-                responses.put(
-                    {
-                        "type": "tool_result",
-                        "call_id": call_id,
-                        "error": {
-                            "kind": "call_error",
-                            "message": f"Ambiguous tool name '{tool_name}' — resolves to multiple allowlisted tools.",
-                            "raw": None,
-                            "available": None,
-                        },
-                    }
-                )
-                self._record(tool_name, arguments, "ambiguous", True, start)
-                return
-
-            tool_id = tool_ids[0]
-
-            from kiln_ai.tools.tool_registry import tool_from_id_and_project
-
-            tool = tool_from_id_and_project(
-                tool_id, project=self._project, task=self._task
-            )
-
-            tool_def = await tool.toolcall_definition()
-            params_schema = tool_def["function"]["parameters"]
-            params_desc = _render_params_schema(params_schema)
-
-            if positional_args:
-                err_msg = (
-                    f"Tool '{tool_name}' must be called with keyword arguments, "
-                    f"e.g. tools.{tool_name}({_example_kwargs(params_schema)}). "
-                    f"Expected parameters: {params_desc}."
-                )
-                responses.put(
-                    {
-                        "type": "tool_result",
-                        "call_id": call_id,
-                        "error": {
-                            "kind": "call_error",
-                            "message": err_msg,
-                            "raw": None,
-                            "available": None,
-                        },
-                    }
-                )
-                self._record(tool_name, arguments, err_msg, True, start)
-                return
-
-            schema_str = json.dumps(params_schema, ensure_ascii=False)
-            try:
-                validate_schema_with_value_error(
-                    arguments,
-                    schema_str,
-                    f"Invalid arguments for tool '{tool_name}'.",
-                )
-            except ValueError as exc:
-                err_msg = f"{exc} Expected parameters: {params_desc}."
-                responses.put(
-                    {
-                        "type": "tool_result",
-                        "call_id": call_id,
-                        "error": {
-                            "kind": "call_error",
-                            "message": err_msg,
-                            "raw": None,
-                            "available": None,
-                        },
-                    }
-                )
-                self._record(tool_name, arguments, err_msg, True, start)
-                return
-
-            result = await tool.run(context, **arguments)
-
-            if result.is_error:
-                is_timeout = isinstance(tool, PythonCodeTool) and "timed out" in (
-                    result.output or ""
-                )
-                kind = "timeout" if is_timeout else "call_error"
-                responses.put(
-                    {
-                        "type": "tool_result",
-                        "call_id": call_id,
-                        "error": {
-                            "kind": kind,
-                            "message": result.error_message or result.output,
-                            "raw": result.output,
-                            "available": None,
-                        },
-                    }
-                )
-                self._record(tool_name, arguments, result.output, True, start)
-            else:
-                responses.put(
-                    {
-                        "type": "tool_result",
-                        "call_id": call_id,
-                        "ok": result.output,
-                    }
-                )
-                self._record(tool_name, arguments, result.output, False, start)
-
-        except asyncio.TimeoutError as exc:
-            logger.warning(
-                "Code tool nested call timed out for '%s': %s",
-                tool_name,
-                exc,
-            )
-            responses.put(
-                {
-                    "type": "tool_result",
-                    "call_id": call_id,
-                    "error": {
-                        "kind": "timeout",
-                        "message": str(exc) or f"Tool '{tool_name}' timed out",
-                        "raw": None,
-                        "available": None,
-                    },
-                }
-            )
-            self._record(tool_name, arguments, str(exc), True, start)
-
-        except Exception as exc:
-            logger.warning(
-                "Code tool nested call failed for '%s': %s",
-                tool_name,
-                exc,
-            )
-            responses.put(
-                {
-                    "type": "tool_result",
-                    "call_id": call_id,
-                    "error": {
-                        "kind": "call_error",
-                        "message": str(exc),
-                        "raw": None,
-                        "available": None,
-                    },
-                }
-            )
-            self._record(tool_name, arguments, str(exc), True, start)
-
-    def _record(
-        self,
-        tool_name: str,
-        arguments: dict[str, Any],
-        output: str,
-        is_error: bool,
-        start: float,
-    ) -> None:
-        if self._tool_call_recorder is None:
-            return
-        duration_ms = int((monotonic() - start) * 1000)
-        preview = output[:1024] if output else ""
-        self._tool_call_recorder(
-            ToolCallLogEntry(
-                tool_name=tool_name,
-                arguments=arguments,
-                output_preview=preview,
-                is_error=is_error,
-                duration_ms=duration_ms,
-            )
-        )
+        return _bridge_result_to_outcome(result)
 
     async def _build_name_map(self) -> dict[str, list[ToolId]]:
-        if self._name_map is not None:
-            return self._name_map
-
-        name_map: dict[str, list[ToolId]] = {}
-        for tool_id in self._code_tool.tool_allowlist:
-            fn_name = await self._canonical_tool_name(tool_id)
-            name_map.setdefault(fn_name, []).append(tool_id)
-
-        self._name_map = name_map
-        return name_map
-
-    async def _canonical_tool_name(self, tool_id: str) -> str:
-        """Return the canonical function name for *tool_id*.
-
-        This is the SINGLE source of truth for the dispatch name used by
-        both ``_build_name_map()`` and ``_get_tools_info()`` / ``list_tools()``.
-        It resolves every tool kind via the same path the child sees,
-        guaranteeing the name the user calls matches the name in the map.
-        """
-        from kiln_ai.tools.tool_registry import tool_from_id_and_project
-
-        tool = tool_from_id_and_project(tool_id, project=self._project, task=self._task)
-        return await tool.name()
-
-    async def _get_tools_info(self) -> list[dict[str, Any]]:
-        """Return tool definitions for ``list_tools()``."""
-        result: list[dict[str, Any]] = []
-        for tool_id in self._code_tool.tool_allowlist:
-            try:
-                from kiln_ai.tools.tool_registry import tool_from_id_and_project
-
-                tool = tool_from_id_and_project(
-                    tool_id, project=self._project, task=self._task
-                )
-                tool_def = await tool.toolcall_definition()
-                result.append(
-                    {
-                        "name": tool_def["function"]["name"],
-                        "description": tool_def["function"]["description"],
-                        "parameters_schema": tool_def["function"]["parameters"],
-                    }
-                )
-            except Exception:
-                fn_name = await self._canonical_tool_name(tool_id)
-                result.append(
-                    {
-                        "name": fn_name,
-                        "description": "(unavailable)",
-                        "parameters_schema": {},
-                    }
-                )
-        return result
+        return await self._build_server(None).name_map()
 
 
-def _render_params_schema(schema: dict[str, Any]) -> str:
-    """Render a JSON schema's properties into a readable parameter list.
+def _bridge_result_to_outcome(result: BridgeResult) -> ChildOutcome:
+    if result.timed_out:
+        return ChildOutcome(timed_out=True, duration_ms=result.duration_ms)
+    if result.crashed:
+        return ChildOutcome(
+            crashed=True,
+            exit_code=result.exit_code,
+            duration_ms=result.duration_ms,
+        )
 
-    Example output: ``a: number (required), b: number (required)``
-    """
-    props = schema.get("properties", {})
-    required = set(schema.get("required", []))
-    if not props:
-        return "(no parameters)"
-    parts: list[str] = []
-    for name, prop in props.items():
-        ptype = prop.get("type", "any")
-        req = "required" if name in required else "optional"
-        parts.append(f"{name}: {ptype} ({req})")
-    return ", ".join(parts)
-
-
-def _example_kwargs(schema: dict[str, Any]) -> str:
-    """Render example keyword-argument syntax from a schema.
-
-    Example output: ``a=..., b=...``
-    """
-    props = schema.get("properties", {})
-    if not props:
-        return ""
-    return ", ".join(f"{name}=..." for name in props)
-
-
-def _poll_get(q: multiprocessing.Queue) -> dict[str, Any] | None:  # type: ignore[type-arg]
-    """Non-blocking get with short timeout so the pump can re-check deadlines."""
-    try:
-        return q.get(timeout=0.1)
-    except (queue.Empty, EOFError, OSError, ValueError):
-        return None
-
-
-def _close_queues(*queues: multiprocessing.Queue) -> None:  # type: ignore[type-arg]
-    for q in queues:
-        try:
-            q.close()
-            q.join_thread()
-        except Exception:
-            pass
+    msg = result.result_msg
+    assert msg is not None
+    if "ok" in msg:
+        return ChildOutcome(
+            ok=msg["ok"],
+            stdout=msg.get("stdout", ""),
+            stderr=msg.get("stderr", ""),
+            duration_ms=result.duration_ms,
+        )
+    return ChildOutcome(
+        error=msg.get("error", "unknown error"),
+        traceback_str=msg.get("traceback"),
+        stdout=msg.get("stdout", ""),
+        stderr=msg.get("stderr", ""),
+        duration_ms=result.duration_ms,
+    )

--- a/libs/core/kiln_ai/tools/code_tool.py
+++ b/libs/core/kiln_ai/tools/code_tool.py
@@ -11,7 +11,6 @@ the shared bridge.
 from __future__ import annotations
 
 import logging
-import multiprocessing
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -137,16 +136,10 @@ class PythonCodeTool(KilnToolInterface):
         self, context: ToolCallContext | None, kwargs: dict[str, Any]
     ) -> ChildOutcome:
         server = self._build_server(context)
-        ctx = multiprocessing.get_context("spawn")
-        requests: multiprocessing.Queue[dict[str, Any]] = ctx.Queue()
-        responses: multiprocessing.Queue[dict[str, Any]] = ctx.Queue()
-
         result = await run_bridged_child(
             target=child_main,
             args=(self._code_tool.code, kwargs),
             timeout_s=float(self._code_tool.timeout_seconds),
-            requests=requests,
-            responses=responses,
             server=server,
         )
         return _bridge_result_to_outcome(result)

--- a/libs/core/kiln_ai/tools/sandbox_bridge.py
+++ b/libs/core/kiln_ai/tools/sandbox_bridge.py
@@ -97,7 +97,7 @@ class NestedToolServer:
     def __init__(
         self,
         allowlist: list[ToolId],
-        project: Project,
+        project: Project | None,
         task: Task | None,
         context: ToolCallContext | None,
         recorder: Callable[[ToolCallLogEntry], None] | None = None,
@@ -394,23 +394,26 @@ async def run_bridged_child(
     target: Callable[..., None],
     args: tuple[Any, ...],
     timeout_s: float,
-    requests: multiprocessing.Queue[dict[str, Any]],
-    responses: multiprocessing.Queue[dict[str, Any]],
     server: NestedToolServer,
 ) -> BridgeResult:
     """Spawn ``target(*args, requests, responses)`` and pump its nested tool calls.
+
+    Owns the full queue lifecycle: it creates the spawn ``requests``/``responses``
+    queues (after the depth/semaphore gates) and closes them in its ``finally``, so
+    neither caller creates or owns queues and cleanup is identical for both.
 
     Dispatches ``tool_call`` / ``list_tools`` messages to *server* and returns a
     :class:`BridgeResult` on the first ``result`` message (raw msg), a timeout, or a
     crash. Enforces the nesting-depth cap (>=10 → error result, no spawn) and acquires
     the shared bounded semaphore only at depth 0 (nested runs bypass — counting them
-    deadlocks the pool). Closes *requests*/*responses* before returning.
+    deadlocks the pool).
     """
     depth = _depth.get()
     if depth >= 10:
-        _close_queues(requests, responses)
         return BridgeResult(
-            result_msg={"error": "max code tool depth exceeded — check for a cycle"}
+            result_msg={
+                "error": "maximum nested code execution depth exceeded — check for a cycle"
+            }
         )
 
     token = _depth.set(depth + 1)
@@ -421,7 +424,13 @@ async def run_bridged_child(
             cm = contextlib.nullcontext()  # type: ignore[assignment]
 
         async with cm:
-            return await _pump(target, args, timeout_s, requests, responses, server)
+            ctx = multiprocessing.get_context("spawn")
+            requests: multiprocessing.Queue[dict[str, Any]] = ctx.Queue()
+            responses: multiprocessing.Queue[dict[str, Any]] = ctx.Queue()
+            try:
+                return await _pump(target, args, timeout_s, requests, responses, server)
+            finally:
+                _close_queues(requests, responses)
     finally:
         _depth.reset(token)
 
@@ -489,7 +498,6 @@ async def _pump(
         if p.is_alive():
             p.kill()
             await loop.run_in_executor(None, p.join, 5)
-        _close_queues(requests, responses)
 
 
 def _render_params_schema(schema: dict[str, Any]) -> str:

--- a/libs/core/kiln_ai/tools/sandbox_bridge.py
+++ b/libs/core/kiln_ai/tools/sandbox_bridge.py
@@ -1,0 +1,537 @@
+"""Shared parent-side sandbox bridge.
+
+Owns everything the parent needs to drive one bridged child run: the bounded
+concurrency pool, the nesting-depth cap, the spawn+pump loop, and the nested
+tool-call server (allowlist resolution, kwarg validation, error-kind mapping,
+recording). Both :class:`~kiln_ai.tools.code_tool.PythonCodeTool` and the code-eval
+adapter build on this.
+
+Parent-side only — may import the Kiln stack (NOT stdlib-only like the child in
+``sandbox/``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import contextvars
+import json
+import logging
+import multiprocessing
+import queue
+import threading
+from dataclasses import dataclass
+from time import monotonic
+from typing import Any, Callable
+
+from kiln_ai.datamodel.json_schema import validate_schema_with_value_error
+from kiln_ai.datamodel.project import Project
+from kiln_ai.datamodel.task import Task
+from kiln_ai.datamodel.tool_id import ToolId
+from kiln_ai.sandbox.spawn import start_process_with_light_main
+from kiln_ai.tools.base_tool import ToolCallContext
+
+logger = logging.getLogger(__name__)
+
+CODE_SANDBOX_MAX_CONCURRENCY = 16
+"""Maximum concurrent top-level sandbox invocations (process-wide).
+
+Shared by code tools and code judges. Raises code tools' prior bound of 8 as a
+side effect of unifying the pool (arch §3.4)."""
+
+_depth: contextvars.ContextVar[int] = contextvars.ContextVar(
+    "_code_sandbox_depth", default=0
+)
+
+_semaphore: asyncio.Semaphore | None = None
+_semaphore_init_lock = threading.Lock()
+
+
+async def _get_semaphore() -> asyncio.Semaphore:
+    """Lazily create the semaphore inside the running event loop."""
+    global _semaphore
+    if _semaphore is None:
+        with _semaphore_init_lock:
+            if _semaphore is None:
+                _semaphore = asyncio.Semaphore(CODE_SANDBOX_MAX_CONCURRENCY)
+    sem = _semaphore
+    assert sem is not None
+    return sem
+
+
+@dataclass
+class ToolCallLogEntry:
+    tool_name: str
+    arguments: dict[str, Any]
+    output_preview: str
+    is_error: bool
+    duration_ms: int
+
+
+@dataclass
+class BridgeResult:
+    """Raw outcome of one bridged child run — no result interpretation.
+
+    Exactly one of a ``result`` message, a timeout, or a crash terminates the run.
+    ``result_msg`` carries the child's final ``result`` dict verbatim (or a synthetic
+    error dict for the depth cap); callers interpret it into their own result type.
+    """
+
+    result_msg: dict[str, Any] | None = None
+    timed_out: bool = False
+    crashed: bool = False
+    exit_code: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+    duration_ms: int = 0
+
+
+class NestedToolServer:
+    """Handles nested tool-call IPC for one bridged run.
+
+    Owns allowlist resolution and the ``serve`` dispatcher (formerly
+    ``PythonCodeTool._serve``). Parameterized on the run's allowlist, project,
+    task, calling context, and optional recorder.
+    """
+
+    def __init__(
+        self,
+        allowlist: list[ToolId],
+        project: Project,
+        task: Task | None,
+        context: ToolCallContext | None,
+        recorder: Callable[[ToolCallLogEntry], None] | None = None,
+    ):
+        self._allowlist = allowlist
+        self._project = project
+        self._task = task
+        self._context = context
+        self._recorder = recorder
+        self._name_map: dict[str, list[ToolId]] | None = None
+
+    async def serve(
+        self,
+        msg: dict[str, Any],
+        responses: multiprocessing.Queue[dict[str, Any]],
+    ) -> None:
+        call_id = msg["call_id"]
+
+        if msg["type"] == "list_tools":
+            try:
+                tools_info = await self.tools_info()
+                responses.put(
+                    {"type": "tool_result", "call_id": call_id, "ok_list": tools_info}
+                )
+            except Exception as exc:
+                responses.put(
+                    {
+                        "type": "tool_result",
+                        "call_id": call_id,
+                        "error": {
+                            "kind": "call_error",
+                            "message": str(exc),
+                            "raw": None,
+                            "available": None,
+                        },
+                    }
+                )
+            return
+
+        tool_name = msg["tool_name"]
+        arguments = msg["arguments"]
+        positional_args: list[Any] = msg.get("positional_args", [])
+        start = monotonic()
+
+        try:
+            name_map = await self.name_map()
+            available_names = sorted(name_map.keys())
+
+            tool_ids = name_map.get(tool_name)
+            if tool_ids is None:
+                err_msg = (
+                    f"Tool '{tool_name}' is not available. "
+                    f"Available tools: {available_names}."
+                )
+                responses.put(
+                    {
+                        "type": "tool_result",
+                        "call_id": call_id,
+                        "error": {
+                            "kind": "not_allowed",
+                            "message": err_msg,
+                            "raw": None,
+                            "available": available_names,
+                        },
+                    }
+                )
+                self._record(tool_name, arguments, "not allowed", True, start)
+                return
+
+            if len(tool_ids) > 1:
+                responses.put(
+                    {
+                        "type": "tool_result",
+                        "call_id": call_id,
+                        "error": {
+                            "kind": "call_error",
+                            "message": f"Ambiguous tool name '{tool_name}' — resolves to multiple allowlisted tools.",
+                            "raw": None,
+                            "available": None,
+                        },
+                    }
+                )
+                self._record(tool_name, arguments, "ambiguous", True, start)
+                return
+
+            tool_id = tool_ids[0]
+
+            from kiln_ai.tools.tool_registry import tool_from_id_and_project
+
+            tool = tool_from_id_and_project(
+                tool_id, project=self._project, task=self._task
+            )
+
+            tool_def = await tool.toolcall_definition()
+            params_schema = tool_def["function"]["parameters"]
+            params_desc = _render_params_schema(params_schema)
+
+            if positional_args:
+                err_msg = (
+                    f"Tool '{tool_name}' must be called with keyword arguments, "
+                    f"e.g. tools.{tool_name}({_example_kwargs(params_schema)}). "
+                    f"Expected parameters: {params_desc}."
+                )
+                responses.put(
+                    {
+                        "type": "tool_result",
+                        "call_id": call_id,
+                        "error": {
+                            "kind": "call_error",
+                            "message": err_msg,
+                            "raw": None,
+                            "available": None,
+                        },
+                    }
+                )
+                self._record(tool_name, arguments, err_msg, True, start)
+                return
+
+            schema_str = json.dumps(params_schema, ensure_ascii=False)
+            try:
+                validate_schema_with_value_error(
+                    arguments,
+                    schema_str,
+                    f"Invalid arguments for tool '{tool_name}'.",
+                )
+            except ValueError as exc:
+                err_msg = f"{exc} Expected parameters: {params_desc}."
+                responses.put(
+                    {
+                        "type": "tool_result",
+                        "call_id": call_id,
+                        "error": {
+                            "kind": "call_error",
+                            "message": err_msg,
+                            "raw": None,
+                            "available": None,
+                        },
+                    }
+                )
+                self._record(tool_name, arguments, err_msg, True, start)
+                return
+
+            result = await tool.run(self._context, **arguments)
+
+            if result.is_error:
+                from kiln_ai.tools.code_tool import PythonCodeTool
+
+                is_timeout = isinstance(tool, PythonCodeTool) and "timed out" in (
+                    result.output or ""
+                )
+                kind = "timeout" if is_timeout else "call_error"
+                responses.put(
+                    {
+                        "type": "tool_result",
+                        "call_id": call_id,
+                        "error": {
+                            "kind": kind,
+                            "message": result.error_message or result.output,
+                            "raw": result.output,
+                            "available": None,
+                        },
+                    }
+                )
+                self._record(tool_name, arguments, result.output, True, start)
+            else:
+                responses.put(
+                    {
+                        "type": "tool_result",
+                        "call_id": call_id,
+                        "ok": result.output,
+                    }
+                )
+                self._record(tool_name, arguments, result.output, False, start)
+
+        except asyncio.TimeoutError as exc:
+            logger.warning(
+                "Nested sandbox call timed out for '%s': %s",
+                tool_name,
+                exc,
+            )
+            responses.put(
+                {
+                    "type": "tool_result",
+                    "call_id": call_id,
+                    "error": {
+                        "kind": "timeout",
+                        "message": str(exc) or f"Tool '{tool_name}' timed out",
+                        "raw": None,
+                        "available": None,
+                    },
+                }
+            )
+            self._record(tool_name, arguments, str(exc), True, start)
+
+        except Exception as exc:
+            logger.warning(
+                "Nested sandbox call failed for '%s': %s",
+                tool_name,
+                exc,
+            )
+            responses.put(
+                {
+                    "type": "tool_result",
+                    "call_id": call_id,
+                    "error": {
+                        "kind": "call_error",
+                        "message": str(exc),
+                        "raw": None,
+                        "available": None,
+                    },
+                }
+            )
+            self._record(tool_name, arguments, str(exc), True, start)
+
+    def _record(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        output: str,
+        is_error: bool,
+        start: float,
+    ) -> None:
+        if self._recorder is None:
+            return
+        duration_ms = int((monotonic() - start) * 1000)
+        preview = output[:1024] if output else ""
+        self._recorder(
+            ToolCallLogEntry(
+                tool_name=tool_name,
+                arguments=arguments,
+                output_preview=preview,
+                is_error=is_error,
+                duration_ms=duration_ms,
+            )
+        )
+
+    async def name_map(self) -> dict[str, list[ToolId]]:
+        if self._name_map is not None:
+            return self._name_map
+
+        name_map: dict[str, list[ToolId]] = {}
+        for tool_id in self._allowlist:
+            fn_name = await self._canonical_tool_name(tool_id)
+            name_map.setdefault(fn_name, []).append(tool_id)
+
+        self._name_map = name_map
+        return name_map
+
+    async def _canonical_tool_name(self, tool_id: str) -> str:
+        """Return the canonical function name for *tool_id*.
+
+        This is the SINGLE source of truth for the dispatch name used by
+        both ``name_map()`` and ``tools_info()`` / ``list_tools()``.
+        It resolves every tool kind via the same path the child sees,
+        guaranteeing the name the user calls matches the name in the map.
+        """
+        from kiln_ai.tools.tool_registry import tool_from_id_and_project
+
+        tool = tool_from_id_and_project(tool_id, project=self._project, task=self._task)
+        return await tool.name()
+
+    async def tools_info(self) -> list[dict[str, Any]]:
+        """Return tool definitions for ``list_tools()``."""
+        result: list[dict[str, Any]] = []
+        for tool_id in self._allowlist:
+            try:
+                from kiln_ai.tools.tool_registry import tool_from_id_and_project
+
+                tool = tool_from_id_and_project(
+                    tool_id, project=self._project, task=self._task
+                )
+                tool_def = await tool.toolcall_definition()
+                result.append(
+                    {
+                        "name": tool_def["function"]["name"],
+                        "description": tool_def["function"]["description"],
+                        "parameters_schema": tool_def["function"]["parameters"],
+                    }
+                )
+            except Exception:
+                fn_name = await self._canonical_tool_name(tool_id)
+                result.append(
+                    {
+                        "name": fn_name,
+                        "description": "(unavailable)",
+                        "parameters_schema": {},
+                    }
+                )
+        return result
+
+
+async def run_bridged_child(
+    *,
+    target: Callable[..., None],
+    args: tuple[Any, ...],
+    timeout_s: float,
+    requests: multiprocessing.Queue[dict[str, Any]],
+    responses: multiprocessing.Queue[dict[str, Any]],
+    server: NestedToolServer,
+) -> BridgeResult:
+    """Spawn ``target(*args, requests, responses)`` and pump its nested tool calls.
+
+    Dispatches ``tool_call`` / ``list_tools`` messages to *server* and returns a
+    :class:`BridgeResult` on the first ``result`` message (raw msg), a timeout, or a
+    crash. Enforces the nesting-depth cap (>=10 → error result, no spawn) and acquires
+    the shared bounded semaphore only at depth 0 (nested runs bypass — counting them
+    deadlocks the pool). Closes *requests*/*responses* before returning.
+    """
+    depth = _depth.get()
+    if depth >= 10:
+        _close_queues(requests, responses)
+        return BridgeResult(
+            result_msg={"error": "max code tool depth exceeded — check for a cycle"}
+        )
+
+    token = _depth.set(depth + 1)
+    try:
+        if depth == 0:
+            cm = await _get_semaphore()
+        else:
+            cm = contextlib.nullcontext()  # type: ignore[assignment]
+
+        async with cm:
+            return await _pump(target, args, timeout_s, requests, responses, server)
+    finally:
+        _depth.reset(token)
+
+
+async def _pump(
+    target: Callable[..., None],
+    args: tuple[Any, ...],
+    timeout_s: float,
+    requests: multiprocessing.Queue[dict[str, Any]],
+    responses: multiprocessing.Queue[dict[str, Any]],
+    server: NestedToolServer,
+) -> BridgeResult:
+    loop = asyncio.get_running_loop()
+    ctx = multiprocessing.get_context("spawn")
+
+    p = ctx.Process(
+        target=target,
+        args=(*args, requests, responses),
+        daemon=True,
+    )
+
+    await loop.run_in_executor(None, start_process_with_light_main, p)
+
+    deadline = monotonic() + timeout_s
+    pending_tasks: set[asyncio.Task[None]] = set()
+    start_time = monotonic()
+
+    try:
+        while True:
+            msg = await loop.run_in_executor(None, _poll_get, requests)
+
+            if monotonic() > deadline:
+                elapsed = int((monotonic() - start_time) * 1000)
+                p.kill()
+                await loop.run_in_executor(None, p.join, 5)
+                return BridgeResult(timed_out=True, duration_ms=elapsed)
+
+            if msg is None:
+                if not p.is_alive() and requests.empty():
+                    elapsed = int((monotonic() - start_time) * 1000)
+                    return BridgeResult(
+                        crashed=True,
+                        exit_code=p.exitcode,
+                        duration_ms=elapsed,
+                    )
+                continue
+
+            if msg["type"] in ("tool_call", "list_tools"):
+                t = asyncio.create_task(server.serve(msg, responses))
+                pending_tasks.add(t)
+                t.add_done_callback(pending_tasks.discard)
+
+            elif msg["type"] == "result":
+                elapsed = int((monotonic() - start_time) * 1000)
+                await loop.run_in_executor(None, p.join, 5)
+                return BridgeResult(
+                    result_msg=msg,
+                    stdout=msg.get("stdout", ""),
+                    stderr=msg.get("stderr", ""),
+                    duration_ms=elapsed,
+                )
+    finally:
+        for t in pending_tasks:
+            t.cancel()
+        if p.is_alive():
+            p.kill()
+            await loop.run_in_executor(None, p.join, 5)
+        _close_queues(requests, responses)
+
+
+def _render_params_schema(schema: dict[str, Any]) -> str:
+    """Render a JSON schema's properties into a readable parameter list.
+
+    Example output: ``a: number (required), b: number (required)``
+    """
+    props = schema.get("properties", {})
+    required = set(schema.get("required", []))
+    if not props:
+        return "(no parameters)"
+    parts: list[str] = []
+    for name, prop in props.items():
+        ptype = prop.get("type", "any")
+        req = "required" if name in required else "optional"
+        parts.append(f"{name}: {ptype} ({req})")
+    return ", ".join(parts)
+
+
+def _example_kwargs(schema: dict[str, Any]) -> str:
+    """Render example keyword-argument syntax from a schema.
+
+    Example output: ``a=..., b=...``
+    """
+    props = schema.get("properties", {})
+    if not props:
+        return ""
+    return ", ".join(f"{name}=..." for name in props)
+
+
+def _poll_get(q: multiprocessing.Queue) -> dict[str, Any] | None:  # type: ignore[type-arg]
+    """Non-blocking get with short timeout so the pump can re-check deadlines."""
+    try:
+        return q.get(timeout=0.1)
+    except (queue.Empty, EOFError, OSError, ValueError):
+        return None
+
+
+def _close_queues(*queues: multiprocessing.Queue) -> None:  # type: ignore[type-arg]
+    for q in queues:
+        try:
+            q.close()
+            q.join_thread()
+        except Exception:
+            pass

--- a/libs/core/kiln_ai/tools/test_base_tools.py
+++ b/libs/core/kiln_ai/tools/test_base_tools.py
@@ -3,6 +3,7 @@ import pytest
 from kiln_ai.tools.base_tool import (
     KilnTool,
     KilnToolInterface,
+    ToolCallContext,
     ToolCallResult,
     UnmanagedKilnTool,
 )
@@ -15,6 +16,22 @@ class TestKilnToolInterface:
         """Test that KilnToolInterface cannot be instantiated directly."""
         with pytest.raises(TypeError):
             KilnToolInterface()  # type: ignore
+
+
+class TestToolCallContext:
+    """Tests for the ToolCallContext dataclass defaults."""
+
+    def test_defaults(self):
+        context = ToolCallContext()
+        assert context.allow_saving is True
+        assert context.eval_output_schema is None
+
+    def test_eval_output_schema_can_be_set(self):
+        context = ToolCallContext(
+            allow_saving=False, eval_output_schema='{"type": "object"}'
+        )
+        assert context.allow_saving is False
+        assert context.eval_output_schema == '{"type": "object"}'
 
 
 class TestUnmanagedKilnTool:

--- a/libs/core/kiln_ai/tools/test_sandbox_bridge.py
+++ b/libs/core/kiln_ai/tools/test_sandbox_bridge.py
@@ -291,13 +291,10 @@ def _empty_server(tmp_path) -> NestedToolServer:
 class TestRunBridgedChild:
     @pytest.mark.asyncio
     async def test_result_message_returned_raw(self, tmp_path):
-        requests, responses = _spawn_queues()
         result = await run_bridged_child(
             target=child_main,
             args=('def run(x):\n    return "hi " + x\n', {"x": "there"}),
             timeout_s=10,
-            requests=requests,
-            responses=responses,
             server=_empty_server(tmp_path),
         )
         assert result.timed_out is False
@@ -307,13 +304,10 @@ class TestRunBridgedChild:
 
     @pytest.mark.asyncio
     async def test_crash_reports_exit_code(self, tmp_path):
-        requests, responses = _spawn_queues()
         result = await run_bridged_child(
             target=child_main,
             args=("import os\ndef run(x):\n    os._exit(4)\n", {"x": "a"}),
             timeout_s=10,
-            requests=requests,
-            responses=responses,
             server=_empty_server(tmp_path),
         )
         assert result.crashed is True
@@ -322,13 +316,10 @@ class TestRunBridgedChild:
 
     @pytest.mark.asyncio
     async def test_timeout_kills_child(self, tmp_path):
-        requests, responses = _spawn_queues()
         result = await run_bridged_child(
             target=child_main,
             args=("import time\ndef run(x):\n    time.sleep(30)\n", {"x": "a"}),
             timeout_s=0.3,
-            requests=requests,
-            responses=responses,
             server=_empty_server(tmp_path),
         )
         assert result.timed_out is True
@@ -336,21 +327,18 @@ class TestRunBridgedChild:
 
     @pytest.mark.asyncio
     async def test_depth_cap_returns_error_without_spawn(self, tmp_path):
-        requests, responses = _spawn_queues()
         token = _depth.set(10)
         try:
             result = await run_bridged_child(
                 target=child_main,
                 args=('def run(x):\n    return "should not run"\n', {"x": "a"}),
                 timeout_s=10,
-                requests=requests,
-                responses=responses,
                 server=_empty_server(tmp_path),
             )
         finally:
             _depth.reset(token)
         assert result.result_msg == {
-            "error": "max code tool depth exceeded — check for a cycle"
+            "error": "maximum nested code execution depth exceeded — check for a cycle"
         }
         assert result.timed_out is False
         assert result.crashed is False

--- a/libs/core/kiln_ai/tools/test_sandbox_bridge.py
+++ b/libs/core/kiln_ai/tools/test_sandbox_bridge.py
@@ -1,0 +1,356 @@
+"""Tests for the shared parent-side sandbox bridge.
+
+Parent-side tests (NestedToolServer, module surface) use fake tool doubles and a
+collecting responses stand-in. The ``run_bridged_child`` tests spawn real children
+via the stdlib child entry point (``sandbox.worker.child_main``), mirroring the
+existing ``test_code_tool_execution.py`` style.
+"""
+
+import multiprocessing
+from unittest.mock import patch
+
+import pytest
+
+from kiln_ai.datamodel.project import Project
+from kiln_ai.sandbox.worker import child_main
+from kiln_ai.tools.base_tool import (
+    KilnToolInterface,
+    ToolCallDefinition,
+    ToolCallResult,
+)
+from kiln_ai.tools.sandbox_bridge import (
+    CODE_SANDBOX_MAX_CONCURRENCY,
+    BridgeResult,
+    NestedToolServer,
+    ToolCallLogEntry,
+    _close_queues,
+    _depth,
+    _example_kwargs,
+    _poll_get,
+    _render_params_schema,
+    run_bridged_child,
+)
+
+REGISTRY_PATH = "kiln_ai.tools.tool_registry.tool_from_id_and_project"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeTool(KilnToolInterface):
+    """Minimal tool double. ``fn_name`` intentionally differs from the tool_id slug."""
+
+    def __init__(
+        self,
+        tool_id: str,
+        fn_name: str,
+        fn_desc: str = "fake",
+        params: dict | None = None,
+        result: ToolCallResult | None = None,
+    ):
+        self._id = tool_id
+        self._name = fn_name
+        self._desc = fn_desc
+        self._params = params or {"type": "object", "properties": {}}
+        self._result = result or ToolCallResult(output="ok")
+
+    async def id(self):
+        return self._id
+
+    async def name(self):
+        return self._name
+
+    async def description(self):
+        return self._desc
+
+    async def toolcall_definition(self) -> ToolCallDefinition:
+        return {
+            "type": "function",
+            "function": {
+                "name": self._name,
+                "description": self._desc,
+                "parameters": self._params,
+            },
+        }
+
+    async def run(self, context=None, **kwargs) -> ToolCallResult:
+        return self._result
+
+
+class _CollectingResponses:
+    """Stand-in for the responses queue — records ``put`` payloads."""
+
+    def __init__(self):
+        self.messages: list[dict] = []
+
+    def put(self, msg: dict) -> None:
+        self.messages.append(msg)
+
+
+def _make_project(tmp_path) -> Project:
+    p = Project(name="test_project", path=tmp_path / "project")
+    p.save_to_file()
+    return p
+
+
+def _spawn_queues():
+    ctx = multiprocessing.get_context("spawn")
+    return ctx.Queue(), ctx.Queue()
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_shared_concurrency_bound_is_16():
+    assert CODE_SANDBOX_MAX_CONCURRENCY == 16
+
+
+def test_bridge_result_defaults():
+    r = BridgeResult()
+    assert r.result_msg is None
+    assert r.timed_out is False
+    assert r.crashed is False
+    assert r.exit_code is None
+    assert r.stdout == ""
+    assert r.stderr == ""
+    assert r.duration_ms == 0
+
+
+def test_render_params_schema():
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "number"}, "b": {"type": "string"}},
+        "required": ["a"],
+    }
+    rendered = _render_params_schema(schema)
+    assert "a: number (required)" in rendered
+    assert "b: string (optional)" in rendered
+
+
+def test_render_params_schema_empty():
+    assert _render_params_schema({"type": "object", "properties": {}}) == (
+        "(no parameters)"
+    )
+
+
+def test_example_kwargs():
+    schema = {"type": "object", "properties": {"a": {}, "b": {}}}
+    assert _example_kwargs(schema) == "a=..., b=..."
+
+
+def test_poll_get_empty_returns_none():
+    requests, responses = _spawn_queues()
+    try:
+        assert _poll_get(requests) is None
+    finally:
+        _close_queues(requests, responses)
+
+
+def test_close_queues_is_idempotent_and_safe():
+    requests, responses = _spawn_queues()
+    _close_queues(requests, responses)
+    # Second close (already closed) must not raise.
+    _close_queues(requests, responses)
+
+
+# ---------------------------------------------------------------------------
+# NestedToolServer
+# ---------------------------------------------------------------------------
+
+
+class TestNestedToolServer:
+    @pytest.mark.asyncio
+    async def test_name_map_uses_tool_name_not_slug(self, tmp_path):
+        project = _make_project(tmp_path)
+        fake = _FakeTool("kiln_tool::add_numbers", "fake_add")
+        server = NestedToolServer(
+            allowlist=["kiln_tool::add_numbers"],
+            project=project,
+            task=None,
+            context=None,
+        )
+        with patch(REGISTRY_PATH, return_value=fake):
+            name_map = await server.name_map()
+        assert name_map == {"fake_add": ["kiln_tool::add_numbers"]}
+
+    @pytest.mark.asyncio
+    async def test_tools_info(self, tmp_path):
+        project = _make_project(tmp_path)
+        params = {"type": "object", "properties": {"a": {"type": "number"}}}
+        fake = _FakeTool(
+            "kiln_tool::add_numbers", "fake_add", fn_desc="adds", params=params
+        )
+        server = NestedToolServer(
+            allowlist=["kiln_tool::add_numbers"],
+            project=project,
+            task=None,
+            context=None,
+        )
+        with patch(REGISTRY_PATH, return_value=fake):
+            info = await server.tools_info()
+        assert info == [
+            {
+                "name": "fake_add",
+                "description": "adds",
+                "parameters_schema": params,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_serve_tool_call_success_and_records(self, tmp_path):
+        project = _make_project(tmp_path)
+        fake = _FakeTool(
+            "kiln_tool::add_numbers", "fake_add", result=ToolCallResult(output="42")
+        )
+        log: list[ToolCallLogEntry] = []
+        server = NestedToolServer(
+            allowlist=["kiln_tool::add_numbers"],
+            project=project,
+            task=None,
+            context=None,
+            recorder=log.append,
+        )
+        responses = _CollectingResponses()
+        msg = {
+            "type": "tool_call",
+            "call_id": 1,
+            "tool_name": "fake_add",
+            "arguments": {},
+        }
+        with patch(REGISTRY_PATH, return_value=fake):
+            await server.serve(msg, responses)
+
+        assert responses.messages == [{"type": "tool_result", "call_id": 1, "ok": "42"}]
+        assert len(log) == 1
+        assert log[0].tool_name == "fake_add"
+        assert log[0].is_error is False
+        assert log[0].output_preview == "42"
+
+    @pytest.mark.asyncio
+    async def test_serve_not_allowed_lists_available(self, tmp_path):
+        project = _make_project(tmp_path)
+        fake = _FakeTool("kiln_tool::add_numbers", "fake_add")
+        log: list[ToolCallLogEntry] = []
+        server = NestedToolServer(
+            allowlist=["kiln_tool::add_numbers"],
+            project=project,
+            task=None,
+            context=None,
+            recorder=log.append,
+        )
+        responses = _CollectingResponses()
+        msg = {
+            "type": "tool_call",
+            "call_id": 2,
+            "tool_name": "missing_tool",
+            "arguments": {},
+        }
+        with patch(REGISTRY_PATH, return_value=fake):
+            await server.serve(msg, responses)
+
+        assert len(responses.messages) == 1
+        err = responses.messages[0]["error"]
+        assert err["kind"] == "not_allowed"
+        assert err["available"] == ["fake_add"]
+        assert log[0].is_error is True
+
+    @pytest.mark.asyncio
+    async def test_serve_list_tools(self, tmp_path):
+        project = _make_project(tmp_path)
+        fake = _FakeTool("kiln_tool::add_numbers", "fake_add", fn_desc="adds")
+        server = NestedToolServer(
+            allowlist=["kiln_tool::add_numbers"],
+            project=project,
+            task=None,
+            context=None,
+        )
+        responses = _CollectingResponses()
+        with patch(REGISTRY_PATH, return_value=fake):
+            await server.serve({"type": "list_tools", "call_id": 3}, responses)
+
+        assert len(responses.messages) == 1
+        reply = responses.messages[0]
+        assert reply["call_id"] == 3
+        assert reply["ok_list"][0]["name"] == "fake_add"
+
+
+# ---------------------------------------------------------------------------
+# run_bridged_child (real spawns)
+# ---------------------------------------------------------------------------
+
+
+def _empty_server(tmp_path) -> NestedToolServer:
+    project = _make_project(tmp_path)
+    return NestedToolServer(allowlist=[], project=project, task=None, context=None)
+
+
+class TestRunBridgedChild:
+    @pytest.mark.asyncio
+    async def test_result_message_returned_raw(self, tmp_path):
+        requests, responses = _spawn_queues()
+        result = await run_bridged_child(
+            target=child_main,
+            args=('def run(x):\n    return "hi " + x\n', {"x": "there"}),
+            timeout_s=10,
+            requests=requests,
+            responses=responses,
+            server=_empty_server(tmp_path),
+        )
+        assert result.timed_out is False
+        assert result.crashed is False
+        assert result.result_msg is not None
+        assert result.result_msg["ok"] == "hi there"
+
+    @pytest.mark.asyncio
+    async def test_crash_reports_exit_code(self, tmp_path):
+        requests, responses = _spawn_queues()
+        result = await run_bridged_child(
+            target=child_main,
+            args=("import os\ndef run(x):\n    os._exit(4)\n", {"x": "a"}),
+            timeout_s=10,
+            requests=requests,
+            responses=responses,
+            server=_empty_server(tmp_path),
+        )
+        assert result.crashed is True
+        assert result.exit_code == 4
+        assert result.result_msg is None
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_child(self, tmp_path):
+        requests, responses = _spawn_queues()
+        result = await run_bridged_child(
+            target=child_main,
+            args=("import time\ndef run(x):\n    time.sleep(30)\n", {"x": "a"}),
+            timeout_s=0.3,
+            requests=requests,
+            responses=responses,
+            server=_empty_server(tmp_path),
+        )
+        assert result.timed_out is True
+        assert result.result_msg is None
+
+    @pytest.mark.asyncio
+    async def test_depth_cap_returns_error_without_spawn(self, tmp_path):
+        requests, responses = _spawn_queues()
+        token = _depth.set(10)
+        try:
+            result = await run_bridged_child(
+                target=child_main,
+                args=('def run(x):\n    return "should not run"\n', {"x": "a"}),
+                timeout_s=10,
+                requests=requests,
+                responses=responses,
+                server=_empty_server(tmp_path),
+            )
+        finally:
+            _depth.reset(token)
+        assert result.result_msg == {
+            "error": "max code tool depth exceeded — check for a cycle"
+        }
+        assert result.timed_out is False
+        assert result.crashed is False

--- a/libs/core/kiln_ai/tools/test_tool_registry.py
+++ b/libs/core/kiln_ai/tools/test_tool_registry.py
@@ -290,8 +290,17 @@ class TestToolRegistry:
                 tool_from_id(tool_id, task=mock_task)
 
     def test_all_built_in_tools_are_registered(self):
-        """Test that all KilnBuiltInToolId enum members are handled by the registry."""
+        """Test that all KilnBuiltInToolId enum members are handled by the registry.
+
+        LLM / LLM_JUDGE are declared in the enum but their tool implementations
+        land in a later phase; until then the registry raises for them.
+        """
+        not_yet_wired = {KilnBuiltInToolId.LLM, KilnBuiltInToolId.LLM_JUDGE}
         for tool_id in KilnBuiltInToolId:
+            if tool_id in not_yet_wired:
+                with pytest.raises(ValueError, match="not yet resolvable"):
+                    tool_from_id(tool_id.value)
+                continue
             # This should not raise an exception
             tool = tool_from_id(tool_id.value)
             assert tool is not None

--- a/libs/core/kiln_ai/tools/test_tool_registry.py
+++ b/libs/core/kiln_ai/tools/test_tool_registry.py
@@ -71,6 +71,39 @@ class TestToolRegistry:
         assert await tool.id() == KilnBuiltInToolId.DIVIDE_NUMBERS
         assert await tool.name() == "divide"
 
+    async def test_tool_from_id_llm(self):
+        """LLM tool ID returns an LlmTool instance."""
+        from kiln_ai.tools.built_in_tools.llm_tools import LlmTool
+
+        tool = tool_from_id(KilnBuiltInToolId.LLM)
+
+        assert isinstance(tool, LlmTool)
+        assert await tool.id() == KilnBuiltInToolId.LLM
+        assert await tool.name() == "llm"
+
+    async def test_tool_from_id_llm_judge(self):
+        """LLM_JUDGE tool ID returns an LlmJudgeTool instance."""
+        from kiln_ai.tools.built_in_tools.llm_tools import LlmJudgeTool
+
+        tool = tool_from_id(KilnBuiltInToolId.LLM_JUDGE)
+
+        assert isinstance(tool, LlmJudgeTool)
+        assert await tool.id() == KilnBuiltInToolId.LLM_JUDGE
+        assert await tool.name() == "llm_judge"
+
+    async def test_tool_from_id_and_project_llm_tools_by_string(self):
+        """Both LLM tool IDs resolve via tool_from_id_and_project with no project."""
+        from kiln_ai.tools.built_in_tools.llm_tools import LlmJudgeTool, LlmTool
+
+        assert isinstance(
+            tool_from_id_and_project("kiln_tool::llm"),
+            LlmTool,
+        )
+        assert isinstance(
+            tool_from_id_and_project("kiln_tool::llm_judge"),
+            LlmJudgeTool,
+        )
+
     async def test_tool_from_id_call_kiln_api(self):
         tool = tool_from_id(KilnBuiltInToolId.CALL_KILN_API)
 
@@ -290,17 +323,8 @@ class TestToolRegistry:
                 tool_from_id(tool_id, task=mock_task)
 
     def test_all_built_in_tools_are_registered(self):
-        """Test that all KilnBuiltInToolId enum members are handled by the registry.
-
-        LLM / LLM_JUDGE are declared in the enum but their tool implementations
-        land in a later phase; until then the registry raises for them.
-        """
-        not_yet_wired = {KilnBuiltInToolId.LLM, KilnBuiltInToolId.LLM_JUDGE}
+        """Test that all KilnBuiltInToolId enum members are handled by the registry."""
         for tool_id in KilnBuiltInToolId:
-            if tool_id in not_yet_wired:
-                with pytest.raises(ValueError, match="not yet resolvable"):
-                    tool_from_id(tool_id.value)
-                continue
             # This should not raise an exception
             tool = tool_from_id(tool_id.value)
             assert tool is not None

--- a/libs/core/kiln_ai/tools/tool_registry.py
+++ b/libs/core/kiln_ai/tools/tool_registry.py
@@ -57,10 +57,16 @@ def tool_from_id_and_project(
                         "kiln_local_api_base_url is not configured. The server must set this before starting."
                     )
                 return KilnApiCallTool(api_base_url=api_base_url)
-            case KilnBuiltInToolId.LLM | KilnBuiltInToolId.LLM_JUDGE:
-                raise ValueError(
-                    f"Tool ID {tool_id} is not yet resolvable by the tool registry."
-                )
+            case KilnBuiltInToolId.LLM:
+                # Lazy import to avoid the tools -> adapter -> tool_registry cycle.
+                from kiln_ai.tools.built_in_tools.llm_tools import LlmTool
+
+                return LlmTool()
+            case KilnBuiltInToolId.LLM_JUDGE:
+                # Lazy import to avoid the tools -> adapter -> tool_registry cycle.
+                from kiln_ai.tools.built_in_tools.llm_tools import LlmJudgeTool
+
+                return LlmJudgeTool()
             case _:
                 raise_exhaustive_enum_error(typed_tool_id)
 

--- a/libs/core/kiln_ai/tools/tool_registry.py
+++ b/libs/core/kiln_ai/tools/tool_registry.py
@@ -57,6 +57,10 @@ def tool_from_id_and_project(
                         "kiln_local_api_base_url is not configured. The server must set this before starting."
                     )
                 return KilnApiCallTool(api_base_url=api_base_url)
+            case KilnBuiltInToolId.LLM | KilnBuiltInToolId.LLM_JUDGE:
+                raise ValueError(
+                    f"Tool ID {tool_id} is not yet resolvable by the tool registry."
+                )
             case _:
                 raise_exhaustive_enum_error(typed_tool_id)
 

--- a/specs/projects/code_judge_llm_calls/architecture.md
+++ b/specs/projects/code_judge_llm_calls/architecture.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: complete
 ---
 
 # Architecture: Code Judge LLM Calls
@@ -119,7 +119,7 @@ Today the pump + nested-call server live inside `PythonCodeTool` (`_run_child`, 
 
 ```python
 # tools/sandbox_bridge.py  (parent-side; may import the Kiln stack — NOT stdlib-only)
-CODE_SANDBOX_MAX_CONCURRENCY = 8
+CODE_SANDBOX_MAX_CONCURRENCY = 16   # shared by code tools + code judges (raises code tools' prior bound of 8)
 _depth: ContextVar[int] = ContextVar("_code_sandbox_depth", default=0)
 _semaphore, _semaphore_lock = None, threading.Lock()
 
@@ -194,7 +194,7 @@ async def evaluate(self, eval_input):
 
 ### 3.4 Concurrency: delete `_code_eval_execution_lock`
 
-Today `v2_eval_code_eval.py` serializes **all** code evals through a single `asyncio.Lock`. That is removed; code evals now run through `run_bridged_child`, which acquires the shared bounded semaphore (`CODE_SANDBOX_MAX_CONCURRENCY = 8`) at depth 0 — the same pool code tools use. This is both **required** (a global lock + LLM latency would serialize every eval item behind one judge call) and a **latency win** (up to 8 concurrent code-eval sandboxes instead of 1). The `_spawn_lock` in `sandbox/spawn.py` still serializes only `p.start()` (sub-ms), shared across both paths.
+Today `v2_eval_code_eval.py` serializes **all** code evals through a single `asyncio.Lock`. That is removed; code evals now run through `run_bridged_child`, which acquires the shared bounded semaphore (`CODE_SANDBOX_MAX_CONCURRENCY = 16`) at depth 0 — the same pool code tools use. This is both **required** (a global lock + LLM latency would serialize every eval item behind one judge call) and a **latency win** (up to 16 concurrent code-eval sandboxes instead of 1). Note the shared pool raises code tools' prior bound (8 → 16) as a side effect of unifying — acceptable and intended. The `_spawn_lock` in `sandbox/spawn.py` still serializes only `p.start()` (sub-ms), shared across both paths.
 
 ## 4. UI changes (`app/web_ui`)
 

--- a/specs/projects/code_judge_llm_calls/architecture.md
+++ b/specs/projects/code_judge_llm_calls/architecture.md
@@ -1,0 +1,239 @@
+---
+status: draft
+---
+
+# Architecture: Code Judge LLM Calls
+
+Single-doc architecture — the one novel component (the sandbox bridge) already has a full component design in [`code_tools/components/execution_engine.md`](../code_tools/components/execution_engine.md); this project reuses it and documents only the deltas. Read that doc for bridge internals (queues, dispatcher, IPC protocol, spawn helper).
+
+## 0. Shape of the change
+
+Everything hangs off one move: **give the code-eval sandbox the code-tool bridge**, then ship the LLM capability as two built-in tools.
+
+```
+score() in sandbox child ──(requests queue: tool_call)──▶ parent pump ──▶ LlmTool/LlmJudgeTool.run() ──▶ adapter_for_task ──▶ model
+        ▲                                                                                                                    │
+        └──────────────────────(responses queue: tool_result = str)──────────────────────────────────────────────────────┘
+```
+
+The child stays stdlib-only; the model call happens entirely parent-side.
+
+## 1. Data model changes (all additive, zero migration)
+
+### 1.1 `CodeEvalProperties` (`datamodel/eval.py`)
+
+```python
+class CodeEvalProperties(BaseModel):
+    type: Literal[V2EvalType.code_eval] = V2EvalType.code_eval
+    code: str
+    reference_keys: list[str] = []
+    timeout_seconds: int = Field(default=180, ge=1, le=300)   # was default=30
+    tool_allowlist: list[ToolId] = Field(default_factory=list) # NEW
+```
+
+- `timeout_seconds` default **30 → 180** (bounds the whole invocation incl. nested LLM calls; max stays 300).
+- `tool_allowlist` mirrors `CodeTool.tool_allowlist`, including a `validate_allowlist` model-validator copied from `CodeTool`: reject `SKILL_TOOL_ID_PREFIX` and `KILN_UNMANAGED_TOOL_ID_PREFIX`, reject duplicates. (No self-reference check — a code eval is not itself a tool.)
+- Existing `validate_code` is unchanged (still requires a module-level `score`).
+
+### 1.2 `KilnBuiltInToolId` (`datamodel/tool_id.py`)
+
+```python
+LLM = "kiln_tool::llm"
+LLM_JUDGE = "kiln_tool::llm_judge"
+```
+
+Both validate through the existing built-in branch of `_check_tool_id` (membership check) with no new parsing.
+
+### 1.3 `ToolCallContext` (`tools/base_tool.py`)
+
+```python
+@dataclass
+class ToolCallContext:
+    allow_saving: bool = True
+    eval_output_schema: str | None = None   # NEW — judge score schema (allow_float_scores=False), JSON string
+```
+
+Additive, defaulted. Set only by the code-eval pump; every other caller and tool ignores it. This is the seam that lets `llm_judge` resolve through the generic `tool_from_id` path yet still see the eval's schema at call time.
+
+## 2. The two built-in tools (`tools/built_in_tools/llm_tools.py`, new)
+
+Both subclass `KilnTool` (same pattern as `math_tools.py`): fixed `parameters_schema`, `async run(context, **kwargs) -> ToolCallResult(output=str)`. Both call a shared parent-side helper.
+
+### 2.1 Shared helper — `run_llm_call(...)`
+
+Extracted from `LlmJudgeEval.evaluate` (the non-g-eval path), lives in `tools/built_in_tools/llm_tools.py` (or `adapters/eval/eval_utils/` if we want eval + tools to share it — see §7):
+
+```python
+async def run_llm_call(
+    *, model: str, provider: str, system_prompt: str | None,
+    rendered_prompt: str, output_json_schema: str | None,
+) -> RunOutput:
+    # validate provider in ModelProviderName -> ValueError
+    # build ephemeral _LlmJudgeTask-style Task(instruction=system_prompt, output_json_schema=output_json_schema)
+    # structured_output_mode = default_structured_output_mode_for_model_provider(..., disallow function_calling)
+    # adapter = adapter_for_task(task, KilnAgentRunConfigProperties(model, provider, SIMPLE, mode),
+    #                            AdapterConfig(allow_saving=False, top_logprobs=None))
+    # _, run_output = await adapter.invoke_returning_run_output(rendered_prompt)
+    # return run_output
+```
+
+Reuses the exact machinery `LlmJudgeEval` already uses; `output_json_schema=None` → free-text run (`run_output.output` is `str`); non-None → structured (`run_output.output` is `dict`). No g-eval, no logprobs.
+
+### 2.2 `LlmTool` (`kiln_tool::llm`, name `"llm"`)
+
+`parameters_schema`:
+
+```json
+{"type":"object","properties":{
+  "prompt":{"type":"string"},"model":{"type":"string"},"provider":{"type":"string"},
+  "input":{"type":"object"},"schema":{"type":"object"},"system_prompt":{"type":"string"}},
+ "required":["prompt","model","provider"],"additionalProperties":false}
+```
+
+`run(context, **kw)`:
+1. `rendered = render_prompt(kw["prompt"], kw.get("input") or {})` — `_template_env.from_string(...).render(**input)`; Jinja errors → raise (mapped to `ToolCallError` by the bridge).
+2. `schema = kw.get("schema")`; if present, `validate_schema_dict(schema, require_object=True)` → ValueError on malformed. `output_json_schema = json.dumps(schema) if schema else None`.
+3. `run_output = await run_llm_call(model=..., provider=..., system_prompt=kw.get("system_prompt"), rendered_prompt=rendered, output_json_schema=output_json_schema)`.
+4. Return `ToolCallResult(output = run_output.output if isinstance(str) else json.dumps(run_output.output))`.
+
+### 2.3 `LlmJudgeTool` (`kiln_tool::llm_judge`, name `"llm_judge"`)
+
+Same `parameters_schema` **without `schema`**.
+
+`run(context, **kw)`:
+1. `if context is None or context.eval_output_schema is None:` → raise `ValueError("llm_judge is only available inside a code judge; use 'llm' with an explicit schema elsewhere.")` (bridge maps to `ToolCallError`).
+2. Render prompt (as above).
+3. `run_output = await run_llm_call(..., output_json_schema=context.eval_output_schema)` — the eval's **allow_float_scores=False** schema.
+4. `scores = build_llm_as_judge_score(run_output, score_from_token_string)` — identical mapping to the stock judge.
+5. Return `ToolCallResult(output = json.dumps(scores))`.
+
+### 2.4 Registry (`tools/tool_registry.py`)
+
+Two new `match` arms returning `LlmTool()` / `LlmJudgeTool()` (no project/task/config needed — everything arrives via kwargs and context).
+
+## 3. Bridge integration (the core work)
+
+### 3.1 Extract a shared parent pump — `tools/sandbox_bridge.py` (new, parent-side)
+
+Today the pump + nested-call server live inside `PythonCodeTool` (`_run_child`, `_serve`, `_build_name_map`, `_get_tools_info`, `_poll_get`, `_close_queues`) and the concurrency primitives are module-level (`_code_tool_depth`, `_get_semaphore`, `CODE_TOOL_MAX_CONCURRENCY`). Extract them into a reusable unit so both `PythonCodeTool` and `CodeEvalAdapter` share one implementation.
+
+```python
+# tools/sandbox_bridge.py  (parent-side; may import the Kiln stack — NOT stdlib-only)
+CODE_SANDBOX_MAX_CONCURRENCY = 8
+_depth: ContextVar[int] = ContextVar("_code_sandbox_depth", default=0)
+_semaphore, _semaphore_lock = None, threading.Lock()
+
+@dataclass
+class BridgeResult:
+    result_msg: dict | None; timed_out: bool; crashed: bool; exit_code: int|None
+    stdout: str; stderr: str; duration_ms: int
+
+class NestedToolServer:
+    """Owns allowlist resolution + _serve for one bridged run."""
+    def __init__(self, allowlist: list[ToolId], project: Project, task: Task | None,
+                 context: ToolCallContext | None, recorder=None): ...
+    async def serve(self, msg: dict, responses: Queue) -> None:   # == today's _serve, verbatim logic
+    async def name_map(self) -> dict[str, list[ToolId]]: ...
+    async def tools_info(self) -> list[dict]: ...
+
+async def run_bridged_child(*, target, args, timeout_s: float,
+                            requests: Queue, responses: Queue,
+                            server: NestedToolServer) -> BridgeResult:
+    """Spawn target(*args, requests, responses); pump requests; serve tool_call/list_tools
+    via server; return on the first 'result' message (raw msg), timeout, or crash.
+    Depth cap (>=10 -> error), semaphore acquired only at depth 0. Verbatim port of
+    PythonCodeTool._run_child, minus result interpretation."""
+```
+
+`PythonCodeTool` becomes a thin caller: builds a `NestedToolServer` (its allowlist, project, task, `ToolCallContext(allow_saving=...)`, recorder), calls `run_bridged_child(target=child_main, args=(code, kwargs))`, then maps `BridgeResult.result_msg` → `ChildOutcome` → `ToolCallResult` exactly as today. **No behavioral change to code tools** — this is a pure refactor guarded by the existing `sandbox/test_code_tool_execution.py` suite.
+
+### 3.2 Code-eval child worker → two queues (`adapters/eval/sandbox_worker.py`)
+
+Convert `run_scorer`'s child from one result queue to the bridge protocol:
+
+```python
+def execute_scorer_bridged(code, inputs, requests: Queue, responses: Queue) -> None:
+    # redirect stdout/stderr (existing)
+    install_tools_modules(requests, responses)      # <-- REUSED from sandbox/tools_api.py
+    namespace = {}; exec(compile(code, "<code_eval>", "exec"), namespace)
+    score_fn = namespace.get("score")               # existing checks: defined/callable/accepts output|trace
+    call_kwargs = {declared params from output/trace/reference_data/task_input}   # existing logic
+    result = call_entrypoint(score_fn, call_kwargs) # existing (sync/async)
+    requests.put({"type":"result","ok":result,"stdout":...,"stderr":...})   # ok = scores DICT (not serialized)
+    # exceptions -> requests.put({"type":"result","error":...,"traceback":...,...})
+```
+
+Key differences from the code-tool child (`sandbox/worker.py`): entry point `score` (not `run`), the param-injection signature logic, and `ok` carries the **scores dict** verbatim (a code eval returns a dict, not a passthrough string — no `_serialize_result`). Everything else (bridge install, stdout capture, traceback trim) mirrors the code-tool child. The old single-queue `run_scorer` is removed; its callers move to the pump.
+
+### 3.3 `CodeEvalAdapter.evaluate` hosts the pump (`adapters/eval/v2_eval_code_eval.py`)
+
+```python
+async def evaluate(self, eval_input):
+    # trust gate unchanged (skip if project untrusted)
+    inputs = {output, trace, reference_data, task_input}   # existing
+    server = NestedToolServer(
+        allowlist=props.tool_allowlist, project=project, task=self.target_task,
+        context=ToolCallContext(allow_saving=False,
+                                eval_output_schema=BaseEval.build_score_schema(self.eval, allow_float_scores=False)),
+        recorder=None,
+    )
+    ctx = multiprocessing.get_context("spawn"); requests, responses = ctx.Queue(), ctx.Queue()
+    res = await run_bridged_child(target=execute_scorer_bridged, args=(props.code, inputs),
+                                  timeout_s=float(props.timeout_seconds),
+                                  requests=requests, responses=responses, server=server)
+    if res.timed_out: raise RuntimeError(f"Code eval scorer timed out after {props.timeout_seconds}s")
+    if res.crashed:   raise RuntimeError(f"Scorer crashed (exit code {res.exit_code})")
+    msg = res.result_msg
+    if "error" in msg: raise RuntimeError(f"Code eval scorer failed: {msg['error']}\n{msg.get('traceback','')}")
+    raw = msg["ok"]                                   # scores dict
+    if not isinstance(raw, dict): raise RuntimeError(...)
+    return V2EvalResult(scores=self._validate_scores(raw))
+```
+
+`_validate_scores` (key-set match, bool/int→float coercion) is unchanged.
+
+### 3.4 Concurrency: delete `_code_eval_execution_lock`
+
+Today `v2_eval_code_eval.py` serializes **all** code evals through a single `asyncio.Lock`. That is removed; code evals now run through `run_bridged_child`, which acquires the shared bounded semaphore (`CODE_SANDBOX_MAX_CONCURRENCY = 8`) at depth 0 — the same pool code tools use. This is both **required** (a global lock + LLM latency would serialize every eval item behind one judge call) and a **latency win** (up to 8 concurrent code-eval sandboxes instead of 1). The `_spawn_lock` in `sandbox/spawn.py` still serializes only `p.start()` (sub-ms), shared across both paths.
+
+## 4. UI changes (`app/web_ui`)
+
+- **Allowlist picker** in `components/eval_types/code_eval_form.svelte`: add the same tool-picker used by the code-tool create/edit page, bound to `properties.tool_allowlist`. Reuse the component wholesale.
+- **Inject the two built-ins into the picker catalog** so `llm` and `llm_judge` are selectable. `llm_judge` is offered only in the code-eval picker context (it errors off-context); `llm` may appear generally.
+- **Editor examples** in `components/eval_types/code_eval_helpers.ts`: add one or two `generate_examples` entries showing `tools.llm_judge(...)` and the cheap-triage pattern. These strings are mirrored byte-for-byte and executed by `test_code_eval_samples.py` — update that fixture in lockstep (see §6).
+- Regenerate the OpenAPI client (`generate_schema.sh`) for the new `tool_allowlist` field.
+
+## 5. Error handling
+
+All nested-call errors already funnel through the bridge's typed mapping (`ToolNotAllowed`/`ToolTimeout`/`ToolCallError`) raised in the author's frame, per `sandbox/tools_api.py`. New surfaces map as:
+
+| Failure | Where | Result |
+|---|---|---|
+| bad provider / unknown model | `run_llm_call` → ValueError | `ToolCallError` in author frame |
+| malformed `schema` (llm) | `validate_schema_dict` → ValueError | `ToolCallError` |
+| Jinja render error | `render_prompt` → UndefinedError/JinjaExtractionError | `ToolCallError` naming the missing key |
+| structured-output parse fail | adapter / `build_llm_as_judge_score` → ValueError | `ToolCallError` ("LLM failed to follow the schema") |
+| provider network/auth/rate error | adapter raises | `ToolCallError` (or `ToolTimeout`) with underlying message |
+| `llm_judge` off-context | `run()` ValueError | `ToolCallError` (clear guidance message) |
+| whole-judge over `timeout_seconds` | pump deadline | code-eval raises RuntimeError (skips/fails the item as today) |
+
+`_serve` already wraps its body in try/except → `call_error`, so a raising tool never hangs the child. Authors may `try/except` these in `score()` to return a degraded score.
+
+## 6. Testing strategy
+
+- **Datamodel** (`test_phase4_data_model.py` peers): `tool_allowlist` validation (skill/unmanaged/dupe rejection), new timeout default, `KilnBuiltInToolId` round-trips, `ToolCallContext` default.
+- **Built-in tools** (new `test_llm_tools.py`, fake adapter double): `llm` text vs schema→JSON-string; `llm_judge` maps pass/fail/critical/1-5 → float and returns JSON scores; off-context error; provider/model/schema/render errors; parity — `llm_judge` output equals a stock `LlmJudgeEval` run for the same schema+prompt.
+- **Bridge refactor** (existing `sandbox/test_code_tool_execution.py`): must stay green unchanged — proves the extraction is behavior-preserving for code tools. Add an identity assertion that code tools and code evals share one `_spawn_lock` and one semaphore.
+- **Code-eval bridge** (real spawns, `test_v2_eval_code_eval.py` / `test_sandbox_worker.py` style): `score()` calls `tools.llm_judge` / `tools.llm` (fake tool double routed through `_serve`), sync and `async def score` with `asyncio.gather`; allowlist enforcement (`ToolNotAllowed`); timeout kills a child mid-LLM-call; concurrency — N code evals run in parallel (regression against the deleted global lock); trust-refusal short-circuits before spawn.
+- **Samples** (`test_code_eval_samples.py`): mirror the new `code_eval_helpers.ts` example strings and execute them through the real sandbox with a stubbed judge tool.
+- **UI** (`code_eval_form.test.ts`): allowlist picker binds; `llm`/`llm_judge` selectable; example snippets present.
+
+## 7. Open decisions (small)
+
+1. **Home of `run_llm_call`.** Either `tools/built_in_tools/llm_tools.py` or a shared `adapters/eval/eval_utils/` module so `LlmJudgeEval` can also adopt it. Leaning: put it beside the tools, and optionally refactor `LlmJudgeEval`'s non-g-eval path onto it in a later cleanup (not required for v1).
+2. **Cost/usage surfacing.** v1: nested calls flow through the existing recorder (name/args/duration/error). Surfacing token cost + the judge's intermediate output per code-eval item is deferred; `run_output.intermediate_outputs` is available if we later want it.
+3. **`llm` general availability.** v1 exposes both tools in the code-eval picker; whether `llm` also lands in the general agent add-tools UI is a one-line catalog change deferred to a follow-up.
+
+## 8. Component-design decision
+
+Single `architecture.md` (this doc). No separate `components/` files: the only deep component (the sandbox bridge) is fully specified in `code_tools/components/execution_engine.md`, and this project's novelty is integration + two small tools, all captured above.

--- a/specs/projects/code_judge_llm_calls/functional_spec.md
+++ b/specs/projects/code_judge_llm_calls/functional_spec.md
@@ -1,0 +1,203 @@
+---
+status: draft
+---
+
+# Functional Spec: Code Judge LLM Calls
+
+## 1. Goal
+
+Let a **code judge** (V2 `code_eval`) call an LLM from inside its `score()` function, so it can do cheap deterministic work in code (filter a 1M-token trace down to the few relevant messages) and then hand that small slice to a subjective LLM for judgement. Today a code judge is pure Python with no model access, so any subjective check forces a full LLM-judge over the entire verbose output.
+
+## 2. Approach — reuse the code-tool bridge
+
+A code judge runs in a **spawned, stdlib-only sandbox subprocess** (`adapters/eval/sandbox_worker.py`). It has no API keys, no model adapters, and no event loop, so it cannot call an LLM directly. Reaching an LLM means bridging out of the sandbox to the parent process, which owns the keys and the async model stack.
+
+The just-shipped **`code_tools`** project already built exactly this bridge for nested *tool* calls (`sandbox/tools_api.py` child side; `tools/code_tool.py` parent pump + `_serve`; two queues; dispatcher thread). This project **reuses that bridge** rather than building a judge-specific one:
+
+- Code judges gain the same two-queue bridge and a **`tool_allowlist`** (mirroring code tools), so `score()` code can call `from kiln import tools` / `async_tools`.
+- The LLM capability ships as **two new built-in tools** (`llm`, `llm_judge`) selectable in the existing tool picker.
+- No new IPC message type, no new synthetic module, no bespoke judge handler. `_serve` / allowlist resolution / `list_tools` / error mapping / recorder / contextvar propagation are reused verbatim.
+
+Consequence (accepted): tools always return a **string**, so structured results come back as a JSON string the author `json.loads` — consistent with the shipped code-tools contract ("results are always `str`").
+
+## 3. The two tools
+
+Both are Kiln built-in tools (`KilnToolInterface`), ids `kiln_tool::llm` and `kiln_tool::llm_judge` (new members of `KilnBuiltInToolId`), resolved through the normal `tool_from_id` path. Both execute **entirely in the parent process**.
+
+### 3.1 `llm` — general-purpose LLM call
+
+Called as `tools.llm(...)`. Parameters (JSON Schema `parameters_schema`):
+
+| Param | Type | Required | Meaning |
+|---|---|---|---|
+| `prompt` | string | yes | Jinja2 template for the user prompt. |
+| `model` | string | yes | Model name (e.g. `gpt-5.5`). |
+| `provider` | string | yes | Provider name (e.g. `openrouter`); must be a valid `ModelProviderName`. |
+| `input` | object | no | Variables for rendering `prompt` (`{{ user_messages }}`). Defaults to `{}`. |
+| `schema` | object | no | JSON Schema for structured output. **Default: none.** |
+| `system_prompt` | string | no | Overrides the default judge/eval system prompt. |
+
+Behavior & return (always a string):
+- **No `schema`** → returns the model's raw **text**.
+- **With `schema`** → returns the structured output **as a JSON string** conforming to `schema`. The author `json.loads` it.
+
+`llm` has no eval coupling — it is a generic "call a model" tool.
+
+### 3.2 `llm_judge` — judge-aware LLM call
+
+Called as `tools.llm_judge(...)`. Same parameters as `llm` **except there is no `schema` param** — the tool automatically applies the **code judge's own eval output-score schema** (`BaseEval.build_score_schema`, the same schema the stock LLM judge uses).
+
+| Param | Type | Required | Meaning |
+|---|---|---|---|
+| `prompt` | string | yes | Jinja2 template for the user prompt. |
+| `model` | string | yes | Model name. |
+| `provider` | string | yes | Provider name. |
+| `input` | object | no | Template variables. |
+| `system_prompt` | string | no | Overrides the default system prompt. |
+
+Behavior & return (always a string):
+- Runs the model with the eval's judge schema as structured output, then **maps the result to float scores exactly as the stock LLM judge does** (`pass`→1.0, `fail`→0.0, `critical`→-1.0, 1–5 stars → float; via `build_llm_as_judge_score`).
+- Returns those scores **as a JSON string** keyed by the eval's score keys — e.g. `{"consent_present": 1.0}` — so `return json.loads(tools.llm_judge(...))` is a valid `score()` return.
+
+`llm_judge` is **not** the stock judge call: the author supplies the prompt (the stock judge builds its prompt from the eval spec/template), and it deliberately **skips** stock-judge machinery — no judge-result caching, no g-eval/logprob mode, no auto-assembled prompt. It borrows only the **output schema** and the **score mapping**.
+
+Because it needs the eval's schema, `llm_judge` is only meaningful inside a code judge (see §6).
+
+### 3.3 Async mirror
+
+Both tools are available on the async proxy for parallelism: `from kiln import async_tools` then `await async_tools.llm(...)` / `await async_tools.llm_judge(...)`, usable under `asyncio.gather`. This comes for free from the existing bridge mirror; `score()` may be `def` or `async def`.
+
+## 4. Developer experience (examples)
+
+**The motivating case** — filter the trace in code, judge the small slice:
+
+```python
+from kiln import tools
+import json
+
+PROMPT = """Did the user explicitly consent to deleting the project?
+Judge only from these user messages:
+
+{{ user_messages }}
+"""
+
+def select_relevant_user_messages(trace):
+    ...  # cheap, deterministic filtering
+
+def score(trace):
+    msgs = select_relevant_user_messages(trace)
+    # llm_judge auto-uses this eval's output schema and returns mapped float scores
+    return json.loads(tools.llm_judge(
+        prompt=PROMPT,
+        input={"user_messages": msgs},
+        model="gpt-5.5",
+        provider="openrouter",
+    ))
+```
+
+**Cheap triage, then conditional deeper judge** — mixing `llm` (custom schema) and `llm_judge`:
+
+```python
+from kiln import tools
+import json
+
+TRIAGE_SCHEMA = {
+    "type": "object",
+    "properties": {"verdict": {"type": "string", "enum": ["safe", "risky"]}},
+    "required": ["verdict"],
+    "additionalProperties": False,
+}
+
+def score(trace):
+    msgs = select_relevant_user_messages(trace)
+    triage = json.loads(tools.llm(
+        prompt="Obviously safe, or worth a closer look?\n{{ msgs }}",
+        input={"msgs": msgs},
+        model="gpt-5.5-mini", provider="openrouter",
+        schema=TRIAGE_SCHEMA,
+    ))
+    if triage["verdict"] == "safe":
+        return {"consent_present": 1.0}
+    return json.loads(tools.llm_judge(
+        prompt="Carefully verify the user consented.\n{{ msgs }}",
+        input={"msgs": msgs},
+        model="gpt-5.5", provider="openrouter",   # stronger model only when needed
+    ))
+```
+
+**Parallel judges** with the async mirror:
+
+```python
+from kiln import async_tools
+import asyncio, json
+
+async def score(trace):
+    msgs = select_relevant_user_messages(trace)
+    tone, safety = await asyncio.gather(
+        async_tools.llm(prompt=TONE_P,  input={"msgs": msgs}, model="gpt-5.5", provider="openrouter", schema=TONE_SCHEMA),
+        async_tools.llm(prompt=SAFE_P, input={"msgs": msgs}, model="gpt-5.5", provider="openrouter", schema=SAFE_SCHEMA),
+    )
+    ...
+```
+
+## 5. Behavior & semantics
+
+- **Parent-side execution (hard invariant).** Both tools run in the main process. The sandbox child never receives API keys, provider config, or the Kiln stack. The child sends `{prompt, model, provider, input, schema?, system_prompt?}` over the bridge; the parent runs the model and returns a string. (Same principle as code_tools: "a code tool never holds an API key.")
+- **Prompt rendering.** `prompt` is rendered as a Jinja2 template against `input` **in the parent** (the child has no Jinja). `input` values are inserted as data, not re-rendered, so trace content in `input` cannot inject template syntax. Reuses the existing `_template_env`.
+- **Model call.** Reuses the stock LLM-judge execution core: build an ephemeral judge `Task` with the resolved `system_prompt` and (for `llm_judge` / `llm`-with-schema) the `output_json_schema`, then `adapter_for_task(...).invoke_returning_run_output(rendered_prompt)`. `llm` with no schema builds a task with no output schema (free text).
+- **Scoring (`llm_judge` only).** Maps structured output to floats via `build_llm_as_judge_score` — identical to the stock judge, guaranteeing parity between a code judge's `llm_judge` call and a plain LLM judge with the same schema.
+- **Return type.** Always `str`. Structured output (`llm` w/ schema, and `llm_judge`) is `json.dumps(...)` of the result.
+
+## 6. Selection & availability
+
+- **Allowlist.** Add `tool_allowlist: list[ToolId]` to `CodeEvalProperties` (additive, mirrors `CodeTool`). A code judge's `score()` may call any allowlisted tool over the bridge — MCP tools, RAG, other code tools, and the two new LLM tools.
+- **Picker.** `llm` and `llm_judge` are injected as selectable built-in tools in the existing tool picker used to populate the allowlist. No bespoke UI — the same schema-builder/picker experience code tools use.
+- **Trust gate.** Unchanged: bridge execution (and therefore any tool call) is gated by the existing code-eval project-trust check. A code judge in an untrusted project skips exactly as it does today.
+- **`llm_judge` context.** `llm_judge` needs the eval's score schema. It is resolved through the normal `tool_from_id` path; the eval's schema is supplied at call time via `ToolCallContext` (additive field), which the code-eval adapter's pump populates. Generic tools ignore the field. If `llm_judge` is ever invoked without eval context (e.g. selected by a non-eval agent), it returns a clear error: "`llm_judge` is only available inside a code judge; use `llm` with an explicit schema elsewhere."
+
+## 7. Errors & edge cases
+
+All surface through the existing bridge error mapping — the tool call raises a typed exception (`ToolCallError` / `ToolTimeout` / `ToolNotAllowed`) in the **author's own stack frame**, or the author reads `is_error`. Cases:
+
+- **Invalid `provider`** (not a `ModelProviderName`) or **unknown `model`** → `ToolCallError` with a clear message.
+- **Invalid `schema`** (`llm` with a malformed JSON Schema) → `ToolCallError`.
+- **Prompt render failure** (undefined Jinja var, bad template) → `ToolCallError` naming the missing key.
+- **Structured-output failure** (model returns output that doesn't satisfy the schema after retries) → `ToolCallError`.
+- **Model/provider/network error** (rate limit, auth, timeout at the provider) → `ToolCallError` (or `ToolTimeout`) with the underlying message; the author may catch and decide how to score.
+- **Nested tool timeout** — if a judge call exceeds the code judge's wall-clock `timeout_seconds`, the whole code-eval invocation times out (existing behavior); the pending call is cancelled.
+- **Tool not in allowlist** — `ToolNotAllowed` listing available tool names (existing behavior).
+- The author is responsible for their own fallback: an uncaught exception fails the code eval (existing behavior); catching lets them return a degraded score.
+
+## 8. Concurrency, timeouts, limits
+
+- **Wall clock.** The code judge's `timeout_seconds` (`CodeEvalProperties`, default 30, min 1, max 300) bounds the whole invocation including all nested LLM calls, exactly as it bounds nested tool calls for code tools. Authors making one or more LLM calls should raise it. *(Open: whether to raise the default or nudge in-UI when an LLM tool is allowlisted — §12.)*
+- **Parallelism.** The parent serves nested calls concurrently (existing pump); the async mirror lets a judge fan out calls under `asyncio.gather`.
+- **Process concurrency.** Reuses the existing top-level spawn bound and `_spawn_lock`; no new limits.
+- **Cost/scale.** An eval run executes the code judge once per eval item, so each allowlisted LLM call is billed per item × per call. This is the intended trade (small filtered prompt vs. a full-trace judge), but it is real spend and should be visible (§10).
+
+## 9. Security model
+
+- Sandbox stays stdlib-only; no secrets or Kiln stack cross the process boundary.
+- All model access is parent-side and subject to the existing trust gate.
+- The author controls prompt + model + provider + the data they pass; this is their own eval code, already trusted-to-run. No new secret storage; providers own auth (same as code_tools).
+
+## 10. Observability / cost
+
+Nested LLM calls should be attributable. Minimum: they flow through the existing tool-call recorder (name, args preview, duration, error) already wired in the pump. *(Open: whether to surface token usage / cost and the judge's intermediate output for a code judge's nested calls, and where — §12.)*
+
+## 11. Out of scope (v1)
+
+- Bespoke `from kiln import llm_judge` module / native `str | dict` returns (superseded by the tool approach).
+- g-eval / logprob-weighted scoring from code (`llm_judge` is structured-output only).
+- Stock-judge caching for author-prompt calls.
+- Exposing `llm` broadly in the agent add-tools UI beyond the code-judge/code-tool picker (can follow later; same tool).
+- Any change to the stock LLM-judge or code-eval `score()` return contract.
+- Injecting the eval schema as a `score()` parameter (`llm_judge` makes it unnecessary).
+
+## 12. Open questions (resolve in architecture)
+
+1. **Code-eval bridge integration.** Migrate the code-eval worker onto the shared `sandbox/worker.py`, or add the bridge to the eval worker by reusing `sandbox/tools_api.py` + an extracted parent pump. (Leaning: extract a shared parent pump from `code_tool.py`; keep the eval worker's `score()`-specific entry + score-dict result.)
+2. **Eval-context wiring for `llm_judge`.** Confirm `ToolCallContext` (additive field carrying the eval score schema) vs. eval-aware construction.
+3. **Timeout default/UX** when an LLM tool is allowlisted.
+4. **Cost/usage surfacing** for nested calls.
+5. **`llm_judge` picker scoping** — show it only in the code-judge picker, or everywhere with a clear error off-context.

--- a/specs/projects/code_judge_llm_calls/functional_spec.md
+++ b/specs/projects/code_judge_llm_calls/functional_spec.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: complete
 ---
 
 # Functional Spec: Code Judge LLM Calls
@@ -170,7 +170,7 @@ All surface through the existing bridge error mapping — the tool call raises a
 
 ## 8. Concurrency, timeouts, limits
 
-- **Wall clock.** The code judge's `timeout_seconds` (`CodeEvalProperties`, default 30, min 1, max 300) bounds the whole invocation including all nested LLM calls, exactly as it bounds nested tool calls for code tools. Authors making one or more LLM calls should raise it. *(Open: whether to raise the default or nudge in-UI when an LLM tool is allowlisted — §12.)*
+- **Wall clock.** The code judge's `timeout_seconds` (`CodeEvalProperties`) bounds the whole invocation including all nested LLM calls, exactly as it bounds nested tool calls for code tools. **The default is raised from 30 → 180s** (min 1, max 300) to accommodate LLM latency; authors making several calls can raise it further, up to the max.
 - **Parallelism.** The parent serves nested calls concurrently (existing pump); the async mirror lets a judge fan out calls under `asyncio.gather`.
 - **Process concurrency.** Reuses the existing top-level spawn bound and `_spawn_lock`; no new limits.
 - **Cost/scale.** An eval run executes the code judge once per eval item, so each allowlisted LLM call is billed per item × per call. This is the intended trade (small filtered prompt vs. a full-trace judge), but it is real spend and should be visible (§10).
@@ -197,7 +197,8 @@ Nested LLM calls should be attributable. Minimum: they flow through the existing
 ## 12. Open questions (resolve in architecture)
 
 1. **Code-eval bridge integration.** Migrate the code-eval worker onto the shared `sandbox/worker.py`, or add the bridge to the eval worker by reusing `sandbox/tools_api.py` + an extracted parent pump. (Leaning: extract a shared parent pump from `code_tool.py`; keep the eval worker's `score()`-specific entry + score-dict result.)
-2. **Eval-context wiring for `llm_judge`.** Confirm `ToolCallContext` (additive field carrying the eval score schema) vs. eval-aware construction.
-3. **Timeout default/UX** when an LLM tool is allowlisted.
-4. **Cost/usage surfacing** for nested calls.
-5. **`llm_judge` picker scoping** — show it only in the code-judge picker, or everywhere with a clear error off-context.
+2. **Eval-context wiring for `llm_judge`.** Confirmed: additive field on `ToolCallContext` carrying the eval score schema, populated by the code-eval pump.
+3. **Cost/usage surfacing** for nested calls.
+4. **`llm_judge` picker scoping** — show it only in the code-judge picker, or everywhere with a clear error off-context.
+
+Resolved: timeout default raised to 180s (§8); `ToolCallContext` wiring approved (§6, #2 above).

--- a/specs/projects/code_judge_llm_calls/implementation_plan.md
+++ b/specs/projects/code_judge_llm_calls/implementation_plan.md
@@ -24,7 +24,7 @@ Phased build order. Details live in `functional_spec.md` and `architecture.md` (
   - New `tools/sandbox_bridge.py`: `NestedToolServer` (`serve`/`name_map`/`tools_info`), `run_bridged_child`, shared depth/semaphore (`CODE_SANDBOX_MAX_CONCURRENCY`).
   - Refactor `PythonCodeTool` to use it — **behavior-preserving**; existing `sandbox/test_code_tool_execution.py` must stay green unchanged.
 
-- [ ] **Phase 4 — Code-eval bridge integration** (arch §3.2–3.4)
+- [x] **Phase 4 — Code-eval bridge integration** (arch §3.2–3.4)
   - `adapters/eval/sandbox_worker.py`: `execute_scorer_bridged` (two-queue, `install_tools_modules`, scores-dict result); remove single-queue `run_scorer`.
   - `CodeEvalAdapter.evaluate`: host `run_bridged_child` with the eval-schema context; delete `_code_eval_execution_lock`.
   - Tests (real spawns): `tools.llm`/`tools.llm_judge` from `score()`, sync + `async def score` w/ `gather`, allowlist enforcement, timeout mid-call, parallel code evals (regression vs deleted global lock), trust short-circuit, shared-lock/semaphore identity.

--- a/specs/projects/code_judge_llm_calls/implementation_plan.md
+++ b/specs/projects/code_judge_llm_calls/implementation_plan.md
@@ -1,0 +1,40 @@
+---
+status: draft
+---
+
+# Implementation Plan: Code Judge LLM Calls
+
+Phased build order. Details live in `functional_spec.md` and `architecture.md` (§ refs below); this is the ordered checklist.
+
+## Phases
+
+- [ ] **Phase 1 — Datamodel foundations** (arch §1)
+  - `CodeEvalProperties`: add `tool_allowlist` (+ `validate_allowlist` ported from `CodeTool`, minus self-ref), bump `timeout_seconds` default 30 → 180.
+  - `KilnBuiltInToolId`: add `LLM` / `LLM_JUDGE`.
+  - `ToolCallContext`: add `eval_output_schema: str | None = None`.
+  - Tests: allowlist validation, timeout default, tool-id round-trips, context default. Zero migration.
+
+- [ ] **Phase 2 — Built-in LLM tools + registry** (arch §2)
+  - `run_llm_call(...)` shared helper (extract from `LlmJudgeEval` non-g-eval path).
+  - `LlmTool` (`kiln_tool::llm`) and `LlmJudgeTool` (`kiln_tool::llm_judge`) in `tools/built_in_tools/llm_tools.py`; Jinja render, schema handling, `build_llm_as_judge_score` mapping, off-context error.
+  - `tool_from_id_and_project`: two new match arms.
+  - Tests (fake adapter): text vs schema→JSON-string; judge float mapping; parity with stock `LlmJudgeEval`; error surfaces.
+
+- [ ] **Phase 3 — Extract shared parent pump** (arch §3.1)
+  - New `tools/sandbox_bridge.py`: `NestedToolServer` (`serve`/`name_map`/`tools_info`), `run_bridged_child`, shared depth/semaphore (`CODE_SANDBOX_MAX_CONCURRENCY`).
+  - Refactor `PythonCodeTool` to use it — **behavior-preserving**; existing `sandbox/test_code_tool_execution.py` must stay green unchanged.
+
+- [ ] **Phase 4 — Code-eval bridge integration** (arch §3.2–3.4)
+  - `adapters/eval/sandbox_worker.py`: `execute_scorer_bridged` (two-queue, `install_tools_modules`, scores-dict result); remove single-queue `run_scorer`.
+  - `CodeEvalAdapter.evaluate`: host `run_bridged_child` with the eval-schema context; delete `_code_eval_execution_lock`.
+  - Tests (real spawns): `tools.llm`/`tools.llm_judge` from `score()`, sync + `async def score` w/ `gather`, allowlist enforcement, timeout mid-call, parallel code evals (regression vs deleted global lock), trust short-circuit, shared-lock/semaphore identity.
+
+- [ ] **Phase 5 — UI, examples & schema** (arch §4, §6)
+  - Allowlist picker in `code_eval_form.svelte` (reuse code-tool picker); inject `llm`/`llm_judge` into the catalog; scope `llm_judge` to the code-eval context.
+  - Add `tools.llm_judge` / cheap-triage examples to `code_eval_helpers.ts`; mirror them in `test_code_eval_samples.py`.
+  - Regenerate OpenAPI client; UI tests.
+
+## Notes
+
+- Phases 3 and 4 are split deliberately: 3 is a pure, test-guarded refactor of shipped code-tool behavior; 4 builds the new path on top. Review each in one sitting.
+- Deferred (not blocking v1): cost/usage surfacing, `llm` in the general agent add-tools UI, refactoring `LlmJudgeEval` onto `run_llm_call` (arch §7).

--- a/specs/projects/code_judge_llm_calls/implementation_plan.md
+++ b/specs/projects/code_judge_llm_calls/implementation_plan.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: complete
 ---
 
 # Implementation Plan: Code Judge LLM Calls

--- a/specs/projects/code_judge_llm_calls/implementation_plan.md
+++ b/specs/projects/code_judge_llm_calls/implementation_plan.md
@@ -8,7 +8,7 @@ Phased build order. Details live in `functional_spec.md` and `architecture.md` (
 
 ## Phases
 
-- [ ] **Phase 1 — Datamodel foundations** (arch §1)
+- [x] **Phase 1 — Datamodel foundations** (arch §1)
   - `CodeEvalProperties`: add `tool_allowlist` (+ `validate_allowlist` ported from `CodeTool`, minus self-ref), bump `timeout_seconds` default 30 → 180.
   - `KilnBuiltInToolId`: add `LLM` / `LLM_JUDGE`.
   - `ToolCallContext`: add `eval_output_schema: str | None = None`.

--- a/specs/projects/code_judge_llm_calls/implementation_plan.md
+++ b/specs/projects/code_judge_llm_calls/implementation_plan.md
@@ -20,7 +20,7 @@ Phased build order. Details live in `functional_spec.md` and `architecture.md` (
   - `tool_from_id_and_project`: two new match arms.
   - Tests (fake adapter): text vs schema→JSON-string; judge float mapping; parity with stock `LlmJudgeEval`; error surfaces.
 
-- [ ] **Phase 3 — Extract shared parent pump** (arch §3.1)
+- [x] **Phase 3 — Extract shared parent pump** (arch §3.1)
   - New `tools/sandbox_bridge.py`: `NestedToolServer` (`serve`/`name_map`/`tools_info`), `run_bridged_child`, shared depth/semaphore (`CODE_SANDBOX_MAX_CONCURRENCY`).
   - Refactor `PythonCodeTool` to use it — **behavior-preserving**; existing `sandbox/test_code_tool_execution.py` must stay green unchanged.
 

--- a/specs/projects/code_judge_llm_calls/implementation_plan.md
+++ b/specs/projects/code_judge_llm_calls/implementation_plan.md
@@ -14,7 +14,7 @@ Phased build order. Details live in `functional_spec.md` and `architecture.md` (
   - `ToolCallContext`: add `eval_output_schema: str | None = None`.
   - Tests: allowlist validation, timeout default, tool-id round-trips, context default. Zero migration.
 
-- [ ] **Phase 2 — Built-in LLM tools + registry** (arch §2)
+- [x] **Phase 2 — Built-in LLM tools + registry** (arch §2)
   - `run_llm_call(...)` shared helper (extract from `LlmJudgeEval` non-g-eval path).
   - `LlmTool` (`kiln_tool::llm`) and `LlmJudgeTool` (`kiln_tool::llm_judge`) in `tools/built_in_tools/llm_tools.py`; Jinja render, schema handling, `build_llm_as_judge_score` mapping, off-context error.
   - `tool_from_id_and_project`: two new match arms.

--- a/specs/projects/code_judge_llm_calls/implementation_plan.md
+++ b/specs/projects/code_judge_llm_calls/implementation_plan.md
@@ -29,7 +29,7 @@ Phased build order. Details live in `functional_spec.md` and `architecture.md` (
   - `CodeEvalAdapter.evaluate`: host `run_bridged_child` with the eval-schema context; delete `_code_eval_execution_lock`.
   - Tests (real spawns): `tools.llm`/`tools.llm_judge` from `score()`, sync + `async def score` w/ `gather`, allowlist enforcement, timeout mid-call, parallel code evals (regression vs deleted global lock), trust short-circuit, shared-lock/semaphore identity.
 
-- [ ] **Phase 5 — UI, examples & schema** (arch §4, §6)
+- [x] **Phase 5 — UI, examples & schema** (arch §4, §6)
   - Allowlist picker in `code_eval_form.svelte` (reuse code-tool picker); inject `llm`/`llm_judge` into the catalog; scope `llm_judge` to the code-eval context.
   - Add `tools.llm_judge` / cheap-triage examples to `code_eval_helpers.ts`; mirror them in `test_code_eval_samples.py`.
   - Regenerate OpenAPI client; UI tests.

--- a/specs/projects/code_judge_llm_calls/phase_plans/phase_1.md
+++ b/specs/projects/code_judge_llm_calls/phase_plans/phase_1.md
@@ -1,0 +1,55 @@
+---
+status: complete
+---
+
+# Phase 1: Datamodel foundations
+
+## Overview
+
+Additive datamodel groundwork for letting code-judge evals call LLM tools from
+their sandboxed `score()`. Zero data migration — every change is a new field,
+new enum member, or new validator. No tools, bridge, adapter, or UI here (later
+phases). See `architecture.md` §1.
+
+## Steps
+
+1. `libs/core/kiln_ai/datamodel/eval.py` — `CodeEvalProperties`:
+   - Bump `timeout_seconds` default `30 → 180` (bounds stay `ge=1, le=300`).
+   - Add `tool_allowlist: list[ToolId] = Field(default_factory=list)`.
+   - Add a `validate_allowlist` model-validator ported from `CodeTool`: reject
+     `SKILL_TOOL_ID_PREFIX`, reject `KILN_UNMANAGED_TOOL_ID_PREFIX`, reject
+     duplicates. OMIT the self-reference check (a code eval is not a tool).
+   - Import `ToolId`, `SKILL_TOOL_ID_PREFIX`, `KILN_UNMANAGED_TOOL_ID_PREFIX`
+     from `kiln_ai.datamodel.tool_id`.
+
+2. `libs/core/kiln_ai/datamodel/tool_id.py` — `KilnBuiltInToolId`: add
+   `LLM = "kiln_tool::llm"` and `LLM_JUDGE = "kiln_tool::llm_judge"`. They
+   validate through the existing built-in membership branch of `_check_tool_id`
+   with no new parsing.
+
+3. `libs/core/kiln_ai/tools/base_tool.py` — `ToolCallContext`: add
+   `eval_output_schema: str | None = None` (additive, defaulted).
+
+4. (Required side effect, not in original 3-file scope) `tool_registry.py`:
+   `tool_from_id_and_project` uses an exhaustive `match` guarded by
+   `raise_exhaustive_enum_error`. Adding enum members without arms breaks
+   `ty check` (and `test_all_built_in_tools_are_registered`). Add a single
+   not-yet-wired arm `case KilnBuiltInToolId.LLM | KilnBuiltInToolId.LLM_JUDGE:`
+   that raises `ValueError("... not yet resolvable ...")`. The real
+   `LlmTool()` / `LlmJudgeTool()` returns land in Phase 2 (arch §2.4).
+
+## Tests
+
+- `test_eval_model.py::TestCodeEvalPropertiesValidation`:
+  - timeout default is now 180.
+  - `tool_allowlist` default empty; valid allowlist accepted (incl. new
+    `kiln_tool::llm` / `kiln_tool::llm_judge`).
+  - allowlist rejects skill IDs, unmanaged IDs, duplicates, invalid IDs.
+  - allowlist ALLOWS a code-tool self-referential ID (no self-ref check).
+- `test_tool_id.py::TestKilnBuiltInToolId`: `LLM` / `LLM_JUDGE` enum values;
+  round-trip through `_check_tool_id` and the `ToolId` pydantic validator;
+  membership.
+- `test_base_tools.py::TestToolCallContext`: default `eval_output_schema is
+  None`; can be set alongside `allow_saving`.
+- `test_tool_registry.py::test_all_built_in_tools_are_registered`: updated so
+  the two not-yet-wired IDs are asserted to raise until Phase 2.

--- a/specs/projects/code_judge_llm_calls/phase_plans/phase_2.md
+++ b/specs/projects/code_judge_llm_calls/phase_plans/phase_2.md
@@ -1,0 +1,97 @@
+---
+status: complete
+---
+
+# Phase 2: Built-in LLM tools + registry
+
+## Overview
+
+Ship the two parent-side built-in tools that let a code judge (and general
+callers) make model calls from a sandboxed `score()`. This phase replaces the
+temporary Phase-1 stub arm in `tool_registry.py` with real `LlmTool()` /
+`LlmJudgeTool()` returns, and adds the shared `run_llm_call` helper extracted
+from `LlmJudgeEval.evaluate`'s non-g-eval path. No sandbox bridge, no
+code-eval adapter changes, no UI (Phases 3–5). See `architecture.md` §2.
+
+Circular-import note: `tools/` importing the adapter stack cycles
+(`base_adapter` imports `tool_registry`). So all adapter/eval imports inside
+`llm_tools.py` are function-local. `RunOutput` is imported from the standalone
+`kiln_ai.adapters.run_output` module (no cycle) for the return annotation.
+
+## Steps
+
+1. New file `libs/core/kiln_ai/tools/built_in_tools/llm_tools.py`:
+   - Module-level imports only from safe modules: `json`, jinja2 errors,
+     `base_tool` (`KilnTool`, `ToolCallContext`, `ToolCallResult`),
+     `datamodel.tool_id.KilnBuiltInToolId`,
+     `datamodel.json_schema.validate_schema_dict`,
+     `utils.jinja_engine` (`_template_env`, `JinjaExtractionError`),
+     `adapters.run_output.RunOutput`.
+   - `_DEFAULT_SYSTEM_PROMPT` — reuse the eval judge default string.
+   - `async def run_llm_call(*, model, provider, system_prompt, rendered_prompt,
+     output_json_schema) -> RunOutput`: function-local imports of
+     `adapter_for_task`, `ModelProviderName`,
+     `default_structured_output_mode_for_model_provider`, `AdapterConfig`,
+     `Project`, `Task`, `PromptGenerators`, `KilnAgentRunConfigProperties`,
+     `StructuredOutputMode`. Validate `provider` in `ModelProviderName`
+     (ValueError otherwise). Build ephemeral `Project` + `Task`
+     (`instruction=system_prompt or _DEFAULT_SYSTEM_PROMPT`,
+     `output_json_schema=output_json_schema`). Compute `structured_output_mode`
+     via `default_structured_output_mode_for_model_provider(..., default=json_schema,
+     disallowed_modes=[function_calling, function_calling_weak])`. Build adapter
+     with `KilnAgentRunConfigProperties(model_name, model_provider_name,
+     prompt_id=SIMPLE, structured_output_mode=mode)` and
+     `AdapterConfig(allow_saving=False, top_logprobs=None)`.
+     `_, run_output = await adapter.invoke_returning_run_output(rendered_prompt)`;
+     return `run_output`.
+   - `_render_prompt(prompt, input_dict)` helper: `_template_env.from_string(...)`
+     `.render(**input_dict)`; wrap jinja errors into a raised ValueError.
+   - `LlmTool(KilnTool)` — id `KilnBuiltInToolId.LLM`, name `"llm"`, params
+     schema per arch §2.2 (`additionalProperties: false`, required
+     prompt/model/provider). `run`: render prompt against `input or {}`; if
+     `schema` present, `validate_schema_dict(schema, require_object=True)` and
+     `output_json_schema = json.dumps(schema)`, else `None`;
+     `run_output = await run_llm_call(...)`; return `ToolCallResult(output =
+     run_output.output if isinstance(run_output.output, str) else
+     json.dumps(run_output.output))`.
+   - `LlmJudgeTool(KilnTool)` — id `KilnBuiltInToolId.LLM_JUDGE`, name
+     `"llm_judge"`, same params minus `schema`. `run`: guard
+     `context is None or context.eval_output_schema is None` → ValueError with
+     the guidance message; render prompt; `run_output = await run_llm_call(...,
+     output_json_schema=context.eval_output_schema)`; function-local import
+     `build_llm_as_judge_score`, `score_from_token_string`;
+     `scores = build_llm_as_judge_score(run_output, score_from_token_string)`;
+     return `ToolCallResult(output=json.dumps(scores))`.
+
+2. `libs/core/kiln_ai/tools/tool_registry.py`: replace the stub
+   `case KilnBuiltInToolId.LLM | KilnBuiltInToolId.LLM_JUDGE: raise ...` with two
+   arms returning `LlmTool()` / `LlmJudgeTool()`. Lazy (function-local) import of
+   the two classes inside the arms to keep the module import graph acyclic
+   (mirrors RAG/code-tool arms).
+
+3. `libs/core/kiln_ai/tools/test_tool_registry.py`: update
+   `test_all_built_in_tools_are_registered` so LLM/LLM_JUDGE now resolve (no
+   longer in the not-yet-wired set).
+
+## Tests
+
+New `libs/core/kiln_ai/tools/built_in_tools/test_llm_tools.py`
+(patch `kiln_ai.adapters.adapter_registry.adapter_for_task` with an AsyncMock
+double — no network):
+
+- `llm` no schema → returns free-text string verbatim.
+- `llm` with schema → returns `json.dumps(dict)`; asserts adapter built with a
+  non-None `output_json_schema` Task.
+- `llm` invalid schema (malformed) → raises.
+- `llm`/`llm_judge` invalid provider → raises ValueError.
+- `llm`/`llm_judge` Jinja render error (missing var) → raises.
+- `llm_judge` off-context (context None / eval_output_schema None) → raises the
+  guidance ValueError; adapter never called.
+- `llm_judge` maps pass/fail/critical → 1.0/0.0/-1.0 and 1–5 → floats; returns a
+  JSON scores string.
+- `llm_judge` parity: scores equal `build_llm_as_judge_score(run_output,
+  score_from_token_string)` for the same structured output.
+- Registry: `tool_from_id_and_project("kiln_tool::llm")` → `LlmTool`,
+  `..::llm_judge` → `LlmJudgeTool`; ids/names correct.
+- `run_llm_call` returns the adapter's `run_output` (str when schema None, dict
+  when set).

--- a/specs/projects/code_judge_llm_calls/phase_plans/phase_3.md
+++ b/specs/projects/code_judge_llm_calls/phase_plans/phase_3.md
@@ -1,0 +1,64 @@
+---
+status: complete
+---
+
+# Phase 3: Extract the shared parent pump
+
+## Overview
+
+Pure, behavior-preserving refactor of shipped code-tool internals (arch §3.1). Today the
+sandbox pump + nested-call server live inside `PythonCodeTool` (`code_tool.py`) and the
+concurrency primitives are module-level. Extract them into a reusable, parent-side unit
+(`tools/sandbox_bridge.py`) so Phase 4 can host the same pump for code evals. No observable
+behavior change to code tools; existing `sandbox/test_code_tool_execution.py` proves it.
+
+## Steps
+
+1. **New file `libs/core/kiln_ai/tools/sandbox_bridge.py`** (parent-side; may import the Kiln stack).
+   Extract from `code_tool.py`:
+   - `CODE_SANDBOX_MAX_CONCURRENCY = 16` — REPLACES `CODE_TOOL_MAX_CONCURRENCY = 8` (arch §3.4;
+     intentionally raises the code-tool bound 8 → 16 as the shared pool unifies).
+   - `_depth: ContextVar[int]` (was `_code_tool_depth`), `_semaphore`, `_semaphore_init_lock`,
+     `_get_semaphore()`.
+   - `ToolCallLogEntry` dataclass (moved; re-exported from `code_tool.py` for API compat).
+   - `BridgeResult` dataclass: `result_msg: dict | None`, `timed_out`, `crashed`, `exit_code`,
+     `stdout`, `stderr`, `duration_ms`.
+   - `NestedToolServer(allowlist, project, task, context, recorder=None)` with `async serve(msg, responses)`
+     (verbatim `_serve` — tool_call + list_tools), `async name_map()` (`_build_name_map`),
+     `async tools_info()` (`_get_tools_info`), plus `_canonical_tool_name` and `_record`.
+     Parameterized on the passed-in allowlist/project/task/context/recorder.
+   - `async run_bridged_child(*, target, args, timeout_s, requests, responses, server) -> BridgeResult`:
+     verbatim port of `_run_child`'s spawn+pump loop MINUS result interpretation. Owns the depth cap
+     (>=10 → error `result_msg`), the depth-0-only semaphore acquisition (moved from `_invoke`),
+     spawns `target(*args, requests, responses)` via `start_process_with_light_main`, dispatches
+     tool_call/list_tools to `server.serve(...)`, returns `BridgeResult` on first `result`, timeout,
+     or crash. Closes the queues in `finally`.
+   - Move `_poll_get`, `_close_queues`, `_render_params_schema`, `_example_kwargs`.
+   - Import cycle guard: `serve` uses a function-local `from kiln_ai.tools.code_tool import PythonCodeTool`
+     for the unchanged `is_timeout` check.
+
+2. **Refactor `PythonCodeTool` (`code_tool.py`) to a thin caller.**
+   - Keep `ChildOutcome` here; re-export `ToolCallLogEntry` from `sandbox_bridge`.
+   - `_invoke(context, kwargs)`: build a `NestedToolServer` (allowlist=`self._code_tool.tool_allowlist`,
+     project, task, `context`, recorder=`self._tool_call_recorder`), create the spawn queues, call
+     `run_bridged_child(target=child_main, args=(self._code_tool.code, kwargs), timeout_s=...)`, map
+     `BridgeResult.result_msg` → `ChildOutcome` EXACTLY as today (ok / error+traceback / timed_out / crashed).
+   - Keep `_build_name_map()` as a thin delegator to a `NestedToolServer` (a test calls it directly).
+   - Delete the now-moved bodies (`_run_child`, `_serve`, `_get_tools_info`, `_canonical_tool_name`,
+     `_record`, depth/semaphore module state, helper fns).
+
+3. **Update references to relocated symbols in tests** (import-path/name only, no behavior changes):
+   - `sandbox/test_code_tool_execution.py`: import `CODE_SANDBOX_MAX_CONCURRENCY` and `_depth` from
+     `sandbox_bridge`; keep `PythonCodeTool`/`ToolCallLogEntry` from `code_tool`. Update the 4 body
+     usages. The `test_semaphore_top_level_only_no_deadlock` count follows the bound (now 16); no `== 8`
+     assertion exists, so no numeric assertion changes.
+
+## Tests
+
+- Existing `sandbox/test_code_tool_execution.py` — stays green unchanged (behavioral proof of the extraction).
+- Existing `sandbox/test_sandbox_shared.py`, `adapters/eval/test_sandbox_worker.py`,
+  `datamodel/test_code_tool.py`, `tools/test_tool_registry.py`, `studio_server/test_code_tool_api.py` — stay green.
+- New `tools/test_sandbox_bridge.py` — module-surface tests: `CODE_SANDBOX_MAX_CONCURRENCY == 16`;
+  `BridgeResult` shape; `NestedToolServer.name_map`/`tools_info` resolve allowlisted tools; `serve`
+  handles tool_call success/not-allowed/list_tools and records via recorder; `run_bridged_child`
+  depth-cap error result; timeout and crash `BridgeResult`s via a fake target; `_poll_get`/`_close_queues`.

--- a/specs/projects/code_judge_llm_calls/phase_plans/phase_4.md
+++ b/specs/projects/code_judge_llm_calls/phase_plans/phase_4.md
@@ -1,0 +1,79 @@
+---
+status: complete
+---
+
+# Phase 4: Code-eval bridge integration
+
+## Overview
+
+Wire the code-eval sandbox onto the shared bridge (arch §3.2–3.4). Code judges can now
+call `from kiln import tools` / `async_tools` (incl. `tools.llm` / `tools.llm_judge`) from
+their `score()`. The single-result-queue scorer worker is replaced by the two-queue bridge
+protocol; `CodeEvalAdapter.evaluate` hosts the parent pump and the per-eval nested-tool
+server; the global code-eval execution lock is deleted (concurrency is now the shared
+depth-0 semaphore inside `run_bridged_child`). Also lands two Phase-3 review carry-forwards:
+queue lifecycle centralization inside `run_bridged_child`, and a generalized depth-cap message.
+
+## Steps
+
+1. **`adapters/eval/sandbox_worker.py`** — replace `run_scorer` + `_execute_scorer` with
+   `execute_scorer_bridged(code, inputs, requests, responses)`:
+   - redirect stdout/stderr (existing), `install_tools_modules(requests, responses)`,
+     `exec(compile(code, "<code_eval>", "exec"), namespace)`.
+   - keep existing `score` lookup + signature checks (defined / callable / accepts
+     `output`|`trace`) and declared-param injection from `output`/`trace`/`reference_data`/
+     `task_input`; each validation-failure puts `{"type":"result","error":...,stdout,stderr}`.
+   - `result = call_entrypoint(score_fn, call_kwargs)` (sync/async).
+   - success: `requests.put({"type":"result","ok":result,stdout,stderr})` — `ok` is the scores
+     dict **verbatim** (no `_serialize_result`).
+   - exception: `requests.put({"type":"result","error":str(exc),"traceback":format_exc(),stdout,stderr})`.
+   - Remove single-queue `run_scorer`; drop `multiprocessing`/`queue`/`start_process_with_light_main` imports.
+
+2. **`adapters/eval/v2_eval_code_eval.py`** — `CodeEvalAdapter.evaluate` hosts the pump:
+   - trust gate unchanged, short-circuits before any spawn.
+   - `inputs = {output, trace, reference_data, task_input}` (existing).
+   - `server = NestedToolServer(allowlist=props.tool_allowlist, project=self.target_task.parent,
+     task=self.target_task, context=ToolCallContext(allow_saving=False,
+     eval_output_schema=BaseEval.build_score_schema(self.eval, allow_float_scores=False)),
+     recorder=None)`.
+   - `res = await run_bridged_child(target=execute_scorer_bridged, args=(props.code, inputs),
+     timeout_s=float(props.timeout_seconds), server=server)`.
+   - `res.timed_out` → RuntimeError timed out; `res.crashed` → RuntimeError crashed;
+     `result_msg` has `error` → RuntimeError failed + traceback; else `raw = result_msg["ok"]`,
+     require dict, `return V2EvalResult(scores=self._validate_scores(raw))`.
+   - Delete `_code_eval_execution_lock` + the `async with`. Keep grant/revoke/is_code_eval_trusted
+     and `_resolve_project_path`/`_validate_scores`.
+
+3. **Carry-forward — centralize queue lifecycle in `run_bridged_child` (`tools/sandbox_bridge.py`)**:
+   - Move `multiprocessing.get_context("spawn")` + two `Queue()` creations INTO `run_bridged_child`
+     (after depth/semaphore gates), close them in its `finally`. Drop the `requests`/`responses`
+     params from the signature. Remove `_close_queues` from `_pump`'s finally.
+   - Update `PythonCodeTool._invoke` to match (no queue creation; drop `multiprocessing` import).
+
+4. **Carry-forward — generalize the depth-cap message**: `"max code tool depth exceeded — check
+   for a cycle"` → `"maximum nested code execution depth exceeded — check for a cycle"`. Update the
+   two tests asserting the old string.
+
+5. **Update existing tests broken by the removal of `run_scorer`**:
+   - `test_sandbox_worker.py` / `test_sandbox_worker_perf.py` / `_heavy_main_bench.py`: sync
+     `run_scorer` helper that spawns `execute_scorer_bridged` via `run_bridged_child` (empty server).
+   - `test_v2_eval_code_eval.py`: patch `run_bridged_child` (AsyncMock → `BridgeResult`) instead of
+     `run_scorer`; remove the now-invalid global-lock serialization test.
+   - `test_sandbox_shared.py` / `test_code_tool_execution.py` (spawn-lock identity + depth msg).
+   - `test_sandbox_bridge.py`: drop `requests`/`responses` kwargs; new depth msg.
+   - `app/desktop/studio_server/test_eval_api.py`: patch `run_bridged_child`.
+
+## Tests
+
+- New `adapters/eval/test_code_eval_bridge.py` (real spawns):
+  - `score()` calls `tools.llm_judge` (patch `adapter_for_task` in parent) → scores route back.
+  - `score()` calls `tools.llm` (text + schema→JSON string).
+  - sync and `async def score` using `asyncio.gather` over two `async_tools.llm` calls.
+  - allowlist enforcement: `tools.<not_allowlisted>` → `ToolNotAllowed`.
+  - timeout kills a child mid-LLM-call (parent-side adapter hangs).
+  - PARALLEL code evals run concurrently (wall-clock < sum of per-item sleeps) — regression vs deleted lock.
+  - trust short-circuit before spawn (`run_bridged_child` not called).
+  - identity: code tools and code evals share one `run_bridged_child` / `_spawn_lock` / semaphore.
+- `test_code_eval_samples.py` — unchanged, still green (real scorer sample code through the bridge).
+</content>
+</invoke>

--- a/specs/projects/code_judge_llm_calls/phase_plans/phase_5.md
+++ b/specs/projects/code_judge_llm_calls/phase_plans/phase_5.md
@@ -1,0 +1,50 @@
+---
+status: complete
+---
+
+# Phase 5: UI, examples & schema
+
+## Overview
+
+Phase 5 is the author-facing surface for the code-judge LLM tools shipped in
+phases 1–4. It makes `llm` / `llm_judge` selectable in the tool picker, adds an
+allowlist picker to the code-eval form (bound to `properties.tool_allowlist`),
+adds two editor examples demonstrating `tools.llm_judge` and the cheap-triage
+`tools.llm` + `tools.llm_judge` pattern (mirrored byte-for-byte in the sandbox
+sample tests), and surgically patches the OpenAPI schema (stopgap; canonical
+regen deferred to the user).
+
+## Steps
+
+1. **Backend catalog** (`app/desktop/studio_server/tool_api.py`,
+   `get_available_tools`): add an always-available `ToolSetType.BUILTIN` set
+   ("AI Models") listing `KilnBuiltInToolId.LLM` and `KilnBuiltInToolId.LLM_JUDGE`
+   (not demo-gated). Update the tool_api tests that assert no builtin set exists.
+2. **llm_judge scoping**: add a `code_eval_context: boolean` (default false) to
+   `ToolsSelectorSettings`; `ToolsSelector.get_tool_options` filters
+   `kiln_tool::llm_judge` from the picker unless the consumer opts in. Only the
+   code-eval form opts in — everywhere else `llm_judge` is hidden (it errors
+   off-context at runtime per functional_spec §6, so this is defense-in-UI, not
+   the only guard). `llm` is always shown.
+3. **Allowlist picker** (`code_eval_form.svelte`): add `export let project_id`,
+   bind a `ToolsSelector` (with `code_eval_context: true`) to
+   `properties.tool_allowlist`, and include `tool_allowlist` in `getProperties()`.
+   Pass `{project_id}` from `eval_config_builder.svelte`.
+4. **Editor examples** (`code_eval_helpers.ts`, `generate_examples`): append
+   "LLM judge" (static, judge auto-uses eval schema) and "Triage then LLM judge"
+   (dynamic safe-branch via `build_return_dict`) examples.
+5. **Schema stopgap** (`app/web_ui/src/lib/api_schema.d.ts`): add
+   `tool_allowlist?: string[]` to `CodeEvalProperties`; bump `timeout_seconds`
+   annotation `@default 30` → `@default 180`. Nothing else.
+
+## Tests
+
+- Python `test_code_eval_samples.py`: byte-exact mirrors of the two new examples
+  executed through the real sandbox with a stubbed `adapter_for_task` judge
+  (schema-routing factory for the triage example's two tool calls).
+- Python `test_tool_api.py`: builtin set present with `llm` + `llm_judge`; update
+  the four tests that assumed no builtin set.
+- Web `code_eval_form.test.ts`: allowlist `ToolsSelector` binds to
+  `tool_allowlist` (via a stub); five example tabs incl. the new labels.
+- Web `code_eval_helpers.test.ts`: `generate_examples` returns 5 with the new
+  labels; new snippets contain `tools.llm_judge` / `tools.llm`.

--- a/specs/projects/code_judge_llm_calls/project_overview.md
+++ b/specs/projects/code_judge_llm_calls/project_overview.md
@@ -34,3 +34,12 @@ Developer ergonomics are key.
 - LLM-as-judges take a schema. The code judge already knows what schema it should produce (its eval output scores). It should be easy enough to wire that up.
 - It should **not force** the schema. A code judge might use two judge calls: first a cheap sanity check, then a deeper call. It might want a custom schema. Or a cheap model checking "definitely safe, or maybe risky (worth a more expensive model to verify)?", then a more expensive model conditionally.
 - See our existing helpers and their optional params. Ideally adding a schema isn't too much of a burden.
+
+## Resolved direction (2026-07-18, scosman)
+
+Rather than a bespoke judge bridge, we **reuse the `code_tools` sandbox bridge**: give code judges the same two-queue bridge + `tool_allowlist` that code tools have, and ship the capability as **two new built-in tools** selectable in the existing tool picker:
+
+- **`llm`** — general-purpose LLM call. Optional `schema` (default none). No schema → text; schema → structured output. Generic.
+- **`llm_judge`** — same, minus `schema`; auto-applies the code judge's own eval output-score schema and returns mapped float scores. Author supplies the prompt, so it's not a stock judge call (no judge caching/g_eval/prompt-templating).
+
+Both are called via `from kiln import tools` (sync) / `async_tools` (async), execute **parent-side** (the sandbox never holds API keys or the Kiln stack), and always return a **string** (JSON for structured/scores; author `json.loads`). Full contract in `functional_spec.md`.

--- a/specs/projects/code_judge_llm_calls/project_overview.md
+++ b/specs/projects/code_judge_llm_calls/project_overview.md
@@ -1,0 +1,36 @@
+---
+status: draft
+---
+
+# Code Judge LLM Calls — Project Overview
+
+Add a feature to **code judges** (V2 `code_eval`): the ability for a code judge's Python to call an **LLM judge** from inside its `score()` function.
+
+## Why
+
+Often the trace or final message is way too verbose. A long trace can be 1M tokens+. Yet the judge is judging something like "was tool call X explicitly requested by the user", which can be filtered down to "the N user messages before calling X". That filtering is easy to build in code, and it's tiny compared to a 500k-token trace. But it still needs a subjective judge to look at the user messages — so a pure code judge today is no good.
+
+## Goal
+
+The ability for code judges to use LLM judges.
+
+Pseudo code:
+
+```python
+prompt = "Check if the attached user messages justify calling the delete project. Requires explicit user consent.\n\nThe user messages\n```\n{input.user_messages}\n```"
+
+def select_relevant_user_messages(...):
+  ...
+
+def score(trace, schema):
+   user_messages = select_relevant_user_messages(trace)
+   return helpers.judge_with_llm(prompt, input={"user_messages": user_messages}, "GPT 5.5", "openrouter", schema)
+```
+
+## Ergonomics (key priority)
+
+Developer ergonomics are key.
+
+- LLM-as-judges take a schema. The code judge already knows what schema it should produce (its eval output scores). It should be easy enough to wire that up.
+- It should **not force** the schema. A code judge might use two judge calls: first a cheap sanity check, then a deeper call. It might want a custom schema. Or a cheap model checking "definitely safe, or maybe risky (worth a more expensive model to verify)?", then a more expensive model conditionally.
+- See our existing helpers and their optional params. Ideally adding a schema isn't too much of a burden.

--- a/specs/projects/code_judge_llm_calls/project_overview.md
+++ b/specs/projects/code_judge_llm_calls/project_overview.md
@@ -1,5 +1,5 @@
 ---
-status: draft
+status: complete
 ---
 
 # Code Judge LLM Calls — Project Overview


### PR DESCRIPTION

## What does this PR do?

Lets a **code judge** (V2 `code_eval`) call an **LLM from inside `score()`**, via two new built-in tools reached over the existing code-tool sandbox bridge:

- `tools.llm(prompt, model, provider, input=, schema=, system_prompt=)` — general LLM call; returns text, or a JSON string when `schema` is given.
- `tools.llm_judge(prompt, model, provider, input=, system_prompt=)` — auto-applies the eval's own score schema and returns mapped float scores (identical mapping to the stock LLM judge).

Both execute **entirely parent-side** — the stdlib-only sandbox child never holds API keys or the Kiln stack — support sync and async (`from kiln import tools` / `async_tools`), and are gated by the existing project-trust check. This enables the motivating pattern: filter a huge trace down to the few relevant messages in cheap Python, then judge only that slice with a subjective model.

Built in 5 phases (full spec under `specs/projects/code_judge_llm_calls/`):

1. **Datamodel** — `CodeEvalProperties.tool_allowlist`, timeout default 30→180, `KilnBuiltInToolId.LLM`/`LLM_JUDGE`, `ToolCallContext.eval_output_schema` (additive, zero migration).
2. **Built-in tools** — `LlmTool` / `LlmJudgeTool` + shared `run_llm_call` (extracted from `LlmJudgeEval`) + registry wiring.
3. **Shared pump** — extract `tools/sandbox_bridge.py` (`NestedToolServer`, `run_bridged_child`); refactor `PythonCodeTool` onto it, behavior-preserving (existing code-tool suite stays green).
4. **Code-eval bridge** — two-queue eval worker + `CodeEvalAdapter` hosts the pump; delete the global `_code_eval_execution_lock` (code evals now run concurrently, shared bounded semaphore = 16).
5. **UI** — tool-allowlist picker in the code-eval form; `llm`/`llm_judge` in the tool catalog (`llm_judge` scoped to the code-eval context); `tools.llm_judge` editor examples, mirror-tested through the real sandbox.

### ⚠️ Before merge
- **Run `app/web_ui/src/lib/generate_schema.sh`.** The `api_schema.d.ts` change here is a hand-edited **stopgap** (only `tool_allowlist` + the timeout default) — the build environment could not run a canonical regen (missing system `tkinter`), so a canonical regen must supersede it.
- **Rebase onto latest `scosman/evals_v2`** — this branch was cut from an earlier commit of the base, which has since advanced.

## Related Issues

N/A.

## Checklists

- [x] Tests have been run locally and passed — full Python core suites and the web suites (`npm run check` / `test_run` / `build`) are green. Caveat: two server-only suites (`test_eval_api.py`) and the canonical OpenAPI schema check could not run in the build sandbox (missing system `tkinter` / drifted deps) and should be confirmed in CI or a full dev env.
- [x] New tests have been added to /lib work — extensive unit + real-spawn coverage (`test_llm_tools.py`, `test_sandbox_bridge.py`, `test_code_eval_bridge.py`, datamodel, `tool_api`, and UI tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLVSnMiaZpRQ5xUEbfcbV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLVSnMiaZpRQ5xUEbfcbV2)_