### PR TITLE
Lower the copilot's golden floor to the goal the app asks for

### DIFF
--- a/app/desktop/studio_server/utils/copilot_utils.py
+++ b/app/desktop/studio_server/utils/copilot_utils.py
@@ -42,7 +42,11 @@ KILN_COPILOT_MODEL_PROVIDER = "kiln"
 KILN_ADAPTER_NAME = "kiln-adapter"
 NUM_SAMPLES_PER_TOPIC = 20
 NUM_TOPICS = 15
-MIN_GOLDEN_EXAMPLES = 25
+# Matches the golden-set goal the eval detail page holds users to
+# (MIN_GOLDEN_DATASET_SIZE). Every example above the reviewed ones is minted unrated, so
+# this is the hand-rating backlog a new spec starts with: a floor above the goal asks for
+# work the app never asks for again.
+MIN_GOLDEN_EXAMPLES = 12
 
 
 def get_copilot_api_key() -> str:

--- a/app/desktop/studio_server/utils/test_copilot_utils.py
+++ b/app/desktop/studio_server/utils/test_copilot_utils.py
@@ -306,6 +306,65 @@ class TestCreateDatasetTaskRuns:
         assert reviewed_run is not None
         assert "golden_tag" in reviewed_run.tags
 
+    def test_golden_set_is_topped_up_to_the_minimum_when_nothing_was_reviewed(self):
+        # The golden floor is the hand-rating backlog a new spec starts with: every
+        # topped-up example is minted unrated, and the eval detail page holds the golden
+        # set to the same number before its human-ratings step can complete.
+        all_examples = [
+            SampleApi(input=f"input_{i}", output=f"output_{i}")
+            for i in range(NUM_SAMPLES_PER_TOPIC * NUM_TOPICS)
+        ]
+
+        task_runs = create_dataset_task_runs(
+            all_examples,
+            [],
+            "test_tag",
+            "train_tag",
+            "val_tag",
+            "golden_tag",
+            "Test Spec",
+        ).task_runs
+
+        golden_runs = [tr for tr in task_runs if "golden_tag" in tr.tags]
+        assert len(golden_runs) == MIN_GOLDEN_EXAMPLES
+        # Topped-up examples carry no human rating — they are the work the user is being
+        # asked to do, which is why the floor tracks the page's goal rather than exceeding
+        # it.
+        assert all(tr.output.rating is None for tr in golden_runs)
+
+    def test_golden_set_keeps_every_reviewed_example_past_the_minimum(self):
+        # The floor tops up, it does not cap: a user who reviewed more than the minimum
+        # keeps all of their rated examples, and gets no unrated ones on top.
+        reviewed_count = MIN_GOLDEN_EXAMPLES + 5
+        all_examples = [
+            SampleApi(input=f"input_{i}", output=f"output_{i}")
+            for i in range(NUM_SAMPLES_PER_TOPIC * NUM_TOPICS)
+        ]
+        reviewed_examples = [
+            ReviewedExample(
+                input=f"reviewed_input_{i}",
+                output=f"reviewed_output_{i}",
+                model_says_meets_spec=True,
+                user_says_meets_spec=True,
+                feedback="",
+            )
+            for i in range(reviewed_count)
+        ]
+
+        task_runs = create_dataset_task_runs(
+            all_examples,
+            reviewed_examples,
+            "test_tag",
+            "train_tag",
+            "val_tag",
+            "golden_tag",
+            "Test Spec",
+        ).task_runs
+
+        golden_runs = [tr for tr in task_runs if "golden_tag" in tr.tags]
+        assert len(golden_runs) == reviewed_count
+        assert all(tr.output.rating is not None for tr in golden_runs)
+
     def test_all_task_runs_have_session_tag(self):
         all_examples = [
             SampleApi(input=f"input_{i}", output=f"output_{i}")

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/+page.svelte
@@ -530,7 +530,7 @@
       required_more_eval_data = progress.dataset_size < MIN_DATASET_SIZE
       required_more_golden_data =
         evaluator?.template !== "rag" &&
-        progress.golden_dataset_size < MIN_DATASET_SIZE
+        progress.golden_dataset_size < MIN_GOLDEN_DATASET_SIZE
       if (required_more_eval_data || required_more_golden_data) {
         partial.add(2)
       }

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_detail.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/[spec_id]/[eval_id]/eval_detail.test.ts
@@ -637,6 +637,51 @@ describe("eval detail page — eval data goals", () => {
     )
   })
 
