### PR TITLE
Prompt optimization: support Evals V2 datasets and configs

### DIFF
--- a/app/desktop/studio_server/prompt_optimization_job_api.py
+++ b/app/desktop/studio_server/prompt_optimization_job_api.py
@@ -14,6 +14,7 @@ from kiln_ai.datamodel import Prompt, PromptOptimizationJob, Task, TaskOutputRat
 from kiln_ai.datamodel.eval import (
     V2_PROPERTY_TYPES,
     Eval,
+    EvalConfig,
     EvalConfigType,
     LlmJudgeProperties,
     V2EvalType,
@@ -91,13 +92,41 @@ _DETERMINISTIC_EVAL_TYPES = {
 }
 
 
+def optimization_unsupported_reason(eval: Eval, config: EvalConfig) -> str | None:
+    """Why the optimization service cannot score this eval, or None if it can.
+
+    The single source of truth for eval-type support: check_eval reports it so
+    the UI marks the eval invalid, and reject_unsupported_evals refuses the job
+    with it, so the two cannot drift apart.
+    """
+    if config.config_type != EvalConfigType.v2:
+        return None
+    props = config.properties
+    if not isinstance(props, V2_PROPERTY_TYPES):
+        return None
+    if props.type in _UNSUPPORTED_OPTIMIZATION_EVAL_TYPES:
+        return (
+            f"Eval '{eval.name}' uses eval type '{props.type.value}', which "
+            "prompt optimization does not support yet."
+        )
+    if props.type in _DETERMINISTIC_EVAL_TYPES and any(
+        score.type != TaskOutputRatingType.pass_fail for score in eval.output_scores
+    ):
+        return (
+            f"Eval '{eval.name}' uses the deterministic eval type "
+            f"'{props.type.value}', which produces pass/fail scores, but has "
+            "output scores that are not pass/fail. Change them to pass/fail "
+            "to use this eval for prompt optimization."
+        )
+    return None
+
+
 def reject_unsupported_evals(task: Task, eval_ids: list[str]) -> None:
     """Refuse a job whose evals the optimization service cannot score.
 
     This runs before the job is submitted (and billed), so a job that would fail
-    the service's own validation fails here first, with the same reasons: eval
-    types the service does not support, and deterministic evals whose output
-    scores are not pass/fail.
+    the service's own validation fails here first, for the same reasons the
+    check_eval endpoint reports (see optimization_unsupported_reason).
 
     Ids that name no eval on the task are left alone: this endpoint does not validate eval
     ids, and this guard is not the place to start.
@@ -111,31 +140,11 @@ def reject_unsupported_evals(task: Task, eval_ids: list[str]) -> None:
             (c for c in eval.configs(readonly=True) if c.id == eval.current_config_id),
             None,
         )
-        if config is None or config.config_type != EvalConfigType.v2:
+        if config is None:
             continue
-        props = config.properties
-        if not isinstance(props, V2_PROPERTY_TYPES):
-            continue
-        if props.type in _UNSUPPORTED_OPTIMIZATION_EVAL_TYPES:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"Eval '{eval.name}' uses eval type '{props.type.value}', which "
-                    "prompt optimization does not support yet."
-                ),
-            )
-        if props.type in _DETERMINISTIC_EVAL_TYPES and any(
-            score.type != TaskOutputRatingType.pass_fail for score in eval.output_scores
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"Eval '{eval.name}' uses the deterministic eval type "
-                    f"'{props.type.value}', which produces pass/fail scores, but has "
-                    "output scores that are not pass/fail. Change them to pass/fail "
-                    "to use this eval for prompt optimization."
-                ),
-            )
+        reason = optimization_unsupported_reason(eval, config)
+        if reason is not None:
+            raise HTTPException(status_code=400, detail=reason)
 
 
 def is_job_status_final(status: str) -> bool:
@@ -175,6 +184,7 @@ class CheckEvalResponse(BaseModel):
     has_default_config: bool
     has_train_set: bool
     model_is_supported: bool
+    unsupported_reason: str | None = None
 
 
 def _get_api_key() -> str:
@@ -531,6 +541,17 @@ def connect_prompt_optimization_job_api(app: FastAPI):
                     has_default_config=False,
                     has_train_set=has_train_split(eval),
                     model_is_supported=False,
+                )
+
+            # The same support rules the submission guard enforces, reported so
+            # the UI marks unsupported evals invalid before submission.
+            unsupported_reason = optimization_unsupported_reason(eval, config)
+            if unsupported_reason is not None:
+                return CheckEvalResponse(
+                    has_default_config=True,
+                    has_train_set=has_train_split(eval),
+                    model_is_supported=False,
+                    unsupported_reason=unsupported_reason,
                 )
 
             # Extract model info from config. Legacy configs carry it at the

--- a/app/desktop/studio_server/prompt_optimization_job_api.py
+++ b/app/desktop/studio_server/prompt_optimization_job_api.py
@@ -38,8 +38,14 @@ from kiln_ai.cli.commands.package_project import (
     PackageForTrainingConfig,
     package_project_for_training,
 )
-from kiln_ai.datamodel import Prompt, PromptOptimizationJob, Task
-from kiln_ai.datamodel.eval import Eval, TaskRunSplit
+from kiln_ai.datamodel import Prompt, PromptOptimizationJob, Task, TaskOutputRatingType
+from kiln_ai.datamodel.eval import (
+    V2_PROPERTY_TYPES,
+    Eval,
+    EvalConfigType,
+    LlmJudgeProperties,
+    V2EvalType,
+)
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.task import TaskRunConfig
 from kiln_ai.utils.config import Config
@@ -55,30 +61,42 @@ from pydantic import BaseModel
 logger = logging.getLogger(__name__)
 
 
-def has_task_run_train_split(eval: Eval) -> bool:
-    """Whether this eval has a train split prompt optimization can actually use.
+def has_train_split(eval: Eval) -> bool:
+    """Whether this eval has a train split.
 
-    The remote optimization service resolves the train filter against the project zip's
-    `runs/` directory, which contains TaskRuns and nothing else, so an EvalInput-backed
-    train split is not usable and reports False rather than an empty set.
+    The optimization service resolves both split types from the project package:
+    TaskRun-backed splits from `runs/` and EvalInput-backed splits from
+    `eval_inputs/`, so any declared train split counts.
     """
-    return isinstance(eval.splits.get("train"), TaskRunSplit)
+    return eval.splits.get("train") is not None
 
 
-def reject_unusable_train_splits(task: Task, eval_ids: list[str]) -> None:
-    """Refuse a job whose evals train on items the remote service cannot read.
+# V2 eval types the optimization service does not support: these need data the
+# service cannot produce (a full conversation trace) or a runtime it does not
+# provide (sandboxed code execution).
+_UNSUPPORTED_OPTIMIZATION_EVAL_TYPES = {
+    V2EvalType.tool_call_check,
+    V2EvalType.step_count_check,
+    V2EvalType.code_eval,
+}
 
-    Phrased as "present but not usable" rather than "is an EvalInputSplit" so a new
-    SplitRef variant is refused by default instead of silently slipping through. The two
-    are equivalent while EvalInputSplit is the only other variant, but the failure mode of
-    the narrower phrasing — optimizing against an empty set — is what the check exists to
-    prevent, and nothing would flag it when the union grows.
+# Deterministic V2 eval types: they produce binary pass/fail scores, so only
+# pass_fail output scores are meaningful for optimization.
+_DETERMINISTIC_EVAL_TYPES = {
+    V2EvalType.exact_match,
+    V2EvalType.pattern_match,
+    V2EvalType.contains,
+    V2EvalType.set_check,
+}
 
-    "Usable" is deferred to has_task_run_train_split rather than re-tested here, so this
-    guard and the has_train_set that check_eval reports cannot drift apart.
 
-    A missing train split is not refused: the UI already gates start on has_train_set, and
-    refusing it here would be a wider behavior change than asked for.
+def reject_unsupported_evals(task: Task, eval_ids: list[str]) -> None:
+    """Refuse a job whose evals the optimization service cannot score.
+
+    This runs before the job is submitted (and billed), so a job that would fail
+    the service's own validation fails here first, with the same reasons: eval
+    types the service does not support, and deterministic evals whose output
+    scores are not pass/fail.
 
     Ids that name no eval on the task are left alone: this endpoint does not validate eval
     ids, and this guard is not the place to start.
@@ -86,16 +104,35 @@ def reject_unusable_train_splits(task: Task, eval_ids: list[str]) -> None:
     evals_by_id = {eval.id: eval for eval in task.evals(readonly=True)}
     for eval_id in eval_ids:
         eval = evals_by_id.get(eval_id)
-        if eval is None:
+        if eval is None or eval.current_config_id is None:
             continue
-        has_train_split = eval.splits.get("train") is not None
-        if has_train_split and not has_task_run_train_split(eval):
+        config = next(
+            (c for c in eval.configs(readonly=True) if c.id == eval.current_config_id),
+            None,
+        )
+        if config is None or config.config_type != EvalConfigType.v2:
+            continue
+        props = config.properties
+        if not isinstance(props, V2_PROPERTY_TYPES):
+            continue
+        if props.type in _UNSUPPORTED_OPTIMIZATION_EVAL_TYPES:
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"Eval '{eval.name}' has a train split that isn't backed by dataset "
-                    "runs. Prompt optimization can only train on dataset runs, so this "
-                    "eval can't be used for prompt optimization."
+                    f"Eval '{eval.name}' uses eval type '{props.type.value}', which "
+                    "prompt optimization does not support yet."
+                ),
+            )
+        if props.type in _DETERMINISTIC_EVAL_TYPES and any(
+            score.type != TaskOutputRatingType.pass_fail for score in eval.output_scores
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Eval '{eval.name}' uses the deterministic eval type "
+                    f"'{props.type.value}', which produces pass/fail scores, but has "
+                    "output scores that are not pass/fail. Change them to pass/fail "
+                    "to use this eval for prompt optimization."
                 ),
             )
 
