### PR TITLE
[eb-v2 review] Git import: bind the trust prompt to the repo it was granted for — sign-off requested

### DIFF
--- a/app/web_ui/src/lib/components/code_tools/code_tool_test_panel.svelte
+++ b/app/web_ui/src/lib/components/code_tools/code_tool_test_panel.svelte
@@ -40,6 +40,9 @@
 
   // Stores the last-built param values for preview display
   let param_values: Record<string, unknown> = {}
+  // Validation error from building the edit-inputs form. Shown inside the edit
+  // dialog so a bad input keeps the dialog open instead of silently closing.
+  let input_error: KilnError | null = null
 
   function parse_schema(
     schema: { [key: string]: unknown } | undefined,
@@ -71,13 +74,19 @@
   function save_and_close_inputs(): boolean {
     try {
       param_values = build_params()
-    } catch {
-      // Let build_params errors surface at run time
+      input_error = null
+      return true
+    } catch (e) {
+      // A required field is missing or an object param is invalid JSON. Keep
+      // the dialog open and surface the error so the typed inputs aren't
+      // discarded and Run Test can't post stale values.
+      input_error = createKilnError(e)
+      return false
     }
-    return true
   }
 
   function open_edit_inputs() {
+    input_error = null
     edit_inputs_dialog.show()
   }
 
@@ -372,6 +381,13 @@
           bind:this={input_components[prop.id]}
         />
       {/each}
+      {#if input_error}
+        <Warning
+          warning_color="error"
+          tight
+          warning_message={input_error.getMessage()}
+        />
+      {/if}
     </div>
   {/if}
 </Dialog>

--- a/app/web_ui/src/lib/components/code_tools/code_tool_test_panel.test.ts
+++ b/app/web_ui/src/lib/components/code_tools/code_tool_test_panel.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
+import { render, cleanup, fireEvent } from "@testing-library/svelte"
+import { tick } from "svelte"
+
+vi.mock("$lib/api_client", () => ({
+  client: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+  },
+}))
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}))
+
+// Stub the dialog so its slot (the edit-inputs form) always renders and the
+// action buttons are exposed for direct invocation.
+vi.mock("$lib/ui/dialog.svelte", async () => {
+  const Stub = await import("../eval_types/__tests__/dialog_stub.svelte")
+  return { default: Stub.default }
+})
+
+import CodeToolTestPanel from "./code_tool_test_panel.svelte"
+import { client } from "$lib/api_client"
+import {
+  actionButtonsByTitle,
+  resetActionButtons,
+} from "../eval_types/__tests__/dialog_stub.svelte"
+
+const parameters_schema = {
+  type: "object",
+  properties: {
+    name: { type: "string", title: "Name" },
+    note: { type: "string", title: "Note" },
+  },
+  required: ["name"],
+}
+
+const baseProps = {
+  project_id: "p1",
+  tool_function_name: "my_tool",
+  tool_description: "desc",
+  parameters_schema,
+  code: "print(1)",
+  timeout_seconds: 5,
+  tool_allowlist: [] as string[],
+}
+
+function doneAction(): () => boolean {
+  const buttons = actionButtonsByTitle["Edit Test Input"]
+  const done = buttons?.find((b) => b.label === "Done")
+  return done?.action as () => boolean
+}
+
+afterEach(() => {
+  cleanup()
+  resetActionButtons()
+  vi.restoreAllMocks()
+})
+
+beforeEach(() => {
+  vi.mocked(client.POST).mockReset()
+})
+
+describe("CodeToolTestPanel edit-inputs validation", () => {
+  it("keeps the dialog open and shows an error when a required field is missing, preserving typed values", async () => {
+    const { container } = render(CodeToolTestPanel, { props: baseProps })
+    await tick()
+
+    // Type into the optional field; leave the required "name" blank.
+    const textareas = container.querySelectorAll("textarea")
+    expect(textareas.length).toBe(2)
+    await fireEvent.input(textareas[1], { target: { value: "keep me" } })
+    await tick()
+
+    // Click "Done" -> build fails on the missing required field.
+    const shouldClose = doneAction()()
+    await tick()
+
+    // Dialog stays open (action returned false) and the error is surfaced.
+    expect(shouldClose).toBe(false)
+    expect(container.textContent).toContain("Required property not set")
+
+    // The typed optional value must not be discarded.
+    const textareasAfter = container.querySelectorAll("textarea")
+    expect((textareasAfter[1] as HTMLTextAreaElement).value).toBe("keep me")
+  })
+
+  it("saves and closes when all required fields are provided", async () => {
+    const { container } = render(CodeToolTestPanel, { props: baseProps })
+    await tick()
+
+    const textareas = container.querySelectorAll("textarea")
+    await fireEvent.input(textareas[0], { target: { value: "Alice" } })
+    await fireEvent.input(textareas[1], { target: { value: "hi" } })
+    await tick()
+
+    const shouldClose = doneAction()()
+    await tick()
+
+    expect(shouldClose).toBe(true)
+    expect(container.textContent).not.toContain("Required property not set")
+
+    // The built values feed the input preview shown on the panel.
+    expect(container.textContent).toContain("Alice")
+  })
+})

