### PR TITLE
[eb-v2 review] Code Tools: parameter validation, allowlist isolation, and wizard fixes

### DIFF
--- a/app/desktop/studio_server/test_code_tool_api.py
+++ b/app/desktop/studio_server/test_code_tool_api.py
@@ -165,6 +165,23 @@ class TestCreateCodeTool:
         assert response.status_code == 400
         assert "run" in response.json()["message"].lower()
 
+    def test_create_reserved_word_param_rejected(
+        self, client, test_project, mock_project_from_id, create_request
+    ):
+        create_request["parameters_schema"] = {
+            "type": "object",
+            "properties": {"from": {"type": "string"}},
+        }
+        with patch(TRUST_PATCH, return_value=True):
+            response = client.post(
+                f"/api/projects/{test_project.id}/code_tools",
+                json=create_request,
+            )
+        assert response.status_code == 400
+        message = response.json()["message"]
+        assert "'from'" in message
+        assert "reserved Python keyword" in message
+
 
 class TestListCodeTools:
     def test_list_empty(self, client, test_project, mock_project_from_id):

--- a/app/web_ui/src/lib/utils/code_tool_helpers.test.ts
+++ b/app/web_ui/src/lib/utils/code_tool_helpers.test.ts
@@ -8,6 +8,7 @@ import {
   generateExamples,
   formatParamPreview,
   plainTextParamsSchema,
+  resolveStep2Code,
 } from "./code_tool_helpers"
 
 describe("extractParams", () => {
@@ -356,6 +357,112 @@ describe("isCodeUnmodified", () => {
     const placeholder = 'def run() -> str:\n    """test"""\n    pass\n'
     const with_import = generateImportHelper("get_user") + placeholder
     expect(isCodeUnmodified(with_import, placeholder)).toBe(false)
+  })
+})
+
+describe("resolveStep2Code", () => {
+  const placeholderA = 'def run() -> str:\n    """A"""\n    return "result"\n'
+  const placeholderB =
+    'def run(x: str) -> str:\n    """B"""\n    return "result"\n'
+
+  it("first visit with no clone seeds the fresh placeholder", () => {
+    const result = resolveStep2Code({
+      code: "",
+      newPlaceholder: placeholderA,
+      generatedPlaceholder: "",
+      schemaChangedHint: false,
+      cloneCode: null,
+    })
+    expect(result).toEqual({
+      code: placeholderA,
+      generatedPlaceholder: placeholderA,
+      schemaChangedHint: false,
+      cloneConsumed: false,
+    })
+  })
+
+  it("first visit with a clone seeds the clone code and marks it consumed", () => {
+    const cloneCode = "def run():\n    return 'cloned'\n"
+    const result = resolveStep2Code({
+      code: "",
+      newPlaceholder: placeholderA,
+      generatedPlaceholder: "",
+      schemaChangedHint: false,
+      cloneCode,
+    })
+    expect(result).toEqual({
+      code: cloneCode,
+      generatedPlaceholder: placeholderA,
+      schemaChangedHint: false,
+      cloneConsumed: true,
+    })
+  })
+
+  it("regenerates an untouched placeholder after a schema change", () => {
+    const result = resolveStep2Code({
+      code: placeholderA,
+      newPlaceholder: placeholderB,
+      generatedPlaceholder: placeholderA,
+      schemaChangedHint: false,
+      cloneCode: null,
+    })
+    expect(result).toEqual({
+      code: placeholderB,
+      generatedPlaceholder: placeholderB,
+      schemaChangedHint: false,
+      cloneConsumed: false,
+    })
+  })
+
+  // The regression this guards: returning to the Code step (browser Back makes
+  // the wizard read as a first visit) must not overwrite authored code.
+  it("preserves user-authored code and flags the schema change", () => {
+    const userCode = placeholderA + "\n# my real implementation\n"
+    const result = resolveStep2Code({
+      code: userCode,
+      newPlaceholder: placeholderB,
+      generatedPlaceholder: placeholderA,
+      schemaChangedHint: false,
+      cloneCode: null,
+    })
+    expect(result).toEqual({
+      code: userCode,
+      generatedPlaceholder: placeholderB,
+      schemaChangedHint: true,
+      cloneConsumed: false,
+    })
+  })
+
+  it("leaves user-authored code untouched when the schema is unchanged", () => {
+    const userCode = placeholderA + "\n# my real implementation\n"
+    const result = resolveStep2Code({
+      code: userCode,
+      newPlaceholder: placeholderA,
+      generatedPlaceholder: placeholderA,
+      schemaChangedHint: true,
+      cloneCode: null,
+    })
+    expect(result).toEqual({
+      code: userCode,
+      generatedPlaceholder: placeholderA,
+      schemaChangedHint: true,
+      cloneConsumed: false,
+    })
+  })
+
+  it("does not re-seed from the clone once the user has code", () => {
+    const userCode = "def run():\n    return 'edited'\n"
+    const result = resolveStep2Code({
+      code: userCode,
+      newPlaceholder: placeholderB,
+      generatedPlaceholder: placeholderA,
+      schemaChangedHint: false,
+      // A stale clone that was already consumed would still be passed as null
+      // by the caller; even if present, existing code wins.
+      cloneCode: "def run():\n    return 'cloned'\n",
+    })
+    expect(result.code).toBe(userCode)
+    expect(result.cloneConsumed).toBe(false)
   })
 })
 

