### PR TITLE
[eb-v2 review] Generate/SDG: load-failure handling and coordination notes

### DIFF
--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/+page.svelte
@@ -11,12 +11,14 @@
   import { client } from "$lib/api_client"
   import { load_task } from "$lib/stores"
   import type { Task } from "$lib/types"
+  import { KilnError, createKilnError } from "$lib/utils/error_handlers"
   import Warning from "$lib/ui/warning.svelte"
 
   // watch out because query param value is not the same as gen_type
   type SynthReasonQueryParam = "eval" | "fine_tune" | "qna"
 
   let loading = true
+  let load_error: KilnError | null = null
   let task: Task | null = null
   $: is_multiturn = task?.turn_mode === "multiturn"
   $: project_id = $page.params.project_id!
@@ -74,10 +76,22 @@
 
   async function handle_routing(req_project_id: string, req_task_id: string) {
     loading = true
+    load_error = null
 
     // Synthetic data generation is single-turn only. For multi-turn tasks
     // don't redirect into the synth/qna flows — show the disabled notice.
-    const loaded_task = await load_task(req_project_id, req_task_id)
+    let loaded_task: Task | null
+    try {
+      loaded_task = await load_task(req_project_id, req_task_id)
+    } catch (e) {
+      if (req_project_id !== project_id || req_task_id !== task_id) return
+      // Show the error instead of spinning forever. The key stays marked as
+      // handled so we don't hot-loop retrying a failing load; navigating to a
+      // different key (or remounting the route) retries naturally.
+      load_error = createKilnError(e)
+      loading = false
+      return
+    }
     if (req_project_id !== project_id || req_task_id !== task_id) return
     task = loaded_task
     if (task?.turn_mode === "multiturn") {
@@ -203,6 +217,15 @@
     {#if loading}
       <div class="w-full min-h-[50vh] flex justify-center items-center">
         <div class="loading loading-spinner loading-lg"></div>
+      </div>
+    {:else if load_error}
+      <div
+        class="w-full min-h-[50vh] flex flex-col justify-center items-center gap-2"
+      >
+        <div class="font-medium">Error Loading Task</div>
+        <div class="text-error text-sm">
+          {load_error.getMessage()}
+        </div>
       </div>
     {:else if is_multiturn}
       <div class="flex flex-col items-center justify-center min-h-[60vh]">

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/__tests__/data_gen_intro_stub.svelte
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/__tests__/data_gen_intro_stub.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  export let generate_subtopics: () => void = () => {}
+  export let generate_samples: () => void = () => {}
+  export let project_id: string = ""
+  export let task_id: string = ""
+  export let is_setup: boolean = false
+</script>
+
+<div
+  data-testid="data-gen-intro-stub"
+  data-project-id={project_id}
+  data-task-id={task_id}
+  data-is-setup={is_setup}
+  data-has-callbacks={!!generate_subtopics && !!generate_samples}
+></div>

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/page.test.ts
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/page.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/svelte"
+import { tick } from "svelte"
+
+// ---------------------------------------------------------------------------
+// Module-level mocks -- must come before the dynamic page import
+// ---------------------------------------------------------------------------
+
+const { mockPage, mockGoto, mockClientGET, mockLoadTask, defaultPageValue } =
+  vi.hoisted(() => {
+    type PageValue = {
+      params: Record<string, string>
+      url: URL
+    }
+    const defaultPageValue = (): PageValue => ({
+      params: { project_id: "proj1", task_id: "task1" },
+      url: new URL("http://localhost/generate/proj1/task1"),
+    })
+    let pageValue: PageValue = defaultPageValue()
+    type Subscriber = (value: PageValue) => void
+    const subscribers = new Set<Subscriber>()
+    const mockPage = {
+      subscribe(fn: Subscriber) {
+        subscribers.add(fn)
+        fn(pageValue)
+        return () => subscribers.delete(fn)
+      },
+      set(v: PageValue) {
+        pageValue = v
+        subscribers.forEach((fn) => fn(v))
+      },
+    }
+
+    const mockGoto = vi.fn()
+    const mockClientGET = vi.fn()
+    const mockLoadTask = vi.fn()
+
+    return { mockPage, mockGoto, mockClientGET, mockLoadTask, defaultPageValue }
+  })
+
+vi.mock("$app/stores", () => ({
+  page: mockPage,
+}))
+
+vi.mock("$app/navigation", () => ({
+  goto: mockGoto,
+}))
+
+vi.mock("$lib/api_client", () => ({
+  client: {
+    GET: mockClientGET,
+  },
+}))
+
+vi.mock("$lib/stores", () => ({
+  load_task: mockLoadTask,
+}))
+
+vi.mock("$lib/agent", () => ({
+  agentInfo: { set: vi.fn() },
+}))
+
+// IndexedDB isn't available in jsdom; back the saved-session store with an
+// in-memory writable that reports "no ongoing session".
+vi.mock("$lib/stores/index_db_store", async () => {
+  const { writable } = await import("svelte/store")
+  return {
+    indexedDBStore: <T>(_key: string, initial: T) => ({
+      store: writable(initial),
+      initialized: Promise.resolve(),
+    }),
+  }
+})
+
+// Q&A store with no saved documents, so routing stays on this page.
+vi.mock("./qna/qna_ui_store", () => ({
+  createQnaStore: () => ({
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribe: (fn: (value: { documents: unknown[] }) => void) => {
+      fn({ documents: [] })
+      return () => {}
+    },
+  }),
+}))
+
+// Stub the heavy intro component; these tests only care about routing state.
+vi.mock("./data_gen_intro.svelte", async () => {
+  const Stub = await import("./__tests__/data_gen_intro_stub.svelte")
+  return { default: Stub.default }
+})
+
+// Dynamic import after all mocks
+const Page = (await import("./+page.svelte")).default
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Flush pending promises and Svelte updates. */
+async function settle() {
+  await tick()
+  await new Promise((r) => setTimeout(r, 0))
+  await tick()
+}
+
+const single_turn_task = { id: "task1", name: "Test Task" }
+
+describe("generate landing +page.svelte routing", () => {
+  beforeEach(() => {
+    mockGoto.mockReset()
+    mockLoadTask.mockReset()
+    mockClientGET.mockReset()
+    // No saved data guide by default
+    mockClientGET.mockResolvedValue({ data: null, error: null })
+    mockPage.set(defaultPageValue())
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("shows a spinner while the task is loading", async () => {
+    mockLoadTask.mockReturnValue(new Promise(() => {})) // never resolves
+    const { container } = render(Page)
+    await tick()
+    expect(container.querySelector(".loading-spinner")).not.toBeNull()
+  })
+
+  it("shows the intro for a single-turn task with no saved session", async () => {
+    mockLoadTask.mockResolvedValue(single_turn_task)
+    const { container } = render(Page)
+    await settle()
+    expect(container.querySelector(".loading-spinner")).toBeNull()
+    expect(
+      container.querySelector("[data-testid='data-gen-intro-stub']"),
+    ).not.toBeNull()
+    expect(mockGoto).not.toHaveBeenCalled()
+  })
+
+  it("shows the multi-turn notice instead of the intro for multi-turn tasks", async () => {
+    mockLoadTask.mockResolvedValue({
+      ...single_turn_task,
+      turn_mode: "multiturn",
+    })
+    const { container } = render(Page)
+    await settle()
+    expect(container.querySelector(".loading-spinner")).toBeNull()
+    expect(container.textContent).toContain(
+      "Synthetic data generation is not supported for multi-turn tasks.",
+    )
+    expect(
+      container.querySelector("[data-testid='data-gen-intro-stub']"),
+    ).toBeNull()
+  })
+
+  it("renders an error state (not an infinite spinner) when the task load fails", async () => {
+    mockLoadTask.mockRejectedValue(new Error("network down"))
+    const { container } = render(Page)
+    await settle()
+    expect(container.querySelector(".loading-spinner")).toBeNull()
+    expect(container.textContent).toContain("Error Loading Task")
+    expect(container.textContent).toContain("network down")
+    expect(
+      container.querySelector("[data-testid='data-gen-intro-stub']"),
+    ).toBeNull()
+  })
+
+  it("does not hot-loop retrying a failing load", async () => {
+    mockLoadTask.mockRejectedValue(new Error("network down"))
+    render(Page)
+    await settle()
+    await settle()
+    // The failed key stays marked as handled: exactly one load attempt.
+    expect(mockLoadTask).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries the load on a subsequent navigation after a failure", async () => {
+    mockLoadTask.mockRejectedValueOnce(new Error("network down"))
+    const { container } = render(Page)
+    await settle()
+    expect(container.textContent).toContain("Error Loading Task")
+
+    // Navigating to a different routing key re-runs routing and recovers.
+    mockLoadTask.mockResolvedValue(single_turn_task)
+    mockPage.set({
+      params: { project_id: "proj1", task_id: "task2" },
+      url: new URL("http://localhost/generate/proj1/task2"),
+    })
+    await settle()
+    expect(container.textContent).not.toContain("Error Loading Task")
+    expect(
+      container.querySelector("[data-testid='data-gen-intro-stub']"),
+    ).not.toBeNull()
+  })
+})

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth_data_guidance_datamodel.ts
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth_data_guidance_datamodel.ts
@@ -203,8 +203,9 @@ export class SynthDataGuidanceDataModel {
   // are the eval's real definition. With no default judge, rebuild the steps the
   // same way the create-judge page would, from the eval's template.
   private judge_eval_steps(): string[] {
-    // Only legacy llm_as_judge configs carry eval_steps; the typed properties
-    // union doesn't declare the key, so read it untyped.
+    // Both legacy config types (llm_as_judge and g_eval) carry eval_steps in
+    // properties; the typed properties union doesn't declare the key, so read
+    // it untyped.
     const props = this.default_judge?.properties as
       | Record<string, unknown>
       | undefined


### PR DESCRIPTION
> **Review-only PR — do not merge.** These changes are already landed on `dchiang/eb-v2-merge` (the eval-builder integration branch); this PR is a focused review surface for one area of that work. Every fix carries an inline comment explaining what was broken and why the fix takes this shape. Comments marked **Personal review requested** are the spots that want human judgment — the rest is context your tooling can skim. Reply on the inline comments (or add new line comments); accepted feedback will be implemented on `eb-v2-merge` and the commit sha posted back here. When review wraps, this PR is closed, not merged — its base and head are throwaway review refs.

Surface: the /generate landing route and its synth-data guidance model. One commit (landed as d8e558a77) — surface a task-load failure on /generate instead of spinning forever, and correct a stale comment about which legacy config types carry eval_steps. About 80% of the diff is tests. One **Personal review requested** comment flags the failed-key retry behavior. This PR also carries three coordination notes as thread comments: a sync map for the overlap with #1630, the synthetic-user event contract the SDG stream consumes, and a shared note on the score-key hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*CI note: the "Check API Schema Bindings" failure here is an artifact of this review PR's pinned snapshot — it flagged an annotation file that has since been added on `dchiang/eb-v2-merge` (78081dd6d). No action needed from reviewers.*
