### PR TITLE
Fix blank Custom API key breaking the app-wide model list

### DIFF
--- a/app/desktop/studio_server/provider_api.py
+++ b/app/desktop/studio_server/provider_api.py
@@ -34,6 +34,7 @@ from kiln_ai.adapters.ollama_tools import (
     parse_ollama_tags,
 )
 from kiln_ai.adapters.provider_tools import (
+    PLACEHOLDER_API_KEY,
     get_all_user_models,
     get_legacy_custom_models,
     provider_name_from_id,
@@ -2200,18 +2201,18 @@ def openai_compatible_providers_load_cache() -> OpenAICompatibleProviderCache | 
             logger.warning("No name for OpenAI compatible provider %s", provider)
             continue
 
-        # API key is optional, as some providers don't require it
-        api_key = provider.get("api_key") or ""
-        openai_client = openai.OpenAI(
-            api_key=api_key,
-            base_url=base_url,
-            # Important: max_retries must be 0 for performance.
-            # It's common for these servers to be down sometimes (could be local app that isn't running)
-            # OpenAI client will retry a few times, with a sleep in between! Big loading perf hit.
-            max_retries=0,
-        )
+        # API key optional - some providers like Ollama don't use it, but the OpenAI client errors without one
+        api_key = provider.get("api_key") or PLACEHOLDER_API_KEY
 
         try:
+            openai_client = openai.OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                # Important: max_retries must be 0 for performance.
+                # It's common for these servers to be down sometimes (could be local app that isn't running)
+                # OpenAI client will retry a few times, with a sleep in between! Big loading perf hit.
+                max_retries=0,
+            )
             provider_models = openai_client.models.list()
             for model in provider_models:
                 models.append(
@@ -2247,7 +2248,9 @@ def openai_compatible_providers_load_cache() -> OpenAICompatibleProviderCache | 
             )
         except Exception:
             logger.error(
-                "Error connecting to OpenAI compatible provider %s", name, exc_info=True
+                "Error loading models from OpenAI compatible provider %s",
+                name,
+                exc_info=True,
             )
             has_error = True
             continue

--- a/app/desktop/studio_server/test_provider_api.py
+++ b/app/desktop/studio_server/test_provider_api.py
@@ -1,5 +1,5 @@
 import json
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from datetime import datetime, timedelta
 from http import HTTPStatus
 from unittest.mock import MagicMock, Mock, patch
@@ -84,29 +84,33 @@ def client(app):
 
 
 @contextmanager
-def patched_non_builtin_available_model_sources():
-    with (
-        patch(
-            "app.desktop.studio_server.provider_api.available_docker_model_runner_models",
-            return_value=None,
-        ),
-        patch(
-            "app.desktop.studio_server.provider_api.all_fine_tuned_models",
-            return_value=None,
-        ),
-        patch(
-            "app.desktop.studio_server.provider_api.openai_compatible_providers",
-            return_value=[],
-        ),
-        patch(
-            "app.desktop.studio_server.provider_api.legacy_custom_models_as_available",
-            return_value={},
-        ),
-        patch(
-            "app.desktop.studio_server.provider_api.user_models_as_available",
-            return_value={},
-        ),
-    ):
+def patched_non_builtin_available_model_sources(patch_openai_compatible: bool = True):
+    """Stub out the non-builtin, non-Ollama model sources /api/available_models pulls
+    from (callers patch connect_ollama themselves).
+
+    Pass patch_openai_compatible=False to exercise the real OpenAI compatible path while
+    the other sources stay stubbed.
+    """
+    with ExitStack() as stack:
+        for target, return_value in (
+            ("available_docker_model_runner_models", None),
+            ("all_fine_tuned_models", None),
+            ("legacy_custom_models_as_available", {}),
+            ("user_models_as_available", {}),
+        ):
+            stack.enter_context(
+                patch(
+                    f"app.desktop.studio_server.provider_api.{target}",
+                    return_value=return_value,
+                )
+            )
+        if patch_openai_compatible:
+            stack.enter_context(
+                patch(
+                    "app.desktop.studio_server.provider_api.openai_compatible_providers",
+                    return_value=[],
+                )
+            )
         yield
 
 
@@ -1278,6 +1282,41 @@ async def test_get_available_models_includes_deprecated_flag(app, client):
     assert models[0]["models"][0]["deprecated"] is True
 
 
+@pytest.mark.asyncio
+async def test_get_available_models_with_blank_api_key_custom_provider(app, client):
+    mock_config = MagicMock()
+    mock_config.get_value.return_value = "mock_key"
+    mock_config.openai_compatible_providers = [
+        {"name": "custom_provider", "base_url": "https://api.test.com", "api_key": ""}
+    ]
+
+    mock_model = MagicMock()
+    mock_model.id = "gpt-4"
+
+    with (
+        patch(
+            "app.desktop.studio_server.provider_api.Config.shared",
+            return_value=mock_config,
+        ),
+        patch(
+            "app.desktop.studio_server.provider_api._openai_compatible_providers_cache",
+            None,
+        ),
+        patch("openai.resources.models.Models.list", return_value=[mock_model]),
+        patch("app.desktop.studio_server.provider_api.built_in_models", []),
+        patched_non_builtin_available_model_sources(patch_openai_compatible=False),
+        patch(
+            "app.desktop.studio_server.provider_api.connect_ollama",
+            side_effect=HTTPException(status_code=500),
+        ),
+    ):
+        response = client.get("/api/available_models")
+
+    assert response.status_code == 200
+    providers = {p["provider_name"]: p for p in response.json()}
+    assert providers["custom_provider"]["models"][0]["id"] == "custom_provider::gpt-4"
+
+
 def test_get_providers_models(client):
     response = client.get("/api/providers/models")
     assert response.status_code == 200
@@ -2111,6 +2150,68 @@ def test_openai_compatible_providers_uncached_invalid_provider():
         result = openai_compatible_providers_load_cache()
         assert result.providers == []
         mock_openai.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "provider_config",
+    [
+        {"name": "test_provider", "base_url": "https://api.test.com", "api_key": ""},
+        {"name": "test_provider", "base_url": "https://api.test.com", "api_key": None},
+        {"name": "test_provider", "base_url": "https://api.test.com"},
+    ],
+    ids=["empty_string_key", "none_key", "missing_key"],
+)
+def test_openai_compatible_providers_uncached_blank_api_key(provider_config):
+    # Real OpenAI client construction: it raises without a key, so a blank key must
+    # fall back to a placeholder rather than breaking the whole model list.
+    mock_model = MagicMock()
+    mock_model.id = "gpt-4"
+
+    with (
+        patch("openai.resources.models.Models.list", return_value=[mock_model]),
+        patch("app.desktop.studio_server.provider_api.Config.shared") as mock_config,
+    ):
+        mock_config.return_value.openai_compatible_providers = [provider_config]
+        result = openai_compatible_providers_load_cache()
+
+        assert not result.had_error
+        assert len(result.providers) == 1
+        assert result.providers[0].models[0].id == "test_provider::gpt-4"
+
+
+def test_openai_compatible_providers_uncached_client_error_isolated():
+    mock_providers = [
+        {
+            "name": "broken_provider",
+            "base_url": "https://api.broken.com",
+            "api_key": "broken_key",
+        },
+        {
+            "name": "working_provider",
+            "base_url": "https://api.test.com",
+            "api_key": "test_key",
+        },
+    ]
+
+    mock_model = MagicMock()
+    mock_model.id = "gpt-4"
+    working_client = MagicMock()
+    working_client.models.list.return_value = [mock_model]
+
+    with (
+        patch(
+            "openai.OpenAI",
+            side_effect=[openai.OpenAIError("Missing credentials"), working_client],
+        ),
+        patch("app.desktop.studio_server.provider_api.Config.shared") as mock_config,
+    ):
+        mock_config.return_value.openai_compatible_providers = mock_providers
+        result = openai_compatible_providers_load_cache()
+
+        # One bad provider shouldn't take out the others
+        assert result.had_error
+        assert len(result.providers) == 1
+        assert result.providers[0].provider_name == "working_provider"
 
 
 def test_openai_compatible_providers_uncached_api_error():

--- a/libs/core/kiln_ai/adapters/provider_tools.py
+++ b/libs/core/kiln_ai/adapters/provider_tools.py
@@ -26,6 +26,10 @@ from kiln_ai.utils.project_utils import project_from_id
 
 logger = logging.getLogger(__name__)
 
+# Some providers (Ollama, LM Studio, other local servers) don't use an API key, but the
+# OpenAI client and LiteLLM both error out when constructed without one. Send this instead.
+PLACEHOLDER_API_KEY = "NA"
+
 
 async def provider_enabled(provider_name: ModelProviderName) -> bool:
     if provider_name == ModelProviderName.ollama:
@@ -687,7 +691,7 @@ def lite_llm_core_config_for_provider(
                 base_url=ollama_base_url + "/v1",
                 additional_body_options={
                     # LiteLLM errors without an api_key, even though Ollama doesn't support one
-                    "api_key": "NA",
+                    "api_key": PLACEHOLDER_API_KEY,
                 },
             )
         case ModelProviderName.docker_model_runner:
@@ -789,7 +793,7 @@ def lite_llm_core_config_for_provider(
                 )
 
             # API key optional - some providers like Ollama don't use it, but LiteLLM errors without one
-            api_key = provider.get("api_key") or "NA"
+            api_key = provider.get("api_key") or PLACEHOLDER_API_KEY
             base_url = provider.get("base_url")
             if base_url is None:
                 raise ValueError(


### PR DESCRIPTION
## What does this PR do?

Connecting an OpenAI-compatible "Custom API" provider with a blank API key took down **every** model in the UI, not just that provider's.

`openai_compatible_providers_load_cache()` passed `provider.get("api_key") or ""` to `openai.OpenAI()`, which raises `OpenAIError: Missing credentials` on an empty key — the `OPENAI_API_KEY` env fallback only applies when `api_key is None`, not `""`. That constructor sat *outside* the `try/except` meant to isolate one bad provider, so the error escaped and `GET /api/available_models` returned 500, leaving the user with a silently empty model dropdown and no error shown anywhere.

The connect dialog marks the API Key field optional (blank keys are legitimate for local servers), and the backend saves `api_key: ""`, so this was reachable through normal UI flow.

Both halves of the bug are fixed in `app/desktop/studio_server/provider_api.py`:

- **Fall back to a placeholder key instead of `""`**, matching the inference path in `provider_tools.py`, which already used `or "NA"` with a comment noting these clients error without a key. The listing path was the outlier. That placeholder is now hoisted into a shared `PLACEHOLDER_API_KEY` constant in `libs/core/kiln_ai/adapters/provider_tools.py` and used at all three fallback sites, so the listing and inference paths can't drift apart.
- **Move the client construction inside the existing `try/except`**, so any future construction failure is isolated to that one provider instead of taking out the whole list. The log message was retitled from "Error connecting to" to "Error loading models from", which reads true for both failure modes.

The blank key is normalized at the point of use rather than on save, since normalizing on save wouldn't repair configs already on disk. The "API key optional" UI affordance is unchanged.

### Tests

Five new cases in `app/desktop/studio_server/test_provider_api.py`:

- Blank key parametrized over empty-string, `None`, and missing-key configs
- One bad provider's client construction failing does not drop the others
- Endpoint-level: `GET /api/available_models` returns 200 with the custom provider's models

These patch `openai.resources.models.Models.list` rather than `openai.OpenAI`, so the *real* constructor runs and the regression is genuinely exercised — the previous tests all passed a non-empty key, and the e2e fixture always registers the mock with `api_key: "NA"`, which is why this was missed. All five were verified failing against the pre-fix code and passing after, and both halves of the fix were mutation-tested independently.

The existing `patched_non_builtin_available_model_sources` helper gained a `patch_openai_compatible` flag so the endpoint test reuses it instead of copying its patch targets.

### Notes for reviewers

Two related items were deliberately left out of scope:

- `had_error` is never surfaced to the UI, so a provider that genuinely *requires* auth is still dropped silently. This matches the pre-existing unreachable-URL behavior, but surfacing it would fully close the silently-empty-dropdown class of problem.
- `docker_model_runner_tools.py`'s hardcoded `"dummy"` key wasn't folded into `PLACEHOLDER_API_KEY` — `provider_tools` imports that module, so sharing the constant would be a circular import. A neutral home under `kiln_ai/utils/` would allow unifying them.

## Related Issues

<!--- Link to related issues. For example: "Fixes: https://github.com/Kiln-AI/Kiln/issues/12345" -->

## Checklists

- [x] Tests have been run locally and passed — full `checks.sh` clean
- [ ] New tests have been added to any work in /lib — the `libs/core` change is a constant extraction with no behavior change; it's covered by the existing `test_provider_tools.py` suite and by the new tests in `app/desktop`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfHevFY7LgDS8Muxyy8fgm)_