### PR TITLE
Halve dev server startup time

### DIFF
--- a/.config/utils/setup_startup.sh
+++ b/.config/utils/setup_startup.sh
@@ -416,7 +416,13 @@ echo "Syncing dependencies for ${branch:-this checkout}..."
 NPM_LOCK="$WEB_UI_DIR/package-lock.json"
 npm_lock_before="$({ cksum <"$NPM_LOCK"; } 2>/dev/null)"
 
-(cd "$PROJECT_ROOT" && uv sync --frozen --all-packages) &
+# --compile-bytecode so the venv's .pyc files are written here, where nothing is
+# waiting on them, rather than by the session's first `import kiln_ai...` — which
+# otherwise compiles thousands of files mid-command, and pays for it again in the
+# reload worker. It walks the whole venv rather than only what this sync installed,
+# every run — but with everything up to date that is well under a second, and it
+# runs alongside the npm install either way.
+(cd "$PROJECT_ROOT" && uv sync --frozen --all-packages --compile-bytecode) &
 py_pid=$!
 (cd "$WEB_UI_DIR" && npm install --no-fund --no-audit) &
 npm_pid=$!

--- a/app/desktop/dev_app.py
+++ b/app/desktop/dev_app.py
@@ -1,0 +1,17 @@
+# The dev server's ASGI app object, in a module of its own.
+#
+# Importing this module pulls in the whole Kiln app tree, which is the slow part
+# of starting the dev server. Only uvicorn's reload worker imports it: the
+# launcher process in dev_server.py names it by import string, and so never pays
+# that cost. Keeping the app object here rather than there is what stops the
+# import tree from running twice per start.
+from app.desktop.dev_env import set_dev_env_vars
+
+# Before make_app() runs — and before importing anything that reads these at
+# import time — which is why the import below is not at the top of the file.
+set_dev_env_vars()
+
+from app.desktop.desktop_server import make_app  # noqa: E402
+
+# Top level app object, as that's needed by auto-reload
+dev_app = make_app()

--- a/app/desktop/dev_env.py
+++ b/app/desktop/dev_env.py
@@ -1,0 +1,16 @@
+# Dev-only. The shipped desktop app must never import this: KILN_DEV_MODE turns on
+# safety nets that only make sense while developing.
+import os
+
+
+def set_dev_env_vars() -> None:
+    """The environment the dev server runs in, in one place.
+
+    Called by the launcher (dev_server.py), so reload workers inherit these, and
+    again by dev_app.py, which builds the app and so must not depend on any
+    particular launcher having run first.
+    """
+    # Skip remote model loading when running the dev server (unless explicitly set)
+    os.environ.setdefault("KILN_SKIP_REMOTE_MODEL_LIST", "true")
+    os.environ["DEBUG_EVENT_LOOP"] = "true"
+    os.environ["KILN_DEV_MODE"] = "true"

--- a/app/desktop/dev_server.py
+++ b/app/desktop/dev_server.py
@@ -1,22 +1,24 @@
 # Run a desktop server for development:
 # - Auto-reload is enabled
 # - Extra logging (level+colors) is enabled
+#
+# The app object lives in app/desktop/dev_app.py and is named here by import
+# string, so only uvicorn's reload worker imports the Kiln app tree. Importing it
+# here too would double the (slow) import cost of every start.
+#
+# The tradeoff: an app that fails to import now fails in that worker, so uvicorn
+# prints the traceback and waits for a file change instead of this process
+# exiting non-zero. Fix the import and it reloads on its own.
 import os
 
 import uvicorn
 
-from app.desktop.desktop_server import make_app
+from app.desktop.dev_env import set_dev_env_vars
 from app.desktop.util.resource_limits import setup_resource_limits
 from kiln_ai.utils.config import Config
 
-# Skip remote model loading when running the dev server (unless explicitly set)
-os.environ.setdefault("KILN_SKIP_REMOTE_MODEL_LIST", "true")
-
-# top level app object, as that's needed by auto-reload
-dev_app = make_app()
-
-os.environ["DEBUG_EVENT_LOOP"] = "true"
-os.environ["KILN_DEV_MODE"] = "true"
+# Set here as well as in dev_app.py so that reload workers inherit them.
+set_dev_env_vars()
 
 
 if __name__ == "__main__":
