### PR TITLE
Deterministic judges: missing nested fields score Fail instead of erroring

### DIFF
--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -6388,6 +6388,23 @@ class TestTestV2EvalDraft:
         assert response.status_code == 200
         assert response.json()["scores"]["accuracy"] == 0.0
 
+    def test_missing_nested_field_scores_fail(
+        self, client, mock_task, mock_task_from_id
+    ):
+        # The output JSON has no `user`, so the expression reaches into a value
+        # that isn't there. That's a scored FAIL, not a request error.
+        mock_task_from_id.return_value = mock_task
+        payload = self._payload()
+        payload["properties"]["value_expression"] = (
+            "(final_message | fromjson).user.status"
+        )
+        payload["eval_input"]["final_message"] = '{"status": "ok"}'
+        response = client.post(self._url(), json=payload)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["scores"]["accuracy"] == 0.0
+        assert body["skipped_reason"] is None
+
     def test_nothing_is_persisted(self, client, mock_task, mock_task_from_id):
         mock_task_from_id.return_value = mock_task
         response = client.post(self._url(), json=self._payload())

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -6388,21 +6388,31 @@ class TestTestV2EvalDraft:
         assert response.status_code == 200
         assert response.json()["scores"]["accuracy"] == 0.0
 
+    @pytest.mark.parametrize(
+        "final_message,expected_score",
+        [
+            # Same expression and same expected_value both times. The only
+            # difference is whether `user` is there, so the 0.0 can only come
+            # from the extraction failing -- not from a value that never matched.
+            ('{"user": {"status": "hello"}}', 1.0),
+            ('{"status": "hello"}', 0.0),
+        ],
+        ids=["field_present", "field_missing"],
+    )
     def test_missing_nested_field_scores_fail(
-        self, client, mock_task, mock_task_from_id
+        self, client, mock_task, mock_task_from_id, final_message, expected_score
     ):
-        # The output JSON has no `user`, so the expression reaches into a value
-        # that isn't there. That's a scored FAIL, not a request error.
+        # Reaching into a value that isn't there is a scored FAIL, not a request error.
         mock_task_from_id.return_value = mock_task
         payload = self._payload()
         payload["properties"]["value_expression"] = (
             "(final_message | fromjson).user.status"
         )
-        payload["eval_input"]["final_message"] = '{"status": "ok"}'
+        payload["eval_input"]["final_message"] = final_message
         response = client.post(self._url(), json=payload)
         assert response.status_code == 200
         body = response.json()
-        assert body["scores"]["accuracy"] == 0.0
+        assert body["scores"]["accuracy"] == expected_score
         assert body["skipped_reason"] is None
 
     def test_nothing_is_persisted(self, client, mock_task, mock_task_from_id):

--- a/libs/core/kiln_ai/adapters/eval/test_v2_eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_eval_helpers.py
@@ -103,6 +103,17 @@ class TestFromjsonExtractionSkip:
         assert "not valid JSON" in detail
         assert "(final_message | fromjson).field" in detail
 
+    def test_extract_value_missing_nested_field_skips_with_message(self):
+        inp = _make_input(final_message='{"status": "ok"}')
+        value, skip, detail = extract_value(
+            "(final_message | fromjson).user.status", inp
+        )
+        assert value is None
+        assert skip == SkippedReason.extraction_failed
+        # Jinja's message names the field that wasn't there; the test pane shows it.
+        assert detail is not None
+        assert "has no attribute 'user'" in detail
+
     def test_extract_value_fromjson_valid_json_passes(self):
         inp = _make_input(final_message='{"status": "ok"}')
         value, skip, _detail = extract_value("(final_message | fromjson).status", inp)
@@ -169,6 +180,28 @@ class TestExtractOutputValue:
         )
         assert value == "val"
         assert fail_result is None
