### PR TITLE
Auto-select test runs with traces in eval judges

### DIFF
--- a/app/web_ui/src/lib/components/eval_types/eval_config_builder.svelte
+++ b/app/web_ui/src/lib/components/eval_types/eval_config_builder.svelte
@@ -27,6 +27,7 @@
     type TestV2EvalResponse,
   } from "$lib/api/v2_eval_api"
   import { validate_result_shape } from "$lib/utils/eval_types/test_run_shape"
+  import { select_default_test_run } from "$lib/utils/eval_types/test_run_selection"
   import {
     parse_reference_data,
     parse_reference_keys,
@@ -237,7 +238,7 @@
       runs_loading = true
       runs_error = null
       available_runs = await fetchTaskRuns(project_id, task_id)
-      selected_task_run = available_runs[0] ?? null
+      selected_task_run = select_default_test_run(available_runs)
     } catch (e) {
       runs_error = createKilnError(e)
     } finally {

--- a/app/web_ui/src/lib/utils/eval_types/test_run_selection.test.ts
+++ b/app/web_ui/src/lib/utils/eval_types/test_run_selection.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest"
+import { select_default_test_run } from "./test_run_selection"
+import type { TaskRunOutput } from "$lib/types"
+
+function run(id: string, trace?: TaskRunOutput["trace"]): TaskRunOutput {
+  return {
+    v: 1,
+    id,
+    input: `input ${id}`,
+    output: { output: `output ${id}`, source: { type: "human" } },
+    tags: [],
+    created_at: new Date().toISOString(),
+    trace,
+  } as unknown as TaskRunOutput
+}
+
+const trace = [{ role: "user", content: "hi" }] as TaskRunOutput["trace"]
+
+describe("select_default_test_run", () => {
+  it("prefers a run with a trace over earlier traceless runs", () => {
+    const traced = run("r3", trace)
+    expect(select_default_test_run([run("r1"), run("r2"), traced])).toBe(traced)
+  })
+
+  it("picks the first run with a trace, keeping the newest-first order", () => {
+    const newer = run("r1", trace)
+    const older = run("r2", trace)
+    expect(select_default_test_run([newer, older])).toBe(newer)
+  })
+
+  it("falls back to the first run when none have a trace", () => {
+    const first = run("r1")
+    expect(select_default_test_run([first, run("r2")])).toBe(first)
+  })
+
+  it("treats an empty trace as no trace", () => {
+    const empty_trace = run("r1", [])
+    const traced = run("r2", trace)
+    expect(select_default_test_run([empty_trace, traced])).toBe(traced)
+    expect(select_default_test_run([empty_trace])).toBe(empty_trace)
+  })
+
+  it("treats a null trace as no trace", () => {
+    const null_trace = run("r1", null)
+    const traced = run("r2", trace)
+    expect(select_default_test_run([null_trace, traced])).toBe(traced)
+  })
+
+  it("returns null for an empty list", () => {
+    expect(select_default_test_run([])).toBeNull()
+  })
+})

--- a/app/web_ui/src/lib/utils/eval_types/test_run_selection.ts
+++ b/app/web_ui/src/lib/utils/eval_types/test_run_selection.ts
@@ -1,0 +1,21 @@
+import type { TaskRunOutput } from "$lib/types"
+
+/**
+ * Pick the dataset run the Test Judge pane should start on.
+ *
+ * Judges that read the execution trace (step_count_check, tool_call_check, and
+ * any check whose output source points at the trace) tell the user nothing
+ * useful about a run without one. A missing trace skips with missing_trace; an
+ * empty trace is worse, since `[]` is truthy in JS and gets sent as a real
+ * trace, then scored as zero steps / zero tool calls -- a misleading result
+ * rather than a skip. So prefer a run that has real trace messages.
+ *
+ * Runs arrive newest-first and that order is preserved, so this picks the most
+ * recent run with a trace, falling back to the most recent run overall.
+ */
+export function select_default_test_run(
+  available_runs: TaskRunOutput[],
+): TaskRunOutput | null {
+  const run_with_trace = available_runs.find((run) => !!run.trace?.length)
+  return run_with_trace ?? available_runs[0] ?? null
+}

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/create_eval_config/page.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/create_eval_config/page.test.ts
@@ -539,6 +539,53 @@ describe("EvalConfigBuilder", () => {
     cleanup()
   })
 
+  describe("default test run selection", () => {
+    function taskRunWithTrace(id: string, trace: unknown[] | null) {
+      return {
+        ...sampleTaskRun,
+        id,
+        input: `input ${id}`,
+        output: { output: `output ${id}`, source: { type: "human" as const } },
+        trace,
+      }
+    }
+
+    async function selectedRunText(runs: unknown[]) {
+      mockFetchTaskRuns.mockResolvedValue(runs)
+      const { container } = await renderBuilder("step_count_check")
+      const card = container.querySelector(
+        "[data-testid='selected-run-card']",
+      ) as HTMLElement
+      expect(card).not.toBeNull()
+      return card.textContent ?? ""
+    }
+
+    it("auto-selects the newest run that has a trace", async () => {
+      const text = await selectedRunText([
+        taskRunWithTrace("no_trace", null),
+        taskRunWithTrace("traced", [{ role: "user", content: "hi" }]),
+      ])
+      expect(text).toContain("input traced")
+      expect(text).not.toContain("input no_trace")
+    })
+
+    it("treats an empty trace as no trace", async () => {
+      const text = await selectedRunText([
+        taskRunWithTrace("empty_trace", []),
+        taskRunWithTrace("traced", [{ role: "user", content: "hi" }]),
+      ])
+      expect(text).toContain("input traced")
+    })
+
+    it("falls back to the newest run when none have a trace", async () => {
+      const text = await selectedRunText([
+        taskRunWithTrace("newest", null),
+        taskRunWithTrace("older", null),
+      ])
+      expect(text).toContain("input newest")
+    })
+  })
+
   describe("trust modal for code_eval", () => {
     it("shows trust dialog when test returns code_eval_not_trusted", async () => {
       const { container } = await renderBuilder("code_eval")

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_judge_form.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_judge_form.svelte
@@ -22,6 +22,7 @@
   import { filename_string_short_validator } from "$lib/utils/input_validators"
   import { createKilnError, type KilnError } from "$lib/utils/error_handlers"
   import { validate_result_shape } from "$lib/utils/eval_types/test_run_shape"
+  import { select_default_test_run } from "$lib/utils/eval_types/test_run_selection"
   import {
     parse_reference_data,
     parse_reference_keys,
@@ -125,7 +126,7 @@
       runs_loading = true
       runs_error = null
       available_runs = await fetchTaskRuns(project_id, task_id)
-      selected_task_run = available_runs[0] ?? null
+      selected_task_run = select_default_test_run(available_runs)
     } catch (e) {
       runs_error = createKilnError(e)
     } finally {

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_judge_form.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_judge_form.test.ts
@@ -1,7 +1,26 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeAll } from "vitest"
-import { render, fireEvent } from "@testing-library/svelte"
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest"
+import { render, fireEvent, cleanup } from "@testing-library/svelte"
 import { tick } from "svelte"
+import * as svelteMod from "svelte"
+
+const mockFetchTaskRuns = vi.fn()
+
+vi.mock("$lib/api/v2_eval_api", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...original,
+    fetchTaskRuns: (...args: unknown[]) => mockFetchTaskRuns(...args),
+  }
+})
 
 vi.mock("$lib/components/code_editor.svelte", async () => {
   const StubModule = await import(
@@ -49,7 +68,52 @@ function render_form(judge_type: "code_eval" | "pattern_match", name: string) {
   })
 }
 
+/**
+ * Render the form and run the onMount callbacks, which load the task runs the
+ * Test Judge pane selects from. onMount doesn't fire on its own under vitest,
+ * so collect the callbacks and invoke them by hand.
+ */
+async function render_form_with_runs(runs: unknown[]) {
+  mockFetchTaskRuns.mockResolvedValue(runs)
+
+  const on_mount_callbacks: Array<() => unknown> = []
+  const spy = vi
+    .spyOn(svelteMod, "onMount")
+    .mockImplementation((fn: () => unknown) => {
+      on_mount_callbacks.push(fn)
+    })
+  const result = render_form("pattern_match", "My Eval")
+  spy.mockRestore()
+
+  for (const callback of on_mount_callbacks) {
+    await callback()
+  }
+  await tick()
+  return result
+}
+
+function task_run(id: string, trace: unknown[] | null) {
+  return {
+    v: 1,
+    id,
+    input: `input ${id}`,
+    output: { output: `output ${id}`, source: { type: "human" as const } },
+    tags: [],
+    created_at: new Date().toISOString(),
+    trace,
+  }
+}
+
 describe("CreateSpecJudgeForm", () => {
+  beforeEach(() => {
+    mockFetchTaskRuns.mockReset()
+    mockFetchTaskRuns.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
   it("seeds the code judge with the real score key, never the quality fallback", () => {
     // With a valid name the starter regenerates with the real key; the
     // placeholder only appears while the name is empty or invalid. Neither
@@ -121,9 +185,46 @@ describe("CreateSpecJudgeForm", () => {
     )
   })
 
+  describe("default test run selection", () => {
+    async function selected_run_text(runs: unknown[]) {
+      const { container } = await render_form_with_runs(runs)
+      const card = container.querySelector(
+        '[data-testid="selected-run-card"]',
+      ) as HTMLElement
+      expect(card).not.toBeNull()
+      return card.textContent ?? ""
+    }
+
+    it("auto-selects the newest run that has a trace", async () => {
+      const text = await selected_run_text([
+        task_run("no_trace", null),
+        task_run("traced", [{ role: "user", content: "hi" }]),
+      ])
+      expect(text).toContain("input traced")
+      expect(text).not.toContain("input no_trace")
+    })
+
+    it("treats an empty trace as no trace", async () => {
+      const text = await selected_run_text([
+        task_run("empty_trace", []),
+        task_run("traced", [{ role: "user", content: "hi" }]),
+      ])
+      expect(text).toContain("input traced")
+    })
+
+    it("falls back to the newest run when none have a trace", async () => {
+      const text = await selected_run_text([
+        task_run("newest", null),
+        task_run("older", null),
+      ])
+      expect(text).toContain("input newest")
+    })
+  })
+
   // Note: hiding the score-key note while the name field has a validation
   // error (name_error -> no output_scores) isn't testable here — FormElement
-  // only starts validating after onMount, which jsdom/vitest doesn't run.
+  // only starts validating after onMount, which plain render_form doesn't
+  // drive (see render_form_with_runs for the manual onMount path).
   // The render-side behavior (no scores -> no note) is covered in
   // code_eval_form.test.ts.
 })


### PR DESCRIPTION
## What does this PR do?

This PR improves the default test run selection in eval judges by preferring runs that have execution traces. Judges that read traces (like `step_count_check` and `tool_call_check`) produce misleading results on runs without traces, so this change ensures the UI starts with a run that has actual trace data when available.

### Changes:

1. **New utility function** (`test_run_selection.ts`): Implements `select_default_test_run()` which selects the newest run with a non-empty trace, falling back to the newest run overall if none have traces.

2. **Updated eval config builders**: Both `eval_config_builder.svelte` and `create_spec_judge_form.svelte` now use the new selection logic instead of always picking the first run.

3. **Comprehensive test coverage**: 
   - Added unit tests for the selection logic in `test_run_selection.test.ts`
   - Added integration tests in both `create_spec_judge_form.test.ts` and `page.test.ts` to verify the behavior in context
   - Enhanced test infrastructure with proper mocking of `fetchTaskRuns` and `onMount` callbacks

The selection logic treats empty traces (`[]`) as "no trace" since an empty array is truthy in JavaScript but produces misleading zero-step/zero-tool-call results rather than a proper skip.

## Related Issues

N/A

## Contributor License Agreement

I confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

https://claude.ai/code/session_01Q85n5Q1Xcq88FmWgdfLiVp