### PR TITLE
[eb-v2 review] Eval V2 core: sandbox, trace persistence, and datamodel guard fixes

### DIFF
--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -6764,9 +6764,9 @@ export interface components {
              * Properties
              * @description Properties to be used to execute the eval config. Legacy configs use a dict; V2 configs use typed properties.
              */
-            properties?: (components["schemas"]["LlmJudgeProperties"] | components["schemas"]["ExactMatchProperties"] | components["schemas"]["PatternMatchProperties"] | components["schemas"]["SetCheckProperties"] | components["schemas"]["ToolCallCheckProperties"] | components["schemas"]["ContainsProperties"] | components["schemas"]["StepCountCheckProperties"] | components["schemas"]["CodeEvalProperties"]) | {
+            properties?: {
                 [key: string]: unknown;
-            } | null;
+            } | (components["schemas"]["LlmJudgeProperties"] | components["schemas"]["ExactMatchProperties"] | components["schemas"]["PatternMatchProperties"] | components["schemas"]["SetCheckProperties"] | components["schemas"]["ToolCallCheckProperties"] | components["schemas"]["ContainsProperties"] | components["schemas"]["StepCountCheckProperties"] | components["schemas"]["CodeEvalProperties"]) | null;
             /** Model Type */
             readonly model_type: string;
         };