+
+    def test_missing_nested_field_fails_not_raises(self):
+        # The JSON parses but has no `user`, so the `.status` lookup happens on a
+        # missing value. That's the model not producing the expected structure: FAIL.
+        inp = _make_input(final_message='{"status": "ok"}')
+        value, fail_result = extract_output_value(
+            "(final_message | fromjson).user.status", inp, _SAMPLE_SCORES
+        )
+        assert value is None
+        assert fail_result is not None
+        assert fail_result.skipped_reason is None
+        assert fail_result.scores == {"s1": 0.0, "s2": 0.0}
+
+    def test_index_past_end_of_trace_fails_not_raises(self):
+        inp = _make_input(trace=[])
+        value, fail_result = extract_output_value(
+            "trace[-1].tool_calls[0].function.name", inp, _SAMPLE_SCORES
+        )
+        assert value is None
+        assert fail_result is not None
+        assert fail_result.skipped_reason is None
+        assert fail_result.scores == {"s1": 0.0, "s2": 0.0}
 
 
 # ---------------------------------------------------------------------------

--- a/libs/core/kiln_ai/adapters/eval/test_v2_eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_eval_helpers.py
@@ -110,7 +110,7 @@ class TestFromjsonExtractionSkip:
         )
         assert value is None
         assert skip == SkippedReason.extraction_failed
-        # Jinja's message names the field that wasn't there; the test pane shows it.
+        # The skip detail preserves Jinja's message, which names the missing field.
         assert detail is not None
         assert "has no attribute 'user'" in detail
 
@@ -197,6 +197,20 @@ class TestExtractOutputValue:
         inp = _make_input(trace=[])
         value, fail_result = extract_output_value(
             "trace[-1].tool_calls[0].function.name", inp, _SAMPLE_SCORES
+        )
+        assert value is None
+        assert fail_result is not None
+        assert fail_result.skipped_reason is None
+        assert fail_result.scores == {"s1": 0.0, "s2": 0.0}
+
+    def test_generator_over_missing_field_fails_not_raises(self):
+        # map() defers its lookups until the generator is drained, so this is the
+        # one shape where the raise escapes the expression call itself.
+        inp = _make_input(trace=[{"content": "no tools"}])
+        value, fail_result = extract_output_value(
+            "trace | map(attribute='tool_calls.0.function.name')",
+            inp,
+            _SAMPLE_SCORES,
         )
         assert value is None
         assert fail_result is not None

--- a/libs/core/kiln_ai/adapters/eval/test_v2_eval_helpers.py
+++ b/libs/core/kiln_ai/adapters/eval/test_v2_eval_helpers.py
@@ -103,17 +103,6 @@ class TestFromjsonExtractionSkip:
         assert "not valid JSON" in detail
         assert "(final_message | fromjson).field" in detail
 
-    def test_extract_value_missing_nested_field_skips_with_message(self):
-        inp = _make_input(final_message='{"status": "ok"}')
-        value, skip, detail = extract_value(
-            "(final_message | fromjson).user.status", inp
-        )
-        assert value is None
-        assert skip == SkippedReason.extraction_failed
-        # The skip detail preserves Jinja's message, which names the missing field.
-        assert detail is not None
-        assert "has no attribute 'user'" in detail
-
     def test_extract_value_fromjson_valid_json_passes(self):
         inp = _make_input(final_message='{"status": "ok"}')
         value, skip, _detail = extract_value("(final_message | fromjson).status", inp)
@@ -181,36 +170,13 @@ class TestExtractOutputValue:
         assert value == "val"
         assert fail_result is None
 