@@ -30,7 +32,7 @@ if __name__ == "__main__":
         os.environ["KILN_LOCAL_API_PORT"] = kiln_port
 
     uvicorn.run(
-        "app.desktop.dev_server:dev_app",
+        "app.desktop.dev_app:dev_app",
         host=Config.shared().kiln_local_api_host,
         port=Config.shared().kiln_local_api_port,
         reload=True,

--- a/app/desktop/test_dev_server.py
+++ b/app/desktop/test_dev_server.py
@@ -1,0 +1,196 @@
+import importlib
+import os
+import runpy
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.desktop.dev_env import set_dev_env_vars
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEV_ENV_VARS = ("KILN_SKIP_REMOTE_MODEL_LIST", "DEBUG_EVENT_LOOP", "KILN_DEV_MODE")
+
+# Run in a subprocess: an in-process check can't tell what dev_server imported
+# from what the test session had already imported.
+LAUNCHER_PROBE = """
+import os
+import sys
+
+import app.desktop.dev_server  # noqa: F401
+
+assert "app.desktop.desktop_server" not in sys.modules, "launcher imported the app tree"
+assert "app.desktop.dev_app" not in sys.modules, "launcher imported the app tree"
+assert os.environ["KILN_SKIP_REMOTE_MODEL_LIST"] == "true"
+assert os.environ["DEBUG_EVENT_LOOP"] == "true"
+assert os.environ["KILN_DEV_MODE"] == "true"
+"""
+
+
+@pytest.fixture
+def run_dev_server_main():
+    """Runs dev_server.py as __main__, with everything it launches stubbed out.
+
+    The module body writes to the real process environment (the dev env vars, and
+    KILN_LOCAL_API_PORT), which anything else running in this worker would
+    otherwise inherit — hence the patch.dict wrapping the whole test.
+    """
+    with patch.dict(os.environ):
+
+        def _run():
+            with (
+                patch("uvicorn.run") as mock_uvicorn_run,
+                patch(
+                    "app.desktop.util.resource_limits.setup_resource_limits"
+                ) as mock_setup_resource_limits,
+                patch("kiln_ai.utils.config.Config.shared") as mock_shared_config,
+            ):
+                mock_shared_config.return_value.kiln_local_api_host = "127.0.0.1"
+                mock_shared_config.return_value.kiln_local_api_port = 8757
+                runpy.run_module("app.desktop.dev_server", run_name="__main__")
+                return mock_uvicorn_run, mock_setup_resource_limits
+
+        yield _run
+
+
+@pytest.fixture
+def env_when_app_built():
+    """Stubs out make_app, and captures the environment dev_app.py imports it in.
+
+    The stub snapshots the environment when dev_app.py looks `make_app` up — at its
+    import statement, not at the call — so a `set_dev_env_vars()` that drifted below
+    that import fails this too, which is the whole reason for the file's noqa.
+    """
+    captured_env = {}
+
+    class EnvCapturingStub(types.ModuleType):
+        def __getattr__(self, name):
+            if name != "make_app":
+                raise AttributeError(name)
+            captured_env.update(os.environ)
+            return lambda: MagicMock(name="fastapi_app")
+
+    desktop_package = sys.modules["app.desktop"]
+    previously_imported = getattr(desktop_package, "dev_app", None)
+
+    # patch.dict restores each dict wholesale, so the stub, the dev_app module the
+    # test imports, and the env vars that import sets all go away with the test.
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "app.desktop.desktop_server": EnvCapturingStub(
+                    "app.desktop.desktop_server"
+                )
+            },
+        ),
+        patch.dict(os.environ),
+    ):
+        sys.modules.pop("app.desktop.dev_app", None)
+        for env_var in DEV_ENV_VARS:
+            os.environ.pop(env_var, None)
+        yield captured_env
+
+    # Importing a submodule also binds it on its package, which patch.dict does not
+    # cover: without this, `from app.desktop import dev_app` would find the module
+    # built with the stub.
+    if previously_imported is None:
+        vars(desktop_package).pop("dev_app", None)
+    else:
+        desktop_package.dev_app = previously_imported
+
+
+def test_launcher_does_not_import_the_app_tree():
+    # The point of the dev_app split: importing the app tree is the slow part of a
+    # start, and the launcher paying it too made every start twice as long.
+    result = subprocess.run(
+        [sys.executable, "-c", LAUNCHER_PROBE],
+        cwd=REPO_ROOT,
+        # Without stripping these the probe's env assertions pass on an inherited
+        # value — conftest's autouse fixture exports one of them for every test.
+        env={k: v for k, v in os.environ.items() if k not in DEV_ENV_VARS},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_serves_the_app_from_the_dev_app_module(run_dev_server_main):
+    mock_uvicorn_run, _ = run_dev_server_main()
+
+    # An import string, not an app object, so the reload worker builds the app.
+    assert mock_uvicorn_run.call_args.args == ("app.desktop.dev_app:dev_app",)
+
+
+def test_uvicorn_run_options(run_dev_server_main):
+    mock_uvicorn_run, mock_setup_resource_limits = run_dev_server_main()
+
+    assert mock_uvicorn_run.call_args.kwargs == {
+        "host": "127.0.0.1",
+        "port": 8757,
+        "reload": True,
+        "reload_delay": 0.1,
+        "timeout_graceful_shutdown": 1,
+    }
+    mock_setup_resource_limits.assert_called_once()
+
+
+def test_kiln_port_is_exported_for_reload_workers(run_dev_server_main):
+    os.environ["KILN_PORT"] = "1234"
+    os.environ.pop("KILN_LOCAL_API_PORT", None)
+
+    run_dev_server_main()
+
+    assert os.environ["KILN_LOCAL_API_PORT"] == "1234"
+
+
+def test_no_kiln_port_leaves_the_configured_port_alone(run_dev_server_main):
+    os.environ.pop("KILN_PORT", None)
+    os.environ.pop("KILN_LOCAL_API_PORT", None)
+
+    run_dev_server_main()
+
+    assert "KILN_LOCAL_API_PORT" not in os.environ
+
+
+def test_launcher_sets_the_dev_env_vars(run_dev_server_main):
+    for env_var in DEV_ENV_VARS:
+        os.environ.pop(env_var, None)
+
+    run_dev_server_main()
+
+    assert [os.environ[env_var] for env_var in DEV_ENV_VARS] == ["true"] * 3
+
+
+def test_dev_app_sets_dev_env_vars_before_importing_the_app(env_when_app_built):
+    dev_app_module = importlib.import_module("app.desktop.dev_app")
+
+    assert {var: env_when_app_built.get(var) for var in DEV_ENV_VARS} == dict.fromkeys(
+        DEV_ENV_VARS, "true"
+    )
+    assert dev_app_module.dev_app is not None
+
+
+def test_set_dev_env_vars_keeps_an_explicit_skip_remote_model_list():
+    with patch.dict(os.environ):
+        os.environ["KILN_SKIP_REMOTE_MODEL_LIST"] = "false"
+
+        set_dev_env_vars()
+
+        assert os.environ["KILN_SKIP_REMOTE_MODEL_LIST"] == "false"
+
+
+@pytest.mark.parametrize("env_var", ["DEBUG_EVENT_LOOP", "KILN_DEV_MODE"])
+def test_set_dev_env_vars_overrides_the_dev_mode_flags(env_var):
+    # Deliberately unlike KILN_SKIP_REMOTE_MODEL_LIST above: running the dev server
+    # is what these two describe, so the dev server decides them.
+    with patch.dict(os.environ):
+        os.environ[env_var] = "false"
+
+        set_dev_env_vars()
+
+        assert os.environ[env_var] == "true"

--- a/specs/projects/cloud_sandbox_dx/architecture.md
+++ b/specs/projects/cloud_sandbox_dx/architecture.md
@@ -582,8 +582,11 @@ Order is load-bearing:
    break silence.
 
 4. **Sync**, both in parallel, same `wait`-both pattern as §1.4:
-   `uv sync --frozen --all-packages` and `npm install --no-fund --no-audit`.
-   `npm install`, not `npm ci` — see F4.
+   `uv sync --frozen --all-packages --compile-bytecode` and
+   `npm install --no-fund --no-audit`. `npm install`, not `npm ci` — see F4.
+   `--compile-bytecode` here rather than in `setup_env.sh`: this is the sync that
+   builds the session's `.venv`, and compiling under it costs a session nothing,
+   where the first import of the app would otherwise compile the whole tree.
 
    `npm install` can rewrite the tracked `package-lock.json`, which nothing else in
    either script does. Hash the file with `cksum` before and after and warn, naming

--- a/specs/projects/cloud_sandbox_dx/functional_spec.md
+++ b/specs/projects/cloud_sandbox_dx/functional_spec.md
@@ -316,10 +316,15 @@ It then does seven things, in this order:
    **9.4 s**. Every failure — no warm tree, a tree on another
    filesystem, a filesystem without hardlinks — falls through to step 5 populating
    `node_modules` from scratch, which is what happened before this existed.
-5. **Sync dependencies for the current branch**, `uv sync --frozen --all-packages`
-   and `npm install` in parallel, so a branch that changed a lockfile is not run
-   against stale packages. This is also what reconciles a seeded tree with the
-   branch's `package.json`.
+5. **Sync dependencies for the current branch**, `uv sync --frozen --all-packages
+   --compile-bytecode` and `npm install` in parallel, so a branch that changed a
+   lockfile is not run against stale packages. This is also what reconciles a
+   seeded tree with the branch's `package.json`. `--compile-bytecode` writes the
+   venv's `.pyc` files here rather than leaving them to the session's first import
+   of the app, which compiles thousands of files and pays for it again in the dev
+   server's reload worker. It walks the whole venv on every run, but with
+   everything already up to date that is well under a second, so re-running the
+   script stays cheap.
 6. **Verify the virtualenv** — Python 3.13 or newer and `tkinter` importable. These
    are properties of `.venv`, so they can only be checked once step 5 has built it.
 


### PR DESCRIPTION
## What does this PR do?

Makes `python -m app.desktop.dev_server` (and everything that launches it — `make dev`, `playwright_server.sh`, `playwright.config.ts`, `check_api_bindings.yml`) start in about half the time, and removes a much larger one-off cost from the first start of a cloud session.

**Two causes, measured before changing anything.** A warm `.agents/scripts/playwright_server.sh start` took ~27s: vite was ready at 2.3s, the backend at 26.2s.

1. **The heavy import tree ran twice per start.** `dev_server.py` built `dev_app = make_app()` at module level, so the launcher process imported the whole Kiln app tree (~15.5s: litellm, vertexai, lancedb) and uvicorn's `reload=True` worker then imported all of it again. The backend log showed the same google-cloud `FutureWarning` twice — once before "Will watch for changes", once in the worker.
2. **The first start of a cloud session compiled the venv's bytecode.** The SessionStart hook's `uv sync` does not compile, so the session's first import wrote ~15,700 `.pyc` files — 34.3s instead of 15.5s, doubled by (1).

**Changes:**

- The app object moves to a new `app/desktop/dev_app.py`, which the launcher names by import string (`"app.desktop.dev_app:dev_app"`). The launcher now imports only uvicorn, `setup_resource_limits`, and `Config`, so the tree is imported once, in the reload worker.
- The dev env vars (`KILN_SKIP_REMOTE_MODEL_LIST`, `DEBUG_EVENT_LOOP`, `KILN_DEV_MODE`) move to `app/desktop/dev_env.py` so both modules set them from one place, keeping the deliberate `setdefault`-vs-forced asymmetry in a single definition. The launcher still sets them so reload workers inherit them.
- `setup_startup.sh` passes `--compile-bytecode` to its `uv sync`, so the `.pyc` files are written where nothing is waiting on them. A re-run against an unchanged venv stays well under a second, and it runs alongside `npm install` regardless.
- `specs/projects/cloud_sandbox_dx/{functional_spec,architecture}.md` updated to match the new sync command.

Behavior deliberately preserved and covered by tests: `KILN_SKIP_REMOTE_MODEL_LIST` defaults before `make_app()` runs, `KILN_PORT` → `KILN_LOCAL_API_PORT`, `setup_resource_limits()`, `reload_delay`, `timeout_graceful_shutdown`, and the `python -m app.desktop.dev_server` entry point itself. No caller changed.

**Results (same machine, stash-and-measure A/B):**

| | before | after |
|---|---|---|
| launcher process import | 16.5s | 0.2s |
| `playwright_server.sh start` (warm) | 20.8s | ~11s |
| google-cloud `FutureWarning` per start | 2 | 1 |

Auto-reload still works (`touch` on a watched file → `WatchFiles detected changes … Reloading` → worker back up), `DEBUG_EVENT_LOOP` slow-task logging is live in the worker, and the seeded playwright sandbox project still renders.

One tradeoff worth knowing, documented in the `dev_server.py` header: a broken import now fails in the reload worker, so uvicorn prints the traceback and waits for a file change rather than the launcher exiting non-zero. Fixing the import reloads on its own; both CI/script consumers already bound their wait (30s and 120s respectively).

Out of scope by request: lazy-importing litellm / vertexai / lancedb off the `kiln_ai.adapters` chain, which would cut roughly another 8s.

## Related Issues

None.

## Contributor License Agreement

<!-- Left for a human to complete: as an agent I cannot make legal attestations. -->

I, @&lt;your-github-username&gt;, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed — `uv run ./checks.sh --agent-mode` exit 0; full python suite 6379 passed
- [x] New tests have been added to any work in /lib — n/a for /lib; 10 new tests added in `app/desktop/test_dev_server.py` covering the launcher's import surface, the env-var contract, and every preserved `uvicorn.run` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXEfAh42pRhLmUKfqwpzRG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXEfAh42pRhLmUKfqwpzRG)_