### PR TITLE
Spec builder: show a notice when full-trace evals leave the Kiln Pro flow

### DIFF
--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/__tests__/task_sample_selector_stub.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/__tests__/task_sample_selector_stub.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  // Stand-in for task_sample_selector. Mirrors its props so binding parents
+  // render without warnings, but does no API work.
+  import type { TaskSampleExample } from "$lib/utils/task_sample_example"
+
+  export let project_id: string = ""
+  export let task_id: string = ""
+  export let selected_example: TaskSampleExample | null = null
+  export let is_prompt_building: boolean = false
+  export let has_unsaved_manual_entry: boolean = false
+
+  // Referenced so the unused-export lint stays quiet for props we only accept.
+  void project_id
+  void task_id
+  void selected_example
+  void is_prompt_building
+  void has_unsaved_manual_entry
+</script>
+
+<div data-testid="task-sample-selector-stub">task sample selector stub</div>

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_form.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_form.svelte
@@ -7,6 +7,7 @@
   import type { FieldConfig } from "../select_template/spec_templates"
   import { filename_string_short_validator } from "$lib/utils/input_validators"
   import TaskSampleSelector from "$lib/utils/task_sample_selector.svelte"
+  import Warning from "$lib/ui/warning.svelte"
   import type { TaskSampleExample } from "$lib/utils/task_sample_example"
   import type { Priority } from "$lib/types"
 
@@ -53,6 +54,10 @@
   // copilot_enabled = copilot is available for this task
   // copilot_allowed = copilot is available AND not blocked by current form state
   $: copilot_allowed = copilot_enabled && !evaluate_full_trace
+
+  // Form state silently drops the form from the copilot flow to the manual one,
+  // which is otherwise only visible as a changed submit label. Say so explicitly.
+  $: show_copilot_unsupported_notice = copilot_enabled && !copilot_allowed
 
   $: computed_warn_before_unload =
     warn_before_unload &&
@@ -150,6 +155,18 @@
       />
     {/if}
   </Collapse>
+
+  <!-- Sits outside the collapse and next to the submit button: the mode switch it
+       explains shows up there, and Advanced Options is closed by default. -->
+  {#if show_copilot_unsupported_notice}
+    <div data-testid="copilot-full-trace-notice" role="status">
+      <Warning
+        warning_color="warning"
+        outline={true}
+        warning_message="Kiln Pro does not support evaluating complete agent history yet. This eval will be created manually."
+      />
+    </div>
+  {/if}
 </FormContainer>
 
 {#if copilot_allowed}

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_form.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_form.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, fireEvent, cleanup } from "@testing-library/svelte"
+import type { FieldConfig } from "../select_template/spec_templates"
+
+vi.mock("$app/navigation", () => ({
+  goto: vi.fn(),
+  beforeNavigate: vi.fn(),
+}))
+
+// TaskSampleSelector fetches candidate runs from the API on mount. Stub it so
+// these tests only exercise create_spec_form's own conditional rendering.
+vi.mock("$lib/utils/task_sample_selector.svelte", async () => {
+  const StubModule = await import(
+    "./__tests__/task_sample_selector_stub.svelte"
+  )
+  return { default: StubModule.default }
+})
+
+// Import the component under test after the mocks are registered.
+const CreateSpecForm = (await import("./create_spec_form.svelte")).default
+
+const NOTICE_TESTID = "copilot-full-trace-notice"
+const SELECTOR_STUB_TESTID = "task-sample-selector-stub"
+
+const field_configs: FieldConfig[] = [
+  {
+    key: "behaviour",
+    label: "Behaviour",
+    description: "The behaviour to enforce.",
+    required: true,
+  },
+]
+
+function render_form(overrides: Record<string, unknown> = {}) {
+  return render(CreateSpecForm, {
+    props: {
+      name: "My Eval",
+      property_values: { behaviour: "Be concise" },
+      initial_property_values: { behaviour: "Be concise" },
+      evaluate_full_trace: false,
+      field_configs,
+      copilot_enabled: true,
+      hide_full_trace_option: false,
+      full_trace_disabled: false,
+      error: null,
+      submitting: false,
+      warn_before_unload: false,
+      project_id: "p1",
+      task_id: "t1",
+      ...overrides,
+    },
+  })
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("CreateSpecForm copilot full-trace notice", () => {
+  it("shows the notice and switches to manual creation when full trace is on", () => {
+    const { queryByTestId, getByText } = render_form({
+      evaluate_full_trace: true,
+    })
+    const notice = queryByTestId(NOTICE_TESTID)
+    expect(notice).not.toBeNull()
+    expect(notice?.textContent).toContain(
+      "does not support evaluating complete agent history",
+    )
+    // The consequence the notice describes: manual submit, no sample selector.
+    expect(getByText("Create Eval")).toBeTruthy()
+    expect(queryByTestId(SELECTOR_STUB_TESTID)).toBeNull()
+  })
+
+  it("hides the notice while the form is still on the copilot path", () => {
+    const { queryByTestId, getByText } = render_form()
+    expect(queryByTestId(NOTICE_TESTID)).toBeNull()
+    expect(getByText("Create with Kiln Pro")).toBeTruthy()
+    expect(queryByTestId(SELECTOR_STUB_TESTID)).not.toBeNull()
+  })
+
+  it("hides the notice when copilot is unavailable for the task", () => {
+    const { queryByTestId } = render_form({
+      copilot_enabled: false,
+      evaluate_full_trace: true,
+    })
+    expect(queryByTestId(NOTICE_TESTID)).toBeNull()
+  })
+
+  it("toggles the notice as the user turns full trace on and off", async () => {
+    const { queryByTestId, container } = render_form()
+    expect(queryByTestId(NOTICE_TESTID)).toBeNull()
+
+    const checkbox = container.querySelector(
+      "#evaluate_full_trace",
+    ) as HTMLInputElement
+    expect(checkbox).not.toBeNull()
+    await fireEvent.click(checkbox)
+    expect(queryByTestId(NOTICE_TESTID)).not.toBeNull()
+
+    await fireEvent.click(checkbox)
+    expect(queryByTestId(NOTICE_TESTID)).toBeNull()
+  })
+})


### PR DESCRIPTION
Toggling 'Evaluate Complete Agent History' in the spec builder silently switched the form from the Kiln Pro guided flow to manual creation: the submit button changed from 'Create with Kiln Pro' to 'Create Eval' and the sample selector disappeared with no explanation. Reported by a design partner who only noticed after creating their eval manually.

This adds a visible warning above the submit button when Kiln Pro is available and the toggle moves the form off the Pro path: 'Kiln Pro does not support evaluating complete agent history yet. This eval will be created manually.' It uses the existing Warning component in the same outline style as other in-form advisories, and sits outside the collapsible Advanced Options section so it stays visible after the section is closed. No gating or creation logic changed.

Includes component tests covering the notice showing/hiding, the submit label flip, the sample selector unmounting, and a full toggle on/off cycle. Verified in the running app.

Fixes KIL-786.

<img width="944" height="426" alt="image" src="https://github.com/user-attachments/assets/7ef0c021-f264-4c6b-ae92-ae79696ad8c8" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)