### PR TITLE
Together: thinking levels (none/high) for DeepSeek V4 Pro + Flash

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -623,6 +623,22 @@ DEEPSEEK_V4_OPENROUTER_THINKING_LEVELS = {
     "Extra High": "xhigh",
 }
 
+# Together does not expose OpenRouter's five reasoning depths for DeepSeek V4. It
+# normalizes server-side ("low"/"medium" -> "high", "xhigh" -> "max") and accepts an
+# invalid value with a 200, so a level being accepted proves nothing.
+#
+# Measured against the live API on a bounded, single-solution puzzle (n=25/arm, no
+# truncated samples): "none" removes the reasoning channel entirely (0/16 responses
+# carried reasoning vs 16/16 for the default, across Flash and Pro). "max" did NOT
+# separate from "high" on reasoning volume (medians 1176 vs 1253, IQRs overlapping,
+# Mann-Whitney p=0.27) even though Together does re-render the prompt for it. So
+# "max" is deliberately omitted: it would be a level that looks like more thinking
+# and measurably is not. Do not re-add it without new evidence.
+DEEPSEEK_V4_TOGETHER_THINKING_LEVELS = {
+    "Off/None": "none",
+    "High": "high",
+}
+
 GROK_4_3_OPENROUTER_THINKING_LEVELS = {
     "Off/None": "none",
     "Low": "low",
@@ -5628,6 +5644,8 @@ built_in_models: List[KilnModel] = [
                 model_id="deepseek-ai/DeepSeek-V4-Pro",
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_data_gen=True,
+                available_thinking_levels=DEEPSEEK_V4_TOGETHER_THINKING_LEVELS,
+                default_thinking_level="high",
             ),
             KilnModelProvider(
                 name=ModelProviderName.featherless_ai,
@@ -5665,6 +5683,8 @@ built_in_models: List[KilnModel] = [
                 model_id="deepseek-ai/DeepSeek-V4-Flash-0731",
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_data_gen=True,
+                available_thinking_levels=DEEPSEEK_V4_TOGETHER_THINKING_LEVELS,
+                default_thinking_level="high",
             ),
         ],
     ),

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -694,6 +694,13 @@ class LiteLlmAdapter(BaseAdapter):
             automatic_allowed_params.append("tools")
         if "tool_choice" in completion_kwargs:
             automatic_allowed_params.append("tool_choice")
+        # LiteLLM's per-provider param lists omit reasoning_effort for several providers
+        # that do honor it (Together's DeepSeek V4 models, for example), so without this
+        # the thinking level is dropped and the knob silently does nothing. We only set
+        # reasoning_effort when the provider declares available_thinking_levels, so
+        # whitelisting it here can't send it to a model that doesn't support it.
+        if "reasoning_effort" in completion_kwargs:
+            automatic_allowed_params.append("reasoning_effort")
 
         return list(set(explicit_allowed_params_validated + automatic_allowed_params))
 

--- a/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_litellm_adapter.py
@@ -1104,6 +1104,14 @@ async def test_litellm_tools_returns_empty_list_without_tools(config, mock_task)
             {"tools": [], "allowed_openai_params": ["custom_param"]},
             ["custom_param", "tools"],
         ),