--- a/app/web_ui/src/lib/utils/code_tool_helpers.test.ts
+++ b/app/web_ui/src/lib/utils/code_tool_helpers.test.ts
@@ -202,28 +202,83 @@ describe("generateCodeToolPlaceholder", () => {
     expect(result).toContain("def run(ids: list[int]) -> str:")
   })
 
-  it("escapes triple quotes in description", () => {
-    const schema = { type: "object", properties: {} }
-    const result = generateCodeToolPlaceholder(schema, 'has """quotes"""')
-    expect(result).not.toContain('"""has """')
-    expect(result).toContain("has ''quotes''")
-  })
-
-  it("escapes Python reserved words in parameter names", () => {
+  // The sandbox invokes run() with keyword arguments keyed by the schema's exact
+  // property names, so the stub must never rename them. Reserved-word names are
+  // rejected by CodeTool validation server-side, not rewritten here.
+  it("uses schema property names verbatim, without renaming", () => {
     const schema = {
       type: "object",
       properties: {
-        def: { type: "string" },
-        return: { type: "integer" },
+        match: { type: "string" },
+        type: { type: "integer" },
       },
-      required: ["def"],
+      required: ["match"],
     }
     const result = generateCodeToolPlaceholder(schema, "test")
-    expect(result).toContain("def_param: str")
-    expect(result).toContain("return_param: int | None = None")
-    expect(result).not.toMatch(/\(def:/)
-    expect(result).not.toMatch(/, return:/)
+    expect(result).toContain(
+      "def run(match: str, type: int | None = None) -> str:",
+    )
   })
+
+  // Each case asserts the exact stub so the docstring stays a valid Python string
+  // for any description (verified against compile() when this table was built).
+  const docstringCases: { name: string; desc: string; escaped: string }[] = [
+    {
+      name: "embedded triple quotes",
+      desc: 'has """quotes"""',
+      escaped: 'has \\"\\"\\"quotes\\"\\"\\"',
+    },
+    {
+      name: "trailing double quote",
+      desc: 'ends with "',
+      escaped: 'ends with \\"',
+    },
+    {
+      name: "trailing backslash",
+      desc: "ends with \\",
+      escaped: "ends with \\\\",
+    },
+    {
+      name: "backslash followed by triple quote",
+      desc: '\\"""',
+      escaped: '\\\\\\"\\"\\"',
+    },
+    {
+      name: "lone double quote",
+      desc: '"',
+      escaped: '\\"',
+    },
+    {
+      name: "lone backslash",
+      desc: "\\",
+      escaped: "\\\\",
+    },
+    {
+      name: "escaped-looking quote sequence",
+      desc: 'mix \\" of \\\\ and """ end "',
+      escaped: 'mix \\\\\\" of \\\\\\\\ and \\"\\"\\" end \\"',
+    },
+    {
+      name: "multiline description",
+      desc: "line one\nline two",
+      escaped: "line one\nline two",
+    },
+    {
+      name: "empty description",
+      desc: "",
+      escaped: "",
+    },
+  ]
+
+  for (const { name, desc, escaped } of docstringCases) {
+    it(`escapes docstring safely: ${name}`, () => {
+      const schema = { type: "object", properties: {} }
+      const result = generateCodeToolPlaceholder(schema, desc)
+      expect(result).toBe(
+        `def run() -> str:\n    """${escaped}"""\n    # TODO: implement\n    return "result"\n`,
+      )
+    })
+  }
 
   it("handles deeply nested array/object types", () => {
     const schema = {

--- a/app/web_ui/src/lib/utils/code_tool_helpers.ts
+++ b/app/web_ui/src/lib/utils/code_tool_helpers.ts
@@ -156,6 +156,81 @@ export function isCodeUnmodified(
   return currentCode.trim() === "" || currentCode === originalPlaceholder
 }
 
+export interface Step2CodeResolution {
+  code: string
+  generatedPlaceholder: string
+  schemaChangedHint: boolean
+  // Whether the clone's seed code was used. When true the caller drops it so a
+  // later return to the Code step doesn't overwrite the user's edits with it.
+  cloneConsumed: boolean
+}
+
+/**
+ * Decide the Code step's editor contents when the user advances from the
+ * Define step.
+ *
+ * Keyed on whether code already exists — not on the wizard step — because the
+ * browser Back button pops the shallow-routing step state, so the step alone
+ * can't tell a first visit from a return. Defaulting to "first visit" would
+ * overwrite the user's authored code with a fresh placeholder. The cases:
+ *
+ *  - No code yet: seed from the clone (if any), else the generated placeholder.
+ *  - Untouched placeholder: regenerate it for the (possibly changed) schema.
+ *  - User-authored code: preserve it, and flag when the schema changed so the
+ *    user knows to reconcile run()'s parameters.
+ */
+export function resolveStep2Code(args: {
+  code: string
+  newPlaceholder: string
+  generatedPlaceholder: string
+  schemaChangedHint: boolean
+  cloneCode: string | null
+}): Step2CodeResolution {
+  const {
+    code,
+    newPlaceholder,
+    generatedPlaceholder,
+    schemaChangedHint,
+    cloneCode,
+  } = args
+
+  if (code === "") {
+    const useClone = !!cloneCode
+    return {
+      code: useClone ? (cloneCode as string) : newPlaceholder,
+      generatedPlaceholder: newPlaceholder,
+      schemaChangedHint: false,
+      cloneConsumed: useClone,
+    }
+  }
+
+  if (isCodeUnmodified(code, generatedPlaceholder)) {
+    return {
+      code: newPlaceholder,
+      generatedPlaceholder: newPlaceholder,
+      schemaChangedHint: false,
+      cloneConsumed: false,
+    }
+  }
+
+  if (newPlaceholder !== generatedPlaceholder) {
+    return {
+      code,
+      generatedPlaceholder: newPlaceholder,
+      schemaChangedHint: true,
+      cloneConsumed: false,
+    }
+  }
+
+  // User-authored code and the schema is unchanged: leave everything as-is.
+  return {
+    code,
+    generatedPlaceholder,
+    schemaChangedHint,
+    cloneConsumed: false,
+  }
+}
+
 /**
  * Format a parameter value for inline preview display.
  *

--- a/app/web_ui/src/lib/utils/code_tool_helpers.ts
+++ b/app/web_ui/src/lib/utils/code_tool_helpers.ts
@@ -58,51 +58,6 @@ function jsonTypeToPython(prop: JsonSchemaProperty): string {
   }
 }
 
-const PYTHON_RESERVED_WORDS = new Set([
-  "False",
-  "None",
-  "True",
-  "and",
-  "as",
-  "assert",
-  "async",
-  "await",
-  "break",
-  "class",
-  "continue",
-  "def",
-  "del",
-  "elif",
-  "else",
-  "except",
-  "finally",
-  "for",
-  "from",
-  "global",
-  "if",
-  "import",
-  "in",
-  "is",
-  "lambda",
-  "nonlocal",
-  "not",
-  "or",
-  "pass",
-  "raise",
-  "return",
-  "try",
-  "while",
-  "with",
-  "yield",
-])
-
-/**
- * Escape a parameter name if it collides with a Python reserved word.
- */
-function safePythonName(name: string): string {
-  return PYTHON_RESERVED_WORDS.has(name) ? `${name}_param` : name
-}
-
 export interface CodeToolParam {
   name: string
   pythonType: string
@@ -141,12 +96,14 @@ function buildParamList(params: CodeToolParam[]): string {
   const requiredParams = params.filter((p) => p.required)
   const optionalParams = params.filter((p) => !p.required)
 
+  // Schema property names are used verbatim: the sandbox calls run() with
+  // keyword arguments keyed by these exact names, so renaming any would break the call.
   const parts: string[] = []
   for (const p of requiredParams) {
-    parts.push(`${safePythonName(p.name)}: ${p.pythonType}`)
+    parts.push(`${p.name}: ${p.pythonType}`)
   }
   for (const p of optionalParams) {
-    parts.push(`${safePythonName(p.name)}: ${p.pythonType} | None = None`)
+    parts.push(`${p.name}: ${p.pythonType} | None = None`)
   }
   return parts.join(", ")
 }
@@ -160,9 +117,9 @@ export function generateCodeToolPlaceholder(
 ): string {
   const params = extractParams(schema)
   const paramList = buildParamList(params)
-  // Prevent the description from prematurely closing the triple-quoted docstring.
-  // Replace any embedded """ with '' (two single-quotes) which is safe inside """.
-  const safeDesc = toolDescription.replace(/"""/g, "''")
+  // Escape backslashes then double-quotes so the description can neither close the
+  // triple-quoted docstring nor leave a dangling escape (e.g. a trailing " or \).
+  const safeDesc = toolDescription.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
 
   return `def run(${paramList}) -> str:
     """${safeDesc}"""

--- a/app/web_ui/src/lib/utils/form_list.svelte
+++ b/app/web_ui/src/lib/utils/form_list.svelte
@@ -13,6 +13,19 @@
   // Unique ID for the list, for scrolling to top after removal
   let id = "form_list_" + Math.random().toString(36).substring(2, 15)
 
+  // The add button, used as a stable in-tree anchor to announce row changes.
+  let add_button_el: HTMLButtonElement | undefined
+
+  // Adding/removing a row is a plain button click, which fires no native
+  // input/change event. Emit a bubbling change like a native control would
+  // (mirrors fancy_select) so ancestor on:change handlers — e.g. unsaved-changes
+  // and tested-state tracking — react to structural row edits. The initial
+  // start_with_one seed runs before mount, so add_button_el is still undefined
+  // then and no spurious event fires.
+  function announce_row_change() {
+    add_button_el?.dispatchEvent(new Event("change", { bubbles: true }))
+  }
+
   function remove_item(index: number) {
     let item = content[index]
     let isItemUnedited = false
@@ -43,6 +56,7 @@
       content.splice(index, 1)
       // trigger reactivity
       content = content
+      announce_row_change()
       // Move the page to the top anchor
       const list = document.getElementById(id)
       if (list) {
@@ -62,6 +76,7 @@
     }
     // Trigger reactivity
     content = content
+    announce_row_change()
     if (focus) {
       // Scroll into view. Async to allow rendering first
       setTimeout(() => {
@@ -108,6 +123,7 @@
 
 <div class="flex place-content-center">
   <button
+    bind:this={add_button_el}
     class="btn btn-sm mt-4 {frozen || hide_add_button ? 'hidden' : ''}"
     on:click={() => add_item(true)}
     id={id + "_add_button"}

--- a/app/web_ui/src/routes/(app)/tools/[project_id]/add_tools/code_tool/+page.svelte
+++ b/app/web_ui/src/routes/(app)/tools/[project_id]/add_tools/code_tool/+page.svelte
@@ -25,9 +25,9 @@
     generateCodeToolPlaceholder,
     generateImportHelper,
     shouldInsertImport,
-    isCodeUnmodified,
     generateExamples,
     plainTextParamsSchema,
+    resolveStep2Code,
   } from "$lib/utils/code_tool_helpers"
 
   import { agentInfo } from "$lib/agent"
@@ -145,26 +145,21 @@
       parameters_schema,
       tool_description,
     )
-    if (current_step === "define") {
-      // First visit to step 2
-      if (clone_code) {
-        code = clone_code
-        clone_code = null
-      } else {
-        code = new_placeholder
-      }
-      generated_placeholder = new_placeholder
-      schema_changed_hint = false
-    } else {
-      // Returning from step 1 after editing schema
-      if (isCodeUnmodified(code, generated_placeholder)) {
-        code = new_placeholder
-        generated_placeholder = new_placeholder
-        schema_changed_hint = false
-      } else if (new_placeholder !== generated_placeholder) {
-        generated_placeholder = new_placeholder
-        schema_changed_hint = true
-      }
+    // Decide the editor contents from the code state itself, not current_step:
+    // browser Back pops the shallow-routing step, so current_step reads
+    // "define" on a return and would wrongly wipe user code with a placeholder.
+    const resolved = resolveStep2Code({
+      code,
+      newPlaceholder: new_placeholder,
+      generatedPlaceholder: generated_placeholder,
+      schemaChangedHint: schema_changed_hint,
+      cloneCode: clone_code,
+    })
+    code = resolved.code
+    generated_placeholder = resolved.generatedPlaceholder
+    schema_changed_hint = resolved.schemaChangedHint
+    if (resolved.cloneConsumed) {
+      clone_code = null
     }
 
     // Push a shallow-routing history entry so browser Back returns to step 1

--- a/libs/core/kiln_ai/datamodel/code_tool.py
+++ b/libs/core/kiln_ai/datamodel/code_tool.py
@@ -1,10 +1,11 @@
 """CodeTool data model — a user-authored Python function stored as a project artifact."""
 
 import ast
+import keyword
 import re
 from typing import Any
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, ValidationInfo, field_validator, model_validator
 from typing_extensions import Self
 
 from kiln_ai.datamodel.basemodel import FilenameString, KilnParentedModel
@@ -71,8 +72,20 @@ class CodeTool(KilnParentedModel):
         return v
 
     @model_validator(mode="after")
-    def validate_parameters_schema(self) -> Self:
+    def validate_parameters_schema(self, info: ValidationInfo) -> Self:
         validate_schema_dict(self.parameters_schema, require_object=True)
+
+        # Parameters are passed to run() as keyword arguments keyed by these names,
+        # and a Python reserved word can never be declared as a run() parameter, so
+        # reject it at authoring. Loaded files are exempt so old projects still open.
+        # Soft keywords (match/case/type/_) are valid identifiers and stay allowed.
+        if not self.loaded_from_file(info):
+            for param_name in self.parameters_schema.get("properties", {}):
+                if keyword.iskeyword(param_name):
+                    raise ValueError(
+                        f"Parameter name '{param_name}' is a reserved Python keyword "
+                        "and cannot be used as a run() parameter. Choose a different name."
+                    )
         return self
 
     @model_validator(mode="after")

--- a/libs/core/kiln_ai/datamodel/test_code_tool.py
+++ b/libs/core/kiln_ai/datamodel/test_code_tool.py
@@ -1,5 +1,7 @@
 """Tests for CodeTool datamodel — validation, defaults, save/load, parent registration."""
 
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -121,6 +123,60 @@ class TestSchemaValidation:
     def test_missing_properties_rejected(self):
         with pytest.raises(ValidationError, match="object with properties"):
             _make_code_tool(parameters_schema={"type": "object"})
+
+    @pytest.mark.parametrize(
+        "param_name",
+        ["from", "class", "return", "lambda", "None", "True", "import"],
+    )
+    def test_reserved_word_param_rejected(self, param_name):
+        schema = {
+            "type": "object",
+            "properties": {param_name: {"type": "string"}},
+        }
+        with pytest.raises(ValidationError, match="reserved Python keyword"):
+            _make_code_tool(parameters_schema=schema)
+
+    @pytest.mark.parametrize("param_name", ["match", "case", "type", "_"])
+    def test_soft_keyword_param_allowed(self, param_name):
+        # Soft keywords are still valid identifiers, so def run(match) works fine.
+        schema = {
+            "type": "object",
+            "properties": {param_name: {"type": "string"}},
+        }
+        ct = _make_code_tool(parameters_schema=schema)
+        assert param_name in ct.parameters_schema["properties"]
+
+    @pytest.mark.parametrize("param_name", ["from_date", "class_name", "query"])
+    def test_normal_param_names_allowed(self, param_name):
+        schema = {
+            "type": "object",
+            "properties": {param_name: {"type": "string"}},
+        }
+        ct = _make_code_tool(parameters_schema=schema)
+        assert param_name in ct.parameters_schema["properties"]
+
+    def test_reserved_word_param_still_loads_from_file(self, tmp_path):
+        # Files saved before the reserved-word check may carry such a parameter;
+        # they must still load, and loaded instances must still accept edits.
+        project = Project(name="test_project", path=tmp_path / "project")
+        project.save_to_file()
+
+        ct = _make_code_tool()
+        ct.parent = project
+        ct.save_to_file()
+
+        assert ct.path is not None
+        data = json.loads(ct.path.read_text())
+        data["parameters_schema"]["properties"] = {"from": {"type": "string"}}
+        ct.path.write_text(json.dumps(data))
+
+        loaded = CodeTool.from_id_and_parent_path(ct.id, project.path)
+        assert loaded is not None
+        assert "from" in loaded.parameters_schema["properties"]
+
+        # Assignment re-runs model validators; archiving a legacy tool must not raise.
+        loaded.is_archived = True
+        loaded.save_to_file()
 
 
 # ---------------------------------------------------------------------------

--- a/libs/core/kiln_ai/sandbox/test_code_tool_execution.py
+++ b/libs/core/kiln_ai/sandbox/test_code_tool_execution.py
@@ -650,6 +650,97 @@ class TestListTools:
         assert tool_list[0]["description"] == "Add two numbers"
 
 
+class TestBrokenAllowlistEntry:
+    """One unresolvable allowlist entry (e.g. a deleted RAG config) must not
+    take down the whole nested-tool surface."""
+
+    BROKEN_ID = "kiln_tool::rag::missing"
+
+    def _patch_registry(self, healthy: FakeTool):
+        def resolver(tool_id, project=None, task=None):
+            if tool_id == self.BROKEN_ID:
+                raise ValueError(f"RAG config not found: {tool_id}")
+            return healthy
+
+        return patch(
+            "kiln_ai.tools.tool_registry.tool_from_id_and_project",
+            side_effect=resolver,
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_tools_shows_healthy_and_unavailable(self, tmp_path):
+        fake = FakeTool("kiln_tool::add_numbers", "fake_add", params=EMPTY_SCHEMA)
+        code = textwrap.dedent("""\
+            import json
+            from kiln import tools
+            def run(x):
+                return json.dumps(tools.list_tools())
+        """)
+        tool = _make_python_code_tool(
+            tmp_path,
+            code,
+            tool_allowlist=["kiln_tool::add_numbers", self.BROKEN_ID],
+        )
+        with self._patch_registry(fake):
+            result = await tool.run(None, x="test")
+        assert not result.is_error
+        tool_list = json.loads(result.output)
+        assert len(tool_list) == 2
+        by_name = {t["name"]: t for t in tool_list}
+        assert by_name["fake_add"]["description"] == "fake"
+        broken = by_name[self.BROKEN_ID]
+        assert broken["description"].startswith("(unavailable:")
+        assert "RAG config not found" in broken["description"]
+
+    @pytest.mark.asyncio
+    async def test_healthy_tool_still_callable(self, tmp_path):
+        fake = FakeTool(
+            "kiln_tool::add_numbers",
+            "fake_add",
+            params=EMPTY_SCHEMA,
+            result=ToolCallResult(output="42"),
+        )
+        code = textwrap.dedent("""\
+            from kiln import tools
+            def run(x):
+                return tools.fake_add()
+        """)
+        tool = _make_python_code_tool(
+            tmp_path,
+            code,
+            tool_allowlist=["kiln_tool::add_numbers", self.BROKEN_ID],
+        )
+        with self._patch_registry(fake):
+            result = await tool.run(None, x="test")
+        assert not result.is_error
+        assert result.output == "42"
+
+    @pytest.mark.asyncio
+    async def test_calling_broken_tool_reports_unavailable(self, tmp_path):
+        fake = FakeTool("kiln_tool::add_numbers", "fake_add", params=EMPTY_SCHEMA)
+        code = textwrap.dedent("""\
+            from kiln.tools import ToolNotAllowed
+            from kiln import tools
+            def run(x):
+                try:
+                    tools.missing_rag()
+                except ToolNotAllowed as e:
+                    return f"unavailable: {e}"
+                return "no error"
+        """)
+        tool = _make_python_code_tool(
+            tmp_path,
+            code,
+            tool_allowlist=["kiln_tool::add_numbers", self.BROKEN_ID],
+        )
+        with self._patch_registry(fake):
+            result = await tool.run(None, x="test")
+        assert not result.is_error
+        assert "unavailable:" in result.output
+        assert "not available" in result.output
+        assert "fake_add" in result.output
+
+
 class TestTimeout:
     @pytest.mark.asyncio
     async def test_timeout_kills_child(self, tmp_path):
@@ -689,6 +780,79 @@ class TestTimeout:
             result = await tool.run(None, x="test")
         assert result.is_error
         assert "timed out" in result.output
+
+
+class TestNestedTimeoutKind:
+    """The dispatcher classifies a nested code tool's timeout from the typed
+    ``timed_out`` flag on its result, never from the error text."""
+
+    def _nested_code_tool(self, project, code: str, timeout_seconds: int = 10):
+        ct = _make_code_tool(
+            code,
+            name="Nested Tool",
+            tool_function_name="nested_tool",
+            parameters_schema=EMPTY_SCHEMA,
+            tool_allowlist=[],
+            timeout_seconds=timeout_seconds,
+        )
+        ct.parent = project
+        return PythonCodeTool(ct, project)
+
+    OUTER_CODE = textwrap.dedent("""\
+        from kiln.tools import ToolCallError, ToolTimeout
+        from kiln import tools
+        def run(x):
+            try:
+                tools.nested_tool()
+            except ToolTimeout:
+                return "timeout"
+            except ToolCallError:
+                return "call_error"
+            return "no error"
+    """)
+
+    @pytest.mark.asyncio
+    async def test_real_nested_timeout_raises_tool_timeout(self, tmp_path):
+        project = _make_project(tmp_path)
+        nested = self._nested_code_tool(
+            project,
+            "import time\ndef run():\n    time.sleep(30)\n",
+            timeout_seconds=1,
+        )
+        outer_ct = _make_code_tool(
+            self.OUTER_CODE, tool_allowlist=["kiln_tool::add_numbers"]
+        )
+        outer_ct.parent = project
+        outer = PythonCodeTool(outer_ct, project)
+        with patch(
+            "kiln_ai.tools.tool_registry.tool_from_id_and_project",
+            return_value=nested,
+        ):
+            result = await outer.run(None, x="test")
+        assert not result.is_error
+        assert result.output == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_failure_text_mentioning_timeout_raises_call_error(self, tmp_path):
+        # An ordinary failure whose message merely contains "timed out" must
+        # not spoof the timeout kind (which callers treat as retryable).
+        project = _make_project(tmp_path)
+        nested = self._nested_code_tool(
+            project,
+            'def run():\n    raise Exception("upstream request timed out after 3 retries")\n',
+        )
+        outer_ct = _make_code_tool(
+            self.OUTER_CODE, tool_allowlist=["kiln_tool::add_numbers"]
+        )
+        outer_ct.parent = project
+        outer = PythonCodeTool(outer_ct, project)
+        with patch(
+            "kiln_ai.tools.tool_registry.tool_from_id_and_project",
+            return_value=nested,
+        ):
+            result = await outer.run(None, x="test")
+        assert not result.is_error
+        assert result.output == "call_error"
 
 
 class TestCrash:

--- a/libs/core/kiln_ai/tools/base_tool.py
+++ b/libs/core/kiln_ai/tools/base_tool.py
@@ -41,6 +41,10 @@ class ToolCallResult(BaseModel):
         default=None,
         description="Human-readable error message, set when is_error is True.",
     )
+    timed_out: bool = Field(
+        default=False,
+        description="Whether the error was the tool hitting its execution time limit. Carried structurally so callers can classify timeouts without parsing output text.",
+    )
 
 
 class KilnToolInterface(ABC):

--- a/libs/core/kiln_ai/tools/code_tool.py
+++ b/libs/core/kiln_ai/tools/code_tool.py
@@ -122,7 +122,9 @@ class PythonCodeTool(KilnToolInterface):
         tool_name = self._code_tool.tool_function_name
         if outcome.timed_out:
             msg = f"Code tool '{tool_name}' timed out after {self._code_tool.timeout_seconds}s"
-            return ToolCallResult(output=msg, is_error=True, error_message=msg)
+            return ToolCallResult(
+                output=msg, is_error=True, error_message=msg, timed_out=True
+            )
         if outcome.crashed:
             msg = f"Code tool '{tool_name}' crashed (exit code {outcome.exit_code})"
             return ToolCallResult(output=msg, is_error=True, error_message=msg)
@@ -372,10 +374,9 @@ class PythonCodeTool(KilnToolInterface):
             result = await tool.run(context, **arguments)
 
             if result.is_error:
-                is_timeout = isinstance(tool, PythonCodeTool) and "timed out" in (
-                    result.output or ""
-                )
-                kind = "timeout" if is_timeout else "call_error"
+                # The result carries timeouts as a typed flag; ordinary failures
+                # whose text merely mentions a timeout must stay call_error.
+                kind = "timeout" if result.timed_out else "call_error"
                 responses.put(
                     {
                         "type": "tool_result",
@@ -467,7 +468,18 @@ class PythonCodeTool(KilnToolInterface):
 
         name_map: dict[str, list[ToolId]] = {}
         for tool_id in self._code_tool.tool_allowlist:
-            fn_name = await self._canonical_tool_name(tool_id)
+            try:
+                fn_name = await self._canonical_tool_name(tool_id)
+            except Exception as exc:
+                # A broken entry (e.g. a deleted RAG config) must not take the
+                # healthy tools down with it. Leaving it out of the map makes
+                # calls to it fail with the standard "not available" error.
+                logger.warning(
+                    "Code tool allowlist entry '%s' failed to resolve: %s",
+                    tool_id,
+                    exc,
+                )
+                continue
             name_map.setdefault(fn_name, []).append(tool_id)
 
         self._name_map = name_map
@@ -488,31 +500,39 @@ class PythonCodeTool(KilnToolInterface):
 
     async def _get_tools_info(self) -> list[dict[str, Any]]:
         """Return tool definitions for ``list_tools()``."""
+        from kiln_ai.tools.tool_registry import tool_from_id_and_project
+
         result: list[dict[str, Any]] = []
         for tool_id in self._code_tool.tool_allowlist:
             try:
-                from kiln_ai.tools.tool_registry import tool_from_id_and_project
-
                 tool = tool_from_id_and_project(
                     tool_id, project=self._project, task=self._task
                 )
                 tool_def = await tool.toolcall_definition()
-                result.append(
-                    {
-                        "name": tool_def["function"]["name"],
-                        "description": tool_def["function"]["description"],
-                        "parameters_schema": tool_def["function"]["parameters"],
-                    }
+            except Exception as exc:
+                # A broken entry (e.g. a deleted RAG config) must not hide the
+                # healthy tools. Its canonical name is unknowable without
+                # resolving it, so list it under its id with the reason.
+                logger.warning(
+                    "Code tool allowlist entry '%s' failed to resolve: %s",
+                    tool_id,
+                    exc,
                 )
-            except Exception:
-                fn_name = await self._canonical_tool_name(tool_id)
                 result.append(
                     {
-                        "name": fn_name,
-                        "description": "(unavailable)",
+                        "name": tool_id,
+                        "description": f"(unavailable: {exc})",
                         "parameters_schema": {},
                     }
                 )
+                continue
+            result.append(
+                {
+                    "name": tool_def["function"]["name"],
+                    "description": tool_def["function"]["description"],
+                    "parameters_schema": tool_def["function"]["parameters"],
+                }
+            )
         return result
 
 

--- a/libs/core/kiln_ai/tools/tool_registry.py
+++ b/libs/core/kiln_ai/tools/tool_registry.py
@@ -146,8 +146,8 @@ def tool_from_id_and_project(
                 f"Code tool not found: {ct_id} in project {project.id} for tool {tool_id}"
             )
 
-        # Lazy import — PythonCodeTool is phase 2; for now return a
-        # lightweight wrapper that has the tool's identity and definition.
+        # Lazy import — PythonCodeTool pulls in the multiprocessing execution
+        # runtime, which most registry lookups never need.
         from kiln_ai.tools.code_tool import PythonCodeTool
 
         return PythonCodeTool(code_tool, project, task)


### PR DESCRIPTION
> **Review-only PR — do not merge.** These changes are already landed on `dchiang/eb-v2-merge` (the eval-builder integration branch); this PR is a focused review surface for one area of that work. Every fix carries an inline comment explaining what was broken and why the fix takes this shape. Comments marked **Personal review requested** are the spots that want human judgment — the rest is context your tooling can skim. Reply on the inline comments (or add new line comments); accepted feedback will be implemented on `eb-v2-merge` and the commit sha posted back here. When review wraps, this PR is closed, not merged — its base and head are throwaway review refs.

Surface: code-tool execution runtime, the CodeTool data model, and the code-tool authoring wizard. Commits: `afe821bd1 (landed as c8876814e)` (isolate broken allowlist entries so one dead entry can't take the whole nested-tool surface down; carry tool timeouts as a typed flag instead of sniffing output text), `4a63c3336 (landed as 34e6367a0)` (reject reserved-word parameter names at authoring and generate docstrings that stay valid for any description), `9665236fc (landed as 5dd2487f8)` (preserve authored code when returning to the wizard's code step), plus one hunk of `1c9a0cb1d (landed as one hunk of 6f1afc872)` (make FormList row add/remove emit a change event so ancestor handlers notice structural edits). Around half the diff is tests. Three **Personal review requested** comments flag the layer/posture choices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*CI note: the "Check API Schema Bindings" failure here is an artifact of this review PR's pinned snapshot — the canonical schema verification lives on `dchiang/eb-v2-merge`. No action needed from reviewers.*