### PR TITLE
Copilot clarify_spec: tolerate providers newer than the generated server client

### DIFF
--- a/app/desktop/studio_server/copilot_api.py
+++ b/app/desktop/studio_server/copilot_api.py
@@ -56,6 +56,9 @@ from app.desktop.studio_server.api_client.kiln_ai_server_client.models import (
     RefineSpecInput,
 )
 from app.desktop.studio_server.api_client.kiln_ai_server_client.models import (
+    ModelProviderName as ServerModelProviderName,
+)
+from app.desktop.studio_server.api_client.kiln_ai_server_client.models import (
     QuestionSet as QuestionSetServerApi,
 )
 from app.desktop.studio_server.api_client.kiln_ai_server_client.models import (
@@ -407,7 +410,21 @@ def connect_copilot_api(app: FastAPI):
         api_key = get_copilot_api_key()
         client = get_authenticated_client(api_key)
 
-        clarify_input = ClarifySpecInput.from_dict(input.model_dump())
+        # The generated server client's ModelProviderName enum is a snapshot of
+        # the server's API, so it can lag behind the core enum. Send only the
+        # providers it knows rather than failing the whole request.
+        supported_provider_values = {p.value for p in ServerModelProviderName}
+        input_dict = input.model_dump()
+        input_dict["providers"] = [
+            p for p in input.providers if p.value in supported_provider_values
+        ]
+        if not input_dict["providers"]:
+            raise HTTPException(
+                status_code=422,
+                detail="None of your connected model providers are supported for spec clarification. Updating Kiln may resolve this.",
+            )
+
+        clarify_input = ClarifySpecInput.from_dict(input_dict)
 
         detailed_result = (
             await clarify_spec_v1_copilot_clarify_spec_post.asyncio_detailed(

--- a/app/desktop/studio_server/test_copilot_api.py
+++ b/app/desktop/studio_server/test_copilot_api.py
@@ -35,6 +35,9 @@ from app.desktop.studio_server.api_client.kiln_ai_server_client.models.job_statu
 from app.desktop.studio_server.api_client.kiln_ai_server_client.models.job_type import (
     JobType,
 )
+from app.desktop.studio_server.api_client.kiln_ai_server_client.models.model_provider_name import (
+    ModelProviderName as ServerModelProviderName,
+)
 from app.desktop.studio_server.api_client.kiln_ai_server_client.models.refine_spec_api_output import (
     RefineSpecApiOutput,
 )
@@ -82,6 +85,51 @@ def clarify_spec_input():
         "providers": ["openai"],
         "num_exemplars": 10,
     }
+
+
+@pytest.fixture
+def clarify_spec_mock_output():
+    mock_output = MagicMock(spec=ClarifySpecOutput)
+    mock_output.to_dict.return_value = {
+        "examples_for_feedback": [
+            {
+                "input": "test input",
+                "output": "test output",
+                "fails_specification": False,
+            }
+        ],
+        "judge_result": {
+            "task_metadata": {
+                "model_name": "gpt-4",
+                "model_provider_name": "openai",
+            },
+            "prompt": "Test judge prompt",
+        },
+        "sdg_session_config": {
+            "topic_generation_config": {
+                "task_metadata": {
+                    "model_name": "gpt-4",
+                    "model_provider_name": "openai",
+                },
+                "prompt": "Test topic generation prompt",
+            },
+            "input_generation_config": {
+                "task_metadata": {
+                    "model_name": "gpt-4",
+                    "model_provider_name": "openai",
+                },
+                "prompt": "Test input generation prompt",
+            },
+            "output_generation_config": {
+                "task_metadata": {
+                    "model_name": "gpt-4",
+                    "model_provider_name": "openai",
+                },
+                "prompt": "Test output generation prompt",
+            },
+        },
+    }
+    return mock_output
 
 
 @pytest.fixture
@@ -212,6 +260,42 @@ class TestClarifySpec:
             result = response.json()
             assert "examples_for_feedback" in result
             assert result["judge_result"]["task_metadata"]["model_name"] == "gpt-4"
+
+    def test_clarify_spec_drops_providers_unknown_to_server_client(
+        self, client, clarify_spec_input, clarify_spec_mock_output, mock_api_key
+    ):
+        # Providers can exist in the core enum before the generated server
+        # client's snapshot of it knows them (e.g. featherless_ai). They should
+        # be dropped from the request, not fail it.
+        clarify_spec_input["providers"] = ["openai", "featherless_ai"]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.parsed = clarify_spec_mock_output
+
+        with patch(
+            "app.desktop.studio_server.copilot_api.clarify_spec_v1_copilot_clarify_spec_post.asyncio_detailed",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_call:
+            response = client.post("/api/copilot/clarify_spec", json=clarify_spec_input)
+            assert response.status_code == 200
+            sent_body = mock_call.call_args.kwargs["body"]
+            assert sent_body.providers == [ServerModelProviderName.OPENAI]
+
+    def test_clarify_spec_no_supported_providers_returns_422(
+        self, client, clarify_spec_input, mock_api_key
+    ):
+        clarify_spec_input["providers"] = ["featherless_ai"]
+
+        with patch(
+            "app.desktop.studio_server.copilot_api.clarify_spec_v1_copilot_clarify_spec_post.asyncio_detailed",
+            new_callable=AsyncMock,
+        ) as mock_call:
+            response = client.post("/api/copilot/clarify_spec", json=clarify_spec_input)
+            assert response.status_code == 422
+            assert "providers" in response.json()["message"]
+            mock_call.assert_not_called()
 
     def test_clarify_spec_no_response(self, client, clarify_spec_input, mock_api_key):
         mock_response = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Fixes a 500 in `/api/copilot/clarify_spec` for any user with a Featherless AI key configured.

**The bug:** the vendored `kiln_ai_server_client`'s `ModelProviderName` enum is a snapshot of the remote server's OpenAPI spec, so it lags behind the core enum whenever a new provider lands (currently `featherless_ai`, added in #1618). The spec builder sends *every* connected provider, and `ClarifySpecInput.from_dict` constructs the client enum for each one — so a single unknown provider raised an unhandled `ValueError` and 500'd the request before it ever left the machine. Providers count as connected even with zero models in the model list (an API key alone is enough), so this bites on current `main` regardless of #1680's rollback, and the client release that #1682 is gated on would ship it.

**The fix:** filter the providers list down to values the generated client knows before marshalling, and return a clear 422 if nothing survives (instead of an opaque failure). This permanently converts "core enum grew a provider before the client snapshot did" from a 500 into graceful degradation — the unknown provider just isn't offered to the server for generation.

**Not in scope:** regenerating the vendored client once the remote service's spec includes `featherless_ai` — that's what actually lets Featherless participate in copilot generation, and should happen as part of the Featherless enablement (#1682) checklist.

## Testing

- New test reproduces the production traceback red→green on the real code path: `clarify_spec` with `providers: ["openai", "featherless_ai"]` previously raised `ValueError: <ModelProviderName.featherless_ai: 'featherless_ai'> is not a valid ModelProviderName`; now returns 200 and the marshalled body contains only `openai`.
- New test: all providers unknown → 422 with a clear message, remote never called.
- Full `test_copilot_api.py` passes (51 tests); ruff check/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)