+        # LiteLLM's param list for some providers (Together, for one) omits
+        # reasoning_effort even though the provider honors it, so we whitelist it
+        # whenever we set it -- otherwise the thinking level is silently dropped.
+        ({"reasoning_effort": "high"}, ["reasoning_effort"]),
+        (
+            {"tools": [], "reasoning_effort": "high"},
+            ["reasoning_effort", "tools"],
+        ),
     ],
 )
 def test_allowed_openai_params_for_completion_kwargs_independent_keys(


### PR DESCRIPTION
Together's DeepSeek V4 provider entries declared no thinking levels, so a run config with a `thinking_level` silently skipped the knob on Together.

This adds `{Off/None, High}` to the `together_ai` entries for **DeepSeek V4 Pro and Flash**, plus the adapter fix without which the knob never reaches Together at all.

Everything below is from real calls against `api.together.xyz`.

## The actual blocker: the knob was being dropped

LiteLLM does **not** list `reasoning_effort` as a supported param for `together_ai`, and Kiln passes `drop_params=True`. So it was discarded before the request went out.

This is observable because Together renders **+79 prompt tokens** for a level it recognizes, which makes "did this reach the server" directly checkable:

| call | prompt tok | verdict |
|---|---|---|
| no knob (control) | 615 | — |
| `reasoning_effort="max"`, **Kiln's shape today** | 615 | **silently dropped** |
| `reasoning_effort="max"` + `allowed_openai_params=["reasoning_effort"]` | **694** | reached the server |
| `reasoning_effort="max"`, `drop_params=False` | — | hard `UnsupportedParamsError` |

The fix reuses Kiln's existing `allowed_openai_params` escape hatch — the same mechanism already used to get `tools` past LiteLLM for this provider. **Without it, adding thinking levels would have shipped a knob that does nothing.**

Note this is *request-level* evidence only: it proves the parameter arrived, not that it changed the model's behavior. Those are separated deliberately below.

## Which levels actually do anything

Together normalizes server-side — its docs state *"'low' and 'medium' map to 'high', and 'xhigh' maps to 'max'"* — and **an invalid value returns HTTP 200**. I sent `reasoning_effort: "banana"` and `"zzz9"`; both were accepted and behaved exactly like the default. So acceptance is worthless as evidence, and every level below is judged on measured output.

### `none` — kept

Bounded, single-solution puzzle, n=8/arm/model, zero truncated samples:

| model | arm | reasoning channel present | median reasoning tok | correct |
|---|---|---|---|---|
| Flash | `none` | **0/8** | — | 8/8 |
| Flash | `high` | **8/8** | 1148 | 8/8 |
| Pro | `none` | **0/8** | — | 8/8 |
| Pro | `high` | **8/8** | 2108 | 8/8 |

Unambiguous: **0/16 vs 16/16**, on both models, with answer quality unaffected.

### `max` — dropped, on a pre-registered decision rule

The rule was fixed before running: *`max` stays only if its reasoning-token distribution separates from `high` — non-overlapping IQRs or rank-sum p < 0.05, with zero truncated samples.*

Earlier attempts were invalid because the prompt was ill-posed and answers ran to the token cap; averaging cap-clipped samples produced numbers that flipped sign between runs. So this used a puzzle **brute-force-verified to have exactly one solution**, which terminates reliably. Flash, n=25/arm, **0 truncated, 75/75 correct**:

| arm | n | median | IQR | min–max | prompt tok |
|---|---|---|---|---|---|
| baseline (no param) | 25 | 1290 | 1247–1392 | 998–2316 | 262 |
| `high` | 25 | 1253 | 1129–1361 | 982–1832 | 262 |
| `max` | 25 | **1176** | 1027–1379 | 877–1653 | **341** |

- `high` vs `max`: **p = 0.27**, IQRs overlap heavily → **fails the rule**
- `max`'s median is *lower* than both `high` and baseline — the opposite direction for a "maximum effort" setting
- (`base` vs `max` p = 0.041, but it is the wrong direction and does not survive Bonferroni across the three comparisons)

So Together genuinely re-renders the prompt for `max` (+79 tokens, 100% reproducible) yet the model does not measurably think more. Shipping it would mean offering a level that looks like more reasoning and demonstrably is not — worse than not offering it. **Omitted, with the reasoning recorded in a code comment so nobody re-adds it without new evidence.**

### `low` / `medium` / `xhigh` — dropped

Aliases of `high`/`max` per Together's docs, and empirically indistinguishable from the two garbage strings.

## What changed

- `ml_model_list.py`: new `DEEPSEEK_V4_TOGETHER_THINKING_LEVELS` = `{none, high}`, applied to the `together_ai` entries for **both** DeepSeek V4 Pro and Flash, with `default_thinking_level="high"` — matching the OpenRouter entries and Together's documented default, so the default path is behavior-neutral.
- `litellm_adapter.py`: whitelist `reasoning_effort` in `_allowed_openai_params_for_completion_kwargs` whenever it is set. Guarded by presence, and we only set it when the provider declares `available_thinking_levels`, so it cannot leak to a model that does not support it.
- `test_litellm_adapter.py`: two cases on the existing parametrized test.

`uv run pytest` on `test_ml_model_list.py` + `test_litellm_adapter.py`: **203 passed**. `ruff check` / `ruff format --check` clean.

## Not verified / caveats

- **`high` is a no-op relative to omitting the parameter** (identical to baseline and to garbage values). It is included as the honest, documented default so the UI has something to show alongside `none`; it adds no capability on its own. The real user-facing capability here is `none`.
- **OpenRouter entries are untouched** — their five-level dict still stands; this PR only changes `together_ai`.
- **Pre-existing runaway, not introduced here.** On an ill-posed prompt, Flash on Together sometimes reasons to the token cap and returns an empty assistant message, which Kiln rejects with `"Model returned an assistant message, but no content or tool calls."` This occurs **at baseline with no reasoning param at all** — i.e. on `main` today — in 1/3 and 2/5 of samples. `none` never did it (0/9), so the new knob is a mitigation, not a cause.
- **`together_ai` was deliberately not added to `test_thinking_level_paid.py`.** Its fixture puzzle is genuinely ambiguous (cat-vs-fish between B and D is undetermined), and Flash spirals on it, hitting the full 32,768-token budget and returning empty content. That is the pre-existing runaway above, not a plumbing bug, so adding the provider there would have shipped knowingly-failing paid cases. OpenRouter's `deepseek_4_flash` cases pass 5/5 today (verified). **Worth fixing that fixture separately.**
- **Only the two DeepSeek V4 models were probed.** Other Together models may also honor `reasoning_effort`; the adapter change makes that possible, but no other provider entry was touched.
- The `max` negative result is specific to this bounded puzzle at n=25. A different task shape could conceivably surface a difference — but the burden of proof sits with re-adding it.
