### PR TITLE
Raise the agent run tool call limit from 30 to 100

### DIFF
--- a/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/adapter_stream.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from kiln_ai.adapters.model_adapters.litellm_adapter import LiteLlmAdapter
 
 MAX_CALLS_PER_TURN = 10
-MAX_TOOL_CALLS_PER_TURN = 30
+MAX_TOOL_CALLS_PER_TURN = 100
 
 logger = logging.getLogger(__name__)
 

--- a/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/litellm_adapter.py
@@ -66,7 +66,7 @@ from kiln_ai.utils.open_ai_types import (
 )
 
 MAX_CALLS_PER_TURN = 10
-MAX_TOOL_CALLS_PER_TURN = 30
+MAX_TOOL_CALLS_PER_TURN = 100
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Bumps `MAX_TOOL_CALLS_PER_TURN` from 30 to 100 in both the blocking (`litellm_adapter.py`) and streaming (`adapter_stream.py`) paths.

This is a minimal replacement for #1669, which removed the limit entirely and added stuck detection / guardrails — more than we want for now. This just raises the cap.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>