### PR TITLE
Regenerate server API client (ships after v1.1.1)

### DIFF
--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/__init__.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/__init__.py
@@ -132,6 +132,7 @@ from .task_run_intermediate_outputs_type_0 import TaskRunIntermediateOutputsType
 from .tools_run_config import ToolsRunConfig
 from .usage import Usage
 from .validation_error import ValidationError
+from .validation_error_context import ValidationErrorContext
 
 __all__ = (
     "AnswerOption",
@@ -254,4 +255,5 @@ __all__ = (
     "ToolsRunConfig",
     "Usage",
     "ValidationError",
+    "ValidationErrorContext",
 )

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/validation_error.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/validation_error.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.validation_error_context import ValidationErrorContext
+
 
 T = TypeVar("T", bound="ValidationError")
 
@@ -16,11 +22,15 @@ class ValidationError:
         loc (list[int | str]):
         msg (str):
         type_ (str):
+        input_ (Any | Unset):
+        ctx (ValidationErrorContext | Unset):
     """
 
     loc: list[int | str]
     msg: str
     type_: str
+    input_: Any | Unset = UNSET
+    ctx: ValidationErrorContext | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -34,6 +44,12 @@ class ValidationError:
 
         type_ = self.type_
 
+        input_ = self.input_
+
+        ctx: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.ctx, Unset):
+            ctx = self.ctx.to_dict()
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -43,11 +59,17 @@ class ValidationError:
                 "type": type_,
             }
         )
+        if input_ is not UNSET:
+            field_dict["input"] = input_
+        if ctx is not UNSET:
+            field_dict["ctx"] = ctx
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.validation_error_context import ValidationErrorContext
+
         d = dict(src_dict)
         loc = []
         _loc = d.pop("loc")
@@ -64,10 +86,21 @@ class ValidationError:
 
         type_ = d.pop("type")
 
+        input_ = d.pop("input", UNSET)
+
+        _ctx = d.pop("ctx", UNSET)
+        ctx: ValidationErrorContext | Unset
+        if isinstance(_ctx, Unset):
+            ctx = UNSET
+        else:
+            ctx = ValidationErrorContext.from_dict(_ctx)
+
         validation_error = cls(
             loc=loc,
             msg=msg,
             type_=type_,
+            input_=input_,
+            ctx=ctx,
         )
 
         validation_error.additional_properties = d

--- a/app/desktop/studio_server/api_client/kiln_ai_server_client/models/validation_error_context.py
+++ b/app/desktop/studio_server/api_client/kiln_ai_server_client/models/validation_error_context.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ValidationErrorContext")
+
+
+@_attrs_define
+class ValidationErrorContext:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        validation_error_context = cls()
+
+        validation_error_context.additional_properties = d
+        return validation_error_context
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties


### PR DESCRIPTION
## What does this PR do?

Regenerates the vendored server API client from kiln_server main.

The only drift is the 422 error schema. `ValidationError` gains optional `input` and `ctx` fields, plus the `ValidationErrorContext` model that backs `ctx`. Everything else in the package is byte-identical to what was committed. The previously committed client was generated against a server running an older FastAPI; kiln_server main is on FastAPI 0.136.3, which adds those two fields to the validation error schema.

No behavior change, so this ships after v1.1.1 rather than blocking it. Both fields are optional, nothing in the desktop reads them, and the committed client already routes unknown keys into `additional_properties`, so it parses the richer 422 bodies either way. The client changes that actually mattered (providers as a plain string list, and the `featherless_ai` enum value) already went out in Kiln PR #1714 "Update SDK, more flexible provider list".

Generated with the fixed `utils/generate_python_sdk.sh` from kiln_server PR #280 "Fix generate_python_sdk.sh: restore File typing for binary uploads (KIL-796)", which restores `File` typing for binary uploads. Confirmed reproducible: two generations, one on an alternate port and one verbatim on the stock script, produced byte-identical output. `project_zip: File` is preserved.

## Checklists

- [X] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib (n/a, generated code)

Ran the CI steps locally: `ruff check`, `ruff format --check .`, `ty check`, `pytest --runslow .`, and `uv build` in libs/core. All green except `test_mcp_adapter_hooks_mcp_integration`, which fails identically on unmodified main on this machine because it spawns an external MCP subprocess.