@@ -479,7 +516,7 @@ def connect_prompt_optimization_job_api(app: FastAPI):
             if not eval.current_config_id:
                 return CheckEvalResponse(
                     has_default_config=False,
-                    has_train_set=has_task_run_train_split(eval),
+                    has_train_set=has_train_split(eval),
                     model_is_supported=False,
                 )
 
@@ -491,18 +528,32 @@ def connect_prompt_optimization_job_api(app: FastAPI):
             except HTTPException:
                 return CheckEvalResponse(
                     has_default_config=False,
-                    has_train_set=has_task_run_train_split(eval),
+                    has_train_set=has_train_split(eval),
                     model_is_supported=False,
                 )
 
-            # Extract model info from config
+            # Extract model info from config. Legacy configs carry it at the
+            # root; V2 LLM-judge configs carry it in their typed properties;
+            # deterministic V2 configs call no model at all, so there is
+            # nothing to check and the model counts as supported.
             model_name = config.model_name
             model_provider = config.model_provider
+            if config.config_type == EvalConfigType.v2:
+                props = config.properties
+                if isinstance(props, LlmJudgeProperties):
+                    model_name = props.model_name
+                    model_provider = props.model_provider
+                else:
+                    return CheckEvalResponse(
+                        has_default_config=True,
+                        has_train_set=has_train_split(eval),
+                        model_is_supported=True,
+                    )
 
             if not model_name or not model_provider:
                 return CheckEvalResponse(
                     has_default_config=True,
-                    has_train_set=has_task_run_train_split(eval),
+                    has_train_set=has_train_split(eval),
                     model_is_supported=False,
                 )
 
