### PR TITLE
Preserve trace and logprobs in R1ThinkingParser

### DIFF
--- a/libs/core/kiln_ai/adapters/parsers/r1_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/r1_parser.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 from kiln_ai.adapters.parsers.base_parser import BaseParser
 from kiln_ai.adapters.run_output import RunOutput
 
@@ -82,7 +84,10 @@ class R1ThinkingParser(BaseParser):
         if thinking_content is not None and len(thinking_content) > 0:
             intermediate_outputs["reasoning"] = thinking_content
 
-        return RunOutput(
+        # replace() rather than a fresh RunOutput so fields we don't touch
+        # (trace, output_logprobs, and anything added later) carry through.
+        return dataclasses.replace(
+            original_output,
             output=result,
             intermediate_outputs=intermediate_outputs,
         )

--- a/libs/core/kiln_ai/adapters/parsers/test_r1_parser.py
+++ b/libs/core/kiln_ai/adapters/parsers/test_r1_parser.py
@@ -1,12 +1,27 @@
 import pytest
+from litellm.types.utils import ChoiceLogprobs
 
 from kiln_ai.adapters.parsers.r1_parser import R1ThinkingParser
 from kiln_ai.adapters.run_output import RunOutput
+from kiln_ai.utils.open_ai_types import ChatCompletionMessageParam
 
 
 @pytest.fixture
 def parser():
     return R1ThinkingParser()
+
+
+@pytest.fixture
+def trace() -> list[ChatCompletionMessageParam]:
+    return [
+        {"role": "user", "content": "What is 2+2?"},
+        {"role": "assistant", "content": "<think>Adding them</think>4"},
+    ]
+
+
+@pytest.fixture
+def logprobs() -> ChoiceLogprobs:
+    return ChoiceLogprobs(content=[])
 
 
 def test_valid_response(parser):
@@ -197,3 +212,33 @@ def test_strip_newlines_with_structured_output(parser):
     parsed = parser.parse_output(response)
     assert parsed.output == {"some_key": "Some content"}
     assert parsed.intermediate_outputs["reasoning"] == "Some thinking"
+
+
+@pytest.mark.parametrize(
+    "allow_missing_thinking,output,intermediate_outputs",
+    [
+        # The parse path: parser extracts thinking from an inline <think> tag
+        (False, "<think>Adding them</think>4", None),
+        # Early return: the provider already parsed reasoning for us
+        (False, "4", {"reasoning": "Adding them"}),
+        # Early return: no </think> tag, and the parser tolerates that
+        (True, "4", None),
+    ],
+    ids=["parse_path", "provider_pre_parsed", "missing_thinking_allowed"],
+)
+def test_preserves_trace_and_logprobs(
+    allow_missing_thinking, output, intermediate_outputs, trace, logprobs
+):
+    parsed = R1ThinkingParser(
+        allow_missing_thinking=allow_missing_thinking
+    ).parse_output(
+        RunOutput(
+            output=output,
+            intermediate_outputs=intermediate_outputs,
+            output_logprobs=logprobs,
+            trace=trace,
+        )
+    )
+    assert parsed.output == "4"
+    assert parsed.trace is trace
+    assert parsed.output_logprobs is logprobs


### PR DESCRIPTION
## What does this PR do?

Updates `R1ThinkingParser.parse_output()` to preserve the `trace` and `output_logprobs` fields from the original `RunOutput` when returning the parsed result. Previously, these fields were lost because the method created a new `RunOutput` instance without copying them over.

The fix uses `dataclasses.replace()` instead of constructing a new `RunOutput`, which automatically carries forward all fields that aren't explicitly overridden. This ensures that metadata like trace information and logprobs are preserved through the parsing pipeline.

## Related Issues

<!-- Link to related issues if applicable -->


## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

https://claude.ai/code/session_01HmehXosNJsU7Z4nRryc2dy