### PR TITLE
Add Qwen 3.8 27B to model list (OpenRouter)

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -216,6 +216,7 @@ class ModelName(str, Enum):
     qwen_3p5_27b = "qwen_3p5_27b"
     qwen_3p5_35b_a3b = "qwen_3p5_35b_a3b"
     qwen_3p8_2p4t_a95b = "qwen_3p8_2p4t_a95b"
+    qwen_3p8_27b = "qwen_3p8_27b"
     qwen_3p7_flash = "qwen_3p7_flash"
     qwen_3p7_plus = "qwen_3p7_plus"
     qwen_3p7_max = "qwen_3p7_max"
@@ -6030,6 +6031,32 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_data_gen=True,
                 supports_function_calling=True,
+            ),
+        ],
+    ),
+    # Qwen 3.8 27B
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3p8_27b,
+        friendly_name="Qwen 3.8 27B",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3.8-27b",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_function_calling=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                ],
+                multimodal_requires_pdf_as_image=True,
             ),
         ],
     ),


### PR DESCRIPTION
## What does this PR do?

Adds **Qwen 3.8 27B** (dense 27B vision-language model, released 2026-08-14) to the model list.

Slack thread: https://getkiln.slack.com/archives/C0AG8U78MNG/p1787072832396829

Test Results

Only the OpenRouter provider is included. Fireworks was investigated and dropped: its marketing page renders a `qwen3p8-27b` model, but the LiteLLM/Fireworks API returns a hard 404 ("Model not found, inaccessible, and/or not deployed") for `accounts/fireworks/models/qwen3p8-27b` — the model isn't actually deployed there yet (it's only days old and also absent from Together AI and SiliconFlow). The model is not yet in the LiteLLM catalog, so there is no pricing metadata, but routing via the openrouter prefix works fine. Config mirrors the predecessor Qwen 3.5 27B: `json_instruction_and_object`, vision/doc-extraction, multimodal (no video), not `reasoning_capable` (adaptive reasoning), no thinking-level dicts.

On the first full run, 4 OpenRouter tests hit transient upstream free-pool errors (429/422); all 4 passed on a single retry, confirming flakes rather than config problems.

Qwen 3.8 27B (openrouter):
- 17 passed, 11 skipped, 0 failed

---
Qwen 3.8 27B (openrouter):
✅ test_data_gen_all_models_providers[qwen_3p8_27b-openrouter]
✅ test_data_gen_sample_all_models_providers[qwen_3p8_27b-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[qwen_3p8_27b-openrouter]
✅ test_all_built_in_models_llm_as_judge[qwen_3p8_27b-openrouter]
✅ test_all_built_in_models_structured_output[qwen_3p8_27b-openrouter]
✅ test_all_built_in_models_structured_input[qwen_3p8_27b-openrouter]
✅ test_structured_output_cot_prompt_builder[qwen_3p8_27b-openrouter]
✅ test_structured_input_cot_prompt_builder[qwen_3p8_27b-openrouter]
✅ test_all_models_providers_plaintext[qwen_3p8_27b-openrouter]
✅ test_cot_prompt_builder[qwen_3p8_27b-openrouter]
✅ test_tools_all_built_in_models[qwen_3p8_27b-openrouter]
✅ test_supports_vision_is_coherent[qwen_3p8_27b-openrouter]
✅ test_provider_bad_request[qwen_3p8_27b-openrouter]
✅ test_extract_document_success[application/pdf-text_probe0-qwen_3p8_27b-openrouter]
✅ test_extract_document_success[image/png-text_probe5-qwen_3p8_27b-openrouter]
✅ test_extract_document_success[image/jpeg-text_probe6-qwen_3p8_27b-openrouter]
✅ test_extract_document_success[image/jpeg-text_probe7-qwen_3p8_27b-openrouter]

## Checklists

- [X] Tests have been run locally and passed
- [X] New tests have been added to any work in /lib

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgYFeguarJLkb6Rvi6bMFz)_