@@ -522,7 +573,7 @@ def connect_prompt_optimization_job_api(app: FastAPI):
 
             return CheckEvalResponse(
                 has_default_config=True,
-                has_train_set=has_task_run_train_split(eval),
+                has_train_set=has_train_split(eval),
                 model_is_supported=response.is_model_supported,
             )
 
@@ -560,7 +611,7 @@ def connect_prompt_optimization_job_api(app: FastAPI):
         if not project:
             raise HTTPException(status_code=404, detail="Project not found")
 
-        reject_unusable_train_splits(task, request.eval_ids)
+        reject_unsupported_evals(task, request.eval_ids)
 
         try:
             # Validate the run config doesn't use tools

--- a/app/desktop/studio_server/test_prompt_optimization_job_api.py
+++ b/app/desktop/studio_server/test_prompt_optimization_job_api.py
@@ -3804,3 +3804,79 @@ def test_check_eval_v2_deterministic_needs_no_model(client, mock_api_key, tmp_pa
     assert result["has_train_set"] is True
     assert result["model_is_supported"] is True
     mock_check.assert_not_called()
+
+
+def test_check_eval_v2_unsupported_type_reports_reason(client, mock_api_key, tmp_path):
+    """check_eval reports the same unsupported reason the submission guard
+    refuses with, so the UI marks the eval invalid before submission."""
+    project = Project(name="Test Project", path=tmp_path / "project.kiln")
+    project.save_to_file()
+    task = Task(name="Test Task", instruction="Test instruction", parent=project)
+    task.save_to_file()
+
+    mock_eval = _eval_with_train_split(TaskRunSplit(filter_id="tag::train"))
+    v2_config = EvalConfig(
+        name="v2-tool-call-check",
+        config_type=EvalConfigType.v2,
+        properties=ToolCallCheckProperties(
+            expected_tools=[ToolCallSpec(tool_name="some_tool")]
+        ),
+    )
+
+    with (
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.eval_from_id",
+            return_value=mock_eval,
+        ),
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.eval_config_from_id",
+            return_value=v2_config,
+        ),
+    ):
+        response = client.get(
+            f"/api/projects/{project.id}/tasks/{task.id}/prompt_optimization_jobs/check_eval",
+            params={"eval_id": "test-eval-id"},
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["has_default_config"] is True
+    assert result["model_is_supported"] is False
+    assert "does not support" in result["unsupported_reason"]
+
+
+def test_check_eval_supported_evals_have_no_unsupported_reason(
+    client, mock_api_key, tmp_path
+):
+    """A supported deterministic V2 eval reports no unsupported reason."""
+    project = Project(name="Test Project", path=tmp_path / "project.kiln")
+    project.save_to_file()
+    task = Task(name="Test Task", instruction="Test instruction", parent=project)
+    task.save_to_file()
+
+    mock_eval = _eval_with_train_split(TaskRunSplit(filter_id="tag::train"))
+    v2_config = EvalConfig(
+        name="v2-exact-match",
+        config_type=EvalConfigType.v2,
+        properties=ExactMatchProperties(expected_value="x"),
+    )
+
+    with (
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.eval_from_id",
+            return_value=mock_eval,
+        ),
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.eval_config_from_id",
+            return_value=v2_config,
+        ),
+    ):
+        response = client.get(
+            f"/api/projects/{project.id}/tasks/{task.id}/prompt_optimization_jobs/check_eval",
+            params={"eval_id": "test-eval-id"},
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["model_is_supported"] is True
+    assert result["unsupported_reason"] is None

--- a/app/desktop/studio_server/test_prompt_optimization_job_api.py
+++ b/app/desktop/studio_server/test_prompt_optimization_job_api.py
@@ -41,20 +41,30 @@ from kiln_ai.cli.commands.package_project import PackageForTrainingConfig
 from kiln_ai.datamodel import Project, PromptOptimizationJob, Task
 from kiln_ai.datamodel.datamodel_enums import ModelProviderName, StructuredOutputMode
 from kiln_ai.datamodel.eval import (
+    CodeEvalProperties,
     Eval,
+    EvalConfig,
+    EvalConfigType,
     EvalInputSplit,
     EvalOutputScore,
+    ExactMatchProperties,
+    LlmJudgeProperties,
     SplitRef,
+    StepCountCheckProperties,
     TaskRunSplit,
+    ToolCallCheckProperties,
+    ToolCallSpec,
 )
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.task import TaskRunConfig
 
 
 # Every check_eval return site reports has_train_set, so each is parametrized over the
-# same cases: absent, usable, and present-but-unusable. A site left reading the legacy
-# train_set_filter_id reports False for all three (these evals carry their splits in
-# `splits`, so the legacy field is None in memory), which the True case catches.
+# same cases: absent, TaskRun-backed, and EvalInput-backed. The optimization service
+# resolves both backing stores from the project package, so both present cases report
+# True. A site left reading the legacy train_set_filter_id reports False for all three
+# (these evals carry their splits in `splits`, so the legacy field is None in memory),
+# which the True cases catch.
 #
 # Factories rather than constructed instances: pydantic's default
 # revalidate_instances='never' means `Eval(splits={"train": s})` stores `s` by reference,
@@ -64,7 +74,7 @@ from kiln_ai.datamodel.task import TaskRunConfig
 TRAIN_SPLIT_CASES = [
     (lambda: None, False),
     (lambda: TaskRunSplit(filter_id="tag::train"), True),
-    (lambda: EvalInputSplit(filter_id="tag::train"), False),
+    (lambda: EvalInputSplit(filter_id="tag::train"), True),
 ]
 
 
@@ -1888,19 +1898,101 @@ def test_check_eval_has_train_set_by_split_backing(
         assert result["model_is_supported"] is True
 
 
+def _attach_eval_config(eval: Eval, **config_kwargs) -> EvalConfig:
+    """Attach a saved EvalConfig to an eval and mark it current."""
+    config = EvalConfig(name="cfg", parent=eval, **config_kwargs)
+    config.save_to_file()
+    eval.current_config_id = config.id
+    eval.save_to_file()
+    return config
+
+
+# (description, config_kwargs factory, expected status, expected message fragment)
+UNSUPPORTED_EVAL_CASES = [
+    (
+        "tool_call_check",
+        lambda: {
+            "config_type": EvalConfigType.v2,
+            "properties": ToolCallCheckProperties(
+                expected_tools=[ToolCallSpec(tool_name="some_tool")]
+            ),
+        },
+        400,
+        "does not support",
+    ),
+    (
+        "step_count_check",
+        lambda: {
+            "config_type": EvalConfigType.v2,
+            "properties": StepCountCheckProperties(
+                count_type="tool_calls", max_count=3
+            ),
+        },
+        400,
+        "does not support",
+    ),
+    (
+        "code_eval",
+        lambda: {
+            "config_type": EvalConfigType.v2,
+            "properties": CodeEvalProperties(
+                code="def score(output):\n    return {}\n"
+            ),
+        },
+        400,
+        "does not support",
+    ),
+    (
+        "exact_match_pass_fail",
+        lambda: {
+            "config_type": EvalConfigType.v2,
+            "properties": ExactMatchProperties(expected_value="x"),
+        },
+        200,
+        None,
+    ),
+    (
+        "llm_judge",
+        lambda: {
+            "config_type": EvalConfigType.v2,
+            "properties": LlmJudgeProperties(
+                model_name="gpt-4o",
+                model_provider="openai",
+                prompt_template="Judge {{ final_message }}",
+            ),
+        },
+        200,
+        None,
+    ),
+    (
+        "legacy_g_eval",
+        lambda: {
+            "config_type": EvalConfigType.g_eval,
+            "model_name": "gpt-4o",
+            "model_provider": "openai",
+            "properties": {"eval_steps": ["Check it."]},
+        },
+        200,
+        None,
+    ),
+]
+
+
 @pytest.mark.parametrize(
-    "train_split_factory,expected_status",
-    [
-        (lambda: EvalInputSplit(filter_id="tag::train"), 400),
-        (lambda: TaskRunSplit(filter_id="tag::train"), 200),
-        # Unchanged behavior: an eval with no train split is not this guard's business.
-        (lambda: None, 200),
-    ],
+    "case_name,config_kwargs_factory,expected_status,expected_fragment",
+    UNSUPPORTED_EVAL_CASES,
+    ids=[case[0] for case in UNSUPPORTED_EVAL_CASES],
 )
-def test_start_prompt_optimization_job_refuses_unusable_train_splits(
-    client, mock_api_key, tmp_path, train_split_factory, expected_status
+def test_start_prompt_optimization_job_refuses_unsupported_evals(
+    client,
+    mock_api_key,
+    tmp_path,
+    case_name,
+    config_kwargs_factory,
+    expected_status,
+    expected_fragment,
 ):
-    """Only a present, non-TaskRun train split is refused, and before any work happens."""
+    """Eval types the optimization service cannot score are refused before any work happens."""
     project = Project(name="Test Project", path=tmp_path / "project.kiln")
     project.save_to_file()
     task = Task(
@@ -1910,8 +2002,9 @@ def test_start_prompt_optimization_job_refuses_unusable_train_splits(
     )
     task.save_to_file()
 
-    eval = _eval_with_train_split(train_split_factory(), parent=task)
+    eval = _eval_with_train_split(TaskRunSplit(filter_id="tag::train"), parent=task)
     eval.save_to_file()
+    _attach_eval_config(eval, **config_kwargs_factory())
 
     mock_run_config = MagicMock()
     mock_run_config.run_config_properties = MagicMock(spec=KilnAgentRunConfigProperties)
@@ -1950,12 +2043,110 @@ def test_start_prompt_optimization_job_refuses_unusable_train_splits(
     if expected_status == 400:
         message = response.json()["message"]
         assert "Test Eval" in message
-        assert "train split that isn't backed by dataset runs" in message
+        assert expected_fragment in message
         # Nothing was packaged, uploaded or recorded before the refusal
         mock_package.assert_not_called()
         assert task.prompt_optimization_jobs() == []
     else:
         assert len(task.prompt_optimization_jobs()) == 1
+
+
+def test_start_prompt_optimization_job_refuses_non_pass_fail_deterministic_eval(
+    client, mock_api_key, tmp_path
+):
+    """A deterministic eval with non-pass_fail output scores is refused."""
+    project = Project(name="Test Project", path=tmp_path / "project.kiln")
+    project.save_to_file()
+    task = Task(name="Test Task", instruction="Test instruction", parent=project)
+    task.save_to_file()
+
+    eval = Eval(
+        name="Five Star Deterministic",
+        splits={
+            "test": TaskRunSplit(filter_id="tag::eval_set"),
+            "train": TaskRunSplit(filter_id="tag::train"),
+        },
+        output_scores=[
+            EvalOutputScore(name="quality", type="five_star", instruction="Rate it.")
+        ],
+        parent=task,
+    )
+    eval.save_to_file()
+    _attach_eval_config(
+        eval,
+        config_type=EvalConfigType.v2,
+        properties=ExactMatchProperties(expected_value="x"),
+    )
+
+    with patch(
+        "app.desktop.studio_server.prompt_optimization_job_api.task_from_id",
+        return_value=task,
+    ):
+        response = client.post(
+            f"/api/projects/{project.id}/tasks/{task.id}/prompt_optimization_jobs/start",
+            json={
+                "target_run_config_id": "test-run-config-id",
+                "eval_ids": [eval.id],
+            },
+        )
+
+    assert response.status_code == 400
+    assert "not pass/fail" in response.json()["message"]
+
+
+def test_start_prompt_optimization_job_accepts_eval_input_train_split(
+    client, mock_api_key, tmp_path
+):
+    """An EvalInput-backed train split is no longer refused: the optimization
+    service resolves eval inputs from the project package."""
+    project = Project(name="Test Project", path=tmp_path / "project.kiln")
+    project.save_to_file()
+    task = Task(name="Test Task", instruction="Test instruction", parent=project)
+    task.save_to_file()
+
+    eval = _eval_with_train_split(EvalInputSplit(filter_id="tag::train"), parent=task)
+    eval.save_to_file()
+    _attach_eval_config(
+        eval,
+        config_type=EvalConfigType.v2,
+        properties=ExactMatchProperties(reference_key="expected"),
+    )
+
+    mock_run_config = MagicMock()
+    mock_run_config.run_config_properties = MagicMock(spec=KilnAgentRunConfigProperties)
+    mock_run_config.run_config_properties.tools_config = None
+
+    with (
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.task_from_id",
+            return_value=task,
+        ),
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.task_run_config_from_id",
+            return_value=mock_run_config,
+        ),
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.package_project_for_training",
+            side_effect=_mock_package_project_for_training,
+        ),
+        patch(
+            "app.desktop.studio_server.api_client.kiln_ai_server_client.api.jobs.start_prompt_optimization_job_v1_jobs_prompt_optimization_job_start_post.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=_make_sdk_response(
+                parsed=JobStartResponse(job_id="remote-job-123")
+            ),
+        ),
+    ):
+        response = client.post(
+            f"/api/projects/{project.id}/tasks/{task.id}/prompt_optimization_jobs/start",
+            json={
+                "target_run_config_id": "test-run-config-id",
+                "eval_ids": [eval.id],
+            },
+        )
+
+    assert response.status_code == 200
+    assert len(task.prompt_optimization_jobs()) == 1
 
 
 def test_start_prompt_optimization_job_ignores_unrequested_evals(
@@ -1977,9 +2168,16 @@ def test_start_prompt_optimization_job_ignores_unrequested_evals(
     task.save_to_file()
 
     refusable_eval = _eval_with_train_split(
-        EvalInputSplit(filter_id="tag::train"), parent=task
+        TaskRunSplit(filter_id="tag::train"), parent=task
     )
     refusable_eval.save_to_file()
+    _attach_eval_config(
+        refusable_eval,
+        config_type=EvalConfigType.v2,
+        properties=ToolCallCheckProperties(
+            expected_tools=[ToolCallSpec(tool_name="some_tool")]
+        ),
+    )
 
     mock_run_config = MagicMock()
     mock_run_config.run_config_properties = MagicMock(spec=KilnAgentRunConfigProperties)
@@ -3516,3 +3714,93 @@ def test_update_prompt_optimization_job_pending_to_running_no_artifacts(
     assert updated_job.created_prompt_id is None
     assert updated_job.created_run_config_id is None
     assert updated_job.optimized_prompt is None
+
+
+def test_check_eval_v2_llm_judge_uses_properties_model(client, mock_api_key, tmp_path):
+    """For a V2 LLM-judge config, the model check uses the model from the typed
+    properties (the config root fields are None for V2)."""
+    project = Project(name="Test Project", path=tmp_path / "project.kiln")
+    project.save_to_file()
+    task = Task(name="Test Task", instruction="Test instruction", parent=project)
+    task.save_to_file()
+
+    mock_eval = _eval_with_train_split(TaskRunSplit(filter_id="tag::train"))
+    v2_config = EvalConfig(
+        name="v2-judge",
+        config_type=EvalConfigType.v2,
+        properties=LlmJudgeProperties(
+            model_name="gpt-4o",
+            model_provider="openai",
+            prompt_template="Judge {{ final_message }}",
+        ),
+    )
+
+    with (
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.eval_from_id",
+            return_value=mock_eval,
+        ),
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.eval_config_from_id",
+            return_value=v2_config,
+        ),
+        patch(
+            "app.desktop.studio_server.api_client.kiln_ai_server_client.api.jobs.check_prompt_optimization_model_supported_v1_jobs_prompt_optimization_job_check_model_supported_get.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=_make_sdk_response(parsed=MagicMock(is_model_supported=True)),
+        ) as mock_check,
+    ):
+        response = client.get(
+            f"/api/projects/{project.id}/tasks/{task.id}/prompt_optimization_jobs/check_eval",
+            params={"eval_id": "test-eval-id"},
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["has_default_config"] is True
+    assert result["has_train_set"] is True
+    assert result["model_is_supported"] is True
+    assert mock_check.call_args.kwargs["model_name"] == "gpt-4o"
+    assert mock_check.call_args.kwargs["model_provider_name"] == "openai"
+
+
+def test_check_eval_v2_deterministic_needs_no_model(client, mock_api_key, tmp_path):
+    """A deterministic V2 config calls no model, so the model counts as
+    supported and no server model check is made."""
+    project = Project(name="Test Project", path=tmp_path / "project.kiln")
+    project.save_to_file()
+    task = Task(name="Test Task", instruction="Test instruction", parent=project)
+    task.save_to_file()
+
+    mock_eval = _eval_with_train_split(TaskRunSplit(filter_id="tag::train"))
+    v2_config = EvalConfig(
+        name="v2-exact-match",
+        config_type=EvalConfigType.v2,
+        properties=ExactMatchProperties(expected_value="x"),
+    )
+
+    with (
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.eval_from_id",
+            return_value=mock_eval,
+        ),
+        patch(
+            "app.desktop.studio_server.prompt_optimization_job_api.eval_config_from_id",
+            return_value=v2_config,
+        ),
+        patch(
+            "app.desktop.studio_server.api_client.kiln_ai_server_client.api.jobs.check_prompt_optimization_model_supported_v1_jobs_prompt_optimization_job_check_model_supported_get.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_check,
+    ):
+        response = client.get(
+            f"/api/projects/{project.id}/tasks/{task.id}/prompt_optimization_jobs/check_eval",
+            params={"eval_id": "test-eval-id"},
+        )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["has_default_config"] is True
+    assert result["has_train_set"] is True
+    assert result["model_is_supported"] is True
+    mock_check.assert_not_called()

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -4662,6 +4662,8 @@ export interface components {
             has_train_set: boolean;
             /** Model Is Supported */
             model_is_supported: boolean;
+            /** Unsupported Reason */
+            unsupported_reason?: string | null;
         };
         /**
          * CheckRunConfigResponse

--- a/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/create_prompt_optimization_job/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/create_prompt_optimization_job/+page.svelte
@@ -517,10 +517,10 @@
         evals_with_configs[index].has_train_set = data.has_train_set
         evals_with_configs[index].model_is_supported = data.model_is_supported
 
-        // If has train set, fetch the size. has_train_set is already
-        // TaskRun-backed-only (the remote optimizer resolves the train filter over the
-        // project zip's runs/), so the filter id read here has to be too, or the two
-        // disagree and the size fetch is silently skipped.
+        // If has train set, fetch the size. The size fetch reads tag counts over
+        // dataset runs, so it only applies to TaskRun-backed train splits. For an
+        // EvalInput-backed train split (now valid for optimization) the size stays
+        // unknown (null) and the empty-set error below does not apply.
         const train_filter_id = task_run_split_filter_id(item.eval, "train")
         if (data.has_train_set && train_filter_id) {
           const train_tag = tagFromFilterId(train_filter_id)

--- a/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/create_prompt_optimization_job/+page.svelte
+++ b/app/web_ui/src/routes/(app)/prompt_optimization/[project_id]/[task_id]/create_prompt_optimization_job/+page.svelte
@@ -516,6 +516,14 @@
         evals_with_configs[index].has_default_config = data.has_default_config
         evals_with_configs[index].has_train_set = data.has_train_set
         evals_with_configs[index].model_is_supported = data.model_is_supported
+        if (data.unsupported_reason) {
+          evals_with_configs[index].other_error = data.unsupported_reason
+        }
+
+        // Reset before the conditional size fetch below: a stale count from a
+        // previous TaskRun-backed split must not survive a switch to an
+        // EvalInput-backed split, where the size is unknown.
+        evals_with_configs[index].train_set_size = null
 
         // If has train set, fetch the size. The size fetch reads tag counts over
         // dataset runs, so it only applies to TaskRun-backed train splits. For an
@@ -565,7 +573,8 @@
 
         const has_errors =
           evals_with_configs[index].judge_error !== null ||
-          evals_with_configs[index].train_error !== null
+          evals_with_configs[index].train_error !== null ||
+          evals_with_configs[index].other_error !== null
         evals_with_configs[index].validation_status = has_errors
           ? "invalid"
           : "valid"

--- a/libs/core/kiln_ai/cli/commands/package_project.py
+++ b/libs/core/kiln_ai/cli/commands/package_project.py
@@ -995,6 +995,29 @@ def export_task_runs(task: Task, exported_task: Task) -> None:
     shutil.copytree(source_runs_dir, dest_runs_dir)
 
 
+def export_eval_inputs(task: Task, exported_task: Task) -> None:
+    """Copy the eval_inputs/ directory from the source task to the exported task.
+
+    Eval inputs are the dataset items behind EvalInput-backed eval splits, so a
+    package that carries evals must carry them for those splits to resolve.
+
+    Args:
+        task: The source task containing the eval inputs
+        exported_task: The exported task to copy eval inputs into
+    """
+    if task.path is None:
+        raise ValueError(f"Task '{task.name}' path is not set")
+    if exported_task.path is None:
+        raise ValueError("Exported task path is not set")
+
+    source_eval_inputs_dir = task.path.parent / "eval_inputs"
+    if not source_eval_inputs_dir.exists() or not source_eval_inputs_dir.is_dir():
+        return
+
+    dest_eval_inputs_dir = exported_task.path.parent / "eval_inputs"
+    shutil.copytree(source_eval_inputs_dir, dest_eval_inputs_dir)
+
+
 def _get_run_config_by_id(task: Task, run_config_id: str) -> TaskRunConfig:
     """Look up a run config by ID from a task's run configs.
 
@@ -1084,6 +1107,10 @@ def package_project_for_training(
             for task in validated_tasks:
                 exported_task = exported_tasks[task.id]  # type: ignore
                 export_task_runs(task, exported_task)
+
+        for task in validated_tasks:
+            exported_task = exported_tasks[task.id]  # type: ignore
+            export_eval_inputs(task, exported_task)
 
         if config.include_documents:
             export_documents(project, exported_project)

--- a/libs/core/kiln_ai/cli/commands/test_package_project.py
+++ b/libs/core/kiln_ai/cli/commands/test_package_project.py
@@ -51,6 +51,7 @@ from .package_project import (
     create_export_directory,
     create_zip,
     export_documents,
+    export_eval_inputs,
     export_evals,
     export_skills,
     export_task,
@@ -2239,6 +2240,83 @@ class TestExportTaskRuns:
 
         dest_runs_dir = exported_task.path.parent / "runs"
         assert not dest_runs_dir.exists()
+
+
+class TestExportEvalInputs:
+    def test_copies_eval_inputs_directory(
+        self, temp_project_with_evals, tmp_path: Path
+    ):
+        from kiln_ai.datamodel.eval import (
+            EvalInput,
+            SingleTurnEvalInputData,
+            UserMessage,
+        )
+
+        source = temp_project_with_evals
+        eval_input = EvalInput(
+            parent=source["task"],
+            data=SingleTurnEvalInputData(user_message=UserMessage(text="hello")),
+            reference={"expected": "HELLO"},
+            tags=["train_tag"],
+        )
+        eval_input.save_to_file()
+
+        _, exported_project = create_export_directory(source["project"])
+        exported_task, _ = export_task(
+            source["task"], source["run_config"], exported_project
+        )
+
+        export_eval_inputs(source["task"], exported_task)
+
+        dest_dir = exported_task.path.parent / "eval_inputs"
+        assert dest_dir.exists()
+        eval_input_files = list(dest_dir.rglob("*.kiln"))
+        assert len(eval_input_files) == 1
+        reloaded = EvalInput.load_from_file(eval_input_files[0])
+        assert reloaded.reference == {"expected": "HELLO"}
+        assert reloaded.tags == ["train_tag"]
+
+    def test_noop_when_no_eval_inputs_directory(self, temp_project, tmp_path: Path):
+        source = temp_project
+        _, exported_project = create_export_directory(source["project"])
+        exported_task, _ = export_task(
+            source["task"], source["run_config"], exported_project
+        )
+
+        export_eval_inputs(source["task"], exported_task)
+
+        dest_dir = exported_task.path.parent / "eval_inputs"
+        assert not dest_dir.exists()
+
+    def test_package_project_for_training_includes_eval_inputs(
+        self, temp_project_with_evals, tmp_path: Path
+    ):
+        from kiln_ai.datamodel.eval import (
+            EvalInput,
+            SingleTurnEvalInputData,
+            UserMessage,
+        )
+
+        source = temp_project_with_evals
+        eval_input = EvalInput(
+            parent=source["task"],
+            data=SingleTurnEvalInputData(user_message=UserMessage(text="hello")),
+        )
+        eval_input.save_to_file()
+
+        output_path = tmp_path / "output" / "with_eval_inputs.zip"
+        package_project_for_training(
+            project=source["project"],
+            task_ids=[source["task"].id],
+            run_config_id=source["run_config"].id,
+            eval_ids=[],
+            output=output_path,
+        )
+
+        import zipfile as _zipfile
+
+        with _zipfile.ZipFile(output_path) as zf:
+            assert any("eval_inputs" in name for name in zf.namelist())
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this does

This PR makes prompt optimization work with Evals V2. It targets the Evals V2 branch (#1695) and changes three areas: project packaging, submission checks, and the eval pre-check.

## Changes

### 1. Package `eval_inputs/` into the project zip

`package_project_for_training` now copies each task's `eval_inputs/` directory (new `export_eval_inputs`, mirroring `export_task_runs`). Eval inputs are the dataset items behind `EvalInput`-backed eval splits. Without them in the package, those splits resolve to zero items in the optimization service.

### 2. Accept `EvalInput`-backed train splits at submission

The old guard (`reject_unusable_train_splits`) refused any train split that was not backed by dataset runs, because the packaged project did not carry eval inputs. With change 1, the optimization service can resolve both split types, so:

- `has_train_set` in `check_eval` now reports true for any declared train split.
- The submission-time refusal of `EvalInput`-backed train splits is removed.

### 3. Refuse unsupported evals before submission (and billing)

A new guard (`reject_unsupported_evals`) refuses, with a clear message and before the job is submitted:

- Evals whose current config uses a V2 type the optimization service does not support: `tool_call_check`, `step_count_check` (they need a full conversation trace), and `code_eval` (not supported yet).
- Deterministic V2 evals (`exact_match`, `pattern_match`, `contains`, `set_check`) whose output scores are not pass/fail. These eval types produce binary pass/fail scores, so other score types cannot be scored correctly.

The optimization service refuses the same configurations on its side; this guard fails first so the user does not submit (and get billed for) a job that will fail.

### 4. `check_eval`: correct model check for V2 configs

`check_eval` read the judge model from `config.model_name` / `config.model_provider`. V2 configs keep these root fields empty, so every V2 eval reported `model_is_supported: false`. Now:

- V2 `llm_judge` configs: the model comes from the typed properties.
- Deterministic V2 configs: they call no model, so the model check passes without a server round trip.

### 5. UI comment update

The train-set size fetch in the job-creation page only applies to run-backed splits; the comment now says so. For an `EvalInput`-backed split the size shows as unknown, with no false "empty training set" error. (A size count for eval-input splits can come later.)

## Tests

- New packaging tests: `export_eval_inputs` copies the directory, is a no-op without one, and `package_project_for_training` includes it in the zip.
- Submission guard tests rewritten: each unsupported V2 type is refused with the right message before packaging; supported V2 and legacy configs pass; `EvalInput`-backed train splits submit; a deterministic eval with a five-star score is refused.
- `check_eval` tests: V2 `llm_judge` model comes from properties; deterministic V2 evals pass the model check with no server call; `has_train_set` cases updated.
- Full test files pass: 113 (packaging) + 91 (desktop API).

## Verified end to end

Sanity-checked against the optimization service with small local projects: reference-based V2 evals on `EvalInput` datasets fail to resolve with the old packaging and run correctly with this change; deterministic and LLM-judge V2 evals, and legacy evals, run correctly; the refused eval types fail fast with clear errors.