-    def test_missing_nested_field_fails_not_raises(self):
-        # The JSON parses but has no `user`, so the `.status` lookup happens on a
-        # missing value. That's the model not producing the expected structure: FAIL.
-        inp = _make_input(final_message='{"status": "ok"}')
-        value, fail_result = extract_output_value(
-            "(final_message | fromjson).user.status", inp, _SAMPLE_SCORES
-        )
-        assert value is None
-        assert fail_result is not None
-        assert fail_result.skipped_reason is None
-        assert fail_result.scores == {"s1": 0.0, "s2": 0.0}
-
-    def test_index_past_end_of_trace_fails_not_raises(self):
+    def test_empty_trace_scores_fail_not_missing_trace_skip(self):
+        # A trace that exists but is empty is not a missing trace: the run did
+        # produce one, it just has nothing in it. That scores FAIL, so the
+        # missing-trace skip must key off `is None`, not falsiness.
         inp = _make_input(trace=[])
         value, fail_result = extract_output_value(
             "trace[-1].tool_calls[0].function.name", inp, _SAMPLE_SCORES
-        )
-        assert value is None
-        assert fail_result is not None
-        assert fail_result.skipped_reason is None
-        assert fail_result.scores == {"s1": 0.0, "s2": 0.0}
-
-    def test_generator_over_missing_field_fails_not_raises(self):
-        # map() defers its lookups until the generator is drained, so this is the
-        # one shape where the raise escapes the expression call itself.
-        inp = _make_input(trace=[{"content": "no tools"}])
-        value, fail_result = extract_output_value(
-            "trace | map(attribute='tool_calls.0.function.name')",
-            inp,
-            _SAMPLE_SCORES,
         )
         assert value is None
         assert fail_result is not None

--- a/libs/core/kiln_ai/datamodel/eval.py
+++ b/libs/core/kiln_ai/datamodel/eval.py
@@ -1028,7 +1028,7 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
             raise ValueError(f"Invalid eval config type: {self.config_type}")
 
     @model_validator(mode="after")
-    def validate_v2_templates_and_expressions(self) -> Self:
+    def validate_v2_templates_and_expressions(self, info: ValidationInfo) -> Self:
         if self.config_type != EvalConfigType.v2 or not isinstance(
             self.properties, BaseModel
         ):
@@ -1037,6 +1037,7 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
         from kiln_ai.utils.jinja_engine import (
             compile_expression_or_raise,
             compile_template_or_raise,
+            expression_variables,
         )
 
         props = self.properties
@@ -1069,6 +1070,25 @@ class EvalConfig(KilnParentedModel, KilnParentModel, parent_of={"runs": EvalRun}
         ):
             if props.value_expression is not None:
                 compile_expression_or_raise(props.value_expression)
+                # Syntax alone isn't enough: a typo'd root variable resolves to
+                # Undefined at eval time, which scores every row a silent 0.0.
+                # Catch it while the author can still see what they typed.
+                #
+                # Authoring-time only. A config written before this check exists
+                # may name a variable we now reject, and refusing to load it would
+                # take the whole eval down rather than the one check that was
+                # already scoring zeros.
+                if not self.loading_from_file(info):
+                    allowed = set(EvalTaskInput.model_fields.keys())
+                    unknown = sorted(
+                        expression_variables(props.value_expression) - allowed
+                    )
+                    if unknown:
+                        raise ValueError(
+                            f"value_expression references unknown variable "
+                            f"'{unknown[0]}'. Available variables: "
+                            f"{', '.join(sorted(allowed))}."
+                        )
 
         return self
 

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -2666,6 +2666,60 @@ class TestV2TemplateValidation:
                 ),
             )
 
