### PR TITLE
Add OpenRouter QA key support for agent testing with live model calls

### DIFF
--- a/.agents/scripts/playwright_server.sh
+++ b/.agents/scripts/playwright_server.sh
@@ -56,6 +56,20 @@ SEED_STAMP="$RUN_DIR/.playwright_seed"
 SETTINGS_FILE="$RUN_DIR/.kiln_ai/settings.yaml"
 SEED_CONTACT="playwright@example.com"
 
+# An OpenRouter key seeded into the sandbox's settings, so the app comes up with a
+# provider connected and live model calls work. Optional: without it the sandbox
+# behaves exactly as it always has, with nothing connected.
+#
+# Deliberately not named OPENROUTER_API_KEY. That name is Config's env fallback for
+# open_router_api_key (libs/core/kiln_ai/utils/config.py) and litellm's too, so
+# under it every `pytest --runpaid` run and every stray script on the machine would
+# start spending against the key without anyone choosing to. Under this name the
+# only thing that spends it is a sandbox seeded on purpose.
+#
+# See .config/utils/claude_cloud_setup.md for where it comes from and the spending
+# limit it must have.
+OPENROUTER_KEY="${OPENROUTER_QA_KEY:-}"
+
 usage() {
   cat <<EOF
 Usage: playwright_server.sh [start|stop|status|reset|snapshot]
@@ -72,6 +86,11 @@ Usage: playwright_server.sh [start|stop|status|reset|snapshot]
 Frontend $FRONTEND_URL, backend $BACKEND_URL. Override the ports with
 KILN_DEV_FRONTEND_PORT / KILN_DEV_BACKEND_PORT, and the data directory with
 KILN_DEV_HOME (default $WEB_UI_DIR/.agent_dev_home).
+
+If OPENROUTER_QA_KEY is set when a sandbox is seeded, it is written into that
+sandbox's settings as a connected OpenRouter provider, and live model calls work.
+Without it nothing is connected. Every call spends real money against a key that
+must carry a hard limit — see .config/utils/claude_cloud_setup.md.
 EOF
 }
 
@@ -244,17 +263,35 @@ is_seeded() { [ -f "$SEED_STAMP" ]; }
 # `#` or `:`, either of which would change the meaning of a plain scalar.
 #
 # user_type + personal_use_contact is what clears the app's registration check.
+#
+# open_router_api_key is the same setting the Settings UI writes when you connect
+# OpenRouter by hand — connect_openrouter() sets that one value and nothing else —
+# so a sandbox seeded with it is indistinguishable from one where a provider was
+# connected through the app.
 write_seed_settings() {
   # $1 = path to project.kiln
-  local escaped
+  local escaped key_line=""
   escaped="$(printf '%s' "$1" | sed "s/'/''/g")"
+  if [ -n "$OPENROUTER_KEY" ]; then
+    key_line="open_router_api_key: '$(printf '%s' "$OPENROUTER_KEY" | sed "s/'/''/g")'"
+  fi
   mkdir -p "$(dirname "$SETTINGS_FILE")" || return 1
+  # Created empty and made private *before* the key goes in, so it is never briefly
+  # readable by anyone else on the machine. chmod rather than a umask, because the
+  # file may already exist from a seed that failed after this point, and truncating
+  # an existing file keeps whatever mode it already had.
+  : >"$SETTINGS_FILE" || return 1
+  chmod 600 "$SETTINGS_FILE" 2>/dev/null
   cat >"$SETTINGS_FILE" <<EOF
 projects:
 - '$escaped'
 user_type: personal
 personal_use_contact: $SEED_CONTACT
 EOF
+  # Appended rather than interpolated as an empty line, so a sandbox with no key
+  # gets the same file it has always had.
+  [ -n "$key_line" ] && echo "$key_line" >>"$SETTINGS_FILE"
+  return 0
 }
 
 # Seeding never fails the server: an agent that asked for a browser gets one, and a
@@ -430,11 +467,39 @@ print_seed_hint() {
   fi
 }
 
+# Whether this sandbox can make a live model call, said out loud on every start.
+# An agent that has to infer it ends up either reporting a missing provider as a
+# bug or assuming a key it does not have, and both cost a whole test lane.
+#
+# Reads settings.yaml rather than the environment, because the file is the answer:
+# the app writes a key there when someone connects a provider through Settings, and
+# the seed only writes one on the start that seeded. Which is also the one case
+# this cannot fix silently — a sandbox seeded before OPENROUTER_QA_KEY was set
+# keeps what it was seeded with, and rewriting the file behind the app's back would
+# throw away a key pasted in by hand.
+report_openrouter_key() {
+  if grep -q '^open_router_api_key:' "$SETTINGS_FILE" 2>/dev/null; then
+    echo "  OpenRouter is connected in this sandbox — live model calls will work,"
+    echo "  and will spend real money against a key with a hard limit on it. Prefer"
+    echo "  GPT-5.6 Luna and keep runs small. See .agents/skills/playwright/."
+    echo ""
+    return 0
+  fi
+
+  if [ -n "$OPENROUTER_KEY" ]; then
+    echo "  OPENROUTER_QA_KEY is set, but this sandbox was seeded without it, so no"
+    echo "  provider is connected. 'reset' reseeds with it (deleting this sandbox),"
+    echo "  or connect OpenRouter through the app's Settings."
+    echo ""
+  fi
+}
+
 # Printed once both servers answer, from the cold-start path and the
 # already-running path alike. They were drifting apart: an agent that ran `start`
 # twice got a different set of instructions the second time.
 print_ready_hints() {
   print_seed_hint
+  report_openrouter_key
   echo "    .agents/scripts/playwright_server.sh stop"
   echo ""
 }

--- a/.agents/scripts/playwright_server.sh
+++ b/.agents/scripts/playwright_server.sh
@@ -70,6 +70,18 @@ SEED_CONTACT="playwright@example.com"
 # limit it must have.
 OPENROUTER_KEY="${OPENROUTER_QA_KEY:-}"
 
+# What the ui_state hint preselects in the model dropdown when a key is seeded.
+# `<provider_id>/<model_id>`, the format available_models_dropdown.svelte parses
+# back apart — so this is exactly the string the app would have stored itself
+# after someone picked the model by hand.
+#
+# It is a default, not a constraint, and it is here rather than only in the skill
+# docs on purpose: cheap-by-default beats cheap-if-the-agent-read-the-guidance.
+# The dropdown drops a value it cannot find in the available models
+# (get_selected_model returns null), so if this id ever goes stale the app comes
+# up with nothing selected rather than something broken.
+SEED_MODEL="openrouter/gpt_5_6_luna"
+
 usage() {
   cat <<EOF
 Usage: playwright_server.sh [start|stop|status|reset|snapshot]
@@ -408,6 +420,13 @@ verify_seed_loaded() {
   echo "         the app does not have and land you on /setup anyway." >&2
 }
 
+# Whether this sandbox's settings carry an OpenRouter key. The file is the answer
+# rather than the environment: the app writes a key there when someone connects a
+# provider through Settings, and the seed only writes one on the start that seeded.
+sandbox_has_openrouter_key() {
+  grep -q '^open_router_api_key:' "$SETTINGS_FILE" 2>/dev/null
+}
+
 # The app's setup gate has two steps disk cannot satisfy: the selected project and
 # task live in localStorage, and the layout redirects to a task picker on mount
 # without them, whatever URL you asked for. This prints the write that gets past it.
@@ -430,6 +449,12 @@ verify_seed_loaded() {
 # particular start did the seeding.
 print_seed_hint() {
   local project_name="" primary_id="" primary_name="" lines="" others=""
+  # The dropdown reads ui_state.selected_model on mount, so preselecting it here
+  # is what saves every lane the find-open-find-click walk through the model
+  # picker. null with no key: preselecting a model the sandbox cannot call would
+  # trade four commands for a confusing dead end.
+  local model_json="null"
+  sandbox_has_openrouter_key && model_json="\"$SEED_MODEL\""
 
   if [ -n "$loaded_project_id" ]; then
     project_name="$(json_field "$SEEDED_PROJECT_DIR/project.kiln" name)"
@@ -455,7 +480,7 @@ print_seed_hint() {
   echo ""
   echo "  Land in the app (the layout redirects to a task picker without this):"
   echo "    playwright-cli open $FRONTEND_URL"
-  echo "    playwright-cli localstorage-set ui_state '{\"current_project_id\":\"$loaded_project_id\",\"current_task_id\":\"$primary_id\",\"selected_model\":null}'"
+  echo "    playwright-cli localstorage-set ui_state '{\"current_project_id\":\"$loaded_project_id\",\"current_task_id\":\"$primary_id\",\"selected_model\":$model_json}'"
   echo "    playwright-cli goto $FRONTEND_URL"
   echo ""
 
@@ -478,10 +503,11 @@ print_seed_hint() {
 # keeps what it was seeded with, and rewriting the file behind the app's back would
 # throw away a key pasted in by hand.
 report_openrouter_key() {
-  if grep -q '^open_router_api_key:' "$SETTINGS_FILE" 2>/dev/null; then
+  if sandbox_has_openrouter_key; then
     echo "  OpenRouter is connected in this sandbox — live model calls will work,"
-    echo "  and will spend real money against a key with a hard limit on it. Prefer"
-    echo "  GPT-5.6 Luna and keep runs small. See .agents/skills/playwright/."
+    echo "  and will spend real money against a key with a hard limit on it. The"
+    echo "  ui_state above preselects GPT-5.6 Luna; keep it, and keep runs small."
+    echo "  See .agents/skills/playwright/."
     echo ""
     return 0
   fi

--- a/.agents/skills/playwright/SKILL.md
+++ b/.agents/skills/playwright/SKILL.md
@@ -42,6 +42,26 @@ The sandbox keeps its data in `app/web_ui/.agent_dev_home` and is seeded from a
 committed fixture project, so the screens have content instead of an onboarding
 wizard. It never touches real Kiln projects.
 
+## A provider may be connected — spend it carefully
+
+If `OPENROUTER_QA_KEY` is set in the environment, seeding writes it into the
+sandbox's settings and the app comes up with OpenRouter connected, so live model
+calls work. `start` reports it when it is there — assume nothing is connected
+until it says so.
+
+When it is connected, it is a real key on a hard, low limit — a runaway loop hits
+it and the next person gets nothing. Use it when a live call is the only way to
+check what you are working on, and:
+
+- **Default to GPT-5.6 Luna** (`openai/gpt-5.6-luna`). Choose another model only
+  when the model itself is what you are testing.
+- Keep every run minimal — one sample, one eval row, one query.
+- Never aim a paid test suite at it (`pytest --runpaid` / `--runprerelease` read
+  `OPENROUTER_API_KEY`, which is deliberately a different variable).
+- Treat a 402 or 429 as budget exhausted: stop and report it, don't retry.
+
+[references/seeded_project.md](references/seeded_project.md) has the details.
+
 ## Three rules that will cost you an afternoon otherwise
 
 **Never trust the first frame.** A screenshot taken right after `open` or `goto` is
@@ -70,6 +90,6 @@ Load only what the task needs.
 |---|---|
 | [references/driving_the_ui.md](references/driving_the_ui.md) | The command surface, and the locator traps in Kiln's UI specifically — duplicate labels, dropdowns, collapsed sections |
 | [references/e2e_suite.md](references/e2e_suite.md) | Running, reading, or debugging `npm run tests:e2e` |
-| [references/seeded_project.md](references/seeded_project.md) | What the fixture contains, screen by screen. Check here before concluding a screen is broken because it came up empty |
-| [references/search_tool.md](references/search_tool.md) | The Docs & Search / RAG part of the fixture, and what a sandbox with no API key can do with it |
+| [references/seeded_project.md](references/seeded_project.md) | What the fixture contains, screen by screen, and whether a model provider is connected. Check here before concluding a screen is broken because it came up empty |
+| [references/search_tool.md](references/search_tool.md) | The Docs & Search / RAG part of the fixture, and what a sandbox with no API key can still do with it |
 | [references/extending_the_fixture.md](references/extending_the_fixture.md) | `reset` and `snapshot` — changing what future sessions start from |

--- a/.agents/skills/playwright/SKILL.md
+++ b/.agents/skills/playwright/SKILL.md
@@ -53,8 +53,10 @@ When it is connected, it is a real key on a hard, low limit — a runaway loop h
 it and the next person gets nothing. Use it when a live call is the only way to
 check what you are working on, and:
 
-- **Default to GPT-5.6 Luna** (`openai/gpt-5.6-luna`). Choose another model only
-  when the model itself is what you are testing.
+- **Default to GPT-5.6 Luna.** The `ui_state` hint `start` prints already
+  preselects it in the model dropdown, so running as-is costs you nothing and
+  picks the cheap model. Change it only when the model itself is what you are
+  testing.
 - Keep every run minimal — one sample, one eval row, one query.
 - Never aim a paid test suite at it (`pytest --runpaid` / `--runprerelease` read
   `OPENROUTER_API_KEY`, which is deliberately a different variable).

--- a/.agents/skills/playwright/references/extending_the_fixture.md
+++ b/.agents/skills/playwright/references/extending_the_fixture.md
@@ -13,7 +13,9 @@ many times you stop and start. Use `reset` when you want the committed fixture
 back, or after pulling a branch whose fixture differs.
 
 It deletes the whole sandbox home, `settings.yaml` included — so any provider you
-connected by hand goes with it, and you will need to paste the key again.
+connected by hand goes with it, and you will need to paste the key again. The
+seed's own OpenRouter key comes back on its own, since reseeding re-reads
+`OPENROUTER_QA_KEY` from the environment.
 
 ## `playwright_server.sh snapshot` — improve the fixture
 

--- a/.agents/skills/playwright/references/search_tool.md
+++ b/.agents/skills/playwright/references/search_tool.md
@@ -16,8 +16,10 @@ worth knowing before you conclude a keyless sandbox cannot exercise RAG at all.
 
 Searching is the part that does need a key: the vector store is `lancedb_hybrid`, and
 a hybrid or vector query embeds the query string live. A full-text-only store would
-not. Connect OpenRouter through Settings → Providers and the tool's own Search panel
-returns chunks from the seeded documents.
+not. With a provider connected — which a sandbox seeded from `OPENROUTER_QA_KEY`
+already has, and `playwright_server.sh start` says so — the tool's own Search panel
+returns chunks from the seeded documents. Without one, connect OpenRouter through
+Settings → Providers first.
 
 Two things about the chain that read like bugs and are not:
 

--- a/.agents/skills/playwright/references/seeded_project.md
+++ b/.agents/skills/playwright/references/seeded_project.md
@@ -68,8 +68,10 @@ the UI or stop at the gate.
 low limit that a runaway loop will hit. Use it when a live call is the only way to
 check the thing you are working on, and keep it cheap:
 
-- **Default to GPT-5.6 Luna** (`openai/gpt-5.6-luna` on OpenRouter). Pick another
-  model only when the thing under test is about that model.
+- **Default to GPT-5.6 Luna.** With a key seeded, the `ui_state` hint `start`
+  prints carries `"selected_model":"openrouter/gpt_5_6_luna"`, so the Run screen
+  comes up with it already chosen — no dropdown walk, and the cheap model by
+  default. Pick another only when the thing under test is about that model.
 - Run the smallest thing that answers the question — one sample, not fifty; one
   eval row, not a full sweep.
 - Never point a paid test suite at it: `pytest --runpaid` and `--runprerelease`

--- a/.agents/skills/playwright/references/seeded_project.md
+++ b/.agents/skills/playwright/references/seeded_project.md
@@ -51,14 +51,35 @@ fix), the sandbox was seeded from an older fixture (`reset`), or the committed
 fixture has gone stale against this branch's datamodel (re-author through the UI,
 then `snapshot`).
 
-## No provider is connected
+## A provider may or may not be connected
 
-A seeded sandbox has no API keys, so you cannot *execute* a new run in it. Seeded
-data is just files the screens read, so the pages render it with nothing connected
-— but if the feature you are working on needs a live model call, you have to
-connect a provider by hand through the UI first.
+Seeded data is just files the screens read, so every page renders it whether or
+not a provider is connected. *Executing* anything — a new run, a data gen, an
+eval, a search query — needs a live model call, and that depends on the sandbox.
 
-The search tool is the exception in one direction and not the other: its index
-rebuilds with no key, and searching it needs one. See
-[search_tool.md](search_tool.md).
+`playwright_server.sh start` tells you which sandbox you have. If it says
+OpenRouter is connected, it is: the seed wrote a key from `OPENROUTER_QA_KEY` into
+this sandbox's `settings.yaml`, which is the same setting the app's Settings
+screen writes, so calls work exactly as a user's would. If it says nothing about
+OpenRouter, nothing is connected and you either connect a provider by hand through
+the UI or stop at the gate.
+
+**When a key is there, it is a real key spending real money**, against a hard
+low limit that a runaway loop will hit. Use it when a live call is the only way to
+check the thing you are working on, and keep it cheap:
+
+- **Default to GPT-5.6 Luna** (`openai/gpt-5.6-luna` on OpenRouter). Pick another
+  model only when the thing under test is about that model.
+- Run the smallest thing that answers the question — one sample, not fifty; one
+  eval row, not a full sweep.
+- Never point a paid test suite at it: `pytest --runpaid` and `--runprerelease`
+  read `OPENROUTER_API_KEY`, which is deliberately not the variable this uses.
+- A 402 or a 429 means the budget is gone. Stop and say so — retrying is how a
+  small limit becomes a blocked afternoon for everyone.
+
+`reset` deletes the sandbox and reseeds it, which re-reads `OPENROUTER_QA_KEY`; a
+sandbox seeded before that variable existed keeps having no provider until then.
+
+The search tool has its own split: the index rebuilds with no key, and searching
+it needs one. See [search_tool.md](search_tool.md).
 

--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -193,9 +193,10 @@ It's a real key on a hard, low spending limit, shared by every lane in the run. 
 burns it leaves the rest of the run with nothing, so the budget is a shared resource to
 protect, not an allowance to use up:
 
-- **Default to GPT-5.6 Luna** (`openai/gpt-5.6-luna`) for anything where the model isn't the
-  point — which is nearly everything in a QA pass. Use a different model only when the thing
-  under test is that model's behavior.
+- **Default to GPT-5.6 Luna** for anything where the model isn't the point — which is nearly
+  everything in a QA pass. The `ui_state` hint each lane's `start` prints already preselects
+  it, so the cheap model is what a lane gets by doing nothing. Use a different model only when
+  the thing under test is that model's behavior.
 - **Smallest run that answers the question.** One sample, one eval row, one search query. A
   QA pass proves the flow works; it doesn't need a populated dataset.
 - **Never point a paid test suite at it.** `pytest --runpaid` and `--runprerelease` read

--- a/.agents/skills/qa/SKILL.md
+++ b/.agents/skills/qa/SKILL.md
@@ -169,32 +169,62 @@ A lane subagent starts with none of your context — brief it like a self-contai
   did.
 - **Find and document only** — no source edits. State the one exception plainly when it
   applies: intentionally corrupting a file in its own scratch project to test error handling.
-- Whether a live model/provider is available in this sandbox (usually not, by default — see
-  below) so it knows which blocked paths are expected, not bugs.
+- Whether a live model/provider is available in this sandbox (check `start`'s output — see
+  below) so it knows which blocked paths are expected and which are bugs. When one *is*
+  connected, pass on the spending rules verbatim: GPT-5.6 Luna by default, smallest possible
+  runs, stop on a 402/429.
 - The report shape you want back: one entry per finding, with area, severity, concrete repro
   steps, expected vs. actual, a file:line reference where relevant, and whether the finding
   falls inside the stated focus window (`git log --oneline -- <file>` settles this when
   unsure).
 - An instruction to clean up its own server/session/scratch directory when done.
 
-## No LLM provider by default
+## Whether an LLM provider is connected — check, don't assume
 
-The seeded dev sandbox has no API key, so anything needing a live model call — LLM-judge
-scoring, synthetic data generation, Copilot-backed flows, provider-gated features — will fail
-or gate off. Tell every lane this up front, but keep the exemption narrow: only the failure
-that's *directly caused by the missing provider itself* (the call can't be made, so that
-specific path stops) is expected/partial, not a bug. Everything else at that same gate is
-still in scope and still gets reported as a real finding — a crash instead of a clean error, a
-gate that fires at the wrong time or not at all, a missing/garbled error message, a "degrade
-gracefully" path that doesn't. The lane should verify all of that reachable-before-the-call
-behavior, not wave the whole area through because a key was missing somewhere downstream of it.
+Some environments set `OPENROUTER_QA_KEY`, and where it's set, seeding a sandbox writes it
+into that sandbox's settings and the app comes up with OpenRouter connected — live model
+calls work, exactly as they would for a user who connected a provider in Settings.
+`playwright_server.sh start` says so in its output when that's the case. **Check the output
+of your own `start` before planning around it**, and tell every lane which world it's in.
+
+### When a key is connected
+
+It's a real key on a hard, low spending limit, shared by every lane in the run. A lane that
+burns it leaves the rest of the run with nothing, so the budget is a shared resource to
+protect, not an allowance to use up:
+
+- **Default to GPT-5.6 Luna** (`openai/gpt-5.6-luna`) for anything where the model isn't the
+  point — which is nearly everything in a QA pass. Use a different model only when the thing
+  under test is that model's behavior.
+- **Smallest run that answers the question.** One sample, one eval row, one search query. A
+  QA pass proves the flow works; it doesn't need a populated dataset.
+- **Never point a paid test suite at it.** `pytest --runpaid` and `--runprerelease` read
+  `OPENROUTER_API_KEY`, deliberately a different variable — don't bridge them.
+- **A 402 or 429 means the budget is gone.** Stop, report it as a run-level note, and don't
+  retry — a retry loop is how one lane ends the whole pass.
+
+Say all of this in each lane's brief. The limit is what actually stops a runaway; the
+guidance is what keeps the run from reaching it.
+
+### When no key is connected
+
+Anything needing a live model call — LLM-judge scoring, synthetic data generation,
+Copilot-backed flows, provider-gated features — will fail or gate off. Tell every lane this up
+front, but keep the exemption narrow: only the failure that's *directly caused by the missing
+provider itself* (the call can't be made, so that specific path stops) is expected/partial,
+not a bug. Everything else at that same gate is still in scope and still gets reported as a
+real finding — a crash instead of a clean error, a gate that fires at the wrong time or not at
+all, a missing/garbled error message, a "degrade gracefully" path that doesn't. The lane
+should verify all of that reachable-before-the-call behavior, not wave the whole area through
+because a key was missing somewhere downstream of it.
 
 If a live model call is actually essential to a lane's coverage — the feature can't be
 meaningfully verified any other way — don't just skip it. Ask the user for an OpenRouter API
 key with a small max-spend limit, scoped to this test run, and connect it through the app's
 own Settings UI (not a raw env var) so it behaves exactly like a real user's connected
 provider. OpenRouter covers most models through one key; only ask for a different provider's
-key if the thing under test is specific to that provider.
+key if the thing under test is specific to that provider. The same spending rules above apply
+to a key given this way, and more so — it's the user's, given for one run.
 
 ## Report shape
 

--- a/.config/utils/claude_cloud_setup.md
+++ b/.config/utils/claude_cloud_setup.md
@@ -24,16 +24,21 @@ environment**. There is no settings page or direct URL for it.
     ```
     cdn.playwright.dev
     playwright.download.prss.microsoft.com
+    openrouter.ai
     ```
 
   - Check **Also include default list of common package managers**. That keeps
     the whole Trusted list: PyPI, npm, apt, and `raw.githubusercontent.com`,
     which the setup script fetches itself from.
 
-The default **Trusted** policy is not enough on its own: the two domains above
-are Playwright's CDN and its download fallback, and on Trusted they answer 403,
-so the environment comes up without a browser. Everything else Kiln's setup
+The default **Trusted** policy is not enough on its own: the first two domains
+above are Playwright's CDN and its download fallback, and on Trusted they answer
+403, so the environment comes up without a browser. Everything else Kiln's setup
 needs is in the default list.
+
+`openrouter.ai` is only needed if you set `OPENROUTER_QA_KEY` below — it is where
+the app's model calls go, and without it the calls die at the proxy and a perfectly
+good key looks broken. Leave it out if you are not using the key.
 
 ## 3. Fill in two fields
 
@@ -46,6 +51,12 @@ UV_SYSTEM_CERTS=true
 The image sets the deprecated `UV_NATIVE_TLS` and the environment config cannot
 unset it, so this **adds** its modern replacement rather than replacing it. Both
 end up live. See "Things to know" below.
+
+Optionally also `OPENROUTER_QA_KEY=sk-or-...`, which connects OpenRouter inside
+the browser sandbox so agents can make real model calls. Read
+["An OpenRouter key for agents"](#an-openrouter-key-for-agents-optional) before
+you set it: the key must carry a hard spending limit, because nothing else limits
+what an agent spends.
 
 **Setup script:** paste the *entire contents* of
 [`.config/utils/claude_code_vm_setup.sh`](claude_code_vm_setup.sh) into the
@@ -112,6 +123,57 @@ You can re-run the whole check any time; it is cheap and idempotent:
 ```
 bash .config/utils/setup_startup.sh
 ```
+
+## An OpenRouter key for agents (optional)
+
+Without a key, the browser sandbox has no provider connected. Agents can drive
+every screen and every flow right up to the point a model call happens, and no
+further — so QA of anything that actually runs a model (generation, evals,
+extraction, chat) stops at the gate.
+
+Setting `OPENROUTER_QA_KEY` in the environment variables fixes that.
+[`playwright_server.sh`](../../.agents/scripts/playwright_server.sh) writes it
+into a sandbox's `settings.yaml` when it seeds that sandbox, which is the same
+thing the app's Settings screen writes when you connect a provider by hand — so
+the app behaves exactly as a real user's does, with OpenRouter connected.
+
+**The key must have a hard, low spending limit. $10/month is the ceiling.**
+
+That is not a style preference. With this set:
+
+- **Agents can read the key.** It is a variable in their shell and a line in a
+  file they can `cat`. So can anything else running in the session.
+- **Agents decide what to spend.** The skills tell them to keep runs small and to
+  prefer a cheap model, and that guidance is followed rather than enforced. The
+  limit on the key is the only thing that actually stops a runaway loop.
+- **A session is not private.** Its transcript, its logs and its disk are all
+  places the key can end up, and none of them are yours alone.
+
+So, when you set it:
+
+- Create a **dedicated key** at <https://openrouter.ai/settings/keys> and use it
+  for nothing else.
+- Set the **credit limit on the key itself**, in OpenRouter's own field. A limit
+  you intend to watch is not a limit.
+- **Never** paste in a personal key, a shared team key, or one that can reach
+  account credit beyond its own limit.
+- **Rotate it** on a schedule, and immediately if a session did something you did
+  not expect. Treat it as burnable: the worst case is that it leaks, spends its
+  limit, and you delete it.
+- Put nothing else secret in the environment variables. They reach every session.
+
+Two smaller things worth knowing:
+
+- The name is deliberately not `OPENROUTER_API_KEY`. That name is what Kiln's
+  `Config` and litellm both read on their own, so under it `pytest --runpaid` and
+  any stray script in the VM would start spending the key without anyone choosing
+  to. `OPENROUTER_QA_KEY` is only ever read where a sandbox is seeded.
+- The key reaches a sandbox when that sandbox is **seeded**. A sandbox that
+  already exists from before you set the variable keeps whatever it was seeded
+  with; `playwright_server.sh start` says so, and `reset` reseeds it. Nothing
+  writes the key to your real `~/.kiln_ai/settings.yaml`, and
+  `playwright_server.sh snapshot` never reads or writes `settings.yaml`, so a key
+  cannot reach the repo through the fixture.
 
 ## Things to know
 

--- a/.config/utils/claude_code_vm_setup.sh
+++ b/.config/utils/claude_code_vm_setup.sh
@@ -22,9 +22,16 @@
 #   raw.githubusercontent.com          this script's own fetch
 #   cdn.playwright.dev                 the browsers --add-playwright installs
 #   playwright.download.prss.microsoft.com   Playwright's download fallback
+#   openrouter.ai                      only with OPENROUTER_QA_KEY set: where the
+#                                      app's model calls go
 #
 # plus "also include default list of common package managers" for npm, PyPI and
 # apt. On the default Trusted policy the browser downloads get a 403.
+#
+# This script never sees OPENROUTER_QA_KEY and must not: it runs once per
+# environment and its disk is snapshotted, so a key written here would outlive its
+# own rotation. The key is a session variable, read where a browser sandbox is
+# seeded — see claude_cloud_setup.md.
 set -u
 
 REF="${KILN_SETUP_REF:-main}"


### PR DESCRIPTION
## What does this PR do?

This PR adds support for connecting an OpenRouter API key to the browser sandbox used for agent testing, enabling live model calls during QA. The changes include:

1. **Cloud setup documentation** (`claude_cloud_setup.md`): Added `openrouter.ai` to the trusted domains list and comprehensive documentation on setting up `OPENROUTER_QA_KEY`, including critical spending limit requirements and security considerations.

2. **Playwright server** (`playwright_server.sh`): 
   - Reads `OPENROUTER_QA_KEY` environment variable and seeds it into the sandbox's `settings.yaml` when creating a new sandbox
   - Added `report_openrouter_key()` function to inform users whether a provider is connected and spending rules when it is
   - Ensures the settings file is created with restricted permissions (600) before writing the key
   - Deliberately uses `OPENROUTER_QA_KEY` (not `OPENROUTER_API_KEY`) to prevent unintended spending by test suites

3. **QA skill documentation** (`.agents/skills/qa/SKILL.md`): Updated guidance for lane subagents to check whether a provider is connected and provided detailed spending rules when one is available (prefer GPT-5.6 Luna, minimal runs, watch for 402/429 errors).

4. **Playwright skill documentation** (`.agents/skills/playwright/SKILL.md` and references): Added documentation about provider connectivity, spending rules, and updated references to clarify the distinction between seeded keys and manually connected providers.

5. **Setup script** (`claude_code_vm_setup.sh`): Added comment explaining that `openrouter.ai` is only needed when `OPENROUTER_QA_KEY` is set, and clarified that the script itself never handles the key.

## Key Design Decisions

- **Separate variable name**: Uses `OPENROUTER_QA_KEY` instead of `OPENROUTER_API_KEY` to prevent accidental spending by `pytest --runpaid` or other test suites that read the standard variable
- **Hard spending limits required**: Documentation emphasizes that the key must have a low, hard spending limit ($10/month ceiling) since agents can read and spend against it
- **Sandbox-scoped**: The key is only written to individual sandbox settings, not to the VM's persistent configuration, preventing key leakage through snapshots
- **Clear user feedback**: `start` command reports whether a provider is connected and the spending rules that apply

## Related Issues

This enables QA testing of features that require live model calls (generation, evals, extraction, chat) without requiring manual provider setup through the UI for each test run.

## Contributor License Agreement

I confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Documentation is comprehensive and covers security implications
- [x] Changes follow existing code patterns and conventions
- [x] No automated tests needed (documentation and script changes)

https://claude.ai/code/session_011UB5a9W5BSTLvRyqH4C6Sm