### PR TITLE
Wrap Code Judge Examples tabs and drop the domain-specific grading example

### DIFF
--- a/app/web_ui/src/lib/components/eval_types/code_eval_form.reference_data.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_form.reference_data.test.ts
@@ -6,7 +6,7 @@ vi.mock("$lib/utils/eval_types/reference_data_ui", () => ({
   SHOW_REFERENCE_DATA_UI: true,
 }))
 
-import { render, fireEvent } from "@testing-library/svelte"
+import { render } from "@testing-library/svelte"
 
 vi.mock("$lib/components/code_editor.svelte", async () => {
   const StubModule = await import("./__tests__/code_editor_stub.svelte")
@@ -56,27 +56,5 @@ describe("CodeEvalForm (reference data shown)", () => {
     expect(el?.getAttribute("data-info-description")).toBe(
       "The Python function can use the model's output, trace, and eval's reference data to drive pragmatic scoring. Faster and cheaper than LLM as a judge.",
     )
-  })
-})
-
-describe("example code correctness (reference data shown)", () => {
-  function get_example_code(container: HTMLElement): string {
-    return container.querySelector(".whitespace-pre")?.textContent ?? ""
-  }
-
-  it("Domain-specific grading uses KilnEvalHelpers.pass_fail with assert_contains result", async () => {
-    const { container } = render(CodeEvalForm)
-    const tabs = container.querySelectorAll(".tab")
-    await fireEvent.click(tabs[2])
-    const domainCode = get_example_code(container)
-    expect(domainCode).toContain("KilnEvalHelpers.pass_fail(contains)")
-  })
-
-  it("Domain-specific grading handles empty expected gracefully", async () => {
-    const { container } = render(CodeEvalForm)
-    const tabs = container.querySelectorAll(".tab")
-    await fireEvent.click(tabs[2])
-    const domainCode = get_example_code(container)
-    expect(domainCode).toContain("if expected else True")
   })
 })

--- a/app/web_ui/src/lib/components/eval_types/code_eval_form.svelte
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_form.svelte
@@ -260,7 +260,8 @@
   ]}
 >
   <div class="flex flex-col gap-4">
