### PR TITLE
Windows: serve the web app for routes with invalid filename characters

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -46,3 +46,27 @@ jobs:
       - name: Build Server
         run: uv build
         working-directory: ./libs/server
+
+  # The web host serves web app routes off the file system, and Windows rejects
+  # filenames that our routes allow. Only a real Windows file system catches that,
+  # so run the web host tests there. Scoped to one test file to stay quick.
+  windows-path-handling-tests:
+    name: Windows Path Handling Tests
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Test Web Host
+        run: uv run python -m pytest app/desktop/studio_server/test_webhost.py

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,6 +56,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # No git operations after checkout; keep the token out of git config.
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3

--- a/app/desktop/studio_server/test_webhost.py
+++ b/app/desktop/studio_server/test_webhost.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import tempfile
 from unittest.mock import patch
@@ -150,3 +151,57 @@ def test_non_api_static_file_still_served(temp_studio, client):
     response = client.get("/page")
     assert response.status_code == 200
     assert "real page" in response.text
+
+
+# The prompt API builds saved prompt IDs as "id::<number>", so every link to a saved
+# prompt puts "::" in the URL path. Windows rejects those characters in a filename.
+SAVED_PROMPT_ROUTE = "/prompts/project-1/task-1/saved/id::246674517812"
+
+
+def stat_failing_on(errno_value):
+    # Patches os.stat globally (starlette calls the module function directly), narrowed
+    # to "::" paths so every other stat still hits the real file system.
+    real_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if "::" in str(path):
+            raise OSError(
+                errno_value,
+                "The filename, directory name, or volume label syntax is incorrect",
+            )
+        return real_stat(path, *args, **kwargs)
+
+    return patch("starlette.staticfiles.os.stat", fake_stat)
+
+
+def test_invalid_filename_error_serves_web_app_fallback(client):
+    with stat_failing_on(errno.EINVAL):
+        response = client.get(SAVED_PROMPT_ROUTE)
+
+    assert response.status_code == 404
+    assert WEB_APP_404_BODY in response.text
+    # Same response a plain missing route gets: the invalid name is a miss, not a
+    # special case the web app has to notice. Indexing raises if a header vanishes.
+    plain_miss = client.get("/route-that-does-not-exist")
+    assert response.headers["cache-control"] == plain_miss.headers["cache-control"]
+    assert response.headers["content-type"] == plain_miss.headers["content-type"]
+
+
+def test_other_os_errors_still_propagate(client):
+    # Only the invalid-filename errno is a miss. Real file system failures must not be
+    # hidden behind the web app's fallback page.
+    with stat_failing_on(errno.EIO):
+        with pytest.raises(OSError) as exc_info:
+            client.get(SAVED_PROMPT_ROUTE)
+
+    assert exc_info.value.errno == errno.EIO
+
+
+def test_invalid_filename_route_served_on_real_filesystem(client):
+    # No mocking. On macOS and Linux "::" is an ordinary missing file; on Windows it is
+    # an invalid name. Both must reach the same fallback page, which is what the
+    # Windows CI job checks against a real Windows file system.
+    response = client.get(SAVED_PROMPT_ROUTE)
+
+    assert response.status_code == 404
+    assert WEB_APP_404_BODY in response.text

--- a/app/desktop/studio_server/webhost.py
+++ b/app/desktop/studio_server/webhost.py
@@ -1,3 +1,4 @@
+import errno
 import mimetypes
 import os
 import sys
@@ -42,6 +43,17 @@ def add_no_cache_headers(response: Response):
 
 # File server that maps /foo/bar to /foo/bar.html (Starlette StaticFiles only does index.html)
 class HTMLStaticFiles(StaticFiles):
+    def lookup_path(self, path: str) -> tuple[str, os.stat_result | None]:
+        try:
+            return super().lookup_path(path)
+        except OSError as e:
+            # Windows raises EINVAL for names with "::" (our saved-prompt routes: "id::123").
+            # No file can exist there, so return StaticFiles' own miss sentinel and let the
+            # html fallback serve the route, exactly as a miss does on macOS and Linux.
+            if e.errno != errno.EINVAL:
+                raise
+            return "", None
+
     async def get_response(self, path: str, scope):
         # API paths must never be served web app content: StaticFiles in html mode
         # answers any miss with the web app's 404.html instead of raising, which


### PR DESCRIPTION
On Windows 11, editing a Saved Prompt description showed a raw error page with [WinError 123] even though the save succeeded. Reported by a design partner; the error made successful saves look failed.

Root cause: saved prompt page URLs contain the API-level prompt ID with a double colon (id::246674517812). After a save, the edit dialog reloads the page. The static file host asks the OS whether a file exists with that name. On macOS and Linux the answer is a clean 'no such file', which falls through to serving the web app. On Windows, '::' is illegal in filenames, so os.stat raises OSError with errno EINVAL instead, which nothing treated as a miss, and the raw exception surfaced as a 500.

The fix overrides lookup_path in HTMLStaticFiles to treat EINVAL as a file miss, returning StaticFiles' own miss sentinel. This covers all three of Starlette's lookup call sites, including the html-mode retry paths that sit outside its exception handling. Other OS errors still propagate. Behavior on macOS and Linux is byte-identical before and after.

Tests: a mocked EINVAL test asserting the web app fallback is served with identical headers to a plain miss, a negative test asserting other OS errors still propagate, and an unmocked real-filesystem test requesting a '::' route, which exercises the FileNotFoundError path on POSIX and the EINVAL path on Windows. All three are mutation-verified. A new windows-latest CI job runs the webhost tests on real Windows on every push, so this class of bug stays covered without manual Windows testing.

Verification note: the Windows job has not yet been shown to fail without the fix. Plan is a throwaway branch with the fix reverted to confirm the job goes red, before relying on it as a regression gate.

Fixes KIL-784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)