+  it("holds golden to the same 12 once a default judge is set", async () => {
+    // A default judge sends this step down a second branch, and that branch used to
+    // measure golden against the test set's 25 while the copy under it named 12. Every
+    // eval with a judge and 12-24 golden items read "You only have 18 golden items. We
+    // suggest at least 12 golden items." -- a bar it had already cleared.
+    setEvalResponse({
+      id: "eval1",
+      name: "Test Eval",
+      eval_set_filter_id: "tag::test",
+      eval_configs_filter_id: "tag::golden",
+      eval_configs: [],
+      output_scores: [{ name: "accuracy", type: "five_star" }],
+      current_config_id: "eval_config1",
+    })
+    setProgressResponse(progress(25, 12))
+
+    const text = visible_text(await render_page())
+
+    expect(text).toContain(
+      "You have 25 test dataset items and 12 golden items.",
+    )
+    expect(text).not.toContain("You require additional eval data")
+  })
+
+  it("still asks for more golden data below 12 once a default judge is set", async () => {
+    // The pair that pins the branch above to the golden goal rather than to no check at
+    // all.
+    setEvalResponse({
+      id: "eval1",
+      name: "Test Eval",
+      eval_set_filter_id: "tag::test",
+      eval_configs_filter_id: "tag::golden",
+      eval_configs: [],
+      output_scores: [{ name: "accuracy", type: "five_star" }],
+      current_config_id: "eval_config1",
+    })
+    setProgressResponse(progress(25, 11))
+
+    const text = visible_text(await render_page())
+
+    expect(text).toContain(
+      "You require additional eval data. You only have 11 golden items. We suggest at least 12 items.",
+    )
+  })
+
   it("asks for more test dataset data below 25", async () => {
     setProgressResponse(progress(24, 30))
 


### PR DESCRIPTION
## What does this PR do?

Sets `MIN_GOLDEN_EXAMPLES` to 12 (`app/desktop/studio_server/utils/copilot_utils.py`), and fixes the golden threshold the eval detail page contradicted itself on.

**The floor.** A spec created with the copilot minted 25 golden examples. Everything above the examples the user actually reviewed is minted *unrated* (`create_task_run_from_sample` attaches no rating), so that number is the hand-rating backlog a new spec starts with — and the eval detail page asks for 12 (`MIN_GOLDEN_DATASET_SIZE`). The floor now matches the goal, halving the backlog. It tops up, it does not cap: a user who reviewed more than 12 keeps all of their rated examples.

Golden is a fixed count taken off the top before the other three datasets divide the remainder, so the 13 examples it no longer claims flow to them. At the default 300 generated samples: test 137→143, val 46→48, train 92→96.

**The threshold.** Two branches decide whether the eval-data step is satisfied. Without a default judge, golden is measured against `MIN_GOLDEN_DATASET_SIZE` (12); with one, it was measured against `MIN_DATASET_SIZE` (25) — under copy that always names 12. A copilot-created eval always has a default judge (`copilot_api.py` sets `current_config_id` at creation), so with this floor at 12 every one of them would have read:

> You only have 12 golden items. We suggest at least 12 items.

The 25 floor is what kept that unreachable. 75bcee3 converted the first branch and the copy and missed the second, so this is a live bug on any eval with a default judge and 12–24 golden items, independent of the floor change.

**Tests.** Four added, all of which fail without their fix:

- `test_golden_set_is_topped_up_to_the_minimum_when_nothing_was_reviewed` — pins the golden count to the floor and that topped-up items carry no rating.
- `test_golden_set_keeps_every_reviewed_example_past_the_minimum` — the floor tops up rather than caps.
- `holds golden to the same 12 once a default judge is set` — the regression; verified failing against the pre-fix page.
- `still asks for more golden data below 12 once a default judge is set` — pins that branch to the golden goal rather than to no check at all.

The existing copilot suite reads `MIN_GOLDEN_EXAMPLES` symbolically rather than hardcoding 25, so nothing else needed updating.

**One judgement call worth a second opinion:** golden drives judge-vs-human correlation, and at n=12 with binary pass/fail spec ratings those metrics are noisy. `correlation_calculator.py` returns `None` whenever every human label lands in one class, which gets likelier at 12 than at 25 — so Compare Judges can show blank metrics more often on evals whose synthetic data skews mostly-passing. 12 is defensible since it is what the UI already asks for; ~15–20 would buy margin against the single-class case while still cutting the backlog.

## Related Issues

<!--- Link to related issues. For example: "Fixes: https://github.com/Kiln-AI/Kiln/issues/12345" -->

## Contributor License Agreement

I, @<your-github-username>, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed — `uv run ./checks.sh --agent-mode` exits 0 (misspell not installed, skipped)
- [ ] New tests have been added to any work in /lib — no changes under `/lib` in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZHRwnf9maxovjVELJRHDF)_