+    @pytest.mark.parametrize(
+        "expression",
+        ["final_message", "trace[-1].content", "task_input | upper", "reference_data"],
+    )
+    def test_value_expression_accepts_every_eval_input_field(self, expression):
+        cfg = _make_v2_eval_config(
+            properties=ExactMatchProperties(
+                expected_value="yes",
+                value_expression=expression,
+            ),
+        )
+        assert cfg.properties.value_expression == expression
+
+    @pytest.mark.parametrize(
+        "expression,unknown",
+        [
+            ("outpt.status", "outpt"),
+            ("messages[-1].content", "messages"),
+            ("final_message ~ typo", "typo"),
+        ],
+    )
+    def test_value_expression_rejects_unknown_variable(self, expression, unknown):
+        """A typo'd root would resolve to Undefined and silently score every row 0.0."""
+        with pytest.raises(
+            ValidationError, match=f"unknown variable '{unknown}'"
+        ) as exc:
+            _make_v2_eval_config(
+                properties=ExactMatchProperties(
+                    expected_value="yes",
+                    value_expression=expression,
+                ),
+            )
+        assert "final_message, reference_data, task_input, trace" in str(exc.value)
+
+    def test_value_expression_unknown_variable_still_loads_from_file(self):
+        """Already-saved configs keep loading; the check gates writes, not reads."""
+        cfg = EvalConfig.model_validate(
+            {
+                "v": 1,
+                "id": "123",
+                "name": "Saved before the check existed",
+                "config_type": "v2",
+                "model_type": "eval_config",
+                "properties": {
+                    "type": "exact_match",
+                    "expected_value": "yes",
+                    "value_expression": "outpt.status",
+                },
+            },
+            context={"loading_from_file": True},
+        )
+        assert isinstance(cfg.properties, ExactMatchProperties)
+        assert cfg.properties.value_expression == "outpt.status"
+
     def test_none_value_expression_skipped(self):
         """value_expression=None (default) should not be validated."""
         cfg = _make_v2_eval_config(

--- a/libs/core/kiln_ai/datamodel/test_eval_model.py
+++ b/libs/core/kiln_ai/datamodel/test_eval_model.py
@@ -2557,6 +2557,16 @@ def _make_v2_eval_config(**kwargs) -> EvalConfig:
     return EvalConfig(name="V2 Test", config_type=EvalConfigType.v2, **kwargs)
 
 
+# One value_expression per EvalTaskInput field, keyed by the root variable it
+# reads. Checked against EvalTaskInput.model_fields so the coverage claim holds.
+_EVAL_INPUT_FIELD_EXPRESSIONS = {
+    "final_message": "final_message",
+    "trace": "trace[-1].content",
+    "task_input": "task_input | upper",
+    "reference_data": "reference_data",
+}
+
+
 class TestV2TemplateValidation:
     def test_valid_prompt_template(self):
         """A prompt_template with a Jinja expression passes validation."""
@@ -2667,10 +2677,13 @@ class TestV2TemplateValidation:
             )
 
     @pytest.mark.parametrize(
-        "expression",
-        ["final_message", "trace[-1].content", "task_input | upper", "reference_data"],
+        "root,expression",
+        list(_EVAL_INPUT_FIELD_EXPRESSIONS.items()),
     )
-    def test_value_expression_accepts_every_eval_input_field(self, expression):
+    def test_value_expression_accepts_every_eval_input_field(self, root, expression):
+        # Tied to the model so a new EvalTaskInput field can't leave this test
+        # named "every field" while silently skipping one.
+        assert set(_EVAL_INPUT_FIELD_EXPRESSIONS) == set(EvalTaskInput.model_fields)
         cfg = _make_v2_eval_config(
             properties=ExactMatchProperties(
                 expected_value="yes",
@@ -2688,7 +2701,13 @@ class TestV2TemplateValidation:
         ],
     )
     def test_value_expression_rejects_unknown_variable(self, expression, unknown):
-        """A typo'd root would resolve to Undefined and silently score every row 0.0."""
+        """A typo'd root fails silently at runtime, so it has to fail loudly here.
+
+        Depending on what the expression does with it, the typo either resolves
+        to Undefined and scores every row 0.0, or -- as with `~`, which
+        stringifies Undefined to '' -- produces a plausible-looking wrong value
+        ('hi' for `final_message ~ typo`) that no one notices.
+        """
         with pytest.raises(
             ValidationError, match=f"unknown variable '{unknown}'"
         ) as exc:

