### PR TITLE
Fix stale API-shape assertions in the eval creation e2e test

### DIFF
--- a/app/web_ui/tests/e2e/eval_creation_flow.spec.ts
+++ b/app/web_ui/tests/e2e/eval_creation_flow.spec.ts
@@ -86,17 +86,21 @@ test("programmatic check: type picker -> judge-only builder creates a template-l
   expect(specs.length).toBe(0)
 
   // The eval is template-less (the user never claimed a template) but still
-  // carries generated filters and priority/status.
-  const evals = await (
+  // carries generated filters and priority/status. The list endpoint wraps the
+  // evals so it can also report how many eval files this build couldn't read.
+  const evals_response = await (
     await apiRequest.get(`/api/projects/${project.id}/tasks/${task.id}/evals`)
   ).json()
-  expect(evals.length).toBe(1)
-  const evaluator = evals[0]
+  expect(evals_response.load_error_count).toBe(0)
+  expect(evals_response.evals.length).toBe(1)
+  const evaluator = evals_response.evals[0]
   expect(evaluator.template).toBeNull()
   expect(evaluator.priority).toBe(1)
   expect(evaluator.status).toBe("active")
-  expect(evaluator.eval_set_filter_id).toBe("tag::eval_no_hate_regex")
-  expect(evaluator.train_set_filter_id).toBe("tag::train_no_hate_regex")
+  // Splits are the only place filters live; the flat eval_set_filter_id /
+  // train_set_filter_id fields are a load-time migration input and always null.
+  expect(evaluator.splits.test.filter_id).toBe("tag::eval_no_hate_regex")
+  expect(evaluator.splits.train.filter_id).toBe("tag::train_no_hate_regex")
 
   // The judge was created with the eval and set as its default, so the eval
   // is ready to run rather than "Not Ready - Configure".


### PR DESCRIPTION
## What does this PR do?

Fixes the one real failure in the Playwright suite: `eval_creation_flow.spec.ts` asserted two API shapes this branch has since changed.

**1. The evals list is wrapped.** `GET /api/projects/{p}/tasks/{t}/evals` returns `EvalsResponse{evals, load_error_count}`, not a bare list — changed by "Let the eval list survive an eval it can't read". The test read `evals.length`, which was `undefined`. Now reads `evals_response.evals`, and also asserts `load_error_count` is 0 so a silently-unreadable eval can't pass as a clean run.

**2. Filters moved into `splits`.** `eval_set_filter_id` / `train_set_filter_id` are documented on the model as "neither read nor written… always saved as null" — a load-time migration input that `migrate_legacy_split_fields` clears. The filters now live in `Eval.splits`, so the assertions read `splits.test.filter_id` and `splits.train.filter_id`.

### Why CI never caught this

`playwright.yml` triggers only on `push`/`pull_request` against `branches: [main]`. Every PR on this branch targets `sfierro/KIL-741`, so the e2e suite has never run on one — the first execution was the merge PR against `main`, six days after the response shape changed. **This PR won't run it either**, for the same reason; the verification below was run locally instead.

## Related Issues

KIL-741

## Contributor License Agreement

<!-- Agents are not permitted to make CLA attestations. This section is left for a human to complete. -->

## Checklists

- [x] Tests have been run locally and passed — `npx playwright test tests/e2e/eval_creation_flow.spec.ts` passes 7/7 (was 1 failed / 6 passed). Full suite: 204 passed, 3 skipped, 1 failed — `data-generation.spec.ts:29`, a pre-existing cold-compile flake in a spec this PR doesn't touch, which CI itself marked flaky on the previous run. `uv run ./checks.sh --agent-mode` exits 0.
- [x] New tests have been added to any work in /lib — no `/lib` changes; this is a test-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLaTpDYCePieYaJKLkTaX1

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLaTpDYCePieYaJKLkTaX1)_