### PR TITLE
Rename eval_tag to test_tag throughout codebase

### DIFF
--- a/app/desktop/studio_server/copilot_api.py
+++ b/app/desktop/studio_server/copilot_api.py
@@ -786,11 +786,11 @@ def connect_copilot_api(app: FastAPI):
             spec_definition=request.definition,
         )
 
-        # 4. Create TaskRuns for eval, train, val, and golden datasets
+        # 4. Create TaskRuns for test, train, val, and golden datasets
         dataset_runs = create_dataset_task_runs(
             all_examples=all_examples,
             reviewed_examples=request.reviewed_examples,
-            eval_tag=tags.eval_tag,
+            test_tag=tags.test_tag,
             train_tag=tags.train_tag,
             val_tag=tags.val_tag,
             golden_tag=tags.golden_tag,

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -1312,7 +1312,7 @@ def connect_evals_api(app: FastAPI):
             splits = {
                 split_name: split
                 for split_name, split in spec_eval_splits(
-                    eval_tag=tags.eval_tag,
+                    test_tag=tags.test_tag,
                     train_tag=tags.train_tag,
                     val_tag=tags.val_tag,
                 ).items()

--- a/app/desktop/studio_server/test_copilot_api.py
+++ b/app/desktop/studio_server/test_copilot_api.py
@@ -466,10 +466,10 @@ class TestCreateSpecWithCopilot:
         # returns these so the copilot can tag the runs it generates; a mix-up here puts
         # generated items in the wrong split's dataset, which nothing downstream notices.
         dataset_run_kwargs = mock_create_dataset_task_runs.call_args.kwargs
-        assert dataset_run_kwargs["eval_tag"] == "eval_test_spec"
+        assert dataset_run_kwargs["test_tag"] == "test_test_spec"
         assert dataset_run_kwargs["train_tag"] == "train_test_spec"
         assert dataset_run_kwargs["val_tag"] == "val_test_spec"
-        assert dataset_run_kwargs["golden_tag"] == "eval_golden_test_spec"
+        assert dataset_run_kwargs["golden_tag"] == "golden_test_spec"
 
         # Verify models were saved
         evals = task.evals()
@@ -478,13 +478,13 @@ class TestCreateSpecWithCopilot:
         assert evals[0].current_config_id is not None
 
         assert evals[0].splits == {
-            "test": TaskRunSplit(filter_id="tag::eval_test_spec"),
+            "test": TaskRunSplit(filter_id="tag::test_test_spec"),
             "train": TaskRunSplit(filter_id="tag::train_test_spec"),
             "val": TaskRunSplit(filter_id="tag::val_test_spec"),
         }
         # Golden is not a split, so nothing above covers it: if it pointed at the test
         # tag, eval-config comparison would score against test items instead of golden.
-        assert evals[0].eval_configs_filter_id == "tag::eval_golden_test_spec"
+        assert evals[0].eval_configs_filter_id == "tag::golden_test_spec"
 
         # Check the raw saved eval file, not the loaded model: what reaches the bytes
         # is invisible in eval.splits. All three splits go to `splits`, and the
@@ -494,7 +494,7 @@ class TestCreateSpecWithCopilot:
         assert saved_eval["eval_set_filter_id"] is None
         assert saved_eval["train_set_filter_id"] is None
         assert saved_eval["splits"] == {
-            "test": {"source": "task_run", "filter_id": "tag::eval_test_spec"},
+            "test": {"source": "task_run", "filter_id": "tag::test_test_spec"},
             "train": {"source": "task_run", "filter_id": "tag::train_test_spec"},
             "val": {"source": "task_run", "filter_id": "tag::val_test_spec"},
         }

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -6560,10 +6560,10 @@ async def test_create_evaluator_generates_filters_scores_priority_status(
 
     assert response.status_code == 200
     result = response.json()
-    assert result["splits"]["test"]["filter_id"] == "tag::eval_my_issue_eval"
+    assert result["splits"]["test"]["filter_id"] == "tag::test_my_issue_eval"
     assert result["splits"]["train"]["filter_id"] == "tag::train_my_issue_eval"
     assert result["splits"]["val"]["filter_id"] == "tag::val_my_issue_eval"
-    assert result["eval_configs_filter_id"] == "tag::eval_golden_my_issue_eval"
+    assert result["eval_configs_filter_id"] == "tag::golden_my_issue_eval"
     assert result["priority"] == 2
     assert result["status"] == "future"
     assert len(result["output_scores"]) == 1
@@ -6573,7 +6573,7 @@ async def test_create_evaluator_generates_filters_scores_priority_status(
     saved_eval = mock_task.evals()[0]
     assert saved_eval.priority == Priority.p2
     assert saved_eval.status == SpecStatus.future
-    assert saved_eval.splits["test"].filter_id == "tag::eval_my_issue_eval"
+    assert saved_eval.splits["test"].filter_id == "tag::test_my_issue_eval"
 
 
 @pytest.mark.asyncio

--- a/app/desktop/studio_server/utils/copilot_utils.py
+++ b/app/desktop/studio_server/utils/copilot_utils.py
@@ -246,17 +246,17 @@ class DatasetTaskRuns:
 def create_dataset_task_runs(
     all_examples: list[SampleApi],
     reviewed_examples: list[ReviewedExample],
-    eval_tag: str,
+    test_tag: str,
     train_tag: str,
     val_tag: str,
     golden_tag: str,
     spec_name: str,
 ) -> DatasetTaskRuns:
-    """Create TaskRuns for eval, train, val, and golden datasets.
+    """Create TaskRuns for test, train, val, and golden datasets.
 
     Samples from all_examples (mutating it) and creates TaskRuns for:
     - Golden dataset (reviewed examples + unrated examples to reach MIN_GOLDEN_EXAMPLES)
-    - Eval dataset (half of the remaining examples)
+    - Test dataset (half of the remaining examples)
     - Val dataset (one third of the other half)
     - Train dataset (the rest)
 
@@ -284,20 +284,20 @@ def create_dataset_task_runs(
         for example in unrated_golden_examples:
             result.add_run(create_task_run_from_sample(example, golden_tag, extra_tags))
 
-    # Sample half the remaining examples for the eval dataset, then split the
+    # Sample half the remaining examples for the test dataset, then split the
     # other half between val (one third) and train (two thirds)
     example_count = len(all_examples)
-    eval_count = example_count // 2
-    remaining_count = example_count - eval_count
+    test_count = example_count // 2
+    remaining_count = example_count - test_count
     val_count = remaining_count // 3
     train_count = remaining_count - val_count
-    eval_examples = sample_and_remove(all_examples, eval_count)
+    test_examples = sample_and_remove(all_examples, test_count)
     val_examples = sample_and_remove(all_examples, val_count)
     train_examples = sample_and_remove(all_examples, train_count)
 
-    # Create TaskRuns for eval examples
-    for example in eval_examples:
-        result.add_run(create_task_run_from_sample(example, eval_tag, extra_tags))
+    # Create TaskRuns for test examples
+    for example in test_examples:
+        result.add_run(create_task_run_from_sample(example, test_tag, extra_tags))
 
     # Create TaskRuns for val examples
     for example in val_examples:

--- a/app/desktop/studio_server/utils/test_copilot_utils.py
+++ b/app/desktop/studio_server/utils/test_copilot_utils.py
@@ -97,36 +97,36 @@ class TestSampleAndRemove:
 class TestCreateTaskRunFromSample:
     def test_creates_task_run_with_correct_input(self):
         sample = SampleApi(input="test input", output="test output")
-        task_run = create_task_run_from_sample(sample, "eval_tag")
+        task_run = create_task_run_from_sample(sample, "some_tag")
         assert task_run.input == "test input"
 
     def test_creates_task_run_with_correct_output(self):
         sample = SampleApi(input="test input", output="test output")
-        task_run = create_task_run_from_sample(sample, "eval_tag")
+        task_run = create_task_run_from_sample(sample, "some_tag")
         assert task_run.output.output == "test output"
 
     def test_creates_task_run_with_tag(self):
         sample = SampleApi(input="test input", output="test output")
-        task_run = create_task_run_from_sample(sample, "eval_tag")
-        assert "eval_tag" in task_run.tags
+        task_run = create_task_run_from_sample(sample, "some_tag")
+        assert "some_tag" in task_run.tags
 
     def test_creates_task_run_with_extra_tags(self):
         sample = SampleApi(input="test input", output="test output")
         task_run = create_task_run_from_sample(
-            sample, "eval_tag", extra_tags=["session_123", "other_tag"]
+            sample, "some_tag", extra_tags=["session_123", "other_tag"]
         )
-        assert "eval_tag" in task_run.tags
+        assert "some_tag" in task_run.tags
         assert "session_123" in task_run.tags
         assert "other_tag" in task_run.tags
 
     def test_creates_task_run_without_extra_tags(self):
         sample = SampleApi(input="test input", output="test output")
-        task_run = create_task_run_from_sample(sample, "eval_tag", extra_tags=None)
-        assert task_run.tags == ["eval_tag"]
+        task_run = create_task_run_from_sample(sample, "some_tag", extra_tags=None)
+        assert task_run.tags == ["some_tag"]
 
     def test_creates_task_run_with_synthetic_data_source(self):
         sample = SampleApi(input="test input", output="test output")
-        task_run = create_task_run_from_sample(sample, "eval_tag")
+        task_run = create_task_run_from_sample(sample, "some_tag")
         assert task_run.input_source.type == DataSourceType.synthetic
         assert task_run.input_source.properties["model_name"] == KILN_COPILOT_MODEL_NAME
         assert (
@@ -263,7 +263,7 @@ class TestCreateDatasetTaskRuns:
         task_runs = create_dataset_task_runs(
             all_examples,
             reviewed_examples,
-            "eval_tag",
+            "test_tag",
             "train_tag",
             "val_tag",
             "golden_tag",
@@ -292,7 +292,7 @@ class TestCreateDatasetTaskRuns:
         task_runs = create_dataset_task_runs(
             all_examples,
             reviewed_examples,
-            "eval_tag",
+            "test_tag",
             "train_tag",
             "val_tag",
             "golden_tag",
@@ -316,7 +316,7 @@ class TestCreateDatasetTaskRuns:
         task_runs = create_dataset_task_runs(
             all_examples,
             reviewed_examples,
-            "eval_tag",
+            "test_tag",
             "train_tag",
             "val_tag",
             "golden_tag",
@@ -340,7 +340,7 @@ class TestCreateDatasetTaskRuns:
         task_runs = create_dataset_task_runs(
             all_examples,
             reviewed_examples,
-            "eval_tag",
+            "test_tag",
             "train_tag",
             "val_tag",
             "golden_tag",
@@ -356,7 +356,7 @@ class TestCreateDatasetTaskRuns:
 
         assert len(session_tags) == 1
 
-    def test_eval_examples_have_eval_tag(self):
+    def test_test_examples_have_test_tag(self):
         all_examples = [
             SampleApi(input=f"input_{i}", output=f"output_{i}")
             for i in range(NUM_SAMPLES_PER_TOPIC * NUM_TOPICS)
@@ -366,17 +366,17 @@ class TestCreateDatasetTaskRuns:
         task_runs = create_dataset_task_runs(
             all_examples,
             reviewed_examples,
-            "eval_tag",
+            "test_tag",
             "train_tag",
             "val_tag",
             "golden_tag",
             "Test Spec",
         ).task_runs
 
-        eval_runs = [tr for tr in task_runs if "eval_tag" in tr.tags]
+        test_runs = [tr for tr in task_runs if "test_tag" in tr.tags]
         num_runs = NUM_SAMPLES_PER_TOPIC * NUM_TOPICS
-        num_eval_runs = (num_runs - MIN_GOLDEN_EXAMPLES) // 2
-        assert len(eval_runs) == num_eval_runs
+        num_test_runs = (num_runs - MIN_GOLDEN_EXAMPLES) // 2
+        assert len(test_runs) == num_test_runs
 
     def test_train_examples_have_train_tag(self):
         all_examples = [
@@ -388,7 +388,7 @@ class TestCreateDatasetTaskRuns:
         task_runs = create_dataset_task_runs(
             all_examples,
             reviewed_examples,
-            "eval_tag",
+            "test_tag",
             "train_tag",
             "val_tag",
             "golden_tag",
@@ -397,8 +397,8 @@ class TestCreateDatasetTaskRuns:
 
         train_runs = [tr for tr in task_runs if "train_tag" in tr.tags]
         num_runs = NUM_SAMPLES_PER_TOPIC * NUM_TOPICS
-        num_eval_runs = (num_runs - MIN_GOLDEN_EXAMPLES) // 2
-        num_remaining = (num_runs - MIN_GOLDEN_EXAMPLES) - num_eval_runs
+        num_test_runs = (num_runs - MIN_GOLDEN_EXAMPLES) // 2
+        num_remaining = (num_runs - MIN_GOLDEN_EXAMPLES) - num_test_runs
         num_val_runs = num_remaining // 3
         num_train_runs = num_remaining - num_val_runs
         assert len(train_runs) == num_train_runs
@@ -413,7 +413,7 @@ class TestCreateDatasetTaskRuns:
         task_runs = create_dataset_task_runs(
             all_examples,
             reviewed_examples,
-            "eval_tag",
+            "test_tag",
             "train_tag",
             "val_tag",
             "golden_tag",
@@ -422,8 +422,8 @@ class TestCreateDatasetTaskRuns:
 
         val_runs = [tr for tr in task_runs if "val_tag" in tr.tags]
         num_runs = NUM_SAMPLES_PER_TOPIC * NUM_TOPICS
-        num_eval_runs = (num_runs - MIN_GOLDEN_EXAMPLES) // 2
-        num_remaining = (num_runs - MIN_GOLDEN_EXAMPLES) - num_eval_runs
+        num_test_runs = (num_runs - MIN_GOLDEN_EXAMPLES) // 2
+        num_remaining = (num_runs - MIN_GOLDEN_EXAMPLES) - num_test_runs
         num_val_runs = num_remaining // 3
         assert len(val_runs) == num_val_runs
 
@@ -437,7 +437,7 @@ class TestCreateDatasetTaskRuns:
         task_runs = create_dataset_task_runs(
             all_examples,
             reviewed_examples,
-            "eval_tag",
+            "test_tag",
             "train_tag",
             "val_tag",
             "golden_tag",

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
@@ -629,16 +629,16 @@
       return
     }
     const test_filter_id = task_run_split_filter_id(evaluator, "test")
-    const eval_tag = test_filter_id
+    const test_tag = test_filter_id
       ? tagFromFilterId(test_filter_id)
       : undefined
     let golden_tag: string | undefined = undefined
     if (evaluator?.eval_configs_filter_id) {
       golden_tag = tagFromFilterId(evaluator.eval_configs_filter_id)
     }
-    if (!eval_tag || (evaluator.template !== "rag" && !golden_tag)) {
+    if (!test_tag || (evaluator.template !== "rag" && !golden_tag)) {
       alert(
-        "No eval or golden dataset tag found. If you're using a custom filter, please setup the dataset manually.",
+        "No test or golden dataset tag found. If you're using a custom filter, please setup the dataset manually.",
       )
       return
     }

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_detail.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_detail.test.ts
@@ -589,7 +589,7 @@ describe("eval detail page — add eval data", () => {
     })
 
     expect(await alert_from_add_eval_data()).toEqual([
-      "No eval or golden dataset tag found. If you're using a custom filter, please setup the dataset manually.",
+      "No test or golden dataset tag found. If you're using a custom filter, please setup the dataset manually.",
     ])
     expect(mockGoto).not.toHaveBeenCalled()
   })

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -686,7 +686,7 @@
     // Adding data means adding TaskRuns, so only a TaskRun-backed test split has a
     // tag to add them under.
     const test_filter_id = task_run_split_filter_id(evalData, "test")
-    const eval_tag = test_filter_id
+    const test_tag = test_filter_id
       ? tagFromFilterId(test_filter_id)
       : undefined
     const golden_tag = evalData.eval_configs_filter_id
@@ -699,9 +699,9 @@
     // reachable in ordinary use: a non-rag eval with no golden set is the expected V2
     // state (functional spec 6.1), and this button appears precisely when the eval's
     // test split is empty.
-    if (!eval_tag || (evalData.template !== "rag" && !golden_tag)) {
+    if (!test_tag || (evalData.template !== "rag" && !golden_tag)) {
       alert(
-        "No eval or golden dataset tag found. If you're using a custom filter, please setup the dataset manually.",
+        "No test or golden dataset tag found. If you're using a custom filter, please setup the dataset manually.",
       )
       return
     }

--- a/app/web_ui/tests/e2e/eval_creation_flow.spec.ts
+++ b/app/web_ui/tests/e2e/eval_creation_flow.spec.ts
@@ -99,7 +99,7 @@ test("programmatic check: type picker -> judge-only builder creates a template-l
   expect(evaluator.status).toBe("active")
   // Splits are the only place filters live; the flat eval_set_filter_id /
   // train_set_filter_id fields are a load-time migration input and always null.
-  expect(evaluator.splits.test.filter_id).toBe("tag::eval_no_hate_regex")
+  expect(evaluator.splits.test.filter_id).toBe("tag::test_no_hate_regex")
   expect(evaluator.splits.train.filter_id).toBe("tag::train_no_hate_regex")
 
   // The judge was created with the eval and set as its default, so the eval

--- a/libs/server/kiln_server/test_spec_api.py
+++ b/libs/server/kiln_server/test_spec_api.py
@@ -181,9 +181,9 @@ def test_create_spec_success(client, project_and_task):
     assert len(evals) == 1
     assert evals[0].name == "Test Spec"
     assert evals[0].id == res["eval_id"]
-    assert evals[0].eval_configs_filter_id == "tag::eval_golden_test_spec"
+    assert evals[0].eval_configs_filter_id == "tag::golden_test_spec"
     assert evals[0].splits == {
-        "test": TaskRunSplit(filter_id="tag::eval_test_spec"),
+        "test": TaskRunSplit(filter_id="tag::test_test_spec"),
         "train": TaskRunSplit(filter_id="tag::train_test_spec"),
         "val": TaskRunSplit(filter_id="tag::val_test_spec"),
     }
@@ -195,7 +195,7 @@ def test_create_spec_success(client, project_and_task):
     assert saved_eval["eval_set_filter_id"] is None
     assert saved_eval["train_set_filter_id"] is None
     assert saved_eval["splits"] == {
-        "test": {"source": "task_run", "filter_id": "tag::eval_test_spec"},
+        "test": {"source": "task_run", "filter_id": "tag::test_test_spec"},
         "train": {"source": "task_run", "filter_id": "tag::train_test_spec"},
         "val": {"source": "task_run", "filter_id": "tag::val_test_spec"},
     }

--- a/libs/server/kiln_server/utils/spec_utils.py
+++ b/libs/server/kiln_server/utils/spec_utils.py
@@ -108,23 +108,25 @@ class SpecEvalTags(NamedTuple):
     want one of four same-typed strings can name it instead of counting positions.
     """
 
-    eval_tag: str
+    test_tag: str
     train_tag: str
     val_tag: str
     golden_tag: str
 
 
 def generate_spec_eval_tags(spec_name: str) -> SpecEvalTags:
-    """Generate eval, train, val, and golden tags for a spec.
+    """Generate test, train, val, and golden tags for a spec.
 
-    `eval_tag` names the TEST set; see spec_eval_splits for why that name persists.
+    Only newly created evals are affected by the names chosen here: an eval stores the
+    concrete tag strings in its saved filters, so evals created by earlier builds keep
+    the tags they were created with.
     """
     tag_suffix = spec_name.lower().replace(" ", "_")
     return SpecEvalTags(
-        eval_tag=f"eval_{tag_suffix}",
+        test_tag=f"test_{tag_suffix}",
         train_tag=f"train_{tag_suffix}",
         val_tag=f"val_{tag_suffix}",
-        golden_tag=f"eval_golden_{tag_suffix}",
+        golden_tag=f"golden_{tag_suffix}",
     )
 
 
@@ -134,7 +136,7 @@ def tag_filter_id(tag: str) -> DatasetFilterId:
 
 
 def spec_eval_splits(
-    *, eval_tag: str, train_tag: str, val_tag: str
+    *, test_tag: str, train_tag: str, val_tag: str
 ) -> dict[EvalSplitName, SplitRef]:
     """The splits a new spec eval is created with, all backed by tagged TaskRuns.
 
@@ -142,16 +144,12 @@ def spec_eval_splits(
     hazard this function exists to remove, so swapping two of them is made unrepresentable
     rather than left to a reader.
 
-    `eval_tag` names the TEST split. "eval_" is the historical prefix for the test set's
-    tag, kept because it is on dataset items in shipped projects; nothing else in this
-    signature carries the legacy vocabulary.
-
     The golden set is not a split and is not returned here: it is TaskRun-only by
     definition, and keeping it out of the splits dict is what keeps that true at the type
     level.
     """
     return {
-        "test": TaskRunSplit(filter_id=tag_filter_id(eval_tag)),
+        "test": TaskRunSplit(filter_id=tag_filter_id(test_tag)),
         "train": TaskRunSplit(filter_id=tag_filter_id(train_tag)),
         "val": TaskRunSplit(filter_id=tag_filter_id(val_tag)),
     }
@@ -181,7 +179,7 @@ def build_spec_eval(
     """
     tags = generate_spec_eval_tags(name)
     splits = spec_eval_splits(
-        eval_tag=tags.eval_tag, train_tag=tags.train_tag, val_tag=tags.val_tag
+        test_tag=tags.test_tag, train_tag=tags.train_tag, val_tag=tags.val_tag
     )
     # Eval.splits is keyed by str, and dict key types are invariant, so the narrower
     # mapping has to be widened rather than passed through.

--- a/libs/server/kiln_server/utils/test_spec_utils.py
+++ b/libs/server/kiln_server/utils/test_spec_utils.py
@@ -119,44 +119,44 @@ class TestSpecEvalTemplate:
 
 class TestGenerateSpecEvalTags:
     def test_generates_correct_tags_for_simple_name(self):
-        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("Test Spec")
-        assert eval_tag == "eval_test_spec"
+        test_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("Test Spec")
+        assert test_tag == "test_test_spec"
         assert train_tag == "train_test_spec"
         assert val_tag == "val_test_spec"
-        assert golden_tag == "eval_golden_test_spec"
+        assert golden_tag == "golden_test_spec"
 
     def test_handles_already_lowercase_name(self):
-        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("my spec")
-        assert eval_tag == "eval_my_spec"
+        test_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("my spec")
+        assert test_tag == "test_my_spec"
         assert train_tag == "train_my_spec"
         assert val_tag == "val_my_spec"
-        assert golden_tag == "eval_golden_my_spec"
+        assert golden_tag == "golden_my_spec"
 
     def test_handles_uppercase_name(self):
-        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("MY SPEC")
-        assert eval_tag == "eval_my_spec"
+        test_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("MY SPEC")
+        assert test_tag == "test_my_spec"
         assert train_tag == "train_my_spec"
         assert val_tag == "val_my_spec"
-        assert golden_tag == "eval_golden_my_spec"
+        assert golden_tag == "golden_my_spec"
 
     def test_handles_single_word_name(self):
-        eval_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("Toxicity")
-        assert eval_tag == "eval_toxicity"
+        test_tag, train_tag, val_tag, golden_tag = generate_spec_eval_tags("Toxicity")
+        assert test_tag == "test_toxicity"
         assert train_tag == "train_toxicity"
         assert val_tag == "val_toxicity"
-        assert golden_tag == "eval_golden_toxicity"
+        assert golden_tag == "golden_toxicity"
 
-    def test_train_tag_uses_train_prefix(self):
-        """Train tag should use 'train_' prefix, not 'eval_train_'."""
-        _, train_tag, _, _ = generate_spec_eval_tags("Test")
-        assert train_tag.startswith("train_")
-        assert not train_tag.startswith("eval_train_")
+    def test_no_tag_uses_the_legacy_eval_prefix(self):
+        """The four tags share a suffix, so each needs its own distinct prefix.
 
-    def test_val_tag_uses_val_prefix(self):
-        """Val tag should use 'val_' prefix, not 'eval_val_'."""
-        _, _, val_tag, _ = generate_spec_eval_tags("Test")
-        assert val_tag.startswith("val_")
-        assert not val_tag.startswith("eval_val_")
+        The test set's tag was once "eval_"-prefixed. Renaming it is only safe while no
+        two tags collide: these are the filters that separate an eval's four datasets, so
+        a duplicate silently merges two of them instead of failing.
+        """
+        tags = generate_spec_eval_tags("Test")
+
+        assert not any(tag.startswith("eval_") for tag in tags)
+        assert len(set(tags)) == len(tags)
 
 
 class TestSpecEvalSplits:
@@ -165,12 +165,12 @@ class TestSpecEvalSplits:
 
     def test_splits_are_task_run_backed_tag_filters(self):
         splits = spec_eval_splits(
-            eval_tag="eval_test", train_tag="train_test", val_tag="val_test"
+            test_tag="test_test", train_tag="train_test", val_tag="val_test"
         )
 
         assert set(splits) == {"test", "train", "val"}
         assert all(isinstance(split, TaskRunSplit) for split in splits.values())
-        assert splits["test"].filter_id == "tag::eval_test"
+        assert splits["test"].filter_id == "tag::test_test"
         assert splits["train"].filter_id == "tag::train_test"
         assert splits["val"].filter_id == "tag::val_test"
 
@@ -185,14 +185,14 @@ class TestBuildSpecEval:
         )
 
         assert tags == SpecEvalTags(
-            eval_tag="eval_test_spec",
+            test_tag="test_test_spec",
             train_tag="train_test_spec",
             val_tag="val_test_spec",
-            golden_tag="eval_golden_test_spec",
+            golden_tag="golden_test_spec",
         )
         assert eval.name == "Test Spec"
         # Golden is not a split, so the split assertions below never cover it.
-        assert eval.eval_configs_filter_id == "tag::eval_golden_test_spec"
+        assert eval.eval_configs_filter_id == "tag::golden_test_spec"
 
     def test_splits_are_built_in_one_step(self, tmp_path):
         """All three splits are set, and stored in the one place splits live.
@@ -210,7 +210,7 @@ class TestBuildSpecEval:
         )
 
         assert eval.splits == {
-            "test": TaskRunSplit(filter_id="tag::eval_test_spec"),
+            "test": TaskRunSplit(filter_id="tag::test_test_spec"),
             "train": TaskRunSplit(filter_id="tag::train_test_spec"),
             "val": TaskRunSplit(filter_id="tag::val_test_spec"),
         }
@@ -218,7 +218,7 @@ class TestBuildSpecEval:
         assert dumped["eval_set_filter_id"] is None
         assert dumped["train_set_filter_id"] is None
         assert dumped["splits"] == {
-            "test": {"source": "task_run", "filter_id": "tag::eval_test_spec"},
+            "test": {"source": "task_run", "filter_id": "tag::test_test_spec"},
             "train": {"source": "task_run", "filter_id": "tag::train_test_spec"},
             "val": {"source": "task_run", "filter_id": "tag::val_test_spec"},
         }

--- a/specs/projects/playwright_seed_project/phase_plans/phase_3.md
+++ b/specs/projects/playwright_seed_project/phase_plans/phase_3.md
@@ -259,9 +259,11 @@ Whole-fixture spend on the authoring key, including everything phase 2 generated
 
 Neither of these is a phase-3 anecdote; both are properties of the create-eval flow.
 
-- **The eval's name fixes its three dataset tags** — `generate_spec_eval_tags` lowercases it
+- **The eval's name fixes its four dataset tags** — `generate_spec_eval_tags` lowercases it
   and replaces spaces with underscores — and nothing in the UI shows that before you submit
-  the form. Choose the name knowing it becomes `eval_…`, `train_…` and `eval_golden_…`.
+  the form. Choose the name knowing it becomes `test_…`, `train_…`, `val_…` and `golden_…`.
+  (The committed fixture predates that naming and carries the older `eval_…` /
+  `eval_golden_…` tags, which is why its files disagree with this list.)
 - **The named pass/fail control only renders on runs already carrying the golden tag.**
   `get_rating_options` returns each eval's output scores with
   `show_for_tags=[golden_set_tag]`, so tagging must come before rating. Rating a golden run


### PR DESCRIPTION
## What does this PR do?

This PR renames the `eval_tag` parameter and variable to `test_tag` throughout the codebase to better reflect its purpose. The test dataset's tag was historically prefixed with `eval_`, but this naming is being updated for clarity. Additionally, the golden tag is renamed from `eval_golden_` to just `golden_` prefix.

### Key Changes:
- **SpecEvalTags**: Renamed `eval_tag` field to `test_tag`
- **generate_spec_eval_tags()**: Updated to return tags with `test_` and `golden_` prefixes instead of `eval_` and `eval_golden_`
- **spec_eval_splits()**: Changed parameter from `eval_tag` to `test_tag`
- **create_dataset_task_runs()**: Renamed `eval_tag` parameter to `test_tag` and updated internal variable names
- **Updated all call sites** across the codebase to use the new parameter names
- **Updated tests** to verify the new tag naming scheme and ensure no tags use the legacy `eval_` prefix

### Backward Compatibility:
The change only affects newly created evals. Existing evals store concrete tag strings in their saved filters, so evals created by earlier builds retain their original tags.

## Related Issues

N/A

## Contributor License Agreement

I confirm that I have read and agree to the Contributors License Agreement.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to verify tag naming (no legacy `eval_` prefix, all tags are unique)

https://claude.ai/code/session_01KAas7Jv5uV38K9ASdmcH4f