### PR TITLE
Remove Featherless AI model entries until a client release supports them

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -1964,14 +1964,6 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 reasoning_capable=True,
             ),
-            KilnModelProvider(
-                name=ModelProviderName.featherless_ai,
-                model_id="openai/gpt-oss-120b",
-                structured_output_mode=StructuredOutputMode.json_instructions,
-                reasoning_capable=True,
-                # Featherless doesn't advertise tool_use for this model
-                supports_function_calling=False,
-            ),
         ],
     ),
     # GPT OSS 20B
@@ -4902,19 +4894,6 @@ built_in_models: List[KilnModel] = [
                 ],
                 max_parallel_requests=2,
             ),
-            KilnModelProvider(
-                name=ModelProviderName.featherless_ai,
-                model_id="google/gemma-4-31B-it",
-                structured_output_mode=StructuredOutputMode.json_instructions,
-                supports_vision=True,
-                multimodal_capable=True,
-                multimodal_mime_types=[
-                    KilnMimeType.JPG,
-                    KilnMimeType.PNG,
-                    KilnMimeType.TXT,
-                    KilnMimeType.MD,
-                ],
-            ),
         ],
     ),
     # Gemma 4 27B (26B A4B MoE)
@@ -5631,13 +5610,6 @@ built_in_models: List[KilnModel] = [
                 uncensored=True,
                 supports_function_calling=False,
             ),
-            KilnModelProvider(
-                name=ModelProviderName.featherless_ai,
-                model_id="mistralai/Mistral-Small-24B-Instruct-2501",
-                structured_output_mode=StructuredOutputMode.json_instructions,
-                uncensored=True,
-                supports_function_calling=False,
-            ),
         ],
     ),
     # DeepSeek R1 0528
@@ -5740,12 +5712,6 @@ built_in_models: List[KilnModel] = [
             ),
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
-                model_id="deepseek-ai/DeepSeek-V4-Pro",
-                structured_output_mode=StructuredOutputMode.json_instructions,
-                supports_data_gen=True,
-            ),
-            KilnModelProvider(
-                name=ModelProviderName.featherless_ai,
                 model_id="deepseek-ai/DeepSeek-V4-Pro",
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_data_gen=True,
@@ -8142,13 +8108,6 @@ built_in_models: List[KilnModel] = [
                 suggested_for_evals=True,
                 suggested_for_data_gen=True,
             ),
-            KilnModelProvider(
-                name=ModelProviderName.featherless_ai,
-                model_id="zai-org/GLM-5.2",
-                structured_output_mode=StructuredOutputMode.json_instructions,
-                suggested_for_evals=True,
-                suggested_for_data_gen=True,
-            ),
         ],
     ),
     # GLM 5.2 Fast — Fireworks speed-optimized serving of GLM 5.2 (routers/ slug, ~2x throughput)
@@ -8624,20 +8583,6 @@ built_in_models: List[KilnModel] = [
             #     ],
             #     multimodal_requires_pdf_as_image=True,
             # ),
-            KilnModelProvider(
-                name=ModelProviderName.featherless_ai,
-                model_id="moonshotai/Kimi-K2.6",
-                structured_output_mode=StructuredOutputMode.json_instructions,
-                supports_data_gen=True,
-                supports_vision=True,
-                multimodal_capable=True,
-                multimodal_mime_types=[
-                    KilnMimeType.JPG,
-                    KilnMimeType.PNG,
-                    KilnMimeType.TXT,
-                    KilnMimeType.MD,
-                ],
-            ),
         ],
     ),
     # Kimi K2.5
@@ -8999,27 +8944,6 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_schema,
                 supports_data_gen=True,
                 suggested_for_evals=True,
-            ),
-            # Featherless serves the raw weights, which emit <think> inline. Use the
-            # optional parser so the tags are stripped when present, and leave
-            # reasoning_capable False since (per the Fireworks note above) M3 does not
-            # always emit reasoning -- requiring it would error on those responses.
-            KilnModelProvider(
-                name=ModelProviderName.featherless_ai,
-                model_id="MiniMaxAI/MiniMax-M3",
-                structured_output_mode=StructuredOutputMode.json_instructions,
-                parser=ModelParserID.optional_r1_thinking,
-                supports_data_gen=True,
-                # Featherless doesn't advertise tool_use for this model
-                supports_function_calling=False,
-                supports_vision=True,
-                multimodal_capable=True,
-                multimodal_mime_types=[
-                    KilnMimeType.JPG,
-                    KilnMimeType.PNG,
-                    KilnMimeType.TXT,
-                    KilnMimeType.MD,
-                ],
             ),
         ],
     ),


### PR DESCRIPTION
## What does this PR do?

Rolls Featherless out of the model list until a client release supports it — PR 1 of a 3-PR stack (this → #TBD ordering → #TBD re-add).

The remote config is synced from main, but no released Kiln client has the Featherless provider plumbing (name map, connect flow, API key handling). Deployed clients therefore render these models with the raw `featherless_ai` ID in the model library, and can't connect the provider to actually use them.

This removes only the 7 `featherless_ai` `KilnModelProvider` entries (GPT OSS 120B, Gemma 4 31B, Mistral Small 3, DeepSeek V4 Pro, GLM 5.2, Kimi K2.6, Minimax M3). All the client-side support from #1618 stays on main so the next app release ships it. The entries return in the follow-up PR, gated on that release being live. The "Featherless provider omitted" comments (Llama gated repos, Phi 4 JSON wrapping, Qwen 3.5 397B quality) also stay, since that knowledge holds for the re-add.

No model has Featherless as its only provider, so no models disappear — they just lose one provider row.

Test Results

No paid tests needed: this only deletes provider entries, no model config changes. Full `checks.sh` passes (format, lint, typecheck, free tests, builds — Python and web).

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib (n/a — removal only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)