-    <div class="tabs tabs-bordered flex-nowrap overflow-x-auto">
+    <!-- .tabs is a grid in DaisyUI v4, so flex is needed for the row to wrap. -->
+    <div class="tabs tabs-bordered flex flex-wrap">
       {#each examples as example, i}
         <button
           type="button"

--- a/app/web_ui/src/lib/components/eval_types/code_eval_form.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_form.test.ts
@@ -194,12 +194,11 @@ describe("CodeEvalForm", () => {
   it("renders example tabs including the LLM tool examples", () => {
     const { container } = render(CodeEvalForm)
     const tabs = container.querySelectorAll(".tab")
-    expect(tabs.length).toBe(5)
+    expect(tabs.length).toBe(4)
     expect(tabs[0].textContent?.trim()).toBe("Parse JSON")
     expect(tabs[1].textContent?.trim()).toBe("Check tool usage")
-    expect(tabs[2].textContent?.trim()).toBe("Domain-specific grading")
-    expect(tabs[3].textContent?.trim()).toBe("LLM judge")
-    expect(tabs[4].textContent?.trim()).toBe("Triage then LLM judge")
+    expect(tabs[2].textContent?.trim()).toBe("LLM judge")
+    expect(tabs[3].textContent?.trim()).toBe("Triage then LLM judge")
   })
 
   it("switches active example tab on click", async () => {
@@ -282,8 +281,8 @@ describe("examples grant the tools they call", () => {
     await tick()
   }
 
-  const LLM_JUDGE_TAB = 3
-  const TRIAGE_TAB = 4
+  const LLM_JUDGE_TAB = 2
+  const TRIAGE_TAB = 3
   const PARSE_JSON_TAB = 0
 
   it("grants llm_judge for the LLM judge example", async () => {
@@ -374,25 +373,6 @@ describe("example code correctness", () => {
   function get_example_code(container: HTMLElement): string {
     return container.querySelector(".whitespace-pre")?.textContent ?? ""
   }
-
-  it("Domain-specific grading uses KilnEvalHelpers.pass_fail with assert_contains result", async () => {
-    const { container } = render(CodeEvalForm)
-    const tabs = container.querySelectorAll(".tab")
-    await fireEvent.click(tabs[2])
-    const domainCode = get_example_code(container)
-    expect(domainCode).toContain("KilnEvalHelpers.pass_fail(contains)")
-  })
-
-  it("Domain-specific grading asserts against a literal marker", async () => {
-    const { container } = render(CodeEvalForm)
-    const tabs = container.querySelectorAll(".tab")
-    await fireEvent.click(tabs[2])
-    const domainCode = get_example_code(container)
-    expect(domainCode).toContain(
-      'contains = KilnEvalHelpers.assert_contains(output, "Summary:")',
-    )
-    expect(domainCode).not.toContain("if expected else True")
-  })
 
   it("no example mentions reference data", async () => {
     const { container } = render(CodeEvalForm)

--- a/app/web_ui/src/lib/components/eval_types/code_eval_helpers.reference_data.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_helpers.reference_data.test.ts
@@ -42,35 +42,8 @@ describe("generate_default_code (reference data shown)", () => {
   })
 })
 
-describe("generate_examples Domain-specific grading (reference data shown)", () => {
-  it("reads expected_answer from reference_data", () => {
-    const examples = generate_examples(undefined)
-    expect(examples[2].label).toBe("Domain-specific grading")
-    expect(examples[2].code).toContain("def score(output, reference_data):")
-    expect(examples[2].code).toContain(
-      'expected = (reference_data or {}).get("expected_answer", "")',
-    )
-  })
-
-  it("guards assert_contains with if expected else True", () => {
-    const examples = generate_examples(undefined)
-    expect(examples[2].code).toContain("if expected else True")
-  })
-
-  it("uses contains as the bool expression", () => {
-    const examples = generate_examples(undefined)
-    expect(examples[2].code).toContain("KilnEvalHelpers.pass_fail(contains)")
-  })
-
-  it("uses word_count-based rating expression for five_star", () => {
-    const scores = [make_score("R", "five_star")]
-    const examples = generate_examples(scores)
-    expect(examples[2].code).toContain(
-      "KilnEvalHelpers.five_star(5 if word_count < 50 else 3 if word_count < 150 else 1)",
-    )
-  })
-
-  it("leaves the other two examples free of reference data", () => {
+describe("generate_examples (reference data shown)", () => {
+  it("leaves the score-key-driven examples free of reference data", () => {
     const examples = generate_examples(undefined)
     expect(examples[0].code).not.toContain("reference_data")
     expect(examples[1].code).not.toContain("reference_data")

--- a/app/web_ui/src/lib/components/eval_types/code_eval_helpers.test.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_helpers.test.ts
@@ -157,20 +157,19 @@ describe("generate_default_code", () => {
 })
 
 describe("generate_examples", () => {
-  // The first three examples are score-key-driven (built via the helper
+  // The first two examples are score-key-driven (built via the helper
   // functions); the last two are hand-written LLM tool examples validated
   // separately below.
   const code_examples = (scores?: EvalOutputScore[]) =>
-    generate_examples(scores).slice(0, 3)
+    generate_examples(scores).slice(0, 2)
 
-  it("returns five examples with correct labels", () => {
+  it("returns four examples with correct labels", () => {
     const examples = generate_examples(undefined)
-    expect(examples).toHaveLength(5)
+    expect(examples).toHaveLength(4)
     expect(examples[0].label).toBe("Parse JSON")
     expect(examples[1].label).toBe("Check tool usage")
-    expect(examples[2].label).toBe("Domain-specific grading")
-    expect(examples[3].label).toBe("LLM judge")
-    expect(examples[4].label).toBe("Triage then LLM judge")
+    expect(examples[2].label).toBe("LLM judge")
+    expect(examples[3].label).toBe("Triage then LLM judge")
   })
 
   it("falls back to quality key when no output_scores", () => {
@@ -210,7 +209,7 @@ describe("generate_examples", () => {
 
   describe("LLM tool examples", () => {
     it("LLM judge example judges the response itself", () => {
-      const example = generate_examples(undefined)[3]
+      const example = generate_examples(undefined)[2]
       expect(example.label).toBe("LLM judge")
       expect(example.code).toContain("from kiln import tools")
       expect(example.code).toContain("tools.llm_judge(")
@@ -221,7 +220,7 @@ describe("generate_examples", () => {
     })
 
     it("Triage example composes tools.llm and tools.llm_judge", () => {
-      const example = generate_examples(undefined)[4]
+      const example = generate_examples(undefined)[3]
       expect(example.label).toBe("Triage then LLM judge")
       expect(example.code).toContain("tools.llm(")
       expect(example.code).toContain("tools.llm_judge(")
@@ -237,7 +236,7 @@ describe("generate_examples", () => {
         make_score("Check", "pass_fail"),
         make_score("Rating", "five_star"),
       ]
-      const example = generate_examples(scores)[4]
+      const example = generate_examples(scores)[3]
       expect(example.code).toContain('return {"check": 1.0, "rating": 5.0}')
     })
   })
@@ -303,30 +302,6 @@ describe("generate_examples", () => {
       const examples = generate_examples(undefined)
       expect(examples[1].code).toContain(
         "KilnEvalHelpers.pass_fail(used_search)",
-      )
-    })
-  })
-
-  describe("Domain-specific grading example", () => {
-    it("asserts against a literal marker instead of reference data", () => {
-      const examples = generate_examples(undefined)
-      expect(examples[2].code).toContain("def score(output):")
-      expect(examples[2].code).toContain(
-        'contains = KilnEvalHelpers.assert_contains(output, "Summary:")',
-      )
-      expect(examples[2].code).not.toContain("if expected else True")
-    })
-
-    it("uses contains as the bool expression", () => {
-      const examples = generate_examples(undefined)
-      expect(examples[2].code).toContain("KilnEvalHelpers.pass_fail(contains)")
-    })
-
-    it("uses word_count-based rating expression for five_star", () => {
-      const scores = [make_score("R", "five_star")]
-      const examples = generate_examples(scores)
-      expect(examples[2].code).toContain(
-        "KilnEvalHelpers.five_star(5 if word_count < 50 else 3 if word_count < 150 else 1)",
       )
     })
   })

--- a/app/web_ui/src/lib/components/eval_types/code_eval_helpers.ts
+++ b/app/web_ui/src/lib/components/eval_types/code_eval_helpers.ts
@@ -216,11 +216,6 @@ export function generate_examples(
     "used_search",
     "max(min(call_count, 5), 1)",
   )
-  const domain_return = build_example_return(
-    scores,
-    "contains",
-    "5 if word_count < 50 else 3 if word_count < 150 else 1",
-  )
   const triage_safe_return = build_return_dict(scores, "passing")
 
   return [
@@ -255,33 +250,6 @@ def score(trace):
     call_count = KilnEvalHelpers.count_tool_calls(tool_calls, "search")
 
     ${tool_return}
-`,
-    },
-    {
-      label: "Domain-specific grading",
-      required_tool_ids: [],
-      code: SHOW_REFERENCE_DATA_UI
-        ? `from kiln_ai.adapters.eval.eval_helpers import KilnEvalHelpers
-
-def score(output, reference_data):
-    """Grade output against domain-specific criteria."""
-    expected = (reference_data or {}).get("expected_answer", "")
-
-    contains = KilnEvalHelpers.assert_contains(output, expected) if expected else True
-
-    word_count = len(output.split())
-
-    ${domain_return}
-`
-        : `from kiln_ai.adapters.eval.eval_helpers import KilnEvalHelpers
-
-def score(output):
-    """Grade output against domain-specific criteria."""
-    contains = KilnEvalHelpers.assert_contains(output, "Summary:")
-
-    word_count = len(output.split())
-
-    ${domain_return}
 `,
     },
     {

--- a/libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py
+++ b/libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py
@@ -9,14 +9,12 @@ code_eval_helpers.ts branches on the SHOW_REFERENCE_DATA_UI flag
 here:
 
   - **Flag OFF (currently shipped).** The reference_data parameter is hidden from the UI.
-    generate_default_code() emits `def score(output, trace, task_input)` and the
-    "Domain-specific grading" example greps the output for a literal string instead of
-    reading reference_data. These fixtures carry no suffix (e.g. DEFAULT_MULTI_CODE,
-    DOMAIN_GRADING_CODE).
+    generate_default_code() emits `def score(output, trace, task_input)`. These fixtures
+    carry no suffix (e.g. DEFAULT_MULTI_CODE).
   - **Flag ON.** The original reference_data-aware snippets. The sandbox still fully
     supports reference_data, so these must keep passing — they are what ships the moment
     SHOW_REFERENCE_DATA_UI flips back to true. These fixtures use a `_REF_DATA` suffix
-    (e.g. DEFAULT_MULTI_CODE_REF_DATA, DOMAIN_GRADING_CODE_REF_DATA).
+    (e.g. DEFAULT_MULTI_CODE_REF_DATA).
 
 The "Parse JSON" and "Check tool usage" examples do not branch on the flag, so they have a
 single fixture each.
@@ -105,20 +103,12 @@ PFC = TaskOutputRatingType.pass_fail_critical
 # ---------------------------------------------------------------------------
 # Sample code fixtures — mirror of code_eval_helpers.ts generate_examples()
 # Each example uses a test eval with both pass_fail and five_star scores
-# (plus pass_fail_critical in the domain example) to exercise the type mapping.
+# to exercise the type mapping.
 # ---------------------------------------------------------------------------
 
 # Scores used by the "See examples" tests: pass_fail + five_star
 EXAMPLE_SCORES_PF_FS = [_score("Check", PF), _score("Rating", FS)]
 EXAMPLE_KEYS_PF_FS = {"check", "rating"}
-
-# Scores with an additional pass_fail_critical
-EXAMPLE_SCORES_PF_FS_PFC = [
-    _score("Check", PF),
-    _score("Rating", FS),
-    _score("Safety", PFC),
-]
-EXAMPLE_KEYS_PF_FS_PFC = {"check", "rating", "safety"}
 
 # Mirror of code_eval_helpers.ts "Parse JSON" example (multi-score).
 PARSE_JSON_CODE = """\
@@ -157,44 +147,6 @@ def score(trace):
     }
 """
 
-# Mirror of code_eval_helpers.ts "Domain-specific grading" example (3-score),
-# SHOW_REFERENCE_DATA_UI = false branch (currently shipped).
-DOMAIN_GRADING_CODE = """\
-from kiln_ai.adapters.eval.eval_helpers import KilnEvalHelpers
-
-def score(output):
-    \"\"\"Grade output against domain-specific criteria.\"\"\"
-    contains = KilnEvalHelpers.assert_contains(output, "Summary:")
-
-    word_count = len(output.split())
-
-    return {  # Adjust each score's logic for your eval
-        "check": KilnEvalHelpers.pass_fail(contains),
-        "rating": KilnEvalHelpers.five_star(5 if word_count < 50 else 3 if word_count < 150 else 1),
-        "safety": KilnEvalHelpers.pass_fail(contains),
-    }
-"""
-
-# Mirror of code_eval_helpers.ts "Domain-specific grading" example (3-score),
-# SHOW_REFERENCE_DATA_UI = true branch.
-DOMAIN_GRADING_CODE_REF_DATA = """\
-from kiln_ai.adapters.eval.eval_helpers import KilnEvalHelpers
-
-def score(output, reference_data):
-    \"\"\"Grade output against domain-specific criteria.\"\"\"
-    expected = (reference_data or {}).get("expected_answer", "")
-
-    contains = KilnEvalHelpers.assert_contains(output, expected) if expected else True
-
-    word_count = len(output.split())
-
-    return {  # Adjust each score's logic for your eval
-        "check": KilnEvalHelpers.pass_fail(contains),
-        "rating": KilnEvalHelpers.five_star(5 if word_count < 50 else 3 if word_count < 150 else 1),
-        "safety": KilnEvalHelpers.pass_fail(contains),
-    }
-"""
-
 
 # ---------------------------------------------------------------------------
 # Single-score (quality fallback) example fixtures — byte-exact mirror of
@@ -230,34 +182,6 @@ def score(trace):
     call_count = KilnEvalHelpers.count_tool_calls(tool_calls, "search")
 
     return {"quality": KilnEvalHelpers.pass_fail(used_search)}
-"""
-
-# SHOW_REFERENCE_DATA_UI = false branch (currently shipped).
-DOMAIN_GRADING_CODE_SINGLE = """\
-from kiln_ai.adapters.eval.eval_helpers import KilnEvalHelpers
-
-def score(output):
-    \"\"\"Grade output against domain-specific criteria.\"\"\"
-    contains = KilnEvalHelpers.assert_contains(output, "Summary:")
-
-    word_count = len(output.split())
-
-    return {"quality": KilnEvalHelpers.pass_fail(contains)}
-"""
-
-# SHOW_REFERENCE_DATA_UI = true branch.
-DOMAIN_GRADING_CODE_SINGLE_REF_DATA = """\
-from kiln_ai.adapters.eval.eval_helpers import KilnEvalHelpers
-
-def score(output, reference_data):
-    \"\"\"Grade output against domain-specific criteria.\"\"\"
-    expected = (reference_data or {}).get("expected_answer", "")
-
-    contains = KilnEvalHelpers.assert_contains(output, expected) if expected else True
-
-    word_count = len(output.split())
-
-    return {"quality": KilnEvalHelpers.pass_fail(contains)}
 """
 
 
@@ -592,196 +516,6 @@ class TestCheckToolUsageExample:
         assert scores["rating"] == 5.0  # max(min(10, 5), 1) == 5
 
 
-class TestDomainGradingExample:
-    """Domain-specific grading example (SHOW_REFERENCE_DATA_UI = false, shipped)."""
-
-    SCORES: ClassVar = EXAMPLE_SCORES_PF_FS_PFC
-    KEYS: ClassVar = EXAMPLE_KEYS_PF_FS_PFC
-
-    @pytest.mark.asyncio
-    async def test_output_contains_marker(self):
-        cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = "Summary: the answer is 42, with a little extra context to pad it out"
-        result = await adapter.evaluate(_inp(final_message=output))
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["check"] == 1.0
-        assert scores["safety"] == 1.0
-        assert scores["rating"] == 5.0
-
-    @pytest.mark.asyncio
-    async def test_output_missing_marker(self):
-        cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = " ".join(["word"] * 20)
-        result = await adapter.evaluate(_inp(final_message=output))
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["check"] == 0.0
-        assert scores["safety"] == 0.0
-
-    @pytest.mark.asyncio
-    async def test_short_output_high_rating(self):
-        """Output with fewer than 50 words gets rating of 5."""
-        cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        result = await adapter.evaluate(_inp(final_message="Summary: short"))
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["rating"] == 5.0
-
-    @pytest.mark.asyncio
-    async def test_long_output_low_rating(self):
-        """Output with 150+ words gets rating of 1."""
-        cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = "Summary: " + " ".join(["word"] * 160)
-        result = await adapter.evaluate(_inp(final_message=output))
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["rating"] == 1.0
-
-    @pytest.mark.asyncio
-    async def test_medium_output_mid_rating(self):
-        """Output with 50-149 words gets rating of 3."""
-        cfg = _make_config(DOMAIN_GRADING_CODE, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = "Summary: " + " ".join(["word"] * 80)
-        result = await adapter.evaluate(_inp(final_message=output))
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["rating"] == 3.0
-
-
-class TestDomainGradingExampleRefData:
-    """Domain-specific grading example (SHOW_REFERENCE_DATA_UI = true branch).
-
-    The sandbox still supports reference_data, so this must keep passing even though the
-    flag currently hides it from the UI.
-    """
-
-    SCORES: ClassVar = EXAMPLE_SCORES_PF_FS_PFC
-    KEYS: ClassVar = EXAMPLE_KEYS_PF_FS_PFC
-
-    @pytest.mark.asyncio
-    async def test_output_contains_expected_answer(self):
-        cfg = _make_config(DOMAIN_GRADING_CODE_REF_DATA, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = "The answer is 42 and here is some additional context to pad it out a bit more words"
-        inp = _inp(
-            final_message=output,
-            reference_data={"expected_answer": "42"},
-        )
-        result = await adapter.evaluate(inp)
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["check"] == 1.0
-        assert scores["safety"] == 1.0
-        assert scores["rating"] == 5.0
-
-    @pytest.mark.asyncio
-    async def test_output_missing_expected_answer(self):
-        cfg = _make_config(DOMAIN_GRADING_CODE_REF_DATA, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = " ".join(["word"] * 20)
-        inp = _inp(
-            final_message=output,
-            reference_data={"expected_answer": "UNICORN_NOT_PRESENT"},
-        )
-        result = await adapter.evaluate(inp)
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["check"] == 0.0
-        assert scores["safety"] == 0.0
-
-    @pytest.mark.asyncio
-    async def test_empty_reference_data(self):
-        """Empty/missing reference_data should not raise -- expected defaults to ''."""
-        cfg = _make_config(DOMAIN_GRADING_CODE_REF_DATA, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = " ".join(["word"] * 30)
-        inp = _inp(final_message=output, reference_data=None)
-        result = await adapter.evaluate(inp)
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["check"] == 1.0
-        assert scores["safety"] == 1.0
-
-    @pytest.mark.asyncio
-    async def test_empty_reference_data_dict(self):
-        """reference_data={} (no expected_answer key) should not raise."""
-        cfg = _make_config(DOMAIN_GRADING_CODE_REF_DATA, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = " ".join(["word"] * 30)
-        inp = _inp(final_message=output, reference_data={})
-        result = await adapter.evaluate(inp)
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["check"] == 1.0
-        assert scores["safety"] == 1.0
-
-    @pytest.mark.asyncio
-    async def test_short_output_high_rating(self):
-        """Output with fewer than 50 words gets rating of 5."""
-        cfg = _make_config(DOMAIN_GRADING_CODE_REF_DATA, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = "short"
-        inp = _inp(final_message=output, reference_data=None)
-        result = await adapter.evaluate(inp)
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["rating"] == 5.0
-
-    @pytest.mark.asyncio
-    async def test_long_output_low_rating(self):
-        """Output with 150+ words gets rating of 1."""
-        cfg = _make_config(DOMAIN_GRADING_CODE_REF_DATA, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = " ".join(["word"] * 160)
-        inp = _inp(final_message=output, reference_data=None)
-        result = await adapter.evaluate(inp)
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["rating"] == 1.0
-
-    @pytest.mark.asyncio
-    async def test_medium_output_mid_rating(self):
-        """Output with 50-149 words gets rating of 3."""
-        cfg = _make_config(DOMAIN_GRADING_CODE_REF_DATA, self.SCORES)
-        adapter = CodeEvalAdapter(cfg)
-        output = " ".join(["word"] * 80)
-        inp = _inp(final_message=output, reference_data=None)
-        result = await adapter.evaluate(inp)
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, self.KEYS, self.SCORES)
-        assert scores["rating"] == 3.0
-
-
 # ---------------------------------------------------------------------------
 # Tests: single-score (quality fallback) example variants — inline-return path
 # ---------------------------------------------------------------------------
@@ -850,66 +584,6 @@ class TestCheckToolUsageExampleSingleScore:
         cfg = _make_config(CHECK_TOOL_USAGE_CODE_SINGLE, SINGLE_SCORE)
         adapter = CodeEvalAdapter(cfg)
         result = await adapter.evaluate(_inp(final_message="result", trace=None))
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, SINGLE_KEYS, SINGLE_SCORE)
-        assert scores["quality"] == 0.0
-
-
-class TestDomainGradingExampleSingleScore:
-    """Single-score Domain-specific grading (SHOW_REFERENCE_DATA_UI = false, shipped)."""
-
-    @pytest.mark.asyncio
-    async def test_output_contains_marker(self):
-        cfg = _make_config(DOMAIN_GRADING_CODE_SINGLE, SINGLE_SCORE)
-        adapter = CodeEvalAdapter(cfg)
-        result = await adapter.evaluate(_inp(final_message="Summary: the answer is 42"))
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, SINGLE_KEYS, SINGLE_SCORE)
-        assert scores["quality"] == 1.0
-
-    @pytest.mark.asyncio
-    async def test_output_missing_marker(self):
-        cfg = _make_config(DOMAIN_GRADING_CODE_SINGLE, SINGLE_SCORE)
-        adapter = CodeEvalAdapter(cfg)
-        result = await adapter.evaluate(_inp(final_message="nothing relevant here"))
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, SINGLE_KEYS, SINGLE_SCORE)
-        assert scores["quality"] == 0.0
-
-
-class TestDomainGradingExampleSingleScoreRefData:
-    """Single-score Domain-specific grading (SHOW_REFERENCE_DATA_UI = true branch)."""
-
-    @pytest.mark.asyncio
-    async def test_output_contains_expected(self):
-        cfg = _make_config(DOMAIN_GRADING_CODE_SINGLE_REF_DATA, SINGLE_SCORE)
-        adapter = CodeEvalAdapter(cfg)
-        inp = _inp(
-            final_message="The answer is 42",
-            reference_data={"expected_answer": "42"},
-        )
-        result = await adapter.evaluate(inp)
-        scores = result.scores
-
-        assert result.skipped_reason is None
-        _assert_valid_scores(scores, SINGLE_KEYS, SINGLE_SCORE)
-        assert scores["quality"] == 1.0
-
-    @pytest.mark.asyncio
-    async def test_output_missing_expected(self):
-        cfg = _make_config(DOMAIN_GRADING_CODE_SINGLE_REF_DATA, SINGLE_SCORE)
-        adapter = CodeEvalAdapter(cfg)
-        inp = _inp(
-            final_message="nothing relevant here",
-            reference_data={"expected_answer": "UNICORN_NOT_PRESENT"},
-        )
-        result = await adapter.evaluate(inp)
         scores = result.scores
 
         assert result.skipped_reason is None


### PR DESCRIPTION
## What does this PR do?

Fixes the example-picker tabs in the **Code Judge Examples** dialog, which overflowed the modal and clipped the last label.

**The fix** — `code_eval_form.svelte`:

```diff
- <div class="tabs tabs-bordered flex-nowrap overflow-x-auto">
+ <!-- .tabs is a grid in DaisyUI v4, so flex is needed for the row to wrap. -->
+ <div class="tabs tabs-bordered flex flex-wrap">
```

The `flex` is load-bearing. DaisyUI v4 sets `.tabs { display: grid }` with `.tab { grid-row-start: 1 }`, so the previous `flex-nowrap` was inert (no flex container existed) and `overflow-x-auto` fell back to a horizontal scroll. Adding `flex flex-wrap` lets the row wrap onto a second line instead.

No modal width change was needed — the dialog already uses `width="wide"`, and `wide` is the widest option `dialog.svelte` offers (`"normal" | "wide"`). The labels overran even at that width, so wrapping is the actual fix.

**Also removes the "Domain-specific grading" example** as a weak illustration. That accounts for most of the diff: it was index 2 of 5, so its removal shifted positional assertions across five TS test files, and `libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py` is an explicit byte-exact mirror of `generate_examples()` — `code_eval_helpers.ts` documents that contract directly above the function — so its four dead fixtures, the `EXAMPLE_SCORES_PF_FS_PFC` constants, and four sandbox test classes came out with it.

7 files, +23/−474.

## Related Issues

<!--- Link to related issues. -->

Targets `sfierro/KIL-741` (Evals V2, #1695) — the Code Judge Examples dialog does not exist on `main`.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

Verified locally against the final tree:

- `npm run test_run` — 120 files, 2310 passed
- `npm run check` — 0 errors (38 pre-existing warnings, none in touched files)
- `npm run lint`, `npm run format_check` — clean
- `pytest libs/core/kiln_ai/adapters/eval/test_code_eval_samples.py` — 32 passed
- `ruff check` + `ruff format --check` — clean

No new tests were added: this is a CSS-class fix plus a deletion. Existing coverage in `code_eval_form.test.ts` already pins tab rendering and activation, and the `/lib` change is purely the removal of fixtures for a deleted example.

## Notes for review

- With one example gone there are now 4 tabs, which fit on a single row at wide width — the wrap fix stays as protection against future or longer labels rather than as something visible today. Before/after screenshots were captured against the seeded fixture project and confirm the wrap works with 5 tabs.
- `shrink-0 whitespace-nowrap` is deliberately retained on the tab buttons; dropping `whitespace-nowrap` would let labels break mid-phrase.
- A near-identical `tabs tabs-bordered` picker in `add_tools/code_tool/+page.svelte` has the same latent issue but three short labels that do not currently clip. Left alone as out of scope — happy to align it in a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_015K5LG17zjoRr5cKPH5H6vW)_