### PR TITLE
Show tool names, not just function names, in the tool picker

### DIFF
--- a/app/desktop/studio_server/test_tool_api.py
+++ b/app/desktop/studio_server/test_tool_api.py
@@ -12,6 +12,7 @@ from app.desktop.studio_server.tool_api import (
 )
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from kiln_ai.datamodel.code_tool import CodeTool
 from kiln_ai.datamodel.datamodel_enums import StructuredOutputMode
 from kiln_ai.datamodel.external_tool_server import ExternalToolServer, ToolServerType
 from kiln_ai.datamodel.project import Project
@@ -951,6 +952,44 @@ def test_get_available_tools_builtin_ai_models_always_present(client, test_proje
         assert by_id["kiln_tool::llm"]["function_name"] == "llm"
         assert by_id["kiln_tool::llm_judge"]["name"] == "LLM Judge"
         assert by_id["kiln_tool::llm_judge"]["function_name"] == "llm_judge"
+
+
+def test_get_available_tools_code_tools_use_display_name(client, test_project):
+    """Code tools expose their display name (not the function name), since several
+    code tools can share a function name. The function name is returned separately."""
+    for display_name in ["Doc Search V1", "Doc Search V2"]:
+        CodeTool(
+            parent=test_project,
+            name=display_name,
+            tool_function_name="search_docs",
+            tool_description="Search the docs",
+            parameters_schema={"type": "object", "properties": {}},
+            code="def run():\n    return 1\n",
+        ).save_to_file()
+
+    with (
+        patch(
+            "app.desktop.studio_server.tool_api.project_from_id"
+        ) as mock_project_from_id,
+        patch("app.desktop.studio_server.tool_api.Config.shared") as mock_config,
+    ):
+        mock_project_from_id.return_value = test_project
+        mock_config_instance = Mock()
+        mock_config_instance.enable_demo_tools = False
+        mock_config_instance.user_id = "test_user"
+        mock_config.return_value = mock_config_instance
+
+        response = client.get(f"/api/projects/{test_project.id}/available_tools")
+
+    assert response.status_code == 200
+    code_tool_sets = [s for s in response.json() if s["type"] == "code"]
+    assert len(code_tool_sets) == 1
+    tools = code_tool_sets[0]["tools"]
+    assert sorted(tool["name"] for tool in tools) == [
+        "Doc Search V1",
+        "Doc Search V2",
+    ]
+    assert {tool["function_name"] for tool in tools} == {"search_docs"}
 
 
 async def test_create_tool_server_whitespace_handling(
@@ -3578,11 +3617,12 @@ async def test_get_available_tools_with_rag_configs(client, test_project):
             rag_set = next(s for s in result if s["set_name"] == "Search Tools (RAG)")
             assert len(rag_set["tools"]) == 2
 
-            # Verify RAG tool details
+            # Verify RAG tool details: the user-facing config name is the tool
+            # name, and the model-facing tool name is the function name.
             tool_names = [tool["name"] for tool in rag_set["tools"]]
 
-            assert "test_rag_config_1" in tool_names
-            assert "test_rag_config_2" in tool_names
+            assert "Test RAG Config 1" in tool_names
+            assert "Test RAG Config 2" in tool_names
 
             # Verify tool IDs are properly formatted
             for tool in rag_set["tools"]:
@@ -3590,20 +3630,16 @@ async def test_get_available_tools_with_rag_configs(client, test_project):
 
             # Find specific tools and check their descriptions
             config1_tool = next(
-                t for t in rag_set["tools"] if t["name"] == "test_rag_config_1"
+                t for t in rag_set["tools"] if t["name"] == "Test RAG Config 1"
             )
-            assert (
-                config1_tool["description"]
-                == "Test RAG Config 1: First test RAG configuration"
-            )
+            assert config1_tool["function_name"] == "test_rag_config_1"
+            assert config1_tool["description"] == "First test RAG configuration"
 
             config2_tool = next(
-                t for t in rag_set["tools"] if t["name"] == "test_rag_config_2"
+                t for t in rag_set["tools"] if t["name"] == "Test RAG Config 2"
             )
-            assert (
-                config2_tool["description"]
-                == "Test RAG Config 2: Second test RAG configuration"
-            )
+            assert config2_tool["function_name"] == "test_rag_config_2"
+            assert config2_tool["description"] == "Second test RAG configuration"
 
 
 async def test_get_available_tools_with_rag_and_mcp(client, test_project):
@@ -3813,7 +3849,8 @@ async def test_available_tools_excludes_archived_rag_and_kiln_task_tools(
 
         # Only the active RAG config should be present
         assert len(rag_set["tools"]) == 1
-        assert rag_set["tools"][0]["name"] == "active_rag"
+        assert rag_set["tools"][0]["name"] == "Active RAG"
+        assert rag_set["tools"][0]["function_name"] == "active_rag"
 
         # Only the active kiln task tool should be present
         assert len(kiln_task_set["tools"]) == 1

--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -324,9 +324,12 @@ def connect_tool_servers_api(app: FastAPI):
         if rag_configs:
             tools = [
                 ToolApiDescription(
+                    # Use the user-facing config name, not the model-facing tool
+                    # name: tool pickers show the name and the function name
+                    # separately, so the name doesn't need to be in description.
                     id=build_rag_tool_id(rag_config.id),
-                    name=rag_config.tool_name,
-                    description=f"{rag_config.name}: {rag_config.tool_description}",
+                    name=rag_config.name,
+                    description=rag_config.tool_description,
                     function_name=rag_config.tool_name,
                 )
                 for rag_config in rag_configs
@@ -453,8 +456,11 @@ def connect_tool_servers_api(app: FastAPI):
         if code_tools:
             code_tool_items = [
                 ToolApiDescription(
+                    # Use the user-facing display name (like the tools list page).
+                    # Several code tools can share a function name, so the display
+                    # name is what tells them apart in tool pickers.
                     id=build_code_tool_id(ct.id),
-                    name=ct.tool_function_name,
+                    name=ct.name,
                     description=ct.tool_description,
                     function_name=ct.tool_function_name,
                 )

--- a/app/web_ui/src/lib/ui/run_config_component/__tests__/form_element_options_stub.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/__tests__/form_element_options_stub.svelte
@@ -12,5 +12,8 @@
       group.options.map((option) => option.value),
     ),
   )}
+  data-options={JSON.stringify(
+    fancy_select_options.flatMap((group) => group.options),
+  )}
   data-value={JSON.stringify(value)}
 ></div>

--- a/app/web_ui/src/lib/ui/run_config_component/tools_selector.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/tools_selector.svelte
@@ -3,7 +3,11 @@
   import type { OptionGroup } from "$lib/ui/fancy_select_types"
   import { available_tools, load_available_tools } from "$lib/stores"
   import { onMount } from "svelte"
-  import type { ToolSetApiDescription, ToolSetType } from "$lib/types"
+  import type {
+    ToolApiDescription,
+    ToolSetApiDescription,
+    ToolSetType,
+  } from "$lib/types"
   import {
     tools_store,
     tools_store_initialized,
@@ -167,6 +171,24 @@
     "demo",
   ]
 
+  // Show the function name alongside the description when it differs from the
+  // display name. Multiple tools (code tools especially) can share a function
+  // name while having distinct display names, so both are needed to tell them
+  // apart. Also makes the function name searchable in the dropdown.
+  function tool_option_description(
+    tool: ToolApiDescription,
+  ): string | undefined {
+    const description = tool.description ? tool.description.trim() : undefined
+    const function_name =
+      tool.function_name && tool.function_name !== tool.name
+        ? tool.function_name
+        : undefined
+    if (!function_name) {
+      return description
+    }
+    return description ? `${function_name}\n${description}` : function_name
+  }
+
   function get_tool_options(
     available_tool_sets: ToolSetApiDescription[] | undefined,
     code_eval_context: boolean,
@@ -211,7 +233,7 @@
           let options = tools.map((tool) => ({
             value: tool.id,
             label: tool.name,
-            description: tool.description ? tool.description.trim() : undefined,
+            description: tool_option_description(tool),
             disabled: tools_selector_settings.mandatory_tools
               ? tools_selector_settings.mandatory_tools.includes(tool.id)
               : false,

--- a/app/web_ui/src/lib/ui/run_config_component/tools_selector.test.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tools_selector.test.ts
@@ -66,6 +66,75 @@ async function option_values(
   return JSON.parse(el?.getAttribute("data-option-values") ?? "[]")
 }
 
+async function options_for(
+  tool_sets: ToolSetApiDescription[],
+  project_id: string,
+): Promise<{ label: string; description?: string }[]> {
+  available_tools.set({ [project_id]: tool_sets })
+  const { container } = render(ToolsSelector, { props: { project_id } })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await tick()
+  const el = container.querySelector('[data-testid="form-element-options"]')
+  return JSON.parse(el?.getAttribute("data-options") ?? "[]")
+}
+
+describe("ToolsSelector option labels", () => {
+  it("shows the display name, with the function name when it differs", async () => {
+    const options = await options_for(
+      [
+        {
+          type: "code",
+          set_name: "Code Tools",
+          tools: [
+            {
+              id: "kiln_tool::code::a",
+              name: "Doc Search V1",
+              description: "Search the docs",
+              function_name: "search_docs",
+            },
+            {
+              id: "kiln_tool::code::b",
+              name: "Doc Search V2",
+              description: "Search the docs",
+              function_name: "search_docs",
+            },
+          ],
+        },
+      ],
+      "proj_ts_labels",
+    )
+
+    expect(options.map((option) => option.label)).toEqual([
+      "Doc Search V1",
+      "Doc Search V2",
+    ])
+    for (const option of options) {
+      expect(option.description).toBe("search_docs\nSearch the docs")
+    }
+  })
+
+  it("does not repeat the function name when it matches the display name", async () => {
+    const options = await options_for(
+      [
+        {
+          type: "mcp",
+          set_name: "MCP Server: Docs",
+          tools: [
+            {
+              id: "kiln_tool::mcp::remote::docs::search",
+              name: "search",
+              description: "Search",
+              function_name: "search",
+            },
+          ],
+        },
+      ],
+      "proj_ts_labels_same",
+    )
+    expect(options.map((option) => option.description)).toEqual(["Search"])
+  })
+})
+
 describe("ToolsSelector code-eval-only tool filtering", () => {
   it("hides llm_judge outside a code-eval context (keeps llm)", async () => {
     const values = await option_values(false, "proj_ts_off")


### PR DESCRIPTION
## Problem

The tool selection dropdown on the Run page labels each option with the API's `name` field, which for some tool types is the **model-facing function name** rather than the **display name** shown on the Tools page. Two code tools that share a function name are indistinguishable in the picker — the naming that tells them apart is lost.

## Fix

**Backend** (`tool_api.py`) — two tool types were discarding or burying their display name:

| Tool type | `name` before | `name` after | `function_name` |
|---|---|---|---|
| Code tools | `tool_function_name` | `ct.name` (display name) | `tool_function_name` |
| Search (RAG) | `tool_name` | `rag_config.name` | `tool_name` |

Search tools previously folded the config name into the description as a `"<name>: <desc>"` prefix; the description is now just the tool description, since the name has its own slot.

**Frontend** (`tools_selector.svelte`) — the picker labels each option with the display name and shows the function name on the sub-line when the two differ. This is generic across tool types, so built-in and demo tools surface their function names too (`LLM` / `llm`, `Addition` / `add`), and the function name becomes searchable in the dropdown (fancy_select matches label + description).

A code tool now reads:

```
Doc Search V1
search_docs
Search the docs
```

Kiln task tools and MCP tools are unaffected — their display name and function name are already the same value.

## Side effect

Run config summaries and evolution tool diffs share the same `get_tool_names_from_ids` lookup, so they now show display names for code and search tools — consistent with the Tools page.

## Tests

- `test_get_available_tools_code_tools_use_display_name` — two code tools sharing one function name stay distinguishable by name.
- Updated the two RAG `available_tools` tests for the new name/description split.
- Two `tools_selector` cases: function name shown when it differs from the label, omitted when it matches. The test stub now exposes full option objects.

Backend `test_tool_api.py` (106) and the related frontend suites (863) pass; ruff and prettier clean.