--- a/libs/core/kiln_ai/utils/jinja_engine.py
+++ b/libs/core/kiln_ai/utils/jinja_engine.py
@@ -123,14 +123,17 @@ def extract(expression: str, data: dict) -> Any:
         ) from e
     try:
         result = compiled(**data)
+        # Materializing inside the try is load-bearing: map/selectattr/groupby
+        # return lazy generators, so their per-item lookups don't run until
+        # list() does. A missing field there raises here, not above.
+        if isinstance(result, types.GeneratorType):
+            result = list(result)
     except UndefinedError as e:
         # A single missing lookup yields Undefined, but any further operation on
         # it (attribute access, indexing, a filter) raises. That's still just
         # missing data, so surface it as an extraction error callers handle --
         # keeping Jinja's message, which names the field that wasn't there.
         raise JinjaExtractionError(str(e)) from e
-    if isinstance(result, types.GeneratorType):
-        result = list(result)
     return result
 
 

--- a/libs/core/kiln_ai/utils/jinja_engine.py
+++ b/libs/core/kiln_ai/utils/jinja_engine.py
@@ -10,6 +10,7 @@ Both envs share trim_blocks=True and lstrip_blocks=True for prompt-friendly outp
 Public API:
   - compile_template_or_raise(template) -> None
   - compile_expression_or_raise(expression) -> None
+  - expression_variables(expression) -> set[str]
   - render_input_transform(transform, task_input) -> str
   - extract(expression, data) -> Any
 """
@@ -86,6 +87,24 @@ def compile_expression_or_raise(expression: str) -> None:
         raise ValueError(
             f"Invalid Jinja2 expression: {e.message} (line {e.lineno})"
         ) from e
+
+
+def expression_variables(expression: str) -> set[str]:
+    """Return the namespace variables a Jinja2 expression reads.
+
+    An expression is not a template -- ``final_message.strip()`` parsed as a
+    template is just literal text with no variables -- so it is wrapped in an
+    output block before the AST walk. Raises ValueError on syntax error.
+    """
+    from jinja2 import meta
+
+    try:
+        ast = _expression_env.parse("{{ " + expression + " }}")
+    except TemplateSyntaxError as e:
+        raise ValueError(
+            f"Invalid Jinja2 expression: {e.message} (line {e.lineno})"
+        ) from e
+    return meta.find_undeclared_variables(ast)
 
 
 def render_input_transform(

--- a/libs/core/kiln_ai/utils/jinja_engine.py
+++ b/libs/core/kiln_ai/utils/jinja_engine.py
@@ -20,7 +20,7 @@ import json
 import types
 from typing import TYPE_CHECKING, Any
 
-from jinja2 import StrictUndefined, TemplateSyntaxError, Undefined
+from jinja2 import StrictUndefined, TemplateSyntaxError, Undefined, UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 
 if TYPE_CHECKING:
@@ -28,10 +28,13 @@ if TYPE_CHECKING:
 
 
 class JinjaExtractionError(ValueError):
-    """Raised when a Jinja2 filter encounters invalid data during extraction.
+    """Raised when a Jinja2 expression encounters missing or invalid data during extraction.
 
-    For example, the ``fromjson`` filter raises this when the input string is
-    not valid JSON.
+    Covers both filters that reject their input (``fromjson`` on a non-JSON
+    string) and expressions that operate on a value that isn't there (reaching
+    into a missing nested field, indexing past the end of a list). Callers treat
+    it as "this input didn't have what the expression asked for" rather than an
+    unexpected crash.
     """
 
 
@@ -108,6 +111,7 @@ def extract(expression: str, data: dict) -> Any:
     - Missing keys return Undefined (not None, not a raise).
     - Explicit null values return None.
     - Generators are auto-materialized to lists.