@@ -7024,13 +7024,21 @@ export interface components {
         };
         /**
          * EvalRun
-         * @description The results of running an eval on a single dataset item.
+         * @description The result of running an eval on a single item, stored as a child of the
+         *     EvalConfig that produced it.
          *
-         *     This is a child of an EvalConfig, which specifies how the scores were generated.
+         *     A run serves one of two purposes:
+         *     - eval_config_eval=False: evaluating a task run — the task was run with
+         *       task_run_config_id (which must be set) and the evaluator scored its output.
+         *     - eval_config_eval=True: evaluating the eval config itself — an existing
+         *       item's output was scored so the evaluator can be compared against human
+         *       ratings. task_run_config_id must be None.
          *
-         *     Eval runs can be one of 2 types:
-         *     1) eval_config_eval=False: we were evaluating a task run (a method of running the task). We get the task input from the dataset_id.input, run the task with the task_run_config, then ran the evaluator on that output. task_run_config_id must be set. The output saved in this model is the output of the task run.
-         *     2) eval_config_eval=True: we were evaluating an eval config (a method of evaluating the task). We used the existing dataset item input/output, and ran the evaluator on it. task_run_config_id must be None. The input/output saved in this model is the input/output of the dataset item.
+         *     The evaluated item comes from exactly one of two mutually-exclusive sources:
+         *     dataset_id (a TaskRun) or eval_input_id (a V2 EvalInput).
+         *
+         *     output and scores may be missing only when skipped_reason is set, marking an
+         *     item that was skipped rather than scored.
          */
         EvalRun: {
             /**

--- a/libs/core/kiln_ai/adapters/eval/eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_runner.py
@@ -261,19 +261,26 @@ class EvalRunner:
 
         # already_run[eval_config_id][run_config_id][dataset_id]
         already_run: Dict[ID_TYPE, Dict[ID_TYPE, Set[ID_TYPE]]] = {}
+        superseded: Dict[Tuple[ID_TYPE, ID_TYPE, ID_TYPE], List[EvalRun]] = {}
         for eval_config in self.eval_configs:
             already_run[eval_config.id] = {}
             for run_config in self.run_configs or []:
                 already_run[eval_config.id][run_config.id] = set()
             for run in eval_config.runs(readonly=True):
                 if (
-                    run.task_run_config_id is not None
-                    and run.task_run_config_id in already_run[eval_config.id]
-                    and self._counts_as_already_run(run, eval_config)
+                    run.task_run_config_id is None
+                    or run.task_run_config_id not in already_run[eval_config.id]
                 ):
+                    continue
+                if self._counts_as_already_run(run, eval_config):
                     already_run[eval_config.id][run.task_run_config_id].add(
                         run.dataset_id
                     )
+                else:
+                    superseded.setdefault(
+                        (eval_config.id, run.task_run_config_id, run.dataset_id),
+                        [],
+                    ).append(run)
 
         return [
             EvalJob(
@@ -281,6 +288,9 @@ class EvalRunner:
                 task_run_config=run_config,
                 type="task_run_eval",
                 eval_config=eval_config,
+                superseded_tombstones=superseded.get(
+                    (eval_config.id, run_config.id, task_run.id), []
+                ),
             )
             for task_run in self.task.runs(readonly=True)
             if filter(task_run)
@@ -646,6 +656,22 @@ class EvalRunner:
             eval_task_input = EvalTaskInput.from_eval_input(job.item, run_output)
             result = await evaluator.evaluate(eval_task_input)
 
+            # Like the legacy runner, only successful task-run-eval records of
+            # a full_trace eval carry the serialized trace (single-shot
+            # generations don't always produce one).
+            trace_json: str | None = None
+            if (
+                result.skipped_reason is None
+                and self.eval.evaluation_data_type == EvalDataType.full_trace
+                and eval_task_input.trace
+            ):
+                trace_json = json.dumps(
+                    eval_task_input.trace,
+                    indent=2,
+                    ensure_ascii=False,
+                    default=_trace_json_default,
+                )
+
             async with self._save_context():
                 eval_run = EvalRun(
                     parent=job.eval_config,
@@ -666,6 +692,7 @@ class EvalRunner:
                     else None,
                     skipped_detail=result.skipped_detail,
                     intermediate_outputs=result.intermediate_outputs,
+                    task_run_trace=trace_json,
                     task_run_usage=run_output.usage,
                 )
                 eval_run.save_to_file()
@@ -681,6 +708,22 @@ class EvalRunner:
             # never persisted so its id is None (EvalRun would fail validation),
             # and dedup compares this field against the item's id.
             dataset_id = job.item.id
+
+            # Like the legacy runner, only successful task-run-eval records of
+            # a full_trace eval carry the serialized trace (single-shot
+            # generations don't always produce one).
+            trace_json: str | None = None
+            if (
+                result.skipped_reason is None
+                and self.eval.evaluation_data_type == EvalDataType.full_trace
+                and eval_task_input.trace
+            ):
+                trace_json = json.dumps(
+                    eval_task_input.trace,
+                    indent=2,
+                    ensure_ascii=False,
+                    default=_trace_json_default,
+                )
 
             async with self._save_context():
                 eval_run = EvalRun(
@@ -700,6 +743,7 @@ class EvalRunner:
                     else None,
                     skipped_detail=result.skipped_detail,
                     intermediate_outputs=result.intermediate_outputs,
+                    task_run_trace=trace_json,
                     task_run_usage=run_output.usage,
                 )
                 eval_run.save_to_file()

--- a/libs/core/kiln_ai/adapters/eval/eval_utils/v2_eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_utils/v2_eval_helpers.py
@@ -1,8 +1,8 @@
 import json
-import re
 from typing import Any
 
-from jinja2 import Undefined
+from jinja2 import TemplateSyntaxError, Undefined, meta, nodes
+from jinja2.parser import Parser
 from kiln_ai.datamodel.eval import (
     EvalOutputScore,
     EvalScores,
@@ -10,7 +10,7 @@ from kiln_ai.datamodel.eval import (
     SkippedReason,
     V2EvalResult,
 )
-from kiln_ai.utils.jinja_engine import JinjaExtractionError, extract
+from kiln_ai.utils.jinja_engine import JinjaExtractionError, _expression_env, extract
 
 
 def build_binary_scores(
@@ -26,14 +26,24 @@ def build_binary_scores(
     return {score.json_key(): value for score in output_scores}
 
 
-# Matches the `trace` identifier as a whole word (e.g. `trace`, `trace[-1]`,
-# `trace | length`) without matching substrings like `retrace` or `tracer`.
-_TRACE_REFERENCE_RE = re.compile(r"\btrace\b")
-
-
 def references_trace(expression: str) -> bool:
-    """True if a Jinja expression references the `trace` variable."""
-    return bool(_TRACE_REFERENCE_RE.search(expression))
+    """True if a Jinja expression references the `trace` variable.
+
+    Uses Jinja's own parser so only genuine variable references count --
+    'trace' appearing as data (a quoted string, a dict key, an attribute of
+    another variable) does not.
+    """
+    try:
+        # Same parse compile_expression performs, wrapped into a template node
+        # so meta can resolve the expression's undeclared (i.e. input) names.
+        parser = Parser(_expression_env, expression, state="variable")
+        template = nodes.Template([nodes.Output([parser.parse_expression()])], lineno=1)
+    except TemplateSyntaxError:
+        # Invalid expressions can't reference anything; the extraction path
+        # owns reporting the syntax error.
+        return False
+    template.set_environment(_expression_env)
+    return "trace" in meta.find_undeclared_variables(template)
 
 
 def extract_value(

--- a/libs/core/kiln_ai/adapters/eval/sandbox_worker.py
+++ b/libs/core/kiln_ai/adapters/eval/sandbox_worker.py
@@ -10,7 +10,9 @@ import multiprocessing
 import multiprocessing.queues
 import queue
 import sys
+import time
 import traceback
+from multiprocessing.process import BaseProcess
 from typing import Any
 
 from kiln_ai.sandbox.entrypoint import call_entrypoint
@@ -93,6 +95,19 @@ def _execute_scorer(
                 "stderr": captured_stderr.getvalue(),
             }
         )
+    except SystemExit as e:
+        # sys.exit() in user code would otherwise kill the child before a
+        # result is queued, surfacing as a generic crash with no explanation.
+        # KeyboardInterrupt is deliberately NOT caught: it means the operator
+        # interrupted the process group, not that the user's code failed.
+        result_queue.put(
+            {
+                "error": f"User code exited via sys.exit({e.code!r}) instead of returning scores",
+                "traceback": traceback.format_exc(),
+                "stdout": captured_stdout.getvalue(),
+                "stderr": captured_stderr.getvalue(),
+            }
+        )
     except Exception:
         result_queue.put(
             {
@@ -124,24 +139,59 @@ def run_scorer(
     q: multiprocessing.Queue = ctx.Queue()  # type: ignore[type-arg]
     p = ctx.Process(target=_execute_scorer, args=(code, inputs, q), daemon=True)
     start_process_with_light_main(p)
-    p.join(timeout=timeout)
-
-    if p.is_alive():
-        p.kill()
-        p.join(timeout=5)
-        raise RuntimeError(f"Code eval scorer timed out after {timeout}s")
 
     try:
-        result: dict[str, Any] = q.get_nowait()
-    except queue.Empty:
-        if p.exitcode not in (0, None):
-            raise RuntimeError(f"Scorer crashed (exit code {p.exitcode})")
-        raise RuntimeError("Scorer process exited without returning results")
+        result = _wait_for_result(p, q, timeout)
+        if result is None:
+            if p.is_alive():
+                p.kill()
+                p.join(timeout=5)
+                raise RuntimeError(f"Code eval scorer timed out after {timeout}s")
+            if p.exitcode not in (0, None):
+                raise RuntimeError(f"Scorer crashed (exit code {p.exitcode})")
+            raise RuntimeError("Scorer process exited without returning results")
     finally:
         q.close()
         q.join_thread()
 
-    if p.exitcode not in (0, None) and "ok" not in result:
+    p.join(timeout=5)
+    if p.is_alive():
+        # Result already in hand; a child that won't exit on its own (e.g.
+        # user code left non-daemon threads running) is force-reaped.
+        p.kill()
+        p.join(timeout=5)
+    elif p.exitcode not in (0, None) and "ok" not in result:
         raise RuntimeError(f"Scorer crashed (exit code {p.exitcode})")
 
     return result
+
+
+def _wait_for_result(
+    p: BaseProcess,
+    q: multiprocessing.queues.Queue,  # type: ignore[type-arg]
+    timeout: float,
+) -> dict[str, Any] | None:
+    """Wait for the child's result dict; None on timeout or silent child death.
+
+    The queue -- not the process -- is the primary wait: a result payload
+    larger than the OS pipe buffer keeps the child's queue feeder thread (and
+    so the child) alive until the parent reads it, so joining first would
+    deadlock and misreport a successful run as a timeout. Short poll intervals
+    let a child that died without reporting be noticed well before the full
+    timeout.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        try:
+            return q.get(timeout=min(0.1, remaining))
+        except queue.Empty:
+            if not p.is_alive():
+                # The child may have flushed its result between the empty read
+                # and the liveness check -- one final grace read.
+                try:
+                    return q.get(timeout=0.1)
+                except queue.Empty:
+                    return None

--- a/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_runner.py
@@ -2031,6 +2031,112 @@ class TestV2FreshGeneration:
         assert parsed[1]["usage"]["output_tokens"] == 7
 
     @pytest.mark.asyncio
+    async def test_task_run_eval_single_turn_full_trace_serializes_trace(
+        self,
+        mock_v2_task_run_eval_runner,
+        mock_v2_task_run_eval_config,
+        mock_run_config,
+        data_source,
+    ):
+        """Single-turn fresh generation over a stored TaskRun: a successful
+        task-run-eval record of a full_trace eval carries the fresh
+        generation's serialized trace (legacy-runner parity)."""
+        mock_v2_task_run_eval_config.parent.evaluation_data_type = (
+            EvalDataType.full_trace
+        )
+        mock_v2_task_run_eval_config.parent.save_to_file()
+
+        item = TaskRun(
+            input="test input",
+            output=TaskOutput(output="stored", source=data_source),
+            parent=mock_v2_task_run_eval_runner.task,
+        )
+        item.save_to_file()
+        fresh_trace: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "test input"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        fresh = TaskRun(
+            input="test input",
+            input_source=data_source,
+            output=TaskOutput(output="hello", source=data_source),
+            trace=fresh_trace,
+        )
+        fresh.id = None
+
+        job = EvalJob(
+            item=item,
+            eval_config=mock_v2_task_run_eval_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+        stub = StubV2Eval(mock_v2_task_run_eval_config)
+        with (
+            patch.object(stub, "run_task", return_value=fresh),
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+        ):
+            assert await mock_v2_task_run_eval_runner.run_job(job) is True
+
+        runs = mock_v2_task_run_eval_config.runs(readonly=True)
+        assert len(runs) == 1
+        saved = runs[0]
+        assert saved.skipped_reason is None
+        assert saved.task_run_trace is not None
+        assert json.loads(saved.task_run_trace) == fresh_trace
+
+    @pytest.mark.asyncio
+    async def test_eval_input_single_turn_full_trace_serializes_trace(
+        self, mock_v2_eval_config, mock_run_config, mock_eval_inputs, data_source
+    ):
+        """Single-turn EvalInput lane: same full_trace contract as above."""
+        mock_v2_eval_config.parent.evaluation_data_type = EvalDataType.full_trace
+        mock_v2_eval_config.parent.save_to_file()
+
+        fresh_trace: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        fresh = TaskRun(
+            input="What is 2+2?",
+            input_source=data_source,
+            output=TaskOutput(output="hello", source=data_source),
+            trace=fresh_trace,
+        )
+        fresh.id = None
+
+        runner = EvalRunner(
+            eval_configs=[mock_v2_eval_config],
+            run_configs=[mock_run_config],
+            eval_run_type="task_run_eval",
+        )
+        job = EvalJob(
+            item=mock_eval_inputs[0],
+            eval_config=mock_v2_eval_config,
+            type="task_run_eval",
+            task_run_config=mock_run_config,
+        )
+        stub = StubV2Eval(mock_v2_eval_config)
+        with (
+            patch.object(stub, "run_task", return_value=fresh),
+            patch(
+                "kiln_ai.adapters.eval.registry.v2_eval_adapter_from_config",
+                return_value=stub,
+            ),
+        ):
+            assert await runner.run_job(job) is True
+
+        runs = mock_v2_eval_config.runs(readonly=True)
+        assert len(runs) == 1
+        saved = runs[0]
+        assert saved.eval_input_id == mock_eval_inputs[0].id
+        assert saved.skipped_reason is None
+        assert saved.task_run_trace is not None
+        assert json.loads(saved.task_run_trace) == fresh_trace
+
+    @pytest.mark.asyncio
     async def test_eval_config_eval_scores_existing_without_fresh_gen(
         self,
         mock_v2_runner,
@@ -3271,7 +3377,7 @@ class TestRecoverableSkipRecollection:
             parent=mock_task,
         )
         task_run.save_to_file()
-        _skip_run(
+        tombstone = _skip_run(
             mock_v2_task_run_eval_config,
             mock_run_config.id,
             SkippedReason.type_not_available,
@@ -3288,6 +3394,10 @@ class TestRecoverableSkipRecollection:
         ):
             jobs = runner.collect_tasks()
         assert {j.item.id for j in jobs} == {task_run.id}
+        # The recovered tombstone rides the job (parity with the EvalInput
+        # lane) so the replacement record can delete it instead of leaving
+        # two records on one item.
+        assert [t.id for t in jobs[0].superseded_tombstones] == [tombstone.id]
 
 
 # -------------------------------------------------------------------

--- a/libs/core/kiln_ai/adapters/eval/test_sandbox_worker.py
+++ b/libs/core/kiln_ai/adapters/eval/test_sandbox_worker.py
@@ -146,6 +146,19 @@ class TestCapture:
         assert "ok" in result
         assert "err msg" in result["stderr"]
 
+    def test_large_captured_output_succeeds(self):
+        # A result payload bigger than the OS pipe buffer (~64KB) keeps the
+        # child alive until the parent drains the queue; the run must succeed
+        # instead of being misreported as a timeout.
+        code = (
+            "def score(output, trace, reference_data, task_input):\n"
+            "    print('x' * 70_000)\n"
+            "    return {'x': 1.0}\n"
+        )
+        result = run_scorer(code, _inputs(), timeout=10)
+        assert result["ok"] == {"x": 1.0}
+        assert len(result["stdout"]) >= 70_000
+
 
 # ---------------------------------------------------------------------------
 # Error cases
@@ -199,6 +212,25 @@ class TestErrors:
         )
         with pytest.raises(RuntimeError, match="exit code"):
             run_scorer(code, _inputs(), timeout=10)
+
+    def test_sys_exit_reported_as_user_error(self):
+        # sys.exit() must surface as a user-code error, not a generic
+        # no-result crash from the child dying silently.
+        code = (
+            "import sys\n"
+            "def score(output, trace, reference_data, task_input):\n"
+            "    sys.exit(2)\n"
+        )
+        result = run_scorer(code, _inputs(), timeout=10)
+        assert "error" in result
+        assert "sys.exit(2)" in result["error"]
+        assert "traceback" in result
+
+    def test_sys_exit_at_module_level(self):
+        code = "import sys\nsys.exit()\n"
+        result = run_scorer(code, _inputs(), timeout=10)
+        assert "error" in result
+        assert "sys.exit" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/libs/core/kiln_ai/adapters/eval/test_v2_datamodel_contracts.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_datamodel_contracts.py
@@ -1,9 +1,10 @@
-"""Tests for Phase 4 data-model robustness improvements.
+"""Contract tests for the V2 eval datamodel and its scoring helpers.
 
 Covers:
-- 5.8: V2_PROPERTY_TYPES explicit tuple matches the V2EvalConfigProperties union
-- 5.9: build_binary_scores accepts output_scores directly (no EvalConfig needed)
-- 5.6: EvalRun validate_input_source error message clarifies V1 vs V2
+- V2_PROPERTY_TYPES explicit tuple stays in sync with the V2EvalConfigProperties union
+- build_binary_scores accepts output_scores directly (no EvalConfig needed)
+- V2 adapters cache output scores at init instead of calling parent_eval() per item
+- EvalRun validate_input_source error message clarifies V1 vs V2 sources
 """
 
 from typing import get_args
@@ -26,7 +27,7 @@ from kiln_ai.datamodel.eval import (
 )
 
 # ---------------------------------------------------------------------------
-# 5.8: V2_PROPERTY_TYPES matches V2EvalConfigProperties union
+# V2_PROPERTY_TYPES matches V2EvalConfigProperties union
 # ---------------------------------------------------------------------------
 
 
@@ -52,7 +53,7 @@ class TestV2PropertyTypes:
 
 
 # ---------------------------------------------------------------------------
-# 5.9: build_binary_scores takes output_scores directly
+# build_binary_scores takes output_scores directly
 # ---------------------------------------------------------------------------
 
 
@@ -83,7 +84,7 @@ class TestBuildBinaryScores:
         assert result == {}
 
     def test_no_eval_config_needed(self):
-        """build_binary_scores no longer requires an EvalConfig or parent_eval() call."""
+        """build_binary_scores works from output_scores alone -- no EvalConfig or parent_eval() call."""
         scores_def = [
             EvalOutputScore(
                 name="check", instruction="test", type=TaskOutputRatingType.pass_fail
@@ -124,7 +125,7 @@ class TestCachedOutputScores:
 
 
 # ---------------------------------------------------------------------------
-# 5.6: validate_input_source error message
+# validate_input_source error message
 # ---------------------------------------------------------------------------
 
 

--- a/libs/core/kiln_ai/adapters/eval/test_v2_eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_eval_helpers.py
@@ -1,9 +1,10 @@
-"""Tests for v2_eval_helpers -- extract_value, extract_output_value, check_reference_key, stringify_for_match."""
+"""Tests for v2_eval_helpers -- extract_value, extract_output_value, check_reference_key, references_trace, stringify_for_match."""
 
 from kiln_ai.adapters.eval.eval_utils.v2_eval_helpers import (
     check_reference_key,
     extract_output_value,
     extract_value,
+    references_trace,
     stringify_for_match,
 )
 from kiln_ai.datamodel.datamodel_enums import TaskOutputRatingType
@@ -54,6 +55,53 @@ class TestExtractValue:
         value, skip, _detail = extract_value("trace", inp)
         assert value == [{"role": "user", "content": "hi"}]
         assert skip is None
+
+    def test_trace_as_string_data_not_treated_as_trace_dependency(self):
+        # 'trace' inside a string literal is data, not a variable reference —
+        # a traceless run must evaluate the expression instead of skipping.
+        inp = _make_input(final_message="the trace is fine", trace=None)
+        value, skip, _detail = extract_value("'trace' in final_message", inp)
+        assert value is True
+        assert skip is None
+
+
+# ---------------------------------------------------------------------------
+# references_trace
+# ---------------------------------------------------------------------------
+
+
+class TestReferencesTrace:
+    def test_bare_variable(self):
+        assert references_trace("trace") is True
+
+    def test_subscript(self):
+        assert references_trace("trace[-1]") is True
+
+    def test_filter(self):
+        assert references_trace("trace | length") is True
+
+    def test_conditional(self):
+        assert references_trace("trace[0].content if trace else final_message") is True
+
+    def test_quoted_string_is_not_a_reference(self):
+        assert references_trace("'trace' in final_message") is False
+
+    def test_dict_key_is_not_a_reference(self):
+        assert references_trace("{'trace': 1}") is False
+
+    def test_attribute_of_other_variable_is_not_a_reference(self):
+        assert references_trace("final_message.trace") is False
+
+    def test_subscript_key_of_other_variable_is_not_a_reference(self):
+        assert references_trace("reference_data['trace']") is False
+
+    def test_similar_identifier_is_not_a_reference(self):
+        assert references_trace("retrace") is False
+
+    def test_invalid_expression_is_not_a_reference(self):
+        # Syntax errors are the extraction path's to report; no trace
+        # dependency is claimed for them.
+        assert references_trace("trace [") is False
 
 
 # ---------------------------------------------------------------------------

--- a/libs/core/kiln_ai/adapters/eval/test_v2_eval_llm_judge.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_eval_llm_judge.py
@@ -309,9 +309,15 @@ class TestLlmJudgeEvalGEval:
         props = _make_props(g_eval=True)
         cfg = _make_config(props)
 
-        with patch(
-            "kiln_ai.adapters.eval.v2_eval_llm_judge.build_g_eval_score"
-        ) as mock_g_eval_score:
+        with (
+            patch(
+                "kiln_ai.adapters.eval.v2_eval_llm_judge.built_in_models_from_provider",
+                return_value=Mock(supports_logprobs=True),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.v2_eval_llm_judge.build_g_eval_score"
+            ) as mock_g_eval_score,
+        ):
             mock_g_eval_score.return_value = {"quality": 4.3}
             result = await LlmJudgeEval(cfg).evaluate(_inp())
 
@@ -339,9 +345,15 @@ class TestLlmJudgeEvalGEval:
         props = _make_props(g_eval=True)
         cfg = _make_config(props)
 
-        with patch(
-            "kiln_ai.adapters.eval.v2_eval_llm_judge.build_g_eval_score"
-        ) as mock_g_eval_score:
+        with (
+            patch(
+                "kiln_ai.adapters.eval.v2_eval_llm_judge.built_in_models_from_provider",
+                return_value=Mock(supports_logprobs=True),
+            ),
+            patch(
+                "kiln_ai.adapters.eval.v2_eval_llm_judge.build_g_eval_score"
+            ) as mock_g_eval_score,
+        ):
             mock_g_eval_score.return_value = {"quality": 3.7}
             await LlmJudgeEval(cfg).evaluate(_inp())
 
@@ -400,32 +412,19 @@ class TestLlmJudgeEvalGEvalFailFast:
         assert result.skipped_reason is None
 
     @pytest.mark.asyncio
-    @patch("kiln_ai.adapters.eval.v2_eval_llm_judge.adapter_for_task")
-    async def test_g_eval_proceeds_when_provider_unknown(self, mock_adapter_for_task):
-        mock_adapter = AsyncMock()
-        mock_adapter.invoke_returning_run_output.return_value = (
-            Mock(),
-            RunOutput(output={"quality": "5"}, intermediate_outputs=None),
-        )
-        mock_adapter_for_task.return_value = mock_adapter
-
+    async def test_g_eval_raises_when_model_unknown(self):
+        # Unknown model: logprobs support can't be verified, so the preflight
+        # must fail loudly before spending on the judge call.
         props = _make_props(g_eval=True)
         cfg = _make_config(props)
+        adapter = LlmJudgeEval(cfg)
 
-        with (
-            patch(
-                "kiln_ai.adapters.eval.v2_eval_llm_judge.built_in_models_from_provider",
-                return_value=None,
-            ),
-            patch(
-                "kiln_ai.adapters.eval.v2_eval_llm_judge.build_g_eval_score"
-            ) as mock_g_eval_score,
+        with patch(
+            "kiln_ai.adapters.eval.v2_eval_llm_judge.built_in_models_from_provider",
+            return_value=None,
         ):
-            mock_g_eval_score.return_value = {"quality": 4.3}
-            result = await LlmJudgeEval(cfg).evaluate(_inp())
-
-        assert result.scores == {"quality": 4.3}
-        assert result.skipped_reason is None
+            with pytest.raises(ValueError, match="not a built-in model"):
+                await adapter.evaluate(_inp())
 
 
 class TestLlmJudgeEvalMissingReferenceData:
@@ -460,6 +459,32 @@ class TestLlmJudgeEvalMissingReferenceData:
         )
         assert result.scores == {"quality": 3.0}
         assert result.skipped_reason is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_template_variable_is_extraction_failure(self):
+        # A typo'd variable is a template-authoring bug, not missing reference
+        # data -- it must not masquerade as missing_reference_key.
+        props = _make_props(prompt_template="Output: {{ final_mesage }}")
+        cfg = _make_config(props)
+        result = await LlmJudgeEval(cfg).evaluate(_inp())
+        assert result.scores == {}
+        assert result.skipped_reason == SkippedReason.extraction_failed
+        assert result.skipped_detail is not None
+        assert "unknown variable" in result.skipped_detail
+        assert "final_mesage" in result.skipped_detail
+
+    @pytest.mark.asyncio
+    async def test_typo_alongside_reference_access_reports_unknown_variable(self):
+        # When the template has both a typo and a missing reference key, the
+        # authoring bug is the primary truth to surface.
+        props = _make_props(
+            prompt_template="{{ reference_data.answer }} vs {{ outpt }}"
+        )
+        cfg = _make_config(props)
+        result = await LlmJudgeEval(cfg).evaluate(_inp(reference_data=None))
+        assert result.skipped_reason == SkippedReason.extraction_failed
+        assert result.skipped_detail is not None
+        assert "outpt" in result.skipped_detail
 
 
 class TestLlmJudgeEvalNoParentEval:

--- a/libs/core/kiln_ai/adapters/eval/v2_eval_llm_judge.py
+++ b/libs/core/kiln_ai/adapters/eval/v2_eval_llm_judge.py
@@ -8,9 +8,9 @@ The prompt_template is rendered with Jinja2 using the EvalTaskInput fields
 as the template namespace.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from jinja2 import UndefinedError
+from jinja2 import UndefinedError, meta
 
 from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.eval.base_eval import BaseEval, BaseV2EvalBridge
@@ -50,6 +50,17 @@ _DEFAULT_SYSTEM_PROMPT = (
     "Your job is to evaluate a model's performance on a task. "
     "Score the output according to the criteria provided."
 )
+
+
+def _unknown_template_variables(template: str, namespace: dict[str, Any]) -> set[str]:
+    """Top-level variables the template uses that aren't EvalTaskInput fields.
+
+    Distinguishes a template-authoring bug (typo'd variable name) from
+    genuinely missing data (e.g. an absent reference_data key) when rendering
+    raises UndefinedError.
+    """
+    ast = _template_env.parse(template)
+    return meta.find_undeclared_variables(ast) - set(namespace)
 
 
 class _LlmJudgeTask(Task, parent_of={}):
@@ -111,6 +122,17 @@ class LlmJudgeEval(BaseV2EvalBridge):
                 skipped_detail=f"Template rendering failed: {e}",
             )
         except UndefinedError as e:
+            # A typo'd template variable and genuinely missing reference data
+            # both raise UndefinedError; only the latter is a data problem.
+            unknown = _unknown_template_variables(props.prompt_template, namespace)
+            if unknown:
+                return V2EvalResult(
+                    skipped_reason=SkippedReason.extraction_failed,
+                    skipped_detail=(
+                        "Template references unknown variable(s): "
+                        + ", ".join(sorted(unknown))
+                    ),
+                )
             return V2EvalResult(
                 skipped_reason=SkippedReason.missing_reference_key,
                 skipped_detail=f"Template references missing data: {e}",
@@ -132,7 +154,18 @@ class LlmJudgeEval(BaseV2EvalBridge):
 
         if props.g_eval:
             model_provider = built_in_models_from_provider(provider, model_name)
-            if model_provider is not None and not model_provider.supports_logprobs:
+            if model_provider is None:
+                # Fail before spending on the judge call: without a built-in
+                # entry, logprobs support can't be verified and the call would
+                # fail deterministically anyway.
+                raise ValueError(
+                    f"g_eval=True requires logprobs support, but model "
+                    f"'{model_name}' is not a built-in model for provider "
+                    f"'{props.model_provider}', so logprobs support can't be "
+                    f"verified. Use a built-in model that supports logprobs, "
+                    f"or disable G-Eval for this judge."
+                )
+            if not model_provider.supports_logprobs:
                 raise ValueError(
                     f"g_eval=True requires logprobs support, but provider "
                     f"'{props.model_provider}' for model '{model_name}' does not "

--- a/libs/core/kiln_ai/adapters/eval/v2_eval_tool_call_check.py
+++ b/libs/core/kiln_ai/adapters/eval/v2_eval_tool_call_check.py
@@ -29,7 +29,7 @@ class ToolCallCheckEval(BaseV2EvalBridge):
 
         actual_calls = self._extract_tool_calls(eval_input.trace)
 
-        passed, _unexpected_fail = self._check(
+        passed = self._check(
             actual_calls,
             props.expected_tools,
             props.match_mode,
@@ -74,17 +74,14 @@ class ToolCallCheckEval(BaseV2EvalBridge):
         expected_tools: list[ToolCallSpec],
         match_mode: str,
         on_unexpected: str,
-    ) -> tuple[bool, bool]:
-        """Check tool calls against expectations.
-
-        Returns (passed, unexpected_fail).
-        """
+    ) -> bool:
+        """Check tool calls against expectations, returning pass/fail."""
         if match_mode == "never":
             for spec in expected_tools:
                 for call in actual_calls:
                     if self._call_matches_spec(call, spec):
-                        return False, False
-            return True, False
+                        return False
+            return True
 
         if match_mode == "any":
             found_any = False
@@ -112,17 +109,14 @@ class ToolCallCheckEval(BaseV2EvalBridge):
         else:
             passed = False
 
-        unexpected_fail = False
         if passed and on_unexpected == "fail":
             for call in actual_calls:
                 if not any(
                     self._call_matches_spec(call, spec) for spec in expected_tools
                 ):
-                    passed = False
-                    unexpected_fail = True
-                    break
+                    return False
 
-        return passed, unexpected_fail
+        return passed
 
     def _check_ordered(
         self,

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -10,6 +10,7 @@ from pydantic import (
     Field,
     JsonValue,
     TypeAdapter,
+    ValidationInfo,
     model_validator,
 )
 from typing_extensions import Self
@@ -647,29 +648,44 @@ class EvalRun(KilnParentedModel):
         return self
 
     @model_validator(mode="after")
-    def validate_output_fields(self) -> Self:
+    def validate_output_fields(self, info: ValidationInfo) -> Self:
         parent_eval_config = self.parent_eval_config()
-        if parent_eval_config and parent_eval_config.config_type == EvalConfigType.v2:
-            return self
         parent_eval = parent_eval_config.parent_eval() if parent_eval_config else None
         if not parent_eval:
+            return self
+
+        evaluation_data_type = parent_eval.evaluation_data_type
+
+        # A full_trace eval scores the conversation trace, so a successful task
+        # run must carry it. Both V1 and V2 writers attach the trace for exactly
+        # this shape (a scored, non-skipped task-run eval of a full_trace eval),
+        # so demanding it back makes a writer that drops the trace fail loudly
+        # instead of persisting a record that can't be re-scored. Historical
+        # files predating this gate are exempt so they still load; new writes
+        # and rebuilds are held to it.
+        if (
+            not self.eval_config_eval
+            and self.skipped_reason is None
+            and evaluation_data_type == EvalDataType.full_trace
+            and self.task_run_trace is None
+            and not self.loaded_from_file(info)
+        ):
+            raise ValueError("full_trace task run eval runs should include trace")
+
+        # Remaining checks are V1-only. V2 deliberately relaxes them: skipped
+        # runs carry no output, and V2 writers never attach a trace to a
+        # final_answer run in the first place.
+        if parent_eval_config.config_type == EvalConfigType.v2:
             return self
 
         if self.output is None and self.skipped_reason is None:
             raise ValueError("V1 EvalRun requires output to be set")
 
-        evaluation_data_type = parent_eval.evaluation_data_type
         if (
             evaluation_data_type == EvalDataType.final_answer
             and self.task_run_trace is not None
         ):
             raise ValueError("final_answer runs should not set trace")
-        elif (
-            not self.eval_config_eval
-            and evaluation_data_type == EvalDataType.full_trace
-            and self.task_run_trace is None
-        ):
-            raise ValueError("full_trace task run eval runs should include trace")
 
         return self
 

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -9,7 +9,7 @@ from pydantic import (
     Discriminator,
     Field,
     JsonValue,
-    ValidationInfo,
+    TypeAdapter,
     model_validator,
 )
 from typing_extensions import Self
@@ -252,6 +252,9 @@ V2EvalConfigProperties = Annotated[
     Discriminator("type"),
 ]
 
+# Parses a raw properties dict into its typed V2 class via the "type" discriminator.
+_V2_PROPERTIES_ADAPTER: TypeAdapter[Any] = TypeAdapter(V2EvalConfigProperties)
+
 # Explicit tuple of V2 property types for isinstance() checks.
 # Must list exactly the same types as the V2EvalConfigProperties union above.
 V2_PROPERTY_TYPES: tuple[type[BaseModel], ...] = (
@@ -428,6 +431,17 @@ class EvalInput(KilnParentedModel):
         description="Tags for filtering eval inputs.",
     )
 
+    @model_validator(mode="after")
+    def validate_tags(self) -> Self:
+        # Empty or space-containing tags can't be selected by tag filters, so
+        # reject them at creation instead of silently dropping the item later.
+        for tag in self.tags:
+            if not tag:
+                raise ValueError("Tags cannot be empty strings")
+            if " " in tag:
+                raise ValueError("Tags cannot contain spaces. Try underscores.")
+        return self
+
 
 class EvalTaskInput(BaseModel):
     """The runtime data bundle passed to V2 evaluators.
@@ -545,13 +559,21 @@ class EvalOutputScore(BaseModel):
 
 class EvalRun(KilnParentedModel):
     """
-    The results of running an eval on a single dataset item.
+    The result of running an eval on a single item, stored as a child of the
+    EvalConfig that produced it.
 
-    This is a child of an EvalConfig, which specifies how the scores were generated.
+    A run serves one of two purposes:
+    - eval_config_eval=False: evaluating a task run — the task was run with
+      task_run_config_id (which must be set) and the evaluator scored its output.
+    - eval_config_eval=True: evaluating the eval config itself — an existing
+      item's output was scored so the evaluator can be compared against human
+      ratings. task_run_config_id must be None.
 
-    Eval runs can be one of 2 types:
-    1) eval_config_eval=False: we were evaluating a task run (a method of running the task). We get the task input from the dataset_id.input, run the task with the task_run_config, then ran the evaluator on that output. task_run_config_id must be set. The output saved in this model is the output of the task run.
-    2) eval_config_eval=True: we were evaluating an eval config (a method of evaluating the task). We used the existing dataset item input/output, and ran the evaluator on it. task_run_config_id must be None. The input/output saved in this model is the input/output of the dataset item.
+    The evaluated item comes from exactly one of two mutually-exclusive sources:
+    dataset_id (a TaskRun) or eval_input_id (a V2 EvalInput).
+
+    output and scores may be missing only when skipped_reason is set, marking an
+    item that was skipped rather than scored.
     """
 
     dataset_id: ID_TYPE | None = Field(
@@ -730,26 +752,25 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
         default=EvalConfigType.g_eval,
         description="This is used to determine the type of eval to run.",
     )
-    properties: V2EvalConfigProperties | dict[str, Any] | None = Field(
+    properties: dict[str, Any] | V2EvalConfigProperties | None = Field(
         default=None,
         description="Properties to be used to execute the eval config. Legacy configs use a dict; V2 configs use typed properties.",
     )
 
     @model_validator(mode="before")
     @classmethod
-    def dispatch_properties_parsing(cls, data: Any, info: ValidationInfo) -> Any:
-        # Pydantic's discriminated-union parsing would reject a plain dict for
-        # `properties` because dicts don't carry a discriminator field. V1 (legacy)
-        # configs store properties as an untyped dict, so we shallow-copy and
-        # re-assign it here to force Pydantic to accept the dict branch of the union.
+    def dispatch_properties_parsing(cls, data: Any) -> Any:
+        # The union lists dict first, so a raw dict always stays a plain dict —
+        # even one whose keys happen to match a typed V2 shape (legacy configs
+        # store arbitrary dicts). V2 configs persist properties as a dict too,
+        # so parse those into the typed union here, before field validation.
         if not isinstance(data, dict):
             return data
-        config_type = data.get("config_type", "g_eval")
-        if config_type != "v2":
+        if data.get("config_type", EvalConfigType.g_eval) == EvalConfigType.v2:
             props = data.get("properties")
-            if props is not None and isinstance(props, dict):
+            if isinstance(props, dict):
                 data = dict(data)
-                data["properties"] = props
+                data["properties"] = _V2_PROPERTIES_ADAPTER.validate_python(props)
         return data
 
     def parent_eval(self) -> Union["Eval", None]:

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -2078,13 +2078,23 @@ def test_v2_eval_config_rejects_root_model_fields():
         )
 
 
-def test_v2_eval_config_requires_typed_properties():
-    """V2 config rejects a raw dict for properties."""
-    with pytest.raises(ValueError, match="V2 config requires typed properties"):
+def test_v2_eval_config_rejects_undiscriminated_dict():
+    """A V2 properties dict without a valid "type" discriminator is rejected."""
+    with pytest.raises(ValidationError, match="type"):
         EvalConfig(
             name="Bad V2",
             config_type=EvalConfigType.v2,
             properties={"eval_steps": ["step"]},
+        )
+
+
+def test_v2_eval_config_requires_typed_properties():
+    """V2 config rejects missing properties."""
+    with pytest.raises(ValueError, match="V2 config requires typed properties"):
+        EvalConfig(
+            name="Bad V2",
+            config_type=EvalConfigType.v2,
+            properties=None,
         )
 
 
@@ -2409,6 +2419,36 @@ def test_eval_input_multi_turn():
     assert ei.data.synthetic_user_info.behavior_guidance is None
 
 
+def test_eval_input_rejects_empty_tag():
+    """An empty tag is rejected: tag filters can never select it."""
+    with pytest.raises(ValidationError, match="Tags cannot be empty strings"):
+        EvalInput(
+            data=SingleTurnEvalInputData(user_message=UserMessage(text="hi")),
+            tags=[""],
+        )
+
+
+def test_eval_input_rejects_tag_with_spaces():
+    """A tag containing spaces is rejected, matching TaskRun tag rules."""
+    with pytest.raises(ValidationError, match="Tags cannot contain spaces"):
+        EvalInput(
+            data=SingleTurnEvalInputData(user_message=UserMessage(text="hi")),
+            tags=["bad tag"],
+        )
+
+
+def test_eval_input_valid_tags_round_trip():
+    """Valid tags are accepted and survive a dump/validate cycle."""
+    tags = ["eval_slice", "scenario:1", "synthetic_user_batch:b1"]
+    ei = EvalInput(
+        data=SingleTurnEvalInputData(user_message=UserMessage(text="hi")),
+        tags=tags,
+    )
+    assert ei.tags == tags
+    rebuilt = EvalInput.model_validate(ei.model_dump())
+    assert rebuilt.tags == tags
+
+
 def test_multi_turn_synthetic_requires_synthetic_user_info():
     """The persona is required — a case without one can't be re-driven."""
     with pytest.raises(ValidationError, match="synthetic_user_info"):
@@ -2728,7 +2768,7 @@ class TestV2TemplateValidation:
             )
 
     def test_reference_data_only_prompt_template_rejected(self):
-        """A prompt_template referencing only reference_data is rejected (D30)."""
+        """A prompt_template referencing only reference_data is rejected: it never varies with the model output."""
         with pytest.raises(ValidationError, match="never references the model output"):
             _make_v2_eval_config(
                 properties=LlmJudgeProperties(
@@ -2750,7 +2790,7 @@ class TestV2TemplateValidation:
         assert cfg is not None
 
     def test_prompt_template_with_trace_passes(self):
-        """A prompt_template referencing trace passes (D30)."""
+        """A prompt_template referencing trace passes: trace counts as model output."""
         cfg = _make_v2_eval_config(
             properties=LlmJudgeProperties(
                 model_name="m",
@@ -2761,7 +2801,7 @@ class TestV2TemplateValidation:
         assert cfg is not None
 
     def test_prompt_template_with_task_input_passes(self):
-        """A prompt_template referencing task_input passes (D30)."""
+        """A prompt_template referencing task_input passes: it varies per run."""
         cfg = _make_v2_eval_config(
             properties=LlmJudgeProperties(
                 model_name="m",
@@ -3004,6 +3044,52 @@ class TestV1EvalConfigCoexistence:
         assert config.properties["type"] == "exact_match"
         assert config.properties["eval_steps"] == ["step1"]
 
+    def test_v1_properties_fully_colliding_with_v2_shape_stay_dict(self):
+        """A legacy properties dict that would parse cleanly as a typed V2 class must still load as a plain dict."""
+        props = {
+            "eval_steps": ["step1"],
+            "type": "llm_judge",
+            "model_name": "m",
+            "model_provider": "p",
+            "prompt_template": "{{ final_message }}",
+        }
+        # Premise: this dict is a valid LlmJudgeProperties payload, so only
+        # explicit dispatch (not union fallback) keeps it untyped below.
+        assert isinstance(LlmJudgeProperties.model_validate(props), LlmJudgeProperties)
+
+        config = EvalConfig.model_validate(
+            {
+                "name": "Full Collision",
+                "config_type": "g_eval",
+                "model_name": "gpt-4",
+                "model_provider": "openai",
+                "properties": props,
+            }
+        )
+        assert config.config_type == EvalConfigType.g_eval
+        assert type(config.properties) is dict
+        assert config.properties["type"] == "llm_judge"
+        assert config.properties["eval_steps"] == ["step1"]
+
+    def test_v2_config_from_dict_round_trips_typed(self):
+        """V2 properties load from a raw dict into the typed class and survive dump/validate."""
+        raw = {
+            "name": "From Disk V2",
+            "config_type": "v2",
+            "properties": {
+                "type": "llm_judge",
+                "model_name": "m",
+                "model_provider": "p",
+                "prompt_template": "{{ final_message }}",
+            },
+        }
+        config = EvalConfig.model_validate(raw)
+        assert isinstance(config.properties, LlmJudgeProperties)
+
+        reloaded = EvalConfig.model_validate(config.model_dump())
+        assert isinstance(reloaded.properties, LlmJudgeProperties)
+        assert reloaded.properties == config.properties
+
     def test_v1_llm_as_judge_config_type_preserved(self):
         config = EvalConfig(
             name="LLM Judge V1",
@@ -3054,7 +3140,7 @@ class TestV1EvalConfigCoexistence:
 
 
 # ---------------------------------------------------------------------------
-# Phase 2: V1 EvalRun output=None guard (Item 1c)
+# Legacy EvalRun output: may be None only when skipped_reason is set
 # ---------------------------------------------------------------------------
 
 
@@ -3164,12 +3250,12 @@ class TestV1EvalRunOutputNoneGuard:
 
 
 # ---------------------------------------------------------------------------
-# Phase 2: CodeEvalProperties dead SyntaxError catch removed (Item 5.4)
+# CodeEvalProperties code validation: must parse and define a score function
 # ---------------------------------------------------------------------------
 
 
-class TestCodeEvalNoDeadSyntaxErrorCatch:
-    """After removing the dead except SyntaxError, ast.parse + score fn check still works."""
+class TestCodeEvalCodeValidation:
+    """CodeEvalProperties.code must be parseable Python defining a module-level score function."""
 
     def test_valid_code_with_score_fn(self):
         props = CodeEvalProperties(
@@ -3406,7 +3492,7 @@ class TestV2EvalResult:
 
 
 # ---------------------------------------------------------------------------
-# D27: expected_tools non-empty (ToolCallCheckProperties)
+# ToolCallCheckProperties.expected_tools must contain at least one tool
 # ---------------------------------------------------------------------------
 class TestToolCallCheckExpectedToolsValidator:
     def test_empty_expected_tools_rejected(self):
@@ -3421,7 +3507,7 @@ class TestToolCallCheckExpectedToolsValidator:
 
 
 # ---------------------------------------------------------------------------
-# D28: ArgMatch regex validation
+# ArgMatch.value must compile as a regex when match_mode is "regex"
 # ---------------------------------------------------------------------------
 class TestArgMatchRegexValidator:
     def test_bad_regex_rejected(self):
@@ -3442,7 +3528,7 @@ class TestArgMatchRegexValidator:
 
 
 # ---------------------------------------------------------------------------
-# D29: reference_key min_length=1
+# reference_key must be a non-empty string when provided
 # ---------------------------------------------------------------------------
 class TestReferenceKeyMinLength:
     def test_exact_match_empty_reference_key_rejected(self):

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -1805,6 +1807,142 @@ def test_validate_output_fields_parametrized(
     else:
         run = EvalRun(**run_data)
         assert run.task_run_trace == trace
+
+
+# ── V2 validate_output_fields: writer-shape matrix ─────────────────────────
+#
+# The V2 eval writers attach task_run_trace for exactly one shape: a scored
+# (non-skipped), non-eval-config task run of a full_trace eval. These pin the
+# datamodel gate to that shape so a writer dropping the trace is rejected, while
+# every shape the writer legitimately leaves trace-less continues to pass.
+
+V2_TRACE = '{"messages": [{"role": "user", "content": "test"}]}'
+
+
+def _v2_eval_and_config(mock_task, data_type=EvalDataType.full_trace):
+    """A V2 (typed-properties) config parented to an eval of the given type."""
+    eval = Eval(
+        name="V2 Eval",
+        parent=mock_task,
+        eval_set_filter_id="tag::tag1",
+        eval_configs_filter_id="tag::tag2",
+        output_scores=[
+            EvalOutputScore(name="accuracy", type=TaskOutputRatingType.pass_fail)
+        ],
+        evaluation_data_type=data_type,
+    )
+    config = EvalConfig(
+        parent=eval,
+        name="V2 Config",
+        config_type=EvalConfigType.v2,
+        properties=LlmJudgeProperties(
+            model_name="gpt-4o",
+            model_provider="openai",
+            prompt_template="Evaluate: {{ final_message }}",
+        ),
+    )
+    return eval, config
+
+
+def test_v2_full_trace_task_run_eval_with_trace_passes(mock_task):
+    _, config = _v2_eval_and_config(mock_task)
+    run = EvalRun(
+        parent=config,
+        eval_input_id="ei1",
+        task_run_config_id="rc1",
+        input="in",
+        output="out",
+        scores={"accuracy": 1.0},
+        task_run_trace=V2_TRACE,
+    )
+    assert run.task_run_trace == V2_TRACE
+
+
+def test_v2_full_trace_task_run_eval_without_trace_rejected(mock_task):
+    _, config = _v2_eval_and_config(mock_task)
+    with pytest.raises(
+        ValueError, match="full_trace task run eval runs should include trace"
+    ):
+        EvalRun(
+            parent=config,
+            eval_input_id="ei1",
+            task_run_config_id="rc1",
+            input="in",
+            output="out",
+            scores={"accuracy": 1.0},
+        )
+
+
+def test_v2_full_trace_skipped_record_without_trace_passes(mock_task):
+    _, config = _v2_eval_and_config(mock_task)
+    run = EvalRun(
+        parent=config,
+        eval_input_id="ei1",
+        task_run_config_id="rc1",
+        input="in",
+        output=None,
+        scores={},
+        skipped_reason=SkippedReason.missing_trace.value,
+    )
+    assert run.task_run_trace is None
+
+
+def test_v2_full_trace_eval_config_eval_without_trace_passes(mock_task):
+    _, config = _v2_eval_and_config(mock_task)
+    run = EvalRun(
+        parent=config,
+        dataset_id="ds1",
+        eval_config_eval=True,
+        task_run_config_id=None,
+        input="in",
+        output="out",
+        scores={"accuracy": 1.0},
+    )
+    assert run.task_run_trace is None
+
+
+def test_v2_final_answer_record_without_trace_passes(mock_task):
+    _, config = _v2_eval_and_config(mock_task, data_type=EvalDataType.final_answer)
+    run = EvalRun(
+        parent=config,
+        eval_input_id="ei1",
+        task_run_config_id="rc1",
+        input="in",
+        output="out",
+        scores={"accuracy": 1.0},
+    )
+    assert run.task_run_trace is None
+
+
+def test_v2_full_trace_trace_less_record_loads_from_file(mock_task, tmp_path):
+    """Historical trace-less full_trace records must still load; the gate holds
+    only new writes and rebuilds, not files already on disk."""
+    mock_task.path = tmp_path / "task.kiln"
+    mock_task.save_to_file()
+    eval, config = _v2_eval_and_config(mock_task)
+    eval.save_to_file()
+    config.save_to_file()
+
+    run = EvalRun(
+        parent=config,
+        eval_input_id="ei1",
+        task_run_config_id="rc1",
+        input="in",
+        output="out",
+        scores={"accuracy": 1.0},
+        task_run_trace=V2_TRACE,
+    )
+    run.save_to_file()
+
+    # Rewrite the persisted record to the trace-less shape a pre-gate writer
+    # could have produced, then confirm it still loads rather than erroring.
+    assert run.path is not None
+    data = json.loads(run.path.read_text())
+    data["task_run_trace"] = None
+    run.path.write_text(json.dumps(data))
+
+    loaded = EvalRun.load_from_file(str(run.path))
+    assert loaded.task_run_trace is None
 
 
 @pytest.mark.parametrize(

--- a/libs/core/kiln_ai/datamodel/tool_id.py
+++ b/libs/core/kiln_ai/datamodel/tool_id.py
@@ -127,11 +127,8 @@ def _check_tool_id(id: str) -> str:
 
     # Code tools must have format: kiln_tool::code::<code_tool_id>
     if id.startswith(CODE_TOOL_ID_PREFIX):
-        ct_id = code_tool_id_from_tool_id(id)
-        if not ct_id:
-            raise ValueError(
-                f"Invalid code tool ID: {id}. Expected format: 'kiln_tool::code::<code_tool_id>'."
-            )
+        # Raises ValueError on malformed IDs; the extracted ID isn't needed here.
+        code_tool_id_from_tool_id(id)
         return id
 
     # SDK / AdapterConfig.unmanaged_tools — not resolved by tool_from_id


### PR DESCRIPTION
> **Review-only PR — do not merge.** These changes are already landed on `dchiang/eb-v2-merge` (the eval-builder integration branch); this PR is a focused review surface for one area of that work. Every fix carries an inline comment explaining what was broken and why the fix takes this shape. Comments marked **Personal review requested** are the spots that want human judgment — the rest is context your tooling can skim. Reply on the inline comments (or add new line comments); accepted feedback will be implemented on `eb-v2-merge` and the commit sha posted back here. When review wraps, this PR is closed, not merged — its base and head are throwaway review refs.

Surface: the V2 eval data model and the eval adapters (sandbox scorer runner, LLM judge, runner). Pure Python; about half the diff is tests. Three commits: d625c94f6 (landed as c22bb4799) — make the EvalConfig properties dispatch real, validate EvalInput tags, rewrite the EvalRun docstring, drop a dead tool-id branch; fdeda160d (landed as 1a5f81c9b) — drain the scorer queue before joining so large scorer output isn't misread as a timeout, handle SystemExit from user scorers, restore single-turn full_trace trace persistence, fail the g_eval logprobs preflight loudly, classify template-authoring errors correctly, parser-based trace-reference detection, superseded-tombstone dedup parity; 551107df4 (landed as 1e19a1883) — make the EvalRun full_trace trace gate V2-aware. Four **Personal review requested** comments flag the contract/invariant calls.

Note: several of these fixes dedupe when #1454 syncs into the branch — they touch the same datamodel/adapter regions, so expect to resolve to this behavior and adopt any copy updates from that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


*CI note: the "Check API Schema Bindings" failure here is an artifact of this review PR's pinned snapshot — the canonical schema verification lives on `dchiang/eb-v2-merge`. No action needed from reviewers.*
