### PR TITLE
get_tool_results: match OpenAI-style role "tool" messages

### DIFF
--- a/libs/core/kiln_ai/adapters/eval/eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/eval_helpers.py
@@ -66,13 +66,18 @@ class KilnEvalHelpers:
 
     @staticmethod
     def get_tool_results(trace: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
-        """Return all tool-result entries from a trace."""
+        """Return all tool-result entries from a trace.
+
+        Kiln traces store tool results as OpenAI-style ``role: "tool"``
+        messages; ``tool_result``-shaped entries are also matched.
+        """
         if not trace:
             return []
         return [
             entry
             for entry in trace
-            if entry.get("role") == "tool_result" or entry.get("type") == "tool_result"
+            if entry.get("role") in ("tool", "tool_result")
+            or entry.get("type") == "tool_result"
         ]
 
     # -- Tool-call matching -------------------------------------------------

--- a/libs/core/kiln_ai/adapters/eval/test_eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/test_eval_helpers.py
@@ -119,6 +119,24 @@ class TestTraceNavigation:
         assert len(results) == 2
         assert results[0]["content"] == "result1"
 
+    def test_get_tool_results_openai_role_tool(self, helpers: KilnEvalHelpers):
+        # Kiln traces store tool results as OpenAI-style role "tool" messages,
+        # so a scorer reading a real trace must get them back.
+        trace = [
+            {"role": "user", "content": "question"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "type": "function"}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "tool output"},
+            {"role": "assistant", "content": "answer"},
+        ]
+        results = helpers.get_tool_results(trace)
+        assert len(results) == 1
+        assert results[0]["tool_call_id"] == "call_1"
+        assert results[0]["content"] == "tool output"
+
 
 # ---------------------------------------------------------------------------
 # Tool-call matching


### PR DESCRIPTION
KilnEvalHelpers.get_tool_results filtered the trace for role "tool_result", but Kiln traces store tool results as OpenAI-style role "tool" messages. On any real trace the helper returned an empty list, so a code judge using it saw tool calls with no results and scored zero.

Two-line fix: the filter now matches role "tool" alongside the tool_result shapes, with a test pinning the OpenAI-format case (tool result recovered by tool_call_id from a realistic trace).

Repro: create a Code judge whose scorer calls KilnEvalHelpers.get_tool_results(trace), run Test Judge against any task run whose trace contains tool calls. Before: always []. After: the tool messages.

This is the minimal release-line fix. The fuller scorer-helper set in #1592 contains the same correction and merges cleanly over this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)