+    - Operating on a missing value raises JinjaExtractionError, never UndefinedError.
     """
     try:
         compiled = _expression_env.compile_expression(
@@ -117,7 +121,14 @@ def extract(expression: str, data: dict) -> Any:
         raise ValueError(
             f"Invalid Jinja2 expression: {e.message} (line {e.lineno})"
         ) from e
-    result = compiled(**data)
+    try:
+        result = compiled(**data)
+    except UndefinedError as e:
+        # A single missing lookup yields Undefined, but any further operation on
+        # it (attribute access, indexing, a filter) raises. That's still just
+        # missing data, so surface it as an extraction error callers handle --
+        # keeping Jinja's message, which names the field that wasn't there.
+        raise JinjaExtractionError(str(e)) from e
     if isinstance(result, types.GeneratorType):
         result = list(result)
     return result

--- a/libs/core/kiln_ai/utils/test_jinja_engine.py
+++ b/libs/core/kiln_ai/utils/test_jinja_engine.py
@@ -208,45 +208,48 @@ class TestExtractOperationsOnMissingData:
     field that wasn't there.
     """
 
-    def test_missing_nested_attribute_raises_extraction_error(self):
-        with pytest.raises(
-            JinjaExtractionError, match="'dict object' has no attribute 'user'"
-        ):
-            extract(
+    @pytest.mark.parametrize(
+        "expression,data,expected_message",
+        [
+            # A filter or operator that forces the Undefined.
+            ("missing | int", {}, "'missing' is undefined"),
+            ("missing + 1", {}, "'missing' is undefined"),
+            # Reaching into a field the parsed JSON doesn't have.
+            (
                 "(final_message | fromjson).user.status",
                 {"final_message": '{"status": "ok"}'},
-            )
+                "'dict object' has no attribute 'user'",
+            ),
+            # Indexing past the end of a list.
+            (
+                "trace[-1].tool_calls[0].function.name",
+                {"trace": []},
+                "has no element -1",
+            ),
+        ],
+    )
+    def test_raising_operation_on_missing_value(
+        self, expression, data, expected_message
+    ):
+        # Only operations that force the value raise; others stay silent, which
+        # test_silent_operation_on_missing_value pins.
+        with pytest.raises(JinjaExtractionError, match=expected_message):
+            extract(expression, data)
 
-    def test_index_past_end_of_list_raises_extraction_error(self):
-        with pytest.raises(JinjaExtractionError, match="has no element -1"):
-            extract("trace[-1].tool_calls[0].function.name", {"trace": []})
-
-    @pytest.mark.parametrize("expression", ["missing | int", "missing + 1"])
-    def test_raising_operation_on_missing_value(self, expression):
-        # Only operations that force the value raise. Many do not: `join` yields
-        # '', `~` concatenates, `==` is False. Those stay silent by design.
-        with pytest.raises(JinjaExtractionError, match="'missing' is undefined"):
-            extract(expression, {})
+    def test_silent_operation_on_missing_value(self):
+        # The other side of the boundary: `~` stringifies Undefined to '' rather
+        # than raising, so a typo'd name yields a wrong value, not an error.
+        assert extract("final_message ~ typo", {"final_message": "hi"}) == "hi"
 
     def test_lazy_generator_over_missing_field_raises_extraction_error(self):
-        # map() is lazy, so this lookup fires during materialization rather than
-        # when the expression is called -- the raise still has to be converted.
+        # The sole guard that generators are materialized inside extract()'s try:
+        # map() defers its per-item lookups, so the raise fires during list(),
+        # not when the compiled expression is called.
         with pytest.raises(
             JinjaExtractionError, match="'dict object' has no attribute 'tool_calls'"
         ):
             extract(
                 "trace | map(attribute='tool_calls.0.function.name')",
-                {"trace": [{"content": "no tools"}]},
-            )
-
-    def test_materialized_generator_over_missing_field_raises_extraction_error(self):
-        # Same expression with `| list`, which materializes inside the compiled
-        # expression instead. Both routes must land on JinjaExtractionError.
-        with pytest.raises(
-            JinjaExtractionError, match="'dict object' has no attribute 'tool_calls'"
-        ):
-            extract(
-                "trace | map(attribute='tool_calls.0.function.name') | list",
                 {"trace": [{"content": "no tools"}]},
             )
 

