### PR TITLE
Fix code judge's Tools picker never loading

### DIFF
--- a/app/web_ui/src/lib/components/eval_types/judge_config_fields.svelte
+++ b/app/web_ui/src/lib/components/eval_types/judge_config_fields.svelte
@@ -17,7 +17,11 @@
    * EvalTypeFormApi and needs model/algo/prompt state its callers own.
    */
   export let eval_config_type: V2EvalType
-  export let project_id: string = ""
+  // Required, with no default: <svelte:component> prop passing isn't
+  // typechecked, so an empty project_id silently reaches the tools pickers and
+  // leaves them loading forever. Keeping this required makes svelte-check catch
+  // a caller that forgets it -- the one relay a test can't guard.
+  export let project_id: string
   export let task_id: string = ""
   export let output_scores: EvalOutputScore[] | undefined = undefined
   export let reference_candidate_keys: string[] = []
@@ -50,11 +54,16 @@
   }
 </script>
 
+<!-- The code judge needs project_id: its tools picker lists that project's
+     tools. It deliberately takes no task_id — ToolsSelector would then
+     overwrite the bound selection with the task's saved tools, clobbering
+     the judge's allowlist. -->
 {#if eval_config_type === "code_eval"}
   <svelte:component
     this={metadata.createFormComponent}
     bind:this={form_ref}
     bind:code_string
+    {project_id}
     {output_scores}
     placeholder_score_key={code_placeholder_score_key}
   />

--- a/app/web_ui/src/lib/components/eval_types/judge_config_fields.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/judge_config_fields.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+/**
+ * Prop-relay guard for JudgeConfigFields.
+ *
+ * Each judge form is rendered through <svelte:component>, so a missing prop is
+ * silently swallowed: the form falls back to its default (an empty project_id),
+ * and the tools picker inside it spins forever instead of erroring. These tests
+ * assert the project context actually reaches the forms that need it.
+ */
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/svelte"
+import { tick } from "svelte"
+import { available_tools } from "$lib/stores"
+import type { ToolSetApiDescription } from "$lib/types"
+
+vi.mock("$lib/components/code_editor.svelte", async () => {
+  const { default: Stub } = await import("./__tests__/code_editor_stub.svelte")
+  return { default: Stub }
+})
+
+vi.mock("$lib/ui/dialog.svelte", async () => {
+  const { default: Stub } = await import("./__tests__/dialog_stub.svelte")
+  return { default: Stub }
+})
+
+vi.mock("$lib/utils/form_element.svelte", async () => {
+  const { default: Stub } = await import("./__tests__/form_element_stub.svelte")
+  return { default: Stub }
+})
+
+vi.mock("$lib/ui/collapse.svelte", async () => {
+  const { default: Stub } = await import("./__tests__/collapse_stub.svelte")
+  return { default: Stub }
+})
+
+vi.mock("$lib/ui/run_config_component/tools_selector.svelte", async () => {
+  const { default: Stub } = await import(
+    "./__tests__/tools_selector_stub.svelte"
+  )
+  return { default: Stub }
+})
+
+// FormList is deliberately NOT stubbed: the real one seeds an empty row, which
+// is what renders the tool-call-check dropdown these tests read.
+const JudgeConfigFields = (await import("./judge_config_fields.svelte")).default
+
+const PROJECT_ID = "proj_judge_fields"
+const TASK_ID = "task_judge_fields"
+
+const mcp_tool_set: ToolSetApiDescription = {
+  type: "mcp",
+  set_name: "MCP Server: demo",
+  tools: [
+    {
+      id: "mcp::remote::demo::search",
+      name: "Search",
+      description: "Search the web",
+      function_name: "search",
+    },
+  ],
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    ;(
+      globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }
+    ).ResizeObserver = ResizeObserverStub
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  available_tools.set({})
+})
+
+describe("JudgeConfigFields project context relay", () => {
+  it("gives the code judge a project_id, so its tools picker can load", () => {
+    const { container } = render(JudgeConfigFields, {
+      props: {
+        eval_config_type: "code_eval",
+        project_id: PROJECT_ID,
+        task_id: TASK_ID,
+      },
+    })
+
+    const tools_selector = container.querySelector(
+      '[data-testid="tools-selector-stub"]',
+    )
+    expect(tools_selector).not.toBeNull()
+    expect(tools_selector?.getAttribute("data-project-id")).toBe(PROJECT_ID)
+  })
+
+  it("gives the tool call check judge both a project_id and a task_id", async () => {
+    available_tools.set({ [PROJECT_ID]: [mcp_tool_set] })
+
+    const { container } = render(JudgeConfigFields, {
+      props: {
+        eval_config_type: "tool_call_check",
+        project_id: PROJECT_ID,
+        task_id: TASK_ID,
+      },
+    })
+
+    // Let the store subscription fire, then flush reactivity.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await tick()
+
+    // The form builds its dropdown options only once it has a non-empty
+    // project_id (to key into the loaded tools) AND task_id, so one option
+    // proves both props arrived.
+    expect(
+      container.querySelector('[data-testid="fancy-option-search"]'),
+    ).not.toBeNull()
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes the code judge's Tools dropdown, which was stuck on "Loading tools..." forever — making LLM / LLM Judge (and RAG/MCP/code tools) unreachable for every code judge, from both entry points.

**Root cause:** `JudgeConfigFields` rendered `CodeEvalForm` without `project_id`, so it fell back to its `""` default. That empty id reached `ToolsSelector`, whose `load_available_tools("")` returns early by design (it skips a `/api/projects//available_tools` call that would 404), so `$available_tools[""]` stayed `undefined` and the picker never left its loading state. The sibling `tool_call_check` branch forwarded the prop correctly — this was an isolated omission from the merge that reconciled the earlier fix with the `evals_v2` `JudgeConfigFields` abstraction.

**Changes:**

- Relay `project_id` on the `code_eval` branch, mirroring `tool_call_check`. `CodeEvalForm` deliberately takes no `task_id`: `ToolsSelector` would then overwrite the bound selection with the task's saved run-config tools, clobbering the judge's tool allowlist. That asymmetry is now documented in the file so it doesn't read as a second oversight.
- Make `project_id` a required prop. `<svelte:component>` prop passing isn't typechecked, but the caller → `JudgeConfigFields` relay is, so dropping the `""` default gives `svelte-check` a compile-time guard on the one path a test can't cover. Both existing callers (`eval_config_builder.svelte`, `create_spec_judge_form.svelte`) already pass a real value.
- Add `judge_config_fields.test.ts` covering the relays a test *can* guard: `project_id` reaching the code judge's tools picker, and `project_id` + `task_id` reaching the tool-call-check judge's tool list. Each relay was mutation-tested — removing any one of the three turns the suite red.

**Verification:** Confirmed in a real browser with Playwright against the seeded fixture project (which has tools configured, so this isn't a vacuous pass). The Tools dropdown populates with AI Models (LLM, LLM Judge) plus Search Tools (RAG) on both the add-judge-to-existing-eval flow and the Spec Builder create-eval-with-judge flow, with zero "Loading tools..." nodes remaining. The `tool_call_check` picker was re-checked for regression and still populates.

## Related Issues

<!--- Maintainer: link the originating issue here. -->

## Contributor License Agreement

<!--- Left for a human to complete: agents on this repo are not permitted to make CLA attestations. -->

## Checklists

- [x] Tests have been run locally and passed — `uv run ./checks.sh --agent-mode` exits 0; full web suite is 121 files / 2323 tests passing
- [x] New tests have been added to any work in /lib — n/a for `/lib` (frontend-only change); regression coverage added at `app/web_ui/src/lib/components/eval_types/judge_config_fields.test.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfG46sqA9MzwPjNM13DJMX)_