### PR TITLE
Bundle eval_helpers in desktop builds so shipped code-eval examples run

### DIFF
--- a/app/desktop/build_desktop_app.sh
+++ b/app/desktop/build_desktop_app.sh
@@ -107,10 +107,13 @@ fi
 
 # Builds the desktop app
 # We should use a spec instead of a long-winded command line
+# eval_helpers is imported only by user scorer code at runtime (the code-eval
+# examples embed the import as a string), so PyInstaller can't discover it.
 pyinstaller $(printf %s "$PLATFORM_OPTS")  \
   --add-data "./taskbar.png:." --add-data "../../web_ui/build:./web_ui/build" \
   --noconfirm --distpath=./desktop/build/dist --workpath=./desktop/build/work \
   -n Kiln --specpath=./desktop/build --hidden-import=tiktoken_ext.openai_public --hidden-import=tiktoken_ext \
+  --hidden-import=kiln_ai.adapters.eval.eval_helpers \
   --hidden-import=litellm \
   --collect-all=litellm \
   --paths=. ./desktop/desktop.py


### PR DESCRIPTION
Release builds are missing kiln_ai.adapters.eval.eval_helpers: nothing in production code imports it statically (user scorer code imports it at runtime inside the sandbox, and the code-eval Examples gallery embeds the import as a string in TypeScript), so PyInstaller never bundles it. Result: Examples gallery entries that use KilnEvalHelpers crash with ModuleNotFoundError on line 1 in the built app, while working fine in dev where the venv has everything.

Fix is a hidden-import flag next to the existing tiktoken/litellm ones. Chose the flag over adding a static import in the sandbox worker: eval_helpers is deliberately lazy-imported to keep sandbox spawn fast, and the flag bundles the module without importing it at startup.

Repro (dev mode cannot reproduce this): build with uv run bash ./app/desktop/build_desktop_app.sh, launch the app from desktop/build/dist, create a Code judge on any task, load the Examples gallery's tool-usage example, and run Test Judge. Before this fix it fails with ModuleNotFoundError; after, it scores. CI does not run PyInstaller builds end to end against the examples, so this needs the manual repro to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)