--- a/libs/core/kiln_ai/utils/test_jinja_engine.py
+++ b/libs/core/kiln_ai/utils/test_jinja_engine.py
@@ -195,24 +195,34 @@ class TestExtractOperationsOnMissingData:
         with pytest.raises(JinjaExtractionError, match="has no element -1"):
             extract("trace[-1].tool_calls[0].function.name", {"trace": []})
 
-    def test_filter_on_missing_value_raises_extraction_error(self):
+    @pytest.mark.parametrize("expression", ["missing | int", "missing + 1"])
+    def test_raising_operation_on_missing_value(self, expression):
+        # Only operations that force the value raise. Many do not: `join` yields
+        # '', `~` concatenates, `==` is False. Those stay silent by design.
         with pytest.raises(JinjaExtractionError, match="'missing' is undefined"):
-            extract("missing | int", {})
+            extract(expression, {})
 
-    def test_operator_on_missing_value_raises_extraction_error(self):
-        with pytest.raises(JinjaExtractionError, match="'missing' is undefined"):
-            extract("missing + 1", {})
+    def test_lazy_generator_over_missing_field_raises_extraction_error(self):
+        # map() is lazy, so this lookup fires during materialization rather than
+        # when the expression is called -- the raise still has to be converted.
+        with pytest.raises(
+            JinjaExtractionError, match="'dict object' has no attribute 'tool_calls'"
+        ):
+            extract(
+                "trace | map(attribute='tool_calls.0.function.name')",
+                {"trace": [{"content": "no tools"}]},
+            )
 
-    def test_missing_top_level_key_still_returns_undefined(self):
-        # Contract unchanged: a bare missing lookup is not an error.
-        assert isinstance(extract("missing", {}), Undefined)
-
-    def test_valid_nested_expression_still_extracts(self):
-        result = extract(
-            "(final_message | fromjson).user.status",
-            {"final_message": '{"user": {"status": "active"}}'},
-        )
-        assert result == "active"
+    def test_materialized_generator_over_missing_field_raises_extraction_error(self):
+        # Same expression with `| list`, which materializes inside the compiled
+        # expression instead. Both routes must land on JinjaExtractionError.
+        with pytest.raises(
+            JinjaExtractionError, match="'dict object' has no attribute 'tool_calls'"
+        ):
+            extract(
+                "trace | map(attribute='tool_calls.0.function.name') | list",
+                {"trace": [{"content": "no tools"}]},
+            )
 
 
 class TestTrimAndLstripBlocks:

--- a/libs/core/kiln_ai/utils/test_jinja_engine.py
+++ b/libs/core/kiln_ai/utils/test_jinja_engine.py
@@ -173,6 +173,48 @@ class TestExtract:
             extract("{{ invalid", {})
 
 
+class TestExtractOperationsOnMissingData:
+    """Operating on a missing value is an extraction error, not an unhandled raise.
+
+    A single missing lookup returns Undefined, but anything done to that
+    Undefined raises inside Jinja. Callers only handle JinjaExtractionError, so
+    extract() must convert -- while keeping Jinja's message, which names the
+    field that wasn't there.
+    """
+
+    def test_missing_nested_attribute_raises_extraction_error(self):
+        with pytest.raises(
+            JinjaExtractionError, match="'dict object' has no attribute 'user'"
+        ):
+            extract(
+                "(final_message | fromjson).user.status",
+                {"final_message": '{"status": "ok"}'},
+            )
+
+    def test_index_past_end_of_list_raises_extraction_error(self):
+        with pytest.raises(JinjaExtractionError, match="has no element -1"):
+            extract("trace[-1].tool_calls[0].function.name", {"trace": []})
+
+    def test_filter_on_missing_value_raises_extraction_error(self):
+        with pytest.raises(JinjaExtractionError, match="'missing' is undefined"):
+            extract("missing | int", {})
+
+    def test_operator_on_missing_value_raises_extraction_error(self):
+        with pytest.raises(JinjaExtractionError, match="'missing' is undefined"):
+            extract("missing + 1", {})
+
+    def test_missing_top_level_key_still_returns_undefined(self):
+        # Contract unchanged: a bare missing lookup is not an error.
+        assert isinstance(extract("missing", {}), Undefined)
+
+    def test_valid_nested_expression_still_extracts(self):
+        result = extract(
+            "(final_message | fromjson).user.status",
+            {"final_message": '{"user": {"status": "active"}}'},
+        )
+        assert result == "active"
+
+
 class TestTrimAndLstripBlocks:
     def test_trim_blocks_strips_newline_after_block_tag(self):
         template = "{% if True %}\nyes\n{% endif %}"

--- a/libs/core/kiln_ai/utils/test_jinja_engine.py
+++ b/libs/core/kiln_ai/utils/test_jinja_engine.py
@@ -7,6 +7,7 @@ from kiln_ai.utils.jinja_engine import (
     JinjaExtractionError,
     compile_expression_or_raise,
     compile_template_or_raise,
+    expression_variables,
     extract,
     render_input_transform,
 )
@@ -171,6 +172,31 @@ class TestExtract:
     def test_malformed_expression_raises_value_error(self):
         with pytest.raises(ValueError, match="Invalid Jinja2 expression"):
             extract("{{ invalid", {})
+
+
+class TestExpressionVariables:
+    @pytest.mark.parametrize(
+        "expression,expected",
+        [
+            # A bare expression has no {{ }} of its own, so it only reports
+            # variables once the function wraps it.
+            ("final_message", {"final_message"}),
+            ("final_message.strip()", {"final_message"}),
+            ("(final_message | fromjson).user.status", {"final_message"}),
+            ("trace | map(attribute='x') | list", {"trace"}),
+            ("outpt.status", {"outpt"}),
+            # Delimiters inside a string literal are lexed as text, not as the
+            # end of the wrapper block.
+            ('final_message ~ "}}"', {"final_message"}),
+            ("'literal'", set()),
+        ],
+    )
+    def test_reports_referenced_variables(self, expression, expected):
+        assert expression_variables(expression) == expected
+
+    def test_syntax_error_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid Jinja2 expression"):
+            expression_variables("final_message[")
 
 
 class TestExtractOperationsOnMissingData:


### PR DESCRIPTION
## What does this PR do?

In the deterministic judges (Exact Match, Contains, Pattern Match, Set Check), an Output to Check expression that reaches into a missing nested field crashed the run instead of scoring Fail.

Before: `(final_message | fromjson).user.status` against JSON with no "user" shows "Unexpected error: 'dict object' has no attribute 'user'". Same for `trace[-1].tool_calls[0].function.name` on an empty trace. Both are canned examples in the dialog. A missing top-level field already scored Fail, so behavior depended on how deep the expression reached.

After: those items score Fail — the model didn't produce the structure the check asked for. Runs with no trace still skip as missing_trace. And because missing fields now fail quietly, saving a judge validates the expression's variables (final_message, trace, task_input, reference_data), so a typo like `outpt.status` is rejected at save with a clear message instead of silently scoring 0% forever.

How: the expression engine converts Jinja's UndefinedError into the extraction error the judges already score as Fail, including lazy map/selectattr results. Only the four deterministic judges are affected; the LLM judge and input transforms use different code paths.

Two judgment calls for review: an empty trace (as opposed to no trace) scores Fail — flip to skip is a two-line change if preferred. The variable check runs on save only; configs saved before it still load.

Out of scope, noted as follow-ups: Fail results don't say which field was missing; TypeError and ZeroDivisionError from typed expressions still escape raw; references_trace false-positives on a JSON field literally named "trace".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