--- a/app/web_ui/src/lib/components/import/__tests__/step_branch_stub.svelte
+++ b/app/web_ui/src/lib/components/import/__tests__/step_branch_stub.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  // Marker stub. Its presence in a test means the wizard advanced to the branch
+  // step (i.e. the trust gate was skipped).
+  export let git_url = ""
+  export let pat_token: string | null = null
+  export let oauth_token: string | null = null
+  export let auth_mode = ""
+  export let on_selected: (
+    branch: string,
+    path: string,
+    needs_credentials: boolean,
+  ) => void
+</script>
+
+<div
+  data-testid="step-branch-stub"
+  data-git-url={git_url}
+  data-pat-token={pat_token}
+  data-oauth-token={oauth_token}
+  data-auth-mode={auth_mode}
+  data-has-on-selected={!!on_selected}
+></div>

--- a/app/web_ui/src/lib/components/import/__tests__/step_credentials_stub.svelte
+++ b/app/web_ui/src/lib/components/import/__tests__/step_credentials_stub.svelte
@@ -1,0 +1,19 @@
+<script lang="ts" context="module">
+  // Captures the success callback so tests can simulate a verified token.
+  export const stepCredentialsProps: {
+    on_success?: (token: string, auth_method: string) => void
+  } = {}
+</script>
+
+<script lang="ts">
+  export let git_url = ""
+  export let initial_token: string | null = null
+  export let on_success: (token: string, auth_method: string) => void
+  stepCredentialsProps.on_success = on_success
+</script>
+
+<div
+  data-testid="step-credentials-stub"
+  data-git-url={git_url}
+  data-initial-token={initial_token}
+></div>

--- a/app/web_ui/src/lib/components/import/__tests__/step_url_stub.svelte
+++ b/app/web_ui/src/lib/components/import/__tests__/step_url_stub.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" context="module">
+  // Captures the callbacks import_project passes so tests can drive the url
+  // step's success paths without any real network/OAuth.
+  export const stepUrlProps: {
+    on_success?: (url: string, auth_method: string) => void
+    on_auth_required?: (url: string) => void
+  } = {}
+</script>
+
+<script lang="ts">
+  export let initial_url = ""
+  export let pat_token: string | null = null
+  export let on_success: (url: string, auth_method: string) => void
+  export let on_auth_required: (url: string) => void
+  stepUrlProps.on_success = on_success
+  stepUrlProps.on_auth_required = on_auth_required
+</script>
+
+<div
+  data-testid="step-url-stub"
+  data-initial-url={initial_url}
+  data-pat-token={pat_token}
+></div>

--- a/app/web_ui/src/lib/components/import/import_project.svelte
+++ b/app/web_ui/src/lib/components/import/import_project.svelte
@@ -103,6 +103,14 @@
   }
 
   function redirect_if_missing_state(step: WizardStep): boolean {
+    // The local trust step depends on the component-local selected file path,
+    // which the store-only validate_step_requirements can't see. A remount or
+    // deep-link to #local-trust starts with no path, so send the user back to
+    // pick a file rather than letting Trust Project import an empty path.
+    if (step === "local_trust_confirm" && !import_project_path) {
+      set_step("local_file")
+      return true
+    }
     if (!validate_step_requirements(step)) {
       clear_wizard_store()
       replaceState(window.location.pathname + window.location.search, {})
@@ -147,7 +155,10 @@
   onMount(() => {
     const url_param = read_url_query_param("url")
     if (url_param) {
-      update_store({ git_url: url_param })
+      // Seed the url step from the deep-link param. Route through adopt_git_url
+      // so a param pointing at a different repo than the persisted session
+      // clears its stale downstream state (and its trust skip).
+      adopt_git_url(url_param)
       if (window.location.hash !== "#git") {
         window.location.hash = "#git"
       }
@@ -166,13 +177,39 @@
     set_step("credentials")
   }
 
+  // Adopt the repo URL the user entered/confirmed on the url step. Trust is
+  // granted per-repo, and clone_path/branch/project all describe whichever repo
+  // was entered before. When the URL changes we drop that downstream state so
+  // it can never be mistaken for the current repo — in particular so the
+  // clone_path-based trust skip below only fires for the same repo the trust
+  // gate was passed for.
+  function adopt_git_url(
+    url: string,
+    extra_fields: Partial<typeof $git_import_wizard_store> = {},
+  ) {
+    const url_changed = url !== $git_import_wizard_store.git_url
+    update_store({
+      git_url: url,
+      ...extra_fields,
+      ...(url_changed
+        ? {
+            clone_path: "",
+            selected_branch: "",
+            selected_project_path: "",
+            selected_project_id: "",
+            selected_project_name: "",
+          }
+        : {}),
+    })
+  }
+
   function on_url_success(url: string, detected_auth_method: string) {
-    update_store({ git_url: url, auth_mode: detected_auth_method })
+    adopt_git_url(url, { auth_mode: detected_auth_method })
     set_step("trust_confirm")
   }
 
   function on_url_auth_required(url: string) {
-    update_store({ git_url: url })
+    adopt_git_url(url)
     go_to_credentials()
   }
 
@@ -190,9 +227,11 @@
         auth_mode: detected_auth_method,
       })
     }
-    // If clone_path is set, the user already passed the trust gate and the
-    // branch step redirected back here for credentials — skip trust and
-    // return directly to branch.
+    // A clone_path here means this repo already reached the branch step, which
+    // is only possible after passing the trust gate for it — the branch step
+    // bounced back for credentials. Skipping trust is safe because
+    // adopt_git_url clears clone_path whenever the URL changes, so it can only
+    // be set for the repo currently being imported.
     if ($git_import_wizard_store.clone_path) {
       set_step("branch")
     } else {
@@ -296,6 +335,12 @@
   }
 
   async function on_local_trust_confirmed() {
+    // Never import without a selected path (e.g. reached here with an empty
+    // path when the file picker was unavailable). Send the user back to pick.
+    if (!import_project_path) {
+      set_step("local_file")
+      return
+    }
     // Navigate back to local_file WITHOUT resetting state (set_step clears
     // the path and error state, which we need to preserve for the import).
     current_step = "local_file"

--- a/app/web_ui/src/lib/components/import/import_project.test.ts
+++ b/app/web_ui/src/lib/components/import/import_project.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
 import { render, cleanup, fireEvent, waitFor } from "@testing-library/svelte"
 import { tick } from "svelte"
+import { get } from "svelte/store"
 
 vi.mock("$lib/api_client", () => ({
   client: {
@@ -47,8 +48,43 @@ vi.mock("$lib/stores/git_import_wizard_store", () => {
   }
 })
 
+// Stub the git step components so the trust-binding flow can be driven via the
+// captured callbacks, with no real network or OAuth.
+vi.mock("./step_url.svelte", async () => {
+  const Stub = await import("./__tests__/step_url_stub.svelte")
+  return { default: Stub.default }
+})
+vi.mock("./step_credentials.svelte", async () => {
+  const Stub = await import("./__tests__/step_credentials_stub.svelte")
+  return { default: Stub.default }
+})
+vi.mock("./step_branch.svelte", async () => {
+  const Stub = await import("./__tests__/step_branch_stub.svelte")
+  return { default: Stub.default }
+})
+
 import ImportProject from "./import_project.svelte"
 import { client } from "$lib/api_client"
+import { git_import_wizard_store } from "$lib/stores/git_import_wizard_store"
+import { stepUrlProps } from "./__tests__/step_url_stub.svelte"
+import { stepCredentialsProps } from "./__tests__/step_credentials_stub.svelte"
+
+type WizardState = Parameters<typeof git_import_wizard_store.set>[0]
+
+function setWizardState(overrides: Partial<WizardState>) {
+  git_import_wizard_store.set({
+    git_url: "",
+    pat_token: null,
+    oauth_token: null,
+    auth_mode: "system_keys",
+    clone_path: "",
+    selected_branch: "",
+    selected_project_path: "",
+    selected_project_id: "",
+    selected_project_name: "",
+    ...overrides,
+  })
+}
 
 const baseProps = {
   create_link: "/create",
@@ -472,5 +508,142 @@ describe("ImportProject local_file conflict handling", () => {
       'button[type="submit"]',
     ) as HTMLButtonElement
     expect(hiddenSubmit?.classList.contains("hidden")).toBe(true)
+  })
+})
+
+describe("ImportProject trust binding per repo", () => {
+  // Reach the git url step through the UI (Svelte 4 onMount does not run under
+  // jsdom/vitest, so hash-driven entry can't be tested here). The store is
+  // pre-seeded to simulate a repo already carried through the wizard.
+  async function renderAtUrlStep() {
+    const result = render(ImportProject, { props: baseProps })
+    await tick()
+    await fireEvent.click(result.getByText("Git Auto Sync"))
+    await tick()
+    return result
+  }
+
+  it("re-entering credentials for the same repo skips trust and returns to branch", async () => {
+    // Repo A has already reached the branch step (clone_path set), which is
+    // only reachable after passing trust for it. A branch that needs
+    // credentials bounces back here; re-verifying the same repo must not
+    // re-prompt trust.
+    setWizardState({
+      git_url: "https://example.com/a.git",
+      clone_path: "/clone/a",
+      auth_mode: "pat_token",
+      pat_token: "tokA",
+    })
+
+    const { container } = await renderAtUrlStep()
+
+    // Same URL: adopt_git_url keeps the existing clone_path.
+    stepUrlProps.on_auth_required?.("https://example.com/a.git")
+    await tick()
+    expect(get(git_import_wizard_store).clone_path).toBe("/clone/a")
+
+    stepCredentialsProps.on_success?.("tokA", "pat_token")
+    await tick()
+
+    expect(
+      container.querySelector('[data-testid="step-branch-stub"]'),
+    ).not.toBe(null)
+    expect(container.textContent).not.toContain("Trust this Project?")
+  })
+
+  it("entering a different repo after Back clears stale trust and lands on trust_confirm", async () => {
+    // Repo A fully entered (clone_path set). User goes Back to the url step and
+    // enters a different, private repo B. Because clone_path belonged to A, the
+    // credentials success must NOT skip trust for B.
+    setWizardState({
+      git_url: "https://example.com/a.git",
+      clone_path: "/clone/a",
+      auth_mode: "pat_token",
+      pat_token: "tokA",
+    })
+
+    const { container } = await renderAtUrlStep()
+
+    // Enter repo B, which requires authentication.
+    stepUrlProps.on_auth_required?.("https://example.com/b.git")
+    await tick()
+
+    // clone_path from A must be cleared by the URL change.
+    expect(get(git_import_wizard_store).clone_path).toBe("")
+
+    // Verify credentials for B.
+    stepCredentialsProps.on_success?.("tokB", "pat_token")
+    await tick()
+
+    expect(container.textContent).toContain("Trust this Project?")
+    expect(container.querySelector('[data-testid="step-branch-stub"]')).toBe(
+      null,
+    )
+  })
+
+  it("re-confirming the same repo url on the url step keeps its downstream state", async () => {
+    // Returning to the url step and submitting the same repo must not wipe the
+    // trust/clone_path already granted for it.
+    setWizardState({
+      git_url: "https://example.com/a.git",
+      clone_path: "/clone/a",
+      auth_mode: "system_keys",
+    })
+
+    await renderAtUrlStep()
+
+    stepUrlProps.on_success?.("https://example.com/a.git", "system_keys")
+    await tick()
+
+    expect(get(git_import_wizard_store).clone_path).toBe("/clone/a")
+  })
+})
+
+describe("ImportProject local trust guard", () => {
+  it("confirming trust with no selected path returns to file selection and does not import", async () => {
+    // Reach the local trust page with an empty path (the file picker was
+    // unavailable, so the manual step showed Continue). Trust Project must not
+    // POST an empty project path.
+    const result = render(ImportProject, { props: baseProps })
+    await tick()
+    await fireEvent.click(result.getByText("Import from Local Folder"))
+    await tick()
+
+    // Make the file picker fail so the Continue button is shown with no path.
+    vi.mocked(client.GET).mockRejectedValue(new Error("No file selector"))
+    const { container } = result
+    const selectBtn = container.querySelector(
+      "button.btn-primary",
+    ) as HTMLButtonElement
+    await fireEvent.click(selectBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    // Continue -> trust page (path is still empty).
+    const continueBtn = container.querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement
+    await fireEvent.click(continueBtn)
+    await tick()
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Trust this Project?")
+    })
+
+    // Trust Project with no path must redirect back, not import.
+    const trustBtn = container.querySelector(
+      "button.btn-warning",
+    ) as HTMLButtonElement
+    await fireEvent.click(trustBtn)
+    await tick()
+    await new Promise((r) => setTimeout(r, 0))
+    await tick()
+
+    expect(container.textContent).not.toContain("Trust this Project?")
+    expect(container.textContent).toContain(
+      "Select or enter the path to a project.kiln file",
+    )
+    expect(vi.mocked(client.POST)).not.toHaveBeenCalled()
   })
 })

--- a/app/web_ui/src/lib/stores/git_import_wizard_store.ts
+++ b/app/web_ui/src/lib/stores/git_import_wizard_store.ts
@@ -49,6 +49,8 @@ export function validate_step_requirements(step: WizardStep): boolean {
   switch (step) {
     case "method":
     case "local_file":
+    // local_trust_confirm depends on the component-local selected file path,
+    // which this store-only check can't see; the component gates it directly.
     case "local_trust_confirm":
     case "url":
       return true


### PR DESCRIPTION
> **Review-only PR — do not merge.** These changes are already landed on `dchiang/eb-v2-merge` (the eval-builder integration branch); this PR is a focused review surface for one area of that work. Every fix carries an inline comment explaining what was broken and why the fix takes this shape. Comments marked **Personal review requested** are the spots that want human judgment — the rest is context your tooling can skim. Reply on the inline comments (or add new line comments); accepted feedback will be implemented on `eb-v2-merge` and the commit sha posted back here. When review wraps, this PR is closed, not merged — its base and head are throwaway review refs.

Surface: the Git-import project wizard and the Code Tool test panel. One commit, `e9c4b294c (landed as ccf082f54)` — bind git-import trust to the repo URL it was granted for (any URL change clears the stale clone/branch/project state that the trust-skip relies on), refuse a local-trust import with no selected path, and stop the code-tool test panel from silently swallowing input-validation errors. Roughly half the diff is the wizard-stub harness and tests. The trust-model trade-offs are called out in two **Personal review requested** comments below — those are the ones I'd like your explicit sign-off on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*CI note: the "Check API Schema Bindings" failure here is an artifact of this review PR's pinned snapshot — the canonical schema verification lives on `dchiang/eb-v2-merge`. No action needed from reviewers.*