### PR TITLE
Share one tool-option builder, and differentiate Kiln Task tools that share a name

### DIFF
--- a/app/web_ui/src/lib/components/eval_types/__tests__/form_element_stub.svelte
+++ b/app/web_ui/src/lib/components/eval_types/__tests__/form_element_stub.svelte
@@ -25,6 +25,10 @@
   export let aria_label: string | null = null
   export let inline_action: InlineAction | null = null
   export let radio_options: RadioOption[] = []
+  export let empty_label: string | undefined = undefined
+  export let empty_state_message: string | undefined = undefined
+  export let empty_state_subtitle: string | undefined = undefined
+  export let empty_state_link: string | undefined = undefined
   export let on_radio_change: (() => void) | null = null
 
   export let validator: (value: unknown) => string | null = () => null
@@ -42,6 +46,10 @@
   data-inline-action-label={inline_action?.label || ""}
   data-hide-label={hide_label ? "true" : "false"}
   data-placeholder={placeholder || ""}
+  data-empty-label={empty_label || ""}
+  data-empty-state-message={empty_state_message || ""}
+  data-empty-state-subtitle={empty_state_subtitle || ""}
+  data-empty-state-link={empty_state_link || ""}
 >
   {#if inputType === "radio"}
     <div data-testid="radio-group-{id}">
@@ -67,13 +75,20 @@
   {:else if inputType === "input"}
     <input type="text" data-testid="input-{id}" {placeholder} bind:value />
   {:else if inputType === "fancy_select"}
-    <div data-testid="fancy-select-{id}">
+    <div
+      data-testid="fancy-select-{id}"
+      data-group-labels={JSON.stringify(
+        fancy_select_options.map((group) => group.label ?? ""),
+      )}
+    >
       {#each fancy_select_options as group}
         {#each group.options as option}
           <button
             type="button"
             data-testid="fancy-option-{option.value}"
             data-value={option.value}
+            data-option-description={option.description || ""}
+            data-badge={option.badge || ""}
             class:selected={value === option.value}
             on:click={() => {
               value = option.value

--- a/app/web_ui/src/lib/components/eval_types/deterministic_forms.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/deterministic_forms.test.ts
@@ -2132,7 +2132,6 @@ describe("ToolCallCheckForm tool option filtering", () => {
     const { container } = render(ToolCallCheckForm, {
       props: {
         project_id: "proj_tcc",
-        task_id: "task_tcc",
         properties: {
           type: "tool_call_check" as const,
           expected_tools: [{ tool_name: "", expected_args: null }],

--- a/app/web_ui/src/lib/components/eval_types/eval_config_builder.svelte
+++ b/app/web_ui/src/lib/components/eval_types/eval_config_builder.svelte
@@ -631,7 +631,6 @@
             bind:this={v2FormComponentRef}
             {eval_config_type}
             {project_id}
-            {task_id}
             {reference_candidate_keys}
             output_scores={evaluator?.output_scores}
             bind:code_string={code_eval_code}

--- a/app/web_ui/src/lib/components/eval_types/judge_config_fields.svelte
+++ b/app/web_ui/src/lib/components/eval_types/judge_config_fields.svelte
@@ -18,7 +18,6 @@
    */
   export let eval_config_type: V2EvalType
   export let project_id: string = ""
-  export let task_id: string = ""
   export let output_scores: EvalOutputScore[] | undefined = undefined
   export let reference_candidate_keys: string[] = []
   // Creation flow only: the code judge seeds its starter code with a static
@@ -77,7 +76,6 @@
     this={metadata.createFormComponent}
     bind:this={form_ref}
     {project_id}
-    {task_id}
   />
 {:else}
   <svelte:component this={metadata.createFormComponent} bind:this={form_ref} />

--- a/app/web_ui/src/lib/components/eval_types/tool_call_check_form.svelte
+++ b/app/web_ui/src/lib/components/eval_types/tool_call_check_form.svelte
@@ -4,11 +4,10 @@
   import FormList from "$lib/utils/form_list.svelte"
   import Collapse from "$lib/ui/collapse.svelte"
   import CloseIcon from "$lib/ui/icons/close_icon.svelte"
-  import { onMount } from "svelte"
   import { available_tools, load_available_tools } from "$lib/stores"
-  import { is_tool_selectable_in_context } from "$lib/stores/tools_store"
   import type { OptionGroup, Option } from "$lib/ui/fancy_select_types"
   import type { ToolSetApiDescription } from "$lib/types"
+  import { build_tool_option_groups } from "$lib/ui/run_config_component/tool_options"
 
   type ToolCallSpec = components["schemas"]["ToolCallSpec"]
 
@@ -23,69 +22,50 @@
   export let project_id: string = ""
   export let task_id: string = ""
 
-  // Options for the tool-name dropdown, grouped by tool set. Values are the
-  // OpenAI-compatible function names (what appears in the trace), not the Kiln
-  // display names.
-  let tool_options: OptionGroup[] = []
-  let known_function_names = new Set<string>()
-  let tools_loading = true
-  let options_built = false
+  $: load_available_tools(project_id)
 
-  onMount(() => {
-    load_available_tools(project_id)
-  })
+  // Options for the tool-name dropdown, built by the same shared builder every
+  // other tool picker uses, so a tool reads the same way here as it does on /run.
+  // The value is the OpenAI-compatible function name a trace records, which the
+  // builder surfaces beside the tool where it differs from its display name.
+  $: tools_loading = $available_tools[project_id] === undefined
+  $: tool_options = build_tool_options($available_tools[project_id])
+  $: known_function_names = new Set(
+    tool_options.flatMap((group) =>
+      group.options.map((option) => String(option.value)),
+    ),
+  )
 
-  // Build the dropdown once the project's tools have loaded.
-  $: maybe_build_tool_options($available_tools[project_id])
-
-  function maybe_build_tool_options(
+  function build_tool_options(
     tool_sets: ToolSetApiDescription[] | undefined,
-  ) {
-    if (!tool_sets || options_built || !project_id || !task_id) return
-    options_built = true
-    build_tool_options(tool_sets)
-  }
+  ): OptionGroup[] {
+    // This form matches tool calls in an agent's trace, so it offers agent tools:
+    // context "none". Whole sets the server marks as sandbox-only are dropped,
+    // because nothing in one can appear in an agent's trace.
+    const groups = build_tool_option_groups(tool_sets, {
+      value_field: "function_name",
+      sandbox_code_context: "none",
+    })
 
-  function build_tool_options(tool_sets: ToolSetApiDescription[]) {
-    const groups: OptionGroup[] = []
-    const fn_names = new Set<string>()
-    for (const tool_set of tool_sets) {
-      if (tool_set.type === "skill") {
-        if (tool_set.tools.length > 0) {
-          const option: Option = {
+    // Every skill is the same `skill` call in the trace, told apart by its name
+    // argument, so the whole set collapses to one option instead of one per skill.
+    const skill_set = (tool_sets ?? []).find(
+      (tool_set) => tool_set.type === "skill" && tool_set.tools.length > 0,
+    )
+    if (skill_set) {
+      groups.push({
+        label: skill_set.set_name,
+        options: [
+          {
             value: "skill",
             label: "Skill",
             description:
               "Covers all skills; the specific skill is matched via the name argument.",
-          }
-          fn_names.add("skill")
-          groups.push({ label: tool_set.set_name, options: [option] })
-        }
-        continue
-      }
-      const options: Option[] = []
-      // This form matches tool calls in an agent's trace, so it selects agent
-      // tools: context "none". Whole sets the server marks as sandbox-only are
-      // dropped, because nothing in one can appear in an agent's trace.
-      const selectable_tools = tool_set.tools.filter((tool) =>
-        is_tool_selectable_in_context(tool.id, tool_set.type, "none"),
-      )
-      for (const tool of selectable_tools) {
-        const function_name = tool.function_name ?? tool.name
-        options.push({
-          value: function_name,
-          label: tool.name,
-          description: function_name,
-        })
-        fn_names.add(function_name)
-      }
-      if (options.length > 0) {
-        groups.push({ label: tool_set.set_name, options })
-      }
+          },
+        ],
+      })
     }
-    tool_options = groups
-    known_function_names = fn_names
-    tools_loading = false
+    return groups
   }
 
   // Preserve tool names that aren't in the current tool list (legacy configs,
@@ -245,7 +225,7 @@
               id="tool_name_{item_index}"
               label="Tool"
               description="The tool that should be called."
-              info_description="The dropdown lists each tool's function name as it appears in the trace, which can differ from its display name in Kiln."
+              info_description="Tools are matched by the function name a trace records, shown beside the tool when it differs from its display name in Kiln."
               inputType="fancy_select"
               fancy_select_options={display_tool_options}
               empty_label="Select a tool"

--- a/app/web_ui/src/lib/components/eval_types/tool_call_check_form.svelte
+++ b/app/web_ui/src/lib/components/eval_types/tool_call_check_form.svelte
@@ -18,9 +18,8 @@
     on_unexpected_tools: "ignore",
   }
 
-  // Project/task context, used to load the available tools for the dropdown.
+  // Project context, used to load the available tools for the dropdown.
   export let project_id: string = ""
-  export let task_id: string = ""
 
   $: load_available_tools(project_id)
 

--- a/app/web_ui/src/lib/components/eval_types/tool_call_check_form.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/tool_call_check_form.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest"
+import { render } from "@testing-library/svelte"
+import { tick } from "svelte"
+import { available_tools } from "$lib/stores"
+import type { ToolSetApiDescription } from "$lib/types"
+
+vi.mock("$lib/utils/form_element.svelte", async () => {
+  const StubModule = await import("./__tests__/form_element_stub.svelte")
+  return { default: StubModule.default }
+})
+
+vi.mock("$lib/utils/form_list.svelte", async () => {
+  const StubModule = await import("./__tests__/form_list_stub.svelte")
+  return { default: StubModule.default }
+})
+
+vi.mock("$lib/ui/collapse.svelte", async () => {
+  const StubModule = await import("./__tests__/collapse_stub.svelte")
+  return { default: StubModule.default }
+})
+
+const ToolCallCheckForm = (await import("./tool_call_check_form.svelte"))
+  .default
+
+const mcp_set: ToolSetApiDescription = {
+  type: "mcp",
+  set_name: "MCP Server: demo",
+  tools: [
+    {
+      id: "mcp::remote::demo::search_docs",
+      name: "search_docs",
+      description: "Search the docs",
+      function_name: "search_docs",
+    },
+  ],
+}
+
+const code_tool_set: ToolSetApiDescription = {
+  type: "code",
+  set_name: "Code Tools",
+  tools: [
+    {
+      id: "code_tool::abc",
+      name: "Word Count",
+      description: "Count words in the output",
+      function_name: "word_count",
+    },
+  ],
+}
+
+const ai_models_set: ToolSetApiDescription = {
+  type: "sandbox_code",
+  set_name: "AI Models",
+  tools: [
+    {
+      id: "kiln_tool::llm",
+      name: "LLM",
+      description: "Call a model",
+      function_name: "llm",
+    },
+  ],
+}
+
+const skill_set: ToolSetApiDescription = {
+  type: "skill",
+  set_name: "Skills",
+  tools: [
+    {
+      id: "kiln_skill::xyz",
+      name: "Research",
+      description: "Do research",
+      function_name: "Research",
+    },
+  ],
+}
+
+type RenderedOption = {
+  value: string
+  label: string
+  description: string
+  badge: string
+}
+
+async function render_options(
+  tool_sets: ToolSetApiDescription[],
+  expected_tool_names: string[] = [""],
+): Promise<{ options: RenderedOption[]; group_labels: string[] }> {
+  const project_id = "proj_" + Math.random().toString(36).slice(2)
+  available_tools.set({ [project_id]: tool_sets })
+  const { container } = render(ToolCallCheckForm, {
+    props: {
+      project_id,
+      task_id: "task_1",
+      properties: {
+        type: "tool_call_check",
+        expected_tools: expected_tool_names.map((tool_name) => ({
+          tool_name,
+          expected_args: null,
+        })),
+        match_mode: "all",
+        on_unexpected_tools: "ignore",
+      },
+    },
+  })
+  await tick()
+  const select = container.querySelector(
+    '[data-testid="fancy-select-tool_name_0"]',
+  )
+  const options = Array.from(
+    select?.querySelectorAll("[data-value]") ?? [],
+  ).map((el) => ({
+    value: el.getAttribute("data-value") ?? "",
+    label: el.querySelector("span")?.textContent?.trim() ?? "",
+    description: el.getAttribute("data-option-description") ?? "",
+    badge: el.getAttribute("data-badge") ?? "",
+  }))
+  return {
+    options,
+    group_labels: JSON.parse(select?.getAttribute("data-group-labels") ?? "[]"),
+  }
+}
+
+describe("ToolCallCheckForm tool dropdown", () => {
+  it("labels by tool name and subtitles by the tool's own description", async () => {
+    // Regression: label and subtitle were both the function name, so every MCP,
+    // Kiln-task, search and skill tool -- where the two match -- showed the same
+    // string twice and dropped its real description.
+    const { options } = await render_options([mcp_set])
+    expect(options).toEqual([
+      {
+        value: "search_docs",
+        label: "search_docs",
+        description: "Search the docs",
+        badge: "",
+      },
+    ])
+  })
+
+  it("shows the function name beside a tool whose display name differs", async () => {
+    const { options } = await render_options([code_tool_set])
+    expect(options).toEqual([
+      {
+        value: "word_count",
+        label: "Word Count",
+        description: "Count words in the output",
+        badge: "word_count",
+      },
+    ])
+  })
+
+  it("selects the function name a trace records, not the tool id", async () => {
+    const { options } = await render_options([code_tool_set, mcp_set])
+    expect(options.map((option) => option.value)).toEqual([
+      "word_count",
+      "search_docs",
+    ])
+  })
+
+  it("collapses every skill into one option", async () => {
+    const { options, group_labels } = await render_options([mcp_set, skill_set])
+    expect(options.map((option) => option.value)).toEqual([
+      "search_docs",
+      "skill",
+    ])
+    expect(group_labels).toEqual(["MCP Server: demo", "Skills"])
+  })
+
+  it("offers the skill option in a project that has only skills", async () => {
+    const { options } = await render_options([skill_set])
+    expect(options.map((option) => option.value)).toEqual(["skill"])
+  })
+
+  it("excludes sandbox-only tools, which can never appear in a trace", async () => {
+    const { options } = await render_options([ai_models_set, mcp_set])
+    expect(options.map((option) => option.value)).toEqual(["search_docs"])
+  })
+
+  it("keeps a saved tool name the project no longer offers", async () => {
+    const { options, group_labels } = await render_options(
+      [mcp_set],
+      ["deleted_tool"],
+    )
+    expect(options.map((option) => option.value)).toEqual([
+      "search_docs",
+      "deleted_tool",
+    ])
+    expect(group_labels).toEqual(["MCP Server: demo", "Other"])
+  })
+
+  it("does not treat a known tool as a custom value", async () => {
+    const { group_labels } = await render_options([mcp_set], ["search_docs"])
+    expect(group_labels).toEqual(["MCP Server: demo"])
+  })
+})

--- a/app/web_ui/src/lib/components/eval_types/tool_call_check_form.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/tool_call_check_form.test.ts
@@ -91,7 +91,6 @@ async function render_options(
   const { container } = render(ToolCallCheckForm, {
     props: {
       project_id,
-      task_id: "task_1",
       properties: {
         type: "tool_call_check",
         expected_tools: expected_tool_names.map((tool_name) => ({

--- a/app/web_ui/src/lib/stores/tools_store.test.ts
+++ b/app/web_ui/src/lib/stores/tools_store.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest"
-import { is_skill_tool_id, split_tool_and_skill_ids } from "./tools_store"
+import type { ToolApiDescription, ToolSetApiDescription } from "$lib/types"
+import {
+  duplicate_tool_names,
+  get_tool_names_from_ids,
+  is_skill_tool_id,
+  kiln_task_tool_server_id,
+  split_tool_and_skill_ids,
+  tool_display_name,
+} from "./tools_store"
 
 describe("tools_store", () => {
   describe("is_skill_tool_id", () => {
@@ -34,6 +42,139 @@ describe("tools_store", () => {
       const result = split_tool_and_skill_ids([])
       expect(result.tool_ids).toEqual([])
       expect(result.skill_ids).toEqual([])
+    })
+  })
+
+  describe("kiln task tool disambiguation", () => {
+    const summarize_tool: ToolApiDescription = {
+      id: "kiln_task::111",
+      name: "summarize",
+      description: "Summarize text",
+    }
+    const summarize_tool_clone: ToolApiDescription = {
+      id: "kiln_task::222",
+      name: "summarize",
+      description: "Summarize text",
+    }
+    const kiln_task_set = (
+      tools: ToolApiDescription[],
+    ): ToolSetApiDescription => ({
+      type: "kiln_task",
+      set_name: "Kiln Tasks as Tools",
+      tools,
+    })
+    const mcp_set = (tools: ToolApiDescription[]): ToolSetApiDescription => ({
+      type: "mcp",
+      set_name: "MCP Server: demo",
+      tools,
+    })
+
+    describe("kiln_task_tool_server_id", () => {
+      it("returns the tool server ID of a Kiln task tool", () => {
+        expect(kiln_task_tool_server_id("kiln_task::121377416728")).toBe(
+          "121377416728",
+        )
+      })
+
+      it("returns null for other tool types", () => {
+        expect(kiln_task_tool_server_id("mcp::local::456::read")).toBe(null)
+        expect(kiln_task_tool_server_id("kiln_tool::add_numbers")).toBe(null)
+      })
+
+      it("returns null when the ID carries no server ID", () => {
+        expect(kiln_task_tool_server_id("kiln_task::")).toBe(null)
+      })
+    })
+
+    describe("duplicate_tool_names", () => {
+      it("finds names shared by tools in the same set", () => {
+        expect(
+          duplicate_tool_names([
+            kiln_task_set([summarize_tool, summarize_tool_clone]),
+          ]),
+        ).toEqual(new Set(["summarize"]))
+      })
+
+      it("finds names shared across different tool sets", () => {
+        expect(
+          duplicate_tool_names([
+            kiln_task_set([summarize_tool]),
+            mcp_set([
+              {
+                id: "mcp::local::1::summarize",
+                name: "summarize",
+                description: null,
+              },
+            ]),
+          ]),
+        ).toEqual(new Set(["summarize"]))
+      })
+
+      it("returns an empty set when every name is unique", () => {
+        expect(
+          duplicate_tool_names([
+            kiln_task_set([summarize_tool]),
+            mcp_set([
+              { id: "mcp::local::1::read", name: "read", description: null },
+            ]),
+          ]),
+        ).toEqual(new Set())
+      })
+
+      it("handles a project with no tool sets", () => {
+        expect(duplicate_tool_names([])).toEqual(new Set())
+      })
+    })
+
+    describe("tool_display_name", () => {
+      it("qualifies an ambiguous Kiln task tool with its tool server ID", () => {
+        expect(tool_display_name(summarize_tool, new Set(["summarize"]))).toBe(
+          "summarize (111)",
+        )
+      })
+
+      it("leaves a unique name alone", () => {
+        expect(tool_display_name(summarize_tool, new Set())).toBe("summarize")
+      })
+
+      it("leaves non-Kiln-task tools alone, since their group already names them", () => {
+        expect(
+          tool_display_name(
+            {
+              id: "mcp::local::1::summarize",
+              name: "summarize",
+              description: null,
+            },
+            new Set(["summarize"]),
+          ),
+        ).toBe("summarize")
+      })
+    })
+
+    describe("get_tool_names_from_ids", () => {
+      it("qualifies only the duplicated names", () => {
+        const project_tools = [
+          kiln_task_set([summarize_tool, summarize_tool_clone]),
+          mcp_set([
+            { id: "mcp::local::1::read", name: "read", description: null },
+          ]),
+        ]
+        expect(
+          get_tool_names_from_ids(
+            ["kiln_task::111", "kiln_task::222", "mcp::local::1::read"],
+            project_tools,
+          ),
+        ).toEqual(["summarize (111)", "summarize (222)", "read"])
+      })
+
+      it("falls back to the ID when a tool is not in the project", () => {
+        expect(
+          get_tool_names_from_ids(
+            ["kiln_task::999"],
+            [kiln_task_set([summarize_tool])],
+          ),
+        ).toEqual(["kiln_task::999"])
+      })
     })
   })
 })

--- a/app/web_ui/src/lib/stores/tools_store.ts
+++ b/app/web_ui/src/lib/stores/tools_store.ts
@@ -1,5 +1,6 @@
 import type {
   ExternalToolApiDescription,
+  ToolApiDescription,
   ToolSetApiDescription,
   ToolSetType,
 } from "$lib/types"
@@ -103,10 +104,63 @@ export function get_tool_names_from_ids(
     return tool_ids // Return IDs if we don't have the tools loaded for some reason
   }
 
+  const duplicates = duplicate_tool_names(project_tools)
   const all_tools = project_tools.flatMap((tool_set) => tool_set.tools)
-  const tool_map = new Map(all_tools.map((tool) => [tool.id, tool.name]))
+  const tool_map = new Map(
+    all_tools.map((tool) => [tool.id, tool_display_name(tool, duplicates)]),
+  )
 
   return tool_ids.map((id) => tool_map.get(id) || id) // Fall back to ID if name not found
+}
+
+// Tool names carried by more than one tool. Counted across every tool set it is
+// given rather than within a set, because a Kiln task tool sharing a name with an
+// MCP tool is exactly as ambiguous as two Kiln task tools sharing one.
+export function duplicate_tool_names(
+  tool_sets: ToolSetApiDescription[],
+): Set<string> {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+  for (const tool_set of tool_sets) {
+    for (const tool of tool_set.tools) {
+      if (seen.has(tool.name)) {
+        duplicates.add(tool.name)
+      }
+      seen.add(tool.name)
+    }
+  }
+  return duplicates
+}
+
+// What to call a tool wherever it is listed for a user.
+//
+// Nothing stops two Kiln task tools from carrying the same name and description --
+// the create form defaults the name to the task's, so two run configs of one task
+// collide by default -- which leaves them indistinguishable in a list or a picker.
+// An ambiguous one is qualified by its tool server id, the same id shown on its
+// detail page and in that page's URL, so the user has something to match against.
+//
+// Only Kiln task tools earn the qualifier: MCP tools are already grouped under
+// their server, and search tools name their RAG config in their description.
+export function tool_display_name(
+  tool: ToolApiDescription,
+  duplicate_names: Set<string>,
+): string {
+  if (!duplicate_names.has(tool.name)) {
+    return tool.name
+  }
+  const tool_server_id = kiln_task_tool_server_id(tool.id)
+  return tool_server_id ? `${tool.name} (${tool_server_id})` : tool.name
+}
+
+const KILN_TASK_TOOL_ID_PREFIX = "kiln_task::"
+
+// The tool server id inside a Kiln task tool id, or null for every other tool type.
+export function kiln_task_tool_server_id(tool_id: string): string | null {
+  if (!tool_id.startsWith(KILN_TASK_TOOL_ID_PREFIX)) {
+    return null
+  }
+  return tool_id.slice(KILN_TASK_TOOL_ID_PREFIX.length) || null
 }
 
 const SKILL_TOOL_ID_PREFIX = "kiln_tool::skill::"

--- a/app/web_ui/src/lib/ui/fancy_select.svelte
+++ b/app/web_ui/src/lib/ui/fancy_select.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation"
   import type { OptionGroup } from "./fancy_select_types"
+  import { filter_option_groups } from "./fancy_select_search"
   import { computePosition, autoUpdate, offset } from "@floating-ui/dom"
   import { onMount, onDestroy } from "svelte"
 
@@ -34,39 +35,8 @@
   let isSearching = false
   let searchInputElement: HTMLInputElement
 
-  // Filter options based on search text - supports multi-word searches
-  function filterOptions(
-    options: OptionGroup[],
-    searchText: string,
-  ): OptionGroup[] {
-    if (!searchText.trim()) {
-      return options
-    }
-
-    // Split search text into words for flexible matching
-    const searchWords = searchText.toLowerCase().trim().split(/\s+/)
-
-    return options
-      .map((group) => ({
-        ...group,
-        options: group.options.filter((option) => {
-          const labelText = option.label.toLowerCase()
-          const descriptionText = option.description?.toLowerCase() || ""
-          // Badges carry searchable identity for some options (a tool's function
-          // name, for one), so they take part in matching.
-          const badgeText = option.badge?.toLowerCase() || ""
-          const combinedText =
-            labelText + " " + descriptionText + " " + badgeText
-
-          // Check if all search words are present in the combined text
-          return searchWords.every((word) => combinedText.includes(word))
-        }),
-      }))
-      .filter((group) => group.options.length > 0)
-  }
-
   // Computed filtered options based on search
-  $: filteredOptions = filterOptions(options, searchText)
+  $: filteredOptions = filter_option_groups(options, searchText)
 
   // Reset search when dropdown closes
   $: if (!listVisible) {

--- a/app/web_ui/src/lib/ui/fancy_select.svelte
+++ b/app/web_ui/src/lib/ui/fancy_select.svelte
@@ -52,7 +52,11 @@
         options: group.options.filter((option) => {
           const labelText = option.label.toLowerCase()
           const descriptionText = option.description?.toLowerCase() || ""
-          const combinedText = labelText + " " + descriptionText
+          // Badges carry searchable identity for some options (a tool's function
+          // name, for one), so they take part in matching.
+          const badgeText = option.badge?.toLowerCase() || ""
+          const combinedText =
+            labelText + " " + descriptionText + " " + badgeText
 
           // Check if all search words are present in the combined text
           return searchWords.every((word) => combinedText.includes(word))

--- a/app/web_ui/src/lib/ui/fancy_select_search.test.ts
+++ b/app/web_ui/src/lib/ui/fancy_select_search.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest"
+import type { OptionGroup } from "./fancy_select_types"
+import { filter_option_groups } from "./fancy_select_search"
+
+const option_groups: OptionGroup[] = [
+  {
+    label: "Models",
+    options: [
+      { value: "gpt_4o", label: "GPT 4o", badge: "Recommended" },
+      {
+        value: "llama_3",
+        label: "Llama 3",
+        description: "Runs on your own hardware",
+      },
+    ],
+  },
+  {
+    label: "Tools",
+    options: [{ value: "counter", label: "Counter", badge: "word_count" }],
+  },
+]
+
+const matches = (search_text: string): string[] =>
+  filter_option_groups(option_groups, search_text).flatMap((group) =>
+    group.options.map((option) => String(option.value)),
+  )
+
+describe("filter_option_groups", () => {
+  it("returns every group untouched when nothing is typed", () => {
+    expect(filter_option_groups(option_groups, "")).toEqual(option_groups)
+    expect(filter_option_groups(option_groups, "   ")).toEqual(option_groups)
+  })
+
+  it("matches on the option label", () => {
+    expect(matches("llama")).toEqual(["llama_3"])
+  })
+
+  it("matches on the option description", () => {
+    expect(matches("hardware")).toEqual(["llama_3"])
+  })
+
+  it("matches on the badge, which carries identity the label does not", () => {
+    // A tool option badges the OpenAI function name a trace records -- the value
+    // being picked -- so it has to be findable. So do "Recommended" and friends.
+    expect(matches("word_count")).toEqual(["counter"])
+    expect(matches("recommended")).toEqual(["gpt_4o"])
+  })
+
+  it("matches badge text case-insensitively", () => {
+    expect(matches("RECOMMENDED")).toEqual(["gpt_4o"])
+  })
+
+  it("requires every word, in any order, across label, description and badge", () => {
+    expect(matches("recommended gpt")).toEqual(["gpt_4o"])
+    // A badge cannot rescue an option whose other words do not match.
+    expect(matches("llama recommended")).toEqual([])
+  })
+
+  it("does not let one option's text match against a neighbour's", () => {
+    expect(matches("counter recommended")).toEqual([])
+  })
+
+  it("drops a group left with no matching options", () => {
+    expect(
+      filter_option_groups(option_groups, "recommended").map(
+        (group) => group.label,
+      ),
+    ).toEqual(["Models"])
+  })
+
+  it("keeps a group's own fields when filtering its options", () => {
+    const with_action: OptionGroup[] = [
+      {
+        label: "Tools",
+        options: [{ value: "counter", label: "Counter", badge: "word_count" }],
+        action_label: "Create New",
+        action_handler: () => {},
+      },
+    ]
+    const [group] = filter_option_groups(with_action, "counter")
+    expect(group.action_label).toBe("Create New")
+    expect(group.action_handler).toBe(with_action[0].action_handler)
+  })
+})

--- a/app/web_ui/src/lib/ui/fancy_select_search.ts
+++ b/app/web_ui/src/lib/ui/fancy_select_search.ts
@@ -1,0 +1,35 @@
+import type { OptionGroup } from "./fancy_select_types"
+
+// Which options survive a dropdown search. Multi-word and order-independent: every
+// word typed has to appear somewhere in an option's searchable text.
+//
+// That text is the label, the description and the badge. Badges carry identity the
+// label does not -- a tool's OpenAI function name, "Recommended", "Requires API
+// Key" -- and anything the user can read on an option should be something they can
+// find it by.
+//
+// Groups left with nothing matching are dropped, so a search never leaves a bare
+// header behind.
+export function filter_option_groups(
+  options: OptionGroup[],
+  search_text: string,
+): OptionGroup[] {
+  if (!search_text.trim()) {
+    return options
+  }
+
+  const search_words = search_text.toLowerCase().trim().split(/\s+/)
+
+  return options
+    .map((group) => ({
+      ...group,
+      options: group.options.filter((option) => {
+        const searchable_text = [option.label, option.description, option.badge]
+          .filter((text) => !!text)
+          .join(" ")
+          .toLowerCase()
+        return search_words.every((word) => searchable_text.includes(word))
+      }),
+    }))
+    .filter((group) => group.options.length > 0)
+}

--- a/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi } from "vitest"
+import type { ToolSetApiDescription } from "$lib/types"
+import {
+  AGENT_TOOL_SET_ORDER,
+  build_tool_option_groups,
+  selectable_tool_sets,
+} from "./tool_options"
+
+const ai_models_set: ToolSetApiDescription = {
+  type: "sandbox_code",
+  set_name: "AI Models",
+  tools: [
+    {
+      id: "kiln_tool::llm",
+      name: "LLM",
+      description: "Call a model",
+      function_name: "llm",
+    },
+    {
+      id: "kiln_tool::llm_judge",
+      name: "LLM Judge",
+      description: "Judge with the eval schema",
+      function_name: "llm_judge",
+    },
+  ],
+}
+
+const mcp_set: ToolSetApiDescription = {
+  type: "mcp",
+  set_name: "MCP Server: demo",
+  tools: [
+    {
+      id: "mcp::remote::demo::search_docs",
+      name: "search_docs",
+      description: "  Search the docs  ",
+      function_name: "search_docs",
+    },
+  ],
+}
+
+const kiln_task_set: ToolSetApiDescription = {
+  type: "kiln_task",
+  set_name: "Kiln Tasks as Tools",
+  tools: [
+    {
+      id: "kiln_task::abc",
+      name: "Summarize",
+      description: null,
+      function_name: "summarize",
+    },
+  ],
+}
+
+const skill_set: ToolSetApiDescription = {
+  type: "skill",
+  set_name: "Skills",
+  tools: [
+    {
+      id: "kiln_skill::xyz",
+      name: "Research",
+      description: "Do research",
+      function_name: "Research",
+    },
+  ],
+}
+
+const all_options = (groups: ReturnType<typeof build_tool_option_groups>) =>
+  groups.flatMap((group) => group.options)
+
+describe("build_tool_option_groups labelling", () => {
+  it("labels by tool name and subtitles by the tool's own description", () => {
+    const [option] = all_options(build_tool_option_groups([mcp_set]))
+    expect(option.label).toBe("search_docs")
+    expect(option.description).toBe("Search the docs")
+  })
+
+  it("omits the subtitle when a tool has no description", () => {
+    const [option] = all_options(build_tool_option_groups([kiln_task_set]))
+    expect(option.description).toBeUndefined()
+  })
+
+  it("selects tool ids by default", () => {
+    const [option] = all_options(build_tool_option_groups([mcp_set]))
+    expect(option.value).toBe("mcp::remote::demo::search_docs")
+    // The function name is not the value here, so it is not worth a badge.
+    expect(option.badge).toBeUndefined()
+  })
+})
+
+describe("build_tool_option_groups function-name value field", () => {
+  const function_name_args = { value_field: "function_name" as const }
+
+  it("selects the function name a trace records", () => {
+    const [option] = all_options(
+      build_tool_option_groups([kiln_task_set], function_name_args),
+    )
+    expect(option.value).toBe("summarize")
+  })
+
+  it("badges the function name only when it differs from the display name", () => {
+    const [differs] = all_options(
+      build_tool_option_groups([kiln_task_set], function_name_args),
+    )
+    expect(differs.badge).toBe("summarize")
+
+    // Regression: the old bespoke picker put the function name in the subtitle, so
+    // every MCP/Kiln-task/RAG/skill tool -- where name and function name match --
+    // rendered the same string twice and lost its real description.
+    const [same] = all_options(
+      build_tool_option_groups([mcp_set], function_name_args),
+    )
+    expect(same.badge).toBeUndefined()
+    expect(same.description).toBe("Search the docs")
+  })
+
+  it("falls back to the tool name when the server sends no function name", () => {
+    const [option] = all_options(
+      build_tool_option_groups(
+        [
+          {
+            ...mcp_set,
+            tools: [
+              {
+                id: "mcp::remote::demo::legacy",
+                name: "legacy_tool",
+                description: null,
+              },
+            ],
+          },
+        ],
+        function_name_args,
+      ),
+    )
+    expect(option.value).toBe("legacy_tool")
+    expect(option.badge).toBeUndefined()
+  })
+})
+
+describe("build_tool_option_groups context scoping", () => {
+  it("hides both sandbox built-ins outside a sandboxed-code context", () => {
+    const values = all_options(
+      build_tool_option_groups([ai_models_set, mcp_set]),
+    ).map((option) => option.value)
+    expect(values).toEqual(["mcp::remote::demo::search_docs"])
+  })
+
+  it("offers llm but not llm_judge in a code-tool context", () => {
+    const values = all_options(
+      build_tool_option_groups([ai_models_set], {
+        sandbox_code_context: "code_tool",
+      }),
+    ).map((option) => option.value)
+    expect(values).toEqual(["kiln_tool::llm"])
+  })
+
+  it("offers both in a code-eval context", () => {
+    const values = all_options(
+      build_tool_option_groups([ai_models_set], {
+        sandbox_code_context: "code_eval",
+      }),
+    ).map((option) => option.value)
+    expect(values).toEqual(["kiln_tool::llm", "kiln_tool::llm_judge"])
+  })
+
+  it("returns no groups when nothing is selectable, so callers show an empty state", () => {
+    expect(build_tool_option_groups([ai_models_set])).toEqual([])
+    expect(build_tool_option_groups(undefined)).toEqual([])
+    expect(build_tool_option_groups([])).toEqual([])
+  })
+})
+
+describe("build_tool_option_groups ordering and grouping", () => {
+  it("orders groups by tool set, not by the order the server returned them", () => {
+    const labels = build_tool_option_groups([mcp_set, kiln_task_set]).map(
+      (group) => group.label,
+    )
+    expect(labels).toEqual(["Kiln Tasks as Tools", "MCP Server: demo"])
+  })
+
+  it("leaves skills out of the default agent set order", () => {
+    expect(AGENT_TOOL_SET_ORDER).not.toContain("skill")
+    expect(build_tool_option_groups([skill_set])).toEqual([])
+  })
+
+  it("includes a set type the caller asks for", () => {
+    const labels = build_tool_option_groups([skill_set, mcp_set], {
+      set_order: [...AGENT_TOOL_SET_ORDER, "skill"],
+    }).map((group) => group.label)
+    expect(labels).toEqual(["MCP Server: demo", "Skills"])
+  })
+})
+
+describe("build_tool_option_groups caller hooks", () => {
+  it("disables the options the caller locks", () => {
+    const options = all_options(
+      build_tool_option_groups([mcp_set, kiln_task_set], {
+        option_disabled: (tool) => tool.id === "kiln_task::abc",
+      }),
+    )
+    expect(options.map((option) => [option.value, option.disabled])).toEqual([
+      ["kiln_task::abc", true],
+      ["mcp::remote::demo::search_docs", false],
+    ])
+  })
+
+  it("attaches a group action in the set's own slot", () => {
+    const action_handler = vi.fn()
+    const groups = build_tool_option_groups([mcp_set, kiln_task_set], {
+      group_action: (set_type) =>
+        set_type === "kiln_task"
+          ? { action_label: "Create New", action_handler }
+          : undefined,
+    })
+    expect(groups.map((group) => group.action_label)).toEqual([
+      "Create New",
+      undefined,
+    ])
+  })
+
+  it("keeps an empty group so its action stays discoverable", () => {
+    const groups = build_tool_option_groups([mcp_set], {
+      group_action: (set_type) =>
+        set_type === "kiln_task"
+          ? {
+              action_label: "Create New",
+              action_handler: vi.fn(),
+              empty_group_label: "Kiln Tasks as Tools",
+            }
+          : undefined,
+    })
+    expect(groups.map((group) => [group.label, group.options.length])).toEqual([
+      ["Kiln Tasks as Tools", 0],
+      ["MCP Server: demo", 1],
+    ])
+  })
+
+  it("does not show a lone action when the project has no tools at all", () => {
+    // The empty state ("Add Tools") has to win here -- FancySelect keys it off an
+    // empty group list, so a placeholder group would suppress it.
+    expect(
+      build_tool_option_groups([], {
+        group_action: () => ({
+          action_label: "Create New",
+          action_handler: vi.fn(),
+          empty_group_label: "Kiln Tasks as Tools",
+        }),
+      }),
+    ).toEqual([])
+  })
+})
+
+describe("selectable_tool_sets", () => {
+  it("drops sets left with no tools by the context filter", () => {
+    expect(
+      selectable_tool_sets([ai_models_set, mcp_set]).map((set) => set.set_name),
+    ).toEqual(["MCP Server: demo"])
+  })
+
+  it("judges emptiness across every set type, including ones no picker orders", () => {
+    // Skills are not in AGENT_TOOL_SET_ORDER, but a project holding only skills is
+    // not a project with no tools.
+    expect(selectable_tool_sets([skill_set]).length).toBe(1)
+  })
+
+  it("does not mutate the caller's tool sets", () => {
+    const sets = [structuredClone(ai_models_set)]
+    selectable_tool_sets(sets, "none")
+    expect(sets[0].tools.length).toBe(2)
+  })
+})

--- a/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
@@ -51,6 +51,25 @@ const kiln_task_set: ToolSetApiDescription = {
   ],
 }
 
+const colliding_kiln_task_set: ToolSetApiDescription = {
+  type: "kiln_task",
+  set_name: "Kiln Tasks as Tools",
+  tools: [
+    {
+      id: "kiln_task::abc",
+      name: "Summarize",
+      description: "Summarize the input",
+      function_name: "summarize",
+    },
+    {
+      id: "kiln_task::def",
+      name: "Summarize",
+      description: "Summarize the input",
+      function_name: "summarize",
+    },
+  ],
+}
+
 const skill_set: ToolSetApiDescription = {
   type: "skill",
   set_name: "Skills",
@@ -84,6 +103,124 @@ describe("build_tool_option_groups labelling", () => {
     expect(option.value).toBe("mcp::remote::demo::search_docs")
     // The function name is not the value here, so it is not worth a badge.
     expect(option.badge).toBeUndefined()
+  })
+})
+
+describe("build_tool_option_groups name disambiguation", () => {
+  it("qualifies colliding Kiln task tools by tool server id", () => {
+    const labels = all_options(
+      build_tool_option_groups([colliding_kiln_task_set]),
+    ).map((option) => option.label)
+    expect(labels).toEqual(["Summarize (abc)", "Summarize (def)"])
+  })
+
+  it("leaves a unique Kiln task tool label untouched", () => {
+    const [option] = all_options(build_tool_option_groups([kiln_task_set]))
+    expect(option.label).toBe("Summarize")
+  })
+
+  it("qualifies a Kiln task tool colliding with a tool in another set", () => {
+    const labels = all_options(
+      build_tool_option_groups([
+        kiln_task_set,
+        { ...mcp_set, tools: [{ ...mcp_set.tools[0], name: "Summarize" }] },
+      ]),
+    ).map((option) => option.label)
+    // Only the Kiln task tool is qualified: the MCP tool is already grouped under
+    // its server.
+    expect(labels).toEqual(["Summarize (abc)", "Summarize"])
+  })
+
+  it("ignores a collision the context filter already hid from this picker", () => {
+    const labels = all_options(
+      build_tool_option_groups([
+        kiln_task_set,
+        {
+          ...ai_models_set,
+          tools: [{ ...ai_models_set.tools[0], name: "Summarize" }],
+        },
+      ]),
+    ).map((option) => option.label)
+    expect(labels).toEqual(["Summarize"])
+  })
+
+  it("ignores a collision with a set this picker does not order", () => {
+    // Skills are not in AGENT_TOOL_SET_ORDER -- they have their own picker -- so a
+    // skill of the same name is not something the user can confuse this option with.
+    const labels = all_options(
+      build_tool_option_groups([
+        kiln_task_set,
+        { ...skill_set, tools: [{ ...skill_set.tools[0], name: "Summarize" }] },
+      ]),
+    ).map((option) => option.label)
+    expect(labels).toEqual(["Summarize"])
+  })
+
+  it("qualifies again once the picker orders the colliding set", () => {
+    const labels = all_options(
+      build_tool_option_groups(
+        [
+          kiln_task_set,
+          {
+            ...skill_set,
+            tools: [{ ...skill_set.tools[0], name: "Summarize" }],
+          },
+        ],
+        { set_order: [...AGENT_TOOL_SET_ORDER, "skill"] },
+      ),
+    ).map((option) => option.label)
+    expect(labels).toEqual(["Summarize (abc)", "Summarize"])
+  })
+})
+
+describe("build_tool_option_groups function-name deduplication", () => {
+  const function_name_args = { value_field: "function_name" as const }
+
+  it("offers one option per function name, not one per tool", () => {
+    // Both tools record the same name in a trace, so a second row would be an
+    // option the user cannot pick: FancySelect check-marks every option whose
+    // value matches the selection, and labels the closed picker from the first.
+    const options = all_options(
+      build_tool_option_groups([colliding_kiln_task_set], function_name_args),
+    )
+    expect(options.map((option) => option.value)).toEqual(["summarize"])
+    expect(options.map((option) => option.label)).toEqual(["Summarize"])
+  })
+
+  it("dedupes across tool sets, keeping the first offered", () => {
+    const groups = build_tool_option_groups(
+      [
+        kiln_task_set,
+        {
+          ...mcp_set,
+          tools: [{ ...mcp_set.tools[0], function_name: "summarize" }],
+        },
+      ],
+      function_name_args,
+    )
+    expect(all_options(groups).map((option) => option.value)).toEqual([
+      "summarize",
+    ])
+    // The MCP group had one tool and lost it, so it is gone rather than an empty
+    // header.
+    expect(groups.map((group) => group.label)).toEqual(["Kiln Tasks as Tools"])
+  })
+
+  it("keeps every distinct function name", () => {
+    const values = all_options(
+      build_tool_option_groups(
+        [colliding_kiln_task_set, mcp_set],
+        function_name_args,
+      ),
+    ).map((option) => option.value)
+    expect(values).toEqual(["summarize", "search_docs"])
+  })
+
+  it("leaves an id-valued picker's options alone", () => {
+    const values = all_options(
+      build_tool_option_groups([colliding_kiln_task_set]),
+    ).map((option) => option.value)
+    expect(values).toEqual(["kiln_task::abc", "kiln_task::def"])
   })
 })
 

--- a/app/web_ui/src/lib/ui/run_config_component/tool_options.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tool_options.ts
@@ -1,0 +1,157 @@
+import type { Option, OptionGroup } from "$lib/ui/fancy_select_types"
+import type {
+  ToolApiDescription,
+  ToolSetApiDescription,
+  ToolSetType,
+} from "$lib/types"
+import {
+  is_tool_selectable_in_context,
+  type SandboxCodeContext,
+} from "$lib/stores/tools_store"
+
+// The order tool sets are shown in, shared by every picker so the same project's
+// tools read the same way wherever they are offered. Skills are excluded: they get
+// their own picker (skills_selector.svelte), and a picker that wants them says so
+// with its own set_order.
+export const AGENT_TOOL_SET_ORDER: ToolSetType[] = [
+  "builtin",
+  "sandbox_code",
+  "code",
+  "search",
+  "kiln_task",
+  "mcp",
+  "demo",
+]
+
+// What an option's value carries. Pickers that configure which tools something may
+// call select the tool itself ("id"). Pickers that match tool calls in a trace
+// select the OpenAI-compatible function name the trace records ("function_name"),
+// which can differ from the tool's display name in Kiln.
+export type ToolOptionValueField = "id" | "function_name"
+
+// An extra affordance on a tool set's group, e.g. "Create New" on Kiln tasks.
+export type ToolOptionGroupAction = {
+  action_label: string
+  action_handler: () => void
+  // Label for a placeholder group shown when the project has tools, but none of
+  // this set type. Without it the affordance would disappear exactly when it is
+  // most useful.
+  empty_group_label?: string
+}
+
+export type BuildToolOptionGroupsArgs = {
+  value_field?: ToolOptionValueField
+  // Which sandboxed-code allowlist the picker edits, if any. Governs whether the
+  // sandbox-only built-ins are offered. Defaults to "none" — an agent-tool picker.
+  sandbox_code_context?: SandboxCodeContext
+  set_order?: ToolSetType[]
+  // Marks options the caller has locked, e.g. mandatory tools.
+  option_disabled?: (
+    tool: ToolApiDescription,
+    tool_set: ToolSetApiDescription,
+  ) => boolean
+  group_action?: (
+    tool_set_type: ToolSetType,
+  ) => ToolOptionGroupAction | undefined
+}
+
+// Tool sets holding at least one tool the given context allows, in the order the
+// server returned them. This is what "does this project have any tools?" means to a
+// picker: judging it on the raw response would never see "no tools" again, because
+// the sandbox-only built-ins ship with every project.
+export function selectable_tool_sets(
+  tool_sets: ToolSetApiDescription[] | undefined,
+  sandbox_code_context: SandboxCodeContext = "none",
+): ToolSetApiDescription[] {
+  return (tool_sets ?? [])
+    .map((tool_set) => ({
+      ...tool_set,
+      tools: tool_set.tools.filter((tool) =>
+        is_tool_selectable_in_context(
+          tool.id,
+          tool_set.type,
+          sandbox_code_context,
+        ),
+      ),
+    }))
+    .filter((tool_set) => tool_set.tools.length > 0)
+}
+
+function tool_option(
+  tool: ToolApiDescription,
+  tool_set: ToolSetApiDescription,
+  value_field: ToolOptionValueField,
+  option_disabled: BuildToolOptionGroupsArgs["option_disabled"],
+): Option {
+  const function_name = tool.function_name ?? tool.name
+  const description = tool.description?.trim()
+  return {
+    value: value_field === "function_name" ? function_name : tool.id,
+    label: tool.name,
+    description: description ? description : undefined,
+    // Only when the selected value isn't already the label: repeating the name as a
+    // badge is noise, but a function name that differs from the display name is the
+    // value being picked, and has to be visible.
+    badge:
+      value_field === "function_name" && function_name !== tool.name
+        ? function_name
+        : undefined,
+    disabled: option_disabled ? option_disabled(tool, tool_set) : false,
+  }
+}
+
+// The canonical dropdown contents for a project's tools: one group per tool set, in
+// set order, labelled by tool name and subtitled by the tool's own description.
+// Every tool picker builds its options from here so they stay consistent; callers
+// layer their own extras (custom values, pseudo-options) on the result.
+//
+// Returns no groups at all when the project has nothing this context can select,
+// which is what a picker's empty state keys on.
+export function build_tool_option_groups(
+  tool_sets: ToolSetApiDescription[] | undefined,
+  {
+    value_field = "id",
+    sandbox_code_context = "none",
+    set_order = AGENT_TOOL_SET_ORDER,
+    option_disabled,
+    group_action,
+  }: BuildToolOptionGroupsArgs = {},
+): OptionGroup[] {
+  const selectable = selectable_tool_sets(tool_sets, sandbox_code_context)
+  if (selectable.length === 0) {
+    // Nothing to offer: the caller shows its empty state rather than a lone action.
+    return []
+  }
+
+  const groups: OptionGroup[] = []
+  for (const set_type of set_order) {
+    const action = group_action ? group_action(set_type) : undefined
+    const sets_of_type = selectable.filter(
+      (tool_set) => tool_set.type === set_type,
+    )
+
+    if (sets_of_type.length === 0) {
+      if (action?.empty_group_label) {
+        groups.push({
+          label: action.empty_group_label,
+          options: [],
+          action_label: action.action_label,
+          action_handler: action.action_handler,
+        })
+      }
+      continue
+    }
+
+    for (const tool_set of sets_of_type) {
+      groups.push({
+        label: tool_set.set_name,
+        options: tool_set.tools.map((tool) =>
+          tool_option(tool, tool_set, value_field, option_disabled),
+        ),
+        action_label: action?.action_label,
+        action_handler: action?.action_handler,
+      })
+    }
+  }
+  return groups
+}

--- a/app/web_ui/src/lib/ui/run_config_component/tool_options.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tool_options.ts
@@ -5,23 +5,39 @@ import type {
   ToolSetType,
 } from "$lib/types"
 import {
+  duplicate_tool_names,
   is_tool_selectable_in_context,
+  tool_display_name,
   type SandboxCodeContext,
 } from "$lib/stores/tools_store"
 
+// Where each tool set type sits in a picker, lowest first, with null for a type no
+// agent picker offers by default: skills get their own picker
+// (skills_selector.svelte), and a picker that wants them says so with its own
+// set_order.
+//
+// Exhaustive on purpose. Anything a picker does not order is dropped silently, so a
+// ToolSetType added server-side has to be a type error here rather than a tool set
+// that quietly stops appearing anywhere in the app.
+const AGENT_TOOL_SET_RANK: Record<ToolSetType, number | null> = {
+  builtin: 0,
+  sandbox_code: 1,
+  code: 2,
+  search: 3,
+  kiln_task: 4,
+  mcp: 5,
+  demo: 6,
+  skill: null,
+}
+
 // The order tool sets are shown in, shared by every picker so the same project's
-// tools read the same way wherever they are offered. Skills are excluded: they get
-// their own picker (skills_selector.svelte), and a picker that wants them says so
-// with its own set_order.
-export const AGENT_TOOL_SET_ORDER: ToolSetType[] = [
-  "builtin",
-  "sandbox_code",
-  "code",
-  "search",
-  "kiln_task",
-  "mcp",
-  "demo",
-]
+// tools read the same way wherever they are offered.
+export const AGENT_TOOL_SET_ORDER: ToolSetType[] = (
+  Object.entries(AGENT_TOOL_SET_RANK) as [ToolSetType, number | null][]
+)
+  .filter((entry): entry is [ToolSetType, number] => entry[1] !== null)
+  .sort(([, a], [, b]) => a - b)
+  .map(([set_type]) => set_type)
 
 // What an option's value carries. Pickers that configure which tools something may
 // call select the tool itself ("id"). Pickers that match tool calls in a trace
@@ -81,13 +97,14 @@ function tool_option(
   tool: ToolApiDescription,
   tool_set: ToolSetApiDescription,
   value_field: ToolOptionValueField,
+  duplicate_names: Set<string>,
   option_disabled: BuildToolOptionGroupsArgs["option_disabled"],
 ): Option {
   const function_name = tool.function_name ?? tool.name
   const description = tool.description?.trim()
   return {
     value: value_field === "function_name" ? function_name : tool.id,
-    label: tool.name,
+    label: tool_display_name(tool, duplicate_names),
     description: description ? description : undefined,
     // Only when the selected value isn't already the label: repeating the name as a
     // badge is noise, but a function name that differs from the display name is the
@@ -123,6 +140,17 @@ export function build_tool_option_groups(
     return []
   }
 
+  // Counted over the sets this picker actually renders -- context-filtered and in
+  // its set order -- because a collision the user cannot see is not one worth
+  // qualifying. Only for an id-valued picker: a "function_name" picker selects the
+  // name a trace records, and colliding tools genuinely share that one value, so
+  // telling those options apart would promise a choice that does not exist.
+  const rendered = selectable.filter((tool_set) =>
+    set_order.includes(tool_set.type),
+  )
+  const duplicate_names =
+    value_field === "id" ? duplicate_tool_names(rendered) : new Set<string>()
+
   const groups: OptionGroup[] = []
   for (const set_type of set_order) {
     const action = group_action ? group_action(set_type) : undefined
@@ -146,12 +174,44 @@ export function build_tool_option_groups(
       groups.push({
         label: tool_set.set_name,
         options: tool_set.tools.map((tool) =>
-          tool_option(tool, tool_set, value_field, option_disabled),
+          tool_option(
+            tool,
+            tool_set,
+            value_field,
+            duplicate_names,
+            option_disabled,
+          ),
         ),
         action_label: action?.action_label,
         action_handler: action?.action_handler,
       })
     }
   }
+
+  // Colliding tools share one function name, so a "function_name" picker would
+  // otherwise offer several rows carrying the same value: FancySelect check-marks
+  // every option matching the selection and labels the closed picker from the
+  // first match, making the extra rows unselectable duplicates. One row per value
+  // is the honest offer.
+  return value_field === "function_name"
+    ? dedupe_options_by_value(groups)
+    : groups
+}
+
+// Keeps the first option carrying each value, and drops a group left with nothing
+// to show rather than rendering a bare header.
+function dedupe_options_by_value(groups: OptionGroup[]): OptionGroup[] {
+  const seen = new Set<unknown>()
   return groups
+    .map((group) => ({
+      ...group,
+      options: group.options.filter((option) => {
+        if (seen.has(option.value)) {
+          return false
+        }
+        seen.add(option.value)
+        return true
+      }),
+    }))
+    .filter((group) => group.options.length > 0 || Boolean(group.action_label))
 }

--- a/app/web_ui/src/lib/ui/run_config_component/tools_selector.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/tools_selector.svelte
@@ -3,15 +3,15 @@
   import type { OptionGroup } from "$lib/ui/fancy_select_types"
   import { available_tools, load_available_tools } from "$lib/stores"
   import { onMount } from "svelte"
-  import type { ToolSetApiDescription, ToolSetType } from "$lib/types"
-  import {
-    tools_store,
-    tools_store_initialized,
-    is_tool_selectable_in_context,
-  } from "$lib/stores/tools_store"
+  import type { ToolSetApiDescription } from "$lib/types"
+  import { tools_store, tools_store_initialized } from "$lib/stores/tools_store"
   import type { SandboxCodeContext } from "$lib/stores/tools_store"
   import { goto } from "$app/navigation"
   import type { ToolsSelectorSettings } from "./tools_selector_settings"
+  import {
+    build_tool_option_groups,
+    selectable_tool_sets,
+  } from "./tool_options"
 
   export let project_id: string
   export let task_id: string | null = null
@@ -70,17 +70,12 @@
     sandbox_code_context: SandboxCodeContext,
   ): Set<string> {
     const ids = new Set<string>()
-    for (const tool_set of available_tool_sets ?? []) {
+    for (const tool_set of selectable_tool_sets(
+      available_tool_sets,
+      sandbox_code_context,
+    )) {
       for (const tool of tool_set.tools) {
-        if (
-          is_tool_selectable_in_context(
-            tool.id,
-            tool_set.type,
-            sandbox_code_context,
-          )
-        ) {
-          ids.add(tool.id)
-        }
+        ids.add(tool.id)
       }
     }
     return ids
@@ -188,92 +183,35 @@
     }
   }
 
-  const tool_set_order: ToolSetType[] = [
-    "builtin",
-    "sandbox_code",
-    "code",
-    "search",
-    "kiln_task",
-    "mcp",
-    "demo",
-  ]
-
   function get_tool_options(
     available_tool_sets: ToolSetApiDescription[] | undefined,
     sandbox_code_context: SandboxCodeContext,
   ): OptionGroup[] {
-    // Emptiness is judged on what this picker can actually offer, not on what the
-    // server returned: the sandbox-only built-ins ship in every project, so a raw
-    // length check would never see "no tools" again and the "Add tools" empty state
-    // would be lost for projects that have configured none.
-    const selectable_tool_sets = (available_tool_sets ?? [])
-      .map((tool_set) => ({
-        ...tool_set,
-        tools: tool_set.tools.filter((tool) =>
-          is_tool_selectable_in_context(
-            tool.id,
-            tool_set.type,
-            sandbox_code_context,
-          ),
-        ),
-      }))
-      .filter((tool_set) => tool_set.tools.length > 0)
-
-    if (selectable_tool_sets.length === 0) {
-      // When there are no available tools, we'll show the empty state "Add tools" button
-      return []
-    }
-
-    let option_groups: OptionGroup[] = []
-
-    tool_set_order.forEach((tool_set_type) => {
-      let action_label: string | undefined = undefined
-      let action_handler: (() => void) | undefined = undefined
-
-      const add_create_kiln_task_tool_action =
-        tool_set_type === "kiln_task" &&
-        !tools_selector_settings.hide_create_kiln_task_tool_button
-      if (add_create_kiln_task_tool_action) {
-        action_label = "Create New"
-        action_handler = () => {
-          goto(`/tools/${project_id}/add_tools/kiln_task`)
+    return build_tool_option_groups(available_tool_sets, {
+      value_field: "id",
+      sandbox_code_context,
+      option_disabled: (tool) =>
+        tools_selector_settings.mandatory_tools
+          ? tools_selector_settings.mandatory_tools.includes(tool.id)
+          : false,
+      group_action: (tool_set_type) => {
+        if (
+          tool_set_type !== "kiln_task" ||
+          tools_selector_settings.hide_create_kiln_task_tool_button
+        ) {
+          return undefined
         }
-      }
-
-      const tool_sets = selectable_tool_sets.filter(
-        (tool_set) => tool_set.type === tool_set_type,
-      )
-
-      if (tool_sets.length > 0) {
-        for (const tool_set of tool_sets) {
-          let options = tool_set.tools.map((tool) => ({
-            value: tool.id,
-            label: tool.name,
-            description: tool.description ? tool.description.trim() : undefined,
-            disabled: tools_selector_settings.mandatory_tools
-              ? tools_selector_settings.mandatory_tools.includes(tool.id)
-              : false,
-          }))
-
-          option_groups.push({
-            label: tool_set.set_name,
-            options,
-            action_label,
-            action_handler,
-          })
+        return {
+          action_label: "Create New",
+          action_handler: () => {
+            goto(`/tools/${project_id}/add_tools/kiln_task`)
+          },
+          // Keep the group when the project has no Kiln task tools yet, so the
+          // "Create New" button stays discoverable.
+          empty_group_label: "Kiln Tasks as Tools",
         }
-      } else if (add_create_kiln_task_tool_action) {
-        // Manually add the kiln_task option group when there are no kiln task tools
-        // For discoverability since we want to show the "Create New" button
-        option_groups.push({
-          label: "Kiln Tasks as Tools",
-          options: [],
-          action_label,
-          action_handler,
-        })
-      }
+      },
     })
-    return option_groups
   }
 
   $: common_props = {

--- a/app/web_ui/src/lib/ui/trace/tool_call.svelte
+++ b/app/web_ui/src/lib/ui/trace/tool_call.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ToolCallMessageParam } from "$lib/types"
   import Output from "$lib/ui/output.svelte"
+  import { kiln_task_tool_server_id } from "$lib/stores/tools_store"
 
   export let tool_call: ToolCallMessageParam
   export let nameTag: string = "Tool Name"
@@ -11,15 +12,11 @@
     if (!project_id) return null
 
     // If we have a persistent_tool_id, try to create a specific link
-    if (persistent_tool_id) {
-      // For Kiln task tools, extract tool_server_id from the persistent_tool_id
-      // Kiln task tool IDs have format: "kiln_task::{tool_server_id}"
-      if (persistent_tool_id.startsWith("kiln_task::")) {
-        const tool_server_id = persistent_tool_id.substring(
-          "kiln_task::".length,
-        )
-        return `/tools/${project_id}/kiln_task/${tool_server_id}`
-      }
+    const tool_server_id = persistent_tool_id
+      ? kiln_task_tool_server_id(persistent_tool_id)
+      : null
+    if (tool_server_id) {
+      return `/tools/${project_id}/kiln_task/${tool_server_id}`
     }
 
     return null

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_judge_form.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/spec_builder/create_spec_judge_form.svelte
@@ -327,7 +327,6 @@
           {reference_candidate_keys}
           code_placeholder_score_key={true}
           {project_id}
-          {task_id}
         />
       </div>
     </FormContainer>

--- a/app/web_ui/src/routes/(app)/tools/[project_id]/kiln_task_tools/+page.svelte
+++ b/app/web_ui/src/routes/(app)/tools/[project_id]/kiln_task_tools/+page.svelte
@@ -116,7 +116,7 @@
         <table class="table table-fixed w-full">
           <thead>
             <tr>
-              <th class="w-32">Tool Name</th>
+              <th class="w-48">Tool Name</th>
               <th class="w-96">Description</th>
               <th class="w-28">Created At</th>
               <th class="w-20">Status</th>
@@ -136,18 +136,30 @@
                 role="button"
                 tabindex={0}
               >
-                <td class="font-medium truncate" title={tool.tool_name}
-                  >{tool.tool_name}</td
-                >
+                <td class="align-top">
+                  <div class="font-medium truncate" title={tool.tool_name}>
+                    {tool.tool_name}
+                  </div>
+                  <!-- Tool names are user-typed and not unique, so the ID is what
+                       tells two same-named tools apart. Shown on every row: an ID
+                       that appears only on the ambiguous ones would make the rows
+                       it is meant to clarify the odd ones out. -->
+                  <div
+                    class="text-xs text-gray-500 font-mono truncate"
+                    title={tool.tool_server_id}
+                  >
+                    {tool.tool_server_id}
+                  </div>
+                </td>
                 <td
-                  class="text-sm truncate"
+                  class="text-sm truncate align-top"
                   title={tool.tool_description || "N/A"}
                   >{tool.tool_description || "N/A"}</td
                 >
-                <td class="text-sm whitespace-nowrap"
+                <td class="text-sm whitespace-nowrap align-top"
                   >{formatDate(tool.created_at)}</td
                 >
-                <td class="text-sm">
+                <td class="text-sm align-top">
                   {#if tool.is_archived}
                     <Warning
                       warning_message="Archived"

--- a/app/web_ui/tests/e2e/act/discover/tools-kiln-task-servers.spec.ts
+++ b/app/web_ui/tests/e2e/act/discover/tools-kiln-task-servers.spec.ts
@@ -323,11 +323,14 @@ test.describe("Tools - Kiln task tools and servers", () => {
   - Seed a run config and kiln task tool via API
   - Route is /tools/{project_id}/kiln_task_tools
   - Table has columns: Tool Name, Description, Created At, Status
+  - Each row shows the tool server ID under the tool name, since tool names are
+    user-typed and two tools can share one
   - Active tool shows "Ready" status
   - Tool name in table is clickable
 
   ## Assertions
   - Tool name "list_test_tool" is visible in the table.
+  - The seeded tool's tool server ID is visible in its row.
   - "Ready" status indicator is visible.
   - Table column headers are visible.
   */
@@ -373,6 +376,7 @@ test.describe("Tools - Kiln task tools and servers", () => {
       },
     )
     expect(toolResp.ok()).toBeTruthy()
+    const tool = (await toolResp.json()) as { id: string }
 
     await page.goto(`/tools/${project.id}/kiln_task_tools`)
 
@@ -394,6 +398,9 @@ test.describe("Tools - Kiln task tools and servers", () => {
     ).toBeVisible()
 
     await expect(page.getByText("list_test_tool")).toBeVisible()
+    // The tool server ID is what tells two same-named tools apart, so every row
+    // carries it.
+    await expect(page.getByText(tool.id)).toBeVisible()
     await expect(page.getByText("Ready")).toBeVisible()
   })
 


### PR DESCRIPTION
## What does this PR do?

Two related commits against the tool pickers.

### 1. Share one tool-option builder (`b7a578d`)

The tool-call-check judge form had its own hand-rolled dropdown builder, so its options diverged from the picker used on `/run`. It labelled each option with the tool name and subtitled it with the function name — the same string for every MCP, Kiln-task, RAG and skill tool (`tool_api.py` sets `function_name=name` for all four). Those options rendered the same text twice and threw away the tool's real description.

New `app/web_ui/src/lib/ui/run_config_component/tool_options.ts` owns what every tool picker needs: sandbox-context filtering, tool-set ordering, grouping by set name, and the canonical option (`label` = tool name, `description` = the tool's own description). Callers layer their own extras on the result — mandatory-tool disabling and the "Create New" Kiln-task affordance for the run picker; the collapsed `skill` option and preserved legacy values for the judge form.

The pickers select different things, so the builder takes a `value_field`: the run picker selects tool **ids** (a handle to a configured tool), the judge form selects the **function name** a trace records (a matcher, which must also accept values no longer in the project). Where that function name differs from the tool's display name it shows as a badge, so the selected value stays visible without repeating the name.

### 2. Differentiate Kiln Task tools that share a name (`82da042`)

A Kiln Task tool's identity in the UI is two user-typed strings, and the defaults push users into collisions: the create form seeds the tool name from the task name, and Clone prefills name and description verbatim. Build two tools off one task — different run config, which is the whole point — and they are pixel-identical in the tools list and in every picker. The clash only surfaced at run time, from the adapter's "Each tool must have a unique name" error.

The fix uses the tool server ID, which is already shown as "ID" on the tool detail page, sits in that page's URL, and is the tail of the tool ID the picker selects — so nothing new is stored or returned. **Display layer only, no API change.**

- The list page carries the ID on every row, muted under the tool name. Uniform rows beat an ID that appears only on ambiguous ones, which would make the rows it is meant to clarify the odd ones out.
- Pickers qualify a label as `name (tool_server_id)` only when the name is ambiguous, counted across the sets the picker actually renders, and only for Kiln Task tools — MCP tools are already grouped under their server, and search tools name their RAG config in their description.
- Qualifying happens only where the option's value is a tool ID. The tool-call-check judge form selects the function name a trace records, and colliding tools genuinely share that one value — it can't offer that choice at all, so it dedupes options by value instead, rather than rendering rows `FancySelect` cannot tell apart.

Helpers live in `tools_store.ts` so they're unit-testable, and `get_tool_names_from_ids` uses them too, since a saved run config's tool list had the identical ambiguity.

### Also, from review of the refactor

- Dropped the `task_id` prop the refactor left dead on `tool_call_check_form`, and its pass-downs through `judge_config_fields`, `eval_config_builder` and `create_spec_judge_form`.
- Covered `FancySelect`'s badge search. The filter is extracted to `fancy_select_search.ts` to be testable at all: `onMount` doesn't run under this project's component render and the dropdown is gated on a `mounted` flag, so it can't be opened from a test.
- Made `AGENT_TOOL_SET_ORDER` exhaustive over `ToolSetType` via a rank record, so a set type added server-side is a type error rather than a picker entry that silently disappears.

### Scope note on `/run`

The `/run` **picker's** options are unchanged by the refactor — set ordering, group labels, the emptiness rule, the "Create New" affordance and mandatory-tool disabling all reduce to the same predicates as the code they replaced.

The `/run` **page** does change in one way worth calling out: badge text now participates in `FancySelect` search, app-wide. That means typing "recommended" in the model picker filters to recommended models, and similar for the fine-tune and saved-run-config dropdowns. This is additive (more text can only widen matching), and every badge producer in the app was enumerated to confirm none becomes misleading — but it is a behavior change beyond the tool pickers, not a pure refactor.

## Related Issues

None.

## Checklists

- [x] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib

`uv run ./checks.sh --agent-mode` passes clean. `npm run check` is at 0 errors and 38 warnings — one *fewer* than before this branch. No `/lib` changes (frontend only), but tests were added throughout:

- `tool_options.test.ts` — labelling, both value fields, badge-only-on-difference, context scoping, ordering, caller hooks, duplicate qualification and dedupe
- `tool_call_check_form.test.ts` — new file; the form had no coverage before
- `fancy_select_search.test.ts` — new file; `FancySelect` filtering had no coverage before
- `tools_store.test.ts` — the new duplicate/display-name helpers
- `tools-kiln-task-servers.spec.ts` (e2e) — now asserts the tool server ID renders on the list row

Both commits were code-reviewed by a separate agent, twice, with the refactor commit reviewed as if unmerged.
