### PR TITLE
Add DeepSeek V4 Flash 0731 providers, MiniMax M2.7 & Inkling (Fireworks), and Muse Spark 1.2 (OpenRouter)

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -58,6 +58,7 @@ class ModelName(str, Enum):
     """
 
     fugu_ultra = "fugu_ultra"
+    muse_spark_1_2 = "muse_spark_1_2"
     muse_spark_1_1 = "muse_spark_1_1"
     llama_3_1_8b = "llama_3_1_8b"
     llama_3_1_70b = "llama_3_1_70b"
@@ -3855,6 +3856,33 @@ built_in_models: List[KilnModel] = [
                 model_id="nvidia/llama-3.1-nemotron-70b-instruct",
                 deprecated=True,
                 supports_function_calling=False,
+            ),
+        ],
+    ),
+    # Muse Spark 1.2
+    KilnModel(
+        family=ModelFamily.muse,
+        name=ModelName.muse_spark_1_2,
+        friendly_name="Muse Spark 1.2",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="meta/muse-spark-1.2",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_function_calling=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    # documents (Meta backend 400s on html/csv uploads, so excluded)
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # images
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                ],
+                multimodal_requires_pdf_as_image=True,
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -5628,8 +5628,14 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.fireworks_ai,
-                model_id="accounts/fireworks/models/deepseek-v4-flash",
+                model_id="accounts/fireworks/models/deepseek-v4-flash-0731",
                 structured_output_mode=StructuredOutputMode.json_schema,
+                supports_data_gen=True,
+            ),
+            KilnModelProvider(
+                name=ModelProviderName.together_ai,
+                model_id="deepseek-ai/DeepSeek-V4-Flash-0731",
+                structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_data_gen=True,
             ),
         ],
@@ -8861,6 +8867,15 @@ built_in_models: List[KilnModel] = [
                 require_openrouter_reasoning=True,
                 parser=ModelParserID.r1_thinking,
             ),
+            # Fireworks exposes M2.7 as a text-only endpoint and does not emit
+            # reasoning unless a reasoning effort is explicitly requested, so we
+            # treat it as a standard model here (mirroring the M3 Fireworks entry).
+            KilnModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                model_id="accounts/fireworks/models/minimax-m2p7",
+                structured_output_mode=StructuredOutputMode.json_schema,
+                supports_data_gen=True,
+            ),
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="MiniMaxAI/MiniMax-M2.7",
@@ -9279,7 +9294,12 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_data_gen=True,
             ),
-            # Fireworks lists Inkling on its site but the API returns 404 (not deployed).
+            KilnModelProvider(
+                name=ModelProviderName.fireworks_ai,
+                model_id="accounts/fireworks/models/inkling",
+                structured_output_mode=StructuredOutputMode.json_instructions,
+                supports_data_gen=True,
+            ),
         ],
     ),
     # Fugu Ultra


### PR DESCRIPTION
## What does this PR do?

Updates `libs/core/kiln_ai/adapters/ml_model_list.py`:

- **DeepSeek V4 Flash** — pin the Fireworks provider to the `deepseek-v4-flash-0731` snapshot (the OpenRouter entry already used `-0731`) and add a **Together AI** provider (`deepseek-ai/DeepSeek-V4-Flash-0731`, `json_instructions`, mirroring the V4 Pro Together config).
- **MiniMax M2.7** — add a **Fireworks** provider (`accounts/fireworks/models/minimax-m2p7`). The entry already existed with OpenRouter + Together providers; this adds the missing Fireworks one, mirroring the M3 Fireworks treatment (`json_schema`, non-reasoning — Fireworks doesn't emit reasoning unless explicitly requested, so Kiln drives chain-of-thought via the multi-turn strategy).
- **Inkling** — re-enable the **Fireworks** provider (`accounts/fireworks/models/inkling`); it previously returned 404 and is now deployed.
- **Muse Spark 1.2** — add Meta's Muse Spark 1.2 via **OpenRouter** (`meta/muse-spark-1.2`), mirroring the 1.1 entry (`json_schema`, function calling, vision + document extraction). `text/html` and `text/csv` are excluded from the extraction MIME set because the Meta backend on OpenRouter rejects those uploads with a 400 (this reproduces on the existing 1.1 entry too).

Requested in Slack: https://getkiln.slack.com/archives/C0AG8U78MNG/p1786467499557449

### Test Results

All slugs were verified against authoritative catalogs (Fireworks `/inference/v1/models`, OpenRouter, Together, models.dev, LiteLLM) before editing, then paid integration tests were run for every changed/new provider. DeepSeek V4 Flash already pointed at the `-0731` OpenRouter slug, so only the Fireworks slug change and the new Together provider are new here. MiniMax M2.7 is text-only on Fireworks (no vision), 196k context; Inkling now serves live on Fireworks (chat + tools, 1M context). Muse Spark 1.2 is multimodal (vision + document extraction) via OpenRouter.

All changed/new providers pass their full paid suites. The one failure on a changed provider (`minimax_m2_7-fireworks_ai` llm_as_judge) was a G-eval judge-value flake — the judge returned a score outside the schema range — and passed on an isolated retry; the underlying API call succeeded. The two Muse Spark 1.2 extraction failures (`text/html`, `text/csv`) are provider-side 400s that reproduce identically on the unchanged 1.1 sibling, and those two MIME types have now been excluded from the 1.2 config. Every other failure is on an **unchanged** provider not touched by this PR: OpenRouter llm_as_judge / thinking-level flakes (empty responses, one 405), the known pre-existing `test_structured_input_cot_prompt_builder` trace assertion for reasoning-capable providers, and — worth flagging separately — `minimax_m2_7-together_ai` now returns `400 model_not_available` because Together no longer serves that model serverless (it requires a dedicated endpoint). That Together entry predates this PR and is left unchanged.

DeepSeek V4 Flash (fireworks_ai):
- 11 passed, 1 skipped

DeepSeek V4 Flash (together_ai):
- 11 passed, 1 skipped

MiniMax M2.7 (fireworks_ai):
- 11 passed, 1 skipped (1 llm_as_judge flake — passed on isolated retry)

Inkling (fireworks_ai):
- 11 passed, 1 skipped

Muse Spark 1.2 (openrouter):
- 17 passed, 8 skipped (`text/html` and `text/csv` doc-extraction excluded after provider 400s)

---
DeepSeek V4 Flash (fireworks_ai):
✅ test_data_gen_all_models_providers[deepseek_4_flash-fireworks_ai]
✅ test_data_gen_sample_all_models_providers[deepseek_4_flash-fireworks_ai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[deepseek_4_flash-fireworks_ai]
✅ test_tools_all_built_in_models[deepseek_4_flash-fireworks_ai]
✅ test_all_built_in_models_structured_input[deepseek_4_flash-fireworks_ai]
✅ test_all_built_in_models_structured_output[deepseek_4_flash-fireworks_ai]
✅ test_all_built_in_models_llm_as_judge[deepseek_4_flash-fireworks_ai]
✅ test_structured_input_cot_prompt_builder[deepseek_4_flash-fireworks_ai]
✅ test_structured_output_cot_prompt_builder[deepseek_4_flash-fireworks_ai]
✅ test_all_models_providers_plaintext[deepseek_4_flash-fireworks_ai]
✅ test_cot_prompt_builder[deepseek_4_flash-fireworks_ai]
⏭️ test_all_built_in_models_logprobs_geval[deepseek_4_flash-fireworks_ai] — skipped (no logprobs support)

DeepSeek V4 Flash (together_ai):
✅ test_data_gen_all_models_providers[deepseek_4_flash-together_ai]
✅ test_data_gen_sample_all_models_providers[deepseek_4_flash-together_ai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[deepseek_4_flash-together_ai]
✅ test_tools_all_built_in_models[deepseek_4_flash-together_ai]
✅ test_all_built_in_models_structured_input[deepseek_4_flash-together_ai]
✅ test_all_built_in_models_structured_output[deepseek_4_flash-together_ai]
✅ test_all_built_in_models_llm_as_judge[deepseek_4_flash-together_ai]
✅ test_structured_input_cot_prompt_builder[deepseek_4_flash-together_ai]
✅ test_structured_output_cot_prompt_builder[deepseek_4_flash-together_ai]
✅ test_all_models_providers_plaintext[deepseek_4_flash-together_ai]
✅ test_cot_prompt_builder[deepseek_4_flash-together_ai]
⏭️ test_all_built_in_models_logprobs_geval[deepseek_4_flash-together_ai] — skipped (no logprobs support)

MiniMax M2.7 (fireworks_ai):
✅ test_data_gen_all_models_providers[minimax_m2_7-fireworks_ai]
✅ test_data_gen_sample_all_models_providers[minimax_m2_7-fireworks_ai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[minimax_m2_7-fireworks_ai]
✅ test_tools_all_built_in_models[minimax_m2_7-fireworks_ai]
✅ test_all_built_in_models_structured_input[minimax_m2_7-fireworks_ai]
✅ test_all_built_in_models_structured_output[minimax_m2_7-fireworks_ai]
⚠️ test_all_built_in_models_llm_as_judge[minimax_m2_7-fireworks_ai] — G-eval judge-value flake (score outside schema range); passed on isolated retry
✅ test_structured_input_cot_prompt_builder[minimax_m2_7-fireworks_ai]
✅ test_structured_output_cot_prompt_builder[minimax_m2_7-fireworks_ai]
✅ test_all_models_providers_plaintext[minimax_m2_7-fireworks_ai]
✅ test_cot_prompt_builder[minimax_m2_7-fireworks_ai]
⏭️ test_all_built_in_models_logprobs_geval[minimax_m2_7-fireworks_ai] — skipped (no logprobs support)

Inkling (fireworks_ai):
✅ test_data_gen_all_models_providers[inkling-fireworks_ai]
✅ test_data_gen_sample_all_models_providers[inkling-fireworks_ai]
✅ test_data_gen_sample_all_models_providers_with_structured_output[inkling-fireworks_ai]
✅ test_tools_all_built_in_models[inkling-fireworks_ai]
✅ test_all_built_in_models_structured_input[inkling-fireworks_ai]
✅ test_all_built_in_models_structured_output[inkling-fireworks_ai]
✅ test_all_built_in_models_llm_as_judge[inkling-fireworks_ai]
✅ test_structured_input_cot_prompt_builder[inkling-fireworks_ai]
✅ test_structured_output_cot_prompt_builder[inkling-fireworks_ai]
✅ test_all_models_providers_plaintext[inkling-fireworks_ai]
✅ test_cot_prompt_builder[inkling-fireworks_ai]
⏭️ test_all_built_in_models_logprobs_geval[inkling-fireworks_ai] — skipped (no logprobs support)

Muse Spark 1.2 (openrouter):
✅ test_data_gen_all_models_providers[muse_spark_1_2-openrouter]
✅ test_data_gen_sample_all_models_providers[muse_spark_1_2-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[muse_spark_1_2-openrouter]
✅ test_tools_all_built_in_models[muse_spark_1_2-openrouter]
✅ test_all_built_in_models_structured_input[muse_spark_1_2-openrouter]
✅ test_all_built_in_models_structured_output[muse_spark_1_2-openrouter]
✅ test_all_built_in_models_llm_as_judge[muse_spark_1_2-openrouter]
✅ test_structured_input_cot_prompt_builder[muse_spark_1_2-openrouter]
✅ test_structured_output_cot_prompt_builder[muse_spark_1_2-openrouter]
✅ test_all_models_providers_plaintext[muse_spark_1_2-openrouter]
✅ test_cot_prompt_builder[muse_spark_1_2-openrouter]
✅ test_provider_bad_request[muse_spark_1_2-openrouter]
✅ test_supports_vision_is_coherent[muse_spark_1_2-openrouter]
⏭️ test_all_built_in_models_logprobs_geval[muse_spark_1_2-openrouter] — skipped (no logprobs support)
Extraction (test_extract_document_success): ✅ application/pdf, ✅ image/png, ✅ image/jpeg (×2); ⏭️ text/plain & text/markdown (passthrough); ⏭️ video/* & audio/* (unsupported); text/html & text/csv excluded from config (provider returns 400 "Invalid upload request").

Pre-existing failures on unchanged providers (cross-checked, not caused by this PR):
❌ test_* [minimax_m2_7-together_ai] — 400 model_not_available (Together no longer serves this model serverless; needs a dedicated endpoint). Pre-existing provider, unchanged by this PR.
❌ test_structured_input_cot_prompt_builder[minimax_m2_7-openrouter] — known trace-length assertion for reasoning-capable providers; passes on fireworks_ai.
⚠️ test_all_built_in_models_llm_as_judge[deepseek_4_flash-openrouter] — judge returned a score above schema max (flake).
⚠️ test_thinking_level_reasoning_content[openrouter/deepseek_4_flash/low] and [.../xhigh] — empty-response flakes.
⚠️ test_all_built_in_models_llm_as_judge[inkling-openrouter] — transient 405 from OpenRouter.
⚠️ test_extract_document_success[text/html] and [text/csv] for muse_spark_1_1-openrouter — Meta backend 400 on html/csv uploads (same as 1.2; 1.1 left unchanged).

## Related Issues

None.

## Contributor License Agreement

I, @tawnymanticore, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib