### PR TITLE
Stop TaskRun.trace from dropping list-valued message content on save

### DIFF
--- a/.agents/skills/kiln-prerelease-check/SKILL.md
+++ b/.agents/skills/kiln-prerelease-check/SKILL.md
@@ -44,6 +44,7 @@ Whitelisted lists:
 - `PRERELEASE_EMBEDDING_MODELS` — one embedding model per embedding-supporting provider.
 - `PRERELEASE_EXTRACTION_MODELS` — one multimodal model per major vendor (OpenAI, Anthropic, Gemini).
 - `PRERELEASE_EXTRACTION_MIME_PROBES` — three mime probes (PDF, PNG, MP3) for the extraction smoke; the full paid test sweeps all 13 mime types per model.
+- `PRERELEASE_MULTIMODAL_TRACE_MODELS` — one multimodal model per major vendor (OpenAI, Anthropic, Gemini) for the multimodal trace round-trip smoke. Every entry must be `multimodal_capable` with `image/png` in its `multimodal_mime_types`.
 - `PRERELEASE_THINKING_MODELS` — five (provider, model, thinking_level) triples covering reasoning content + a "none" negation case.
 
 This whitelist is the thing most likely to go stale, so it's the main target of the pin sweep in Phase 4. The fan-out tests (e.g. `test_extract_document_success` over every model × mime type, `test_paid_generate_embeddings_basic` over every embedding) are **only `@pytest.mark.paid`** — not `@pytest.mark.prerelease` — and are out of scope for this skill.
@@ -179,7 +180,8 @@ from kiln_ai.adapters.ml_model_list import built_in_models
 from kiln_ai.adapters.ml_embedding_model_list import built_in_embedding_models
 from kiln_ai.adapters.pytest_prerelease_whitelist import (
     PRERELEASE_CHAT_MODELS, PRERELEASE_EMBEDDING_MODELS,
-    PRERELEASE_EXTRACTION_MODELS, PRERELEASE_THINKING_MODELS,
+    PRERELEASE_EXTRACTION_MODELS, PRERELEASE_MULTIMODAL_TRACE_MODELS,
+    PRERELEASE_THINKING_MODELS,
 )
 
 def chat_status(name, provider):
@@ -196,8 +198,9 @@ def emb_status(name, provider):
             return 'NO_PROVIDER' if p is None else 'OK'
     return 'MODEL_REMOVED_OR_RENAMED'
 
-print('== chat / extraction ==')
-for n,p in PRERELEASE_CHAT_MODELS + PRERELEASE_EXTRACTION_MODELS:
+print('== chat / extraction / multimodal trace ==')
+for n,p in (PRERELEASE_CHAT_MODELS + PRERELEASE_EXTRACTION_MODELS
+            + PRERELEASE_MULTIMODAL_TRACE_MODELS):
     print(f'{chat_status(n,p):>22}  {n}  ({p})')
 print('== embedding ==')
 for n,p in PRERELEASE_EMBEDDING_MODELS:
@@ -257,6 +260,7 @@ The prerelease set should cover, at minimum:
 | Thinking-level reasoning (whitelist) | `test_thinking_level_reasoning_content_prerelease_smoke` |
 | Reranker | `test_reranker_integration_success` |
 | Document extraction (whitelist of models × probe mime types) | `test_extract_document_success_prerelease_smoke`, `test_provider_bad_request_prerelease_smoke` |
+| Multimodal trace round trip — image survives the model call, the save and the reload (whitelist) | `libs/core/kiln_ai/adapters/model_adapters/test_multimodal_trace_paid.py::test_multimodal_trace_survives_save_to_file` |
 | Semantic chunker (real embedding integration) | `test_semantic_chunker_real_integration` |
 | Fireworks fine-tune | `test_fetch_all_deployments` |
 | Prompt caching (Anthropic + OpenAI + Gemini + Fireworks + Together) | `test_prompt_caching_cache_hit` |
@@ -337,6 +341,7 @@ One scannable table covering **every prerelease test that ran**, grouped by cove
 | Prompt caching | `test_prompt_caching_cache_hit` (7) | ✅×7 | |
 | Document extraction | `…extract_document_*_prerelease_smoke` (N) | ✅×N | |
 | Semantic chunker | `test_semantic_chunker_real_integration` | ✅ | |
+| Multimodal trace round trip | `test_multimodal_trace_survives_save_to_file` (3) | ✅×3 | |
 | Vertex live connect | `test_connect_vertex_live` | ❌ | <one-line cause> |
 | Fireworks fine-tune | `test_fetch_all_deployments` | ✅ | |
 

--- a/.agents/skills/kiln-prerelease-check/SKILL.md
+++ b/.agents/skills/kiln-prerelease-check/SKILL.md
@@ -198,10 +198,16 @@ def emb_status(name, provider):
             return 'NO_PROVIDER' if p is None else 'OK'
     return 'MODEL_REMOVED_OR_RENAMED'
 
-print('== chat / extraction / multimodal trace ==')
-for n,p in (PRERELEASE_CHAT_MODELS + PRERELEASE_EXTRACTION_MODELS
-            + PRERELEASE_MULTIMODAL_TRACE_MODELS):
-    print(f'{chat_status(n,p):>22}  {n}  ({p})')
+# One block per list: several lists hold the same pin, and Phase 4 re-pins each list
+# on its own, so a row is only actionable if you can see which list it came from.
+for label, entries in (
+    ('chat', PRERELEASE_CHAT_MODELS),
+    ('extraction', PRERELEASE_EXTRACTION_MODELS),
+    ('multimodal trace', PRERELEASE_MULTIMODAL_TRACE_MODELS),
+):
+    print(f'== {label} ==')
+    for n,p in entries:
+        print(f'{chat_status(n,p):>22}  {n}  ({p})')
 print('== embedding ==')
 for n,p in PRERELEASE_EMBEDDING_MODELS:
     print(f'{emb_status(n,p):>22}  {n}  ({p})')

--- a/app/desktop/studio_server/data_gen_api.py
+++ b/app/desktop/studio_server/data_gen_api.py
@@ -34,16 +34,14 @@ from kiln_ai.utils.async_job_runner import AsyncJobRunner
 from kiln_ai.utils.open_ai_types import (
     ChatCompletionAssistantMessageParamWrapper,
     ChatCompletionMessageParam,
+    ChatCompletionSystemMessageParamWrapper,
+    ChatCompletionUserMessageParamWrapper,
 )
 from kiln_server.project_api import project_from_id
 from kiln_server.task_api import task_from_id
 from kiln_server.utils.agent_checks.policy import (
     ALLOW_AGENT,
     agent_policy_require_approval,
-)
-from openai.types.chat import (
-    ChatCompletionSystemMessageParam,
-    ChatCompletionUserMessageParam,
 )
 from pydantic import BaseModel, Field
 
@@ -1020,11 +1018,11 @@ The topic path for this sample is:
         task = task_from_id(project_id, task_id)
 
         # Build trace in OpenAI message format using the task instruction as system prompt
-        system_msg: ChatCompletionSystemMessageParam = {
+        system_msg: ChatCompletionSystemMessageParamWrapper = {
             "role": "system",
             "content": task.instruction,
         }
-        user_msg: ChatCompletionUserMessageParam = {
+        user_msg: ChatCompletionUserMessageParamWrapper = {
             "role": "user",
             "content": input.query,
         }

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -4440,12 +4440,12 @@ export interface components {
         };
         /**
          * ChatCompletionAssistantMessageParamWrapper
-         * @description Almost exact copy of ChatCompletionAssistantMessageParam, but two changes.
+         * @description An assistant message in a trace.
          *
-         *     First change: List[T] instead of Iterable[T] for tool_calls and content. Addresses pydantic issue.
-         *     https://github.com/pydantic/pydantic/issues/9541
-         *
-         *     Second change: Add reasoning_content to the message. A LiteLLM property for reasoning data.
+         *     Almost a copy of the OpenAI SDK's ChatCompletionAssistantMessageParam, with the
+         *     `content` and `tool_calls` type changes described in this module's docstring, and
+         *     three added fields: `reasoning_content` (sent on to the provider), plus
+         *     `latency_ms` and `usage` (Kiln-only, stripped before the message is sent).
          */
         ChatCompletionAssistantMessageParamWrapper: {
             /**
@@ -4455,7 +4455,9 @@ export interface components {
             role: "assistant";
             audio?: components["schemas"]["Audio"] | null;
             /** Content */
-            content?: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartRefusalParam"])[] | null;
+            content?: string | {
+                [key: string]: unknown;
+            }[] | null;
             /** Reasoning Content */
             reasoning_content?: string | null;
             function_call?: components["schemas"]["FunctionCall"] | null;
@@ -4470,61 +4472,17 @@ export interface components {
             usage?: components["schemas"]["MessageUsage"] | null;
         };
         /**
-         * ChatCompletionContentPartImageParam
-         * @description Learn about [image inputs](https://platform.openai.com/docs/guides/vision).
-         */
-        ChatCompletionContentPartImageParam: {
-            image_url: components["schemas"]["ImageURL"];
-            /**
-             * Type
-             * @constant
-             */
-            type: "image_url";
-        };
-        /**
-         * ChatCompletionContentPartInputAudioParam
-         * @description Learn about [audio inputs](https://platform.openai.com/docs/guides/audio).
-         */
-        ChatCompletionContentPartInputAudioParam: {
-            input_audio: components["schemas"]["InputAudio"];
-            /**
-             * Type
-             * @constant
-             */
-            type: "input_audio";
-        };
-        /** ChatCompletionContentPartRefusalParam */
-        ChatCompletionContentPartRefusalParam: {
-            /** Refusal */
-            refusal: string;
-            /**
-             * Type
-             * @constant
-             */
-            type: "refusal";
-        };
-        /**
-         * ChatCompletionContentPartTextParam
-         * @description Learn about [text inputs](https://platform.openai.com/docs/guides/text-generation).
-         */
-        ChatCompletionContentPartTextParam: {
-            /** Text */
-            text: string;
-            /**
-             * Type
-             * @constant
-             */
-            type: "text";
-        };
-        /**
          * ChatCompletionDeveloperMessageParamWrapper
-         * @description Almost exact copy of ChatCompletionDeveloperMessageParam, with one change:
-         *     List[T] instead of Iterable[T] for content. Addresses pydantic issue.
-         *     https://github.com/pydantic/pydantic/issues/9541
+         * @description A developer message in a trace.
+         *
+         *     Almost an exact copy of the OpenAI SDK's ChatCompletionDeveloperMessageParam;
+         *     only the type of `content` differs. See this module's docstring for why.
          */
         ChatCompletionDeveloperMessageParamWrapper: {
             /** Content */
-            content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
+            content: string | {
+                [key: string]: unknown;
+            }[];
             /**
              * Role
              * @constant
@@ -4561,13 +4519,16 @@ export interface components {
         };
         /**
          * ChatCompletionSystemMessageParamWrapper
-         * @description Almost exact copy of ChatCompletionSystemMessageParam, with one change:
-         *     List[T] instead of Iterable[T] for content. Addresses pydantic issue.
-         *     https://github.com/pydantic/pydantic/issues/9541
+         * @description A system message in a trace.
+         *
+         *     Almost an exact copy of the OpenAI SDK's ChatCompletionSystemMessageParam;
+         *     only the type of `content` differs. See this module's docstring for why.
          */
         ChatCompletionSystemMessageParamWrapper: {
             /** Content */
-            content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
+            content: string | {
+                [key: string]: unknown;
+            }[];
             /**
              * Role
              * @constant
@@ -4576,10 +4537,19 @@ export interface components {
             /** Name */
             name?: string;
         };
-        /** ChatCompletionToolMessageParamWrapper */
+        /**
+         * ChatCompletionToolMessageParamWrapper
+         * @description A tool-result message in a trace.
+         *
+         *     Almost a copy of the OpenAI SDK's ChatCompletionToolMessageParam, with the
+         *     `content` type change described in this module's docstring, and the Kiln-only
+         *     fields below - all of them stripped before the message is sent to a provider.
+         */
         ChatCompletionToolMessageParamWrapper: {
             /** Content */
-            content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
+            content: string | {
+                [key: string]: unknown;
+            }[];
             /**
              * Role
              * @constant
@@ -4596,16 +4566,19 @@ export interface components {
         };
         /**
          * ChatCompletionUserMessageParamWrapper
-         * @description Almost exact copy of ChatCompletionUserMessageParam, with one change:
-         *     List[T] instead of Iterable[T] for content. Addresses pydantic issue.
-         *     https://github.com/pydantic/pydantic/issues/9541
+         * @description A user message in a trace.
+         *
+         *     Almost an exact copy of the OpenAI SDK's ChatCompletionUserMessageParam; only
+         *     the type of `content` differs. See this module's docstring for why.
          *
          *     This is the multimodal message type: its content parts include images, audio
          *     and files, not only text.
          */
         ChatCompletionUserMessageParamWrapper: {
             /** Content */
-            content: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartImageParam"] | components["schemas"]["ChatCompletionContentPartInputAudioParam"] | components["schemas"]["File"])[];
+            content: string | {
+                [key: string]: unknown;
+            }[];
             /**
              * Role
              * @constant
@@ -7399,27 +7372,6 @@ export interface components {
             output: string;
         };
         /**
-         * File
-         * @description Learn about [file inputs](https://platform.openai.com/docs/guides/text) for text generation.
-         */
-        File: {
-            file: components["schemas"]["FileFile"];
-            /**
-             * Type
-             * @constant
-             */
-            type: "file";
-        };
-        /** FileFile */
-        FileFile: {
-            /** File Data */
-            file_data?: string;
-            /** File Id */
-            file_id?: string;
-            /** Filename */
-            filename?: string;
-        };
-        /**
          * FileInfo
          * @description Metadata about an uploaded file.
          */
@@ -8023,26 +7975,6 @@ export interface components {
             core_requirement: string;
             /** Hallucinations Examples */
             hallucinations_examples: string;
-        };
-        /** ImageURL */
-        ImageURL: {
-            /** Url */
-            url: string;
-            /**
-             * Detail
-             * @enum {string}
-             */
-            detail?: "auto" | "low" | "high";
-        };
-        /** InputAudio */
-        InputAudio: {
-            /** Data */
-            data: string;
-            /**
-             * Format
-             * @enum {string}
-             */
-            format: "wav" | "mp3";
         };
         /** InputsBatchResultItem */
         InputsBatchResultItem: {

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -4442,7 +4442,7 @@ export interface components {
          * ChatCompletionAssistantMessageParamWrapper
          * @description Almost exact copy of ChatCompletionAssistantMessageParam, but two changes.
          *
-         *     First change: List[T] instead of Iterable[T] for tool_calls. Addresses pydantic issue.
+         *     First change: List[T] instead of Iterable[T] for tool_calls and content. Addresses pydantic issue.
          *     https://github.com/pydantic/pydantic/issues/9541
          *
          *     Second change: Add reasoning_content to the message. A LiteLLM property for reasoning data.
@@ -4517,12 +4517,12 @@ export interface components {
             type: "text";
         };
         /**
-         * ChatCompletionDeveloperMessageParam
-         * @description Developer-provided instructions that the model should follow, regardless of
-         *     messages sent by the user. With o1 models and newer, `developer` messages
-         *     replace the previous `system` messages.
+         * ChatCompletionDeveloperMessageParamWrapper
+         * @description Almost exact copy of ChatCompletionDeveloperMessageParam, with one change:
+         *     List[T] instead of Iterable[T] for content. Addresses pydantic issue.
+         *     https://github.com/pydantic/pydantic/issues/9541
          */
-        ChatCompletionDeveloperMessageParam: {
+        ChatCompletionDeveloperMessageParamWrapper: {
             /** Content */
             content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
             /**
@@ -4560,12 +4560,12 @@ export interface components {
             type: "function";
         };
         /**
-         * ChatCompletionSystemMessageParam
-         * @description Developer-provided instructions that the model should follow, regardless of
-         *     messages sent by the user. With o1 models and newer, use `developer` messages
-         *     for this purpose instead.
+         * ChatCompletionSystemMessageParamWrapper
+         * @description Almost exact copy of ChatCompletionSystemMessageParam, with one change:
+         *     List[T] instead of Iterable[T] for content. Addresses pydantic issue.
+         *     https://github.com/pydantic/pydantic/issues/9541
          */
-        ChatCompletionSystemMessageParam: {
+        ChatCompletionSystemMessageParamWrapper: {
             /** Content */
             content: string | components["schemas"]["ChatCompletionContentPartTextParam"][];
             /**
@@ -4595,11 +4595,15 @@ export interface components {
             error_message?: string | null;
         };
         /**
-         * ChatCompletionUserMessageParam
-         * @description Messages sent by an end user, containing prompts or additional context
-         *     information.
+         * ChatCompletionUserMessageParamWrapper
+         * @description Almost exact copy of ChatCompletionUserMessageParam, with one change:
+         *     List[T] instead of Iterable[T] for content. Addresses pydantic issue.
+         *     https://github.com/pydantic/pydantic/issues/9541
+         *
+         *     This is the multimodal message type: its content parts include images, audio
+         *     and files, not only text.
          */
-        ChatCompletionUserMessageParam: {
+        ChatCompletionUserMessageParamWrapper: {
             /** Content */
             content: string | (components["schemas"]["ChatCompletionContentPartTextParam"] | components["schemas"]["ChatCompletionContentPartImageParam"] | components["schemas"]["ChatCompletionContentPartInputAudioParam"] | components["schemas"]["File"])[];
             /**
@@ -6251,7 +6255,7 @@ export interface components {
             /** Error Type */
             error_type: string;
             /** Trace */
-            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParam"] | components["schemas"]["ChatCompletionSystemMessageParam"] | components["schemas"]["ChatCompletionUserMessageParam"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper"] | components["schemas"]["ChatCompletionToolMessageParamWrapper"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
+            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParamWrapper"] | components["schemas"]["ChatCompletionSystemMessageParamWrapper"] | components["schemas"]["ChatCompletionUserMessageParamWrapper"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper"] | components["schemas"]["ChatCompletionToolMessageParamWrapper"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
         };
         /**
          * Eval
@@ -11476,7 +11480,7 @@ export interface components {
              * Trace
              * @description The trace of the task run in OpenAI format. This is the list of messages that were sent to/from the model.
              */
-            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParam"] | components["schemas"]["ChatCompletionSystemMessageParam"] | components["schemas"]["ChatCompletionUserMessageParam"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper"] | components["schemas"]["ChatCompletionToolMessageParamWrapper"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
+            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParamWrapper"] | components["schemas"]["ChatCompletionSystemMessageParamWrapper"] | components["schemas"]["ChatCompletionUserMessageParamWrapper"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper"] | components["schemas"]["ChatCompletionToolMessageParamWrapper"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
             /**
              * Parent Task Run Id
              * @description The ID of the parent task run. This is the ID of the task run that contains this task run.
@@ -11557,7 +11561,7 @@ export interface components {
              * Trace
              * @description The trace of the task run in OpenAI format. This is the list of messages that were sent to/from the model.
              */
-            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParam"] | components["schemas"]["ChatCompletionSystemMessageParam"] | components["schemas"]["ChatCompletionUserMessageParam"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper"] | components["schemas"]["ChatCompletionToolMessageParamWrapper"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
+            trace?: (components["schemas"]["ChatCompletionDeveloperMessageParamWrapper"] | components["schemas"]["ChatCompletionSystemMessageParamWrapper"] | components["schemas"]["ChatCompletionUserMessageParamWrapper"] | components["schemas"]["ChatCompletionAssistantMessageParamWrapper"] | components["schemas"]["ChatCompletionToolMessageParamWrapper"] | components["schemas"]["ChatCompletionFunctionMessageParam"])[] | null;
             /**
              * Parent Task Run Id
              * @description The ID of the parent task run. This is the ID of the task run that contains this task run.

--- a/app/web_ui/src/lib/types.ts
+++ b/app/web_ui/src/lib/types.ts
@@ -129,9 +129,9 @@ export type AvailableProviderInfo =
   components["schemas"]["AvailableProviderInfo"]
 
 export type TraceMessage =
-  | components["schemas"]["ChatCompletionDeveloperMessageParam"]
-  | components["schemas"]["ChatCompletionSystemMessageParam"]
-  | components["schemas"]["ChatCompletionUserMessageParam"]
+  | components["schemas"]["ChatCompletionDeveloperMessageParamWrapper"]
+  | components["schemas"]["ChatCompletionSystemMessageParamWrapper"]
+  | components["schemas"]["ChatCompletionUserMessageParamWrapper"]
   | components["schemas"]["ChatCompletionAssistantMessageParamWrapper"]
   | components["schemas"]["ChatCompletionToolMessageParamWrapper"]
   | components["schemas"]["ChatCompletionFunctionMessageParam"]

--- a/libs/core/kiln_ai/adapters/errors.py
+++ b/libs/core/kiln_ai/adapters/errors.py
@@ -11,7 +11,7 @@ Provides:
 from __future__ import annotations
 
 import litellm
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from kiln_ai.utils.open_ai_types import ChatCompletionMessageParam, Trace
 
@@ -25,6 +25,11 @@ class ErrorWithTrace(BaseModel):
     Returned by endpoints that run a task adapter when the adapter throws
     after starting a run (LLM calls made, tools invoked, etc.).
     """
+
+    # validate_assignment so that assigning `trace` after construction gets the same
+    # guard as passing it in - without it the `Trace` annotation below would advertise
+    # a protection this model does not apply, unlike TaskRun which sets it.
+    model_config = ConfigDict(validate_assignment=True)
 
     message: str
     error_type: str

--- a/libs/core/kiln_ai/adapters/errors.py
+++ b/libs/core/kiln_ai/adapters/errors.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import litellm
 from pydantic import BaseModel
 
-from kiln_ai.utils.open_ai_types import ChatCompletionMessageParam
+from kiln_ai.utils.open_ai_types import ChatCompletionMessageParam, Trace
 
 _GENERIC_FALLBACK_MESSAGE = "An unexpected error occurred."
 
@@ -28,7 +28,7 @@ class ErrorWithTrace(BaseModel):
 
     message: str
     error_type: str
-    trace: list[ChatCompletionMessageParam] | None = None
+    trace: Trace | None = None
 
 
 class KilnRunError(Exception):

--- a/libs/core/kiln_ai/adapters/model_adapters/mcp_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/mcp_adapter.py
@@ -25,7 +25,7 @@ from kiln_ai.utils.config import Config
 from kiln_ai.utils.open_ai_types import (
     ChatCompletionAssistantMessageParamWrapper,
     ChatCompletionMessageParam,
-    ChatCompletionUserMessageParam,
+    ChatCompletionUserMessageParamWrapper,
 )
 
 
@@ -225,7 +225,7 @@ class MCPAdapter(BaseAdapter):
     def _build_single_turn_trace(
         input: InputType, output: str | dict
     ) -> list[ChatCompletionMessageParam]:
-        user_message: ChatCompletionUserMessageParam = {
+        user_message: ChatCompletionUserMessageParamWrapper = {
             "role": "user",
             "content": input
             if isinstance(input, str)

--- a/libs/core/kiln_ai/adapters/model_adapters/test_multimodal_trace_paid.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_multimodal_trace_paid.py
@@ -1,0 +1,172 @@
+"""End-to-end paid tests for multimodal (list-valued) message content in a trace.
+
+A message's `content` is normally a string. For a multimodal message it is a list of
+parts instead - text plus an image, audio or a file. That list is the only copy of the
+image: nothing else in a TaskRun carries it, so if it is dropped on the way to disk it
+is gone for good.
+
+It used to be dropped. Every role declared `content` as `Iterable[T]`, which pydantic
+validates into a single-use iterator; serializing read it, the read emptied it, and
+`save_to_file` wrote `content: []` with no error and no warning. The unit tests in
+`libs/core/kiln_ai/utils/test_open_ai_types.py` pin the model layer. These run the whole
+path against a real provider: a real image goes to a real multimodal model, the answer
+proves the model received the image, and the image part is read back off disk afterwards.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kiln_ai import datamodel
+from kiln_ai.adapters.adapter_registry import adapter_for_task
+from kiln_ai.adapters.extractors.litellm_extractor import encode_file_litellm_format
+from kiln_ai.adapters.pytest_prerelease_whitelist import (
+    PRERELEASE_MULTIMODAL_TRACE_MODELS,
+)
+from kiln_ai.datamodel.datamodel_enums import ModelProviderName, StructuredOutputMode
+from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
+from kiln_ai.datamodel.task_run import TaskRun
+from kiln_ai.pytest_mock_files import MockFileFactoryMimeType
+from kiln_ai.utils.open_ai_types import (
+    ChatCompletionMessageParam,
+    ChatCompletionUserMessageParamWrapper,
+)
+
+# The PNG the mock file factory hands back is the Kodak "kodim23" parrots photo. Any
+# model that actually looked at it says one of these; a model that received an empty
+# content list cannot.
+IMAGE_ANSWER_TERMS = ["parrot", "bird", "macaw"]
+
+
+def build_multimodal_task(tmp_path: Path) -> datamodel.Task:
+    project = datamodel.Project(name="test", path=tmp_path / "test.kiln")
+    project.save_to_file()
+
+    task = datamodel.Task(
+        parent=project,
+        name="describe the image",
+        instruction=(
+            "You describe images. Answer the user's question about the image they "
+            "sent, in one short sentence."
+        ),
+    )
+    task.save_to_file()
+    return task
+
+
+def build_image_message(
+    image_path: Path, provider: ModelProviderName
+) -> ChatCompletionUserMessageParamWrapper:
+    """A user message whose content is a list of parts: text, then a real PNG."""
+    return {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Here is an image."},
+            encode_file_litellm_format(
+                image_path, MockFileFactoryMimeType.PNG.value, provider
+            ),
+        ],
+    }
+
+
+def image_part_of(message: ChatCompletionMessageParam) -> dict:
+    content = message["content"]
+    assert isinstance(content, list), (
+        f"content is a {type(content).__name__}, not a list of parts - the multimodal "
+        "message lost its parts"
+    )
+    assert len(content) == 2, f"expected 2 content parts, got {len(content)}"
+    return content[1]
+
+
+def run_config(model_name: str, provider: str) -> KilnAgentRunConfigProperties:
+    return KilnAgentRunConfigProperties(
+        model_name=model_name,
+        model_provider_name=ModelProviderName(provider),
+        prompt_id="simple_prompt_builder",
+        structured_output_mode=StructuredOutputMode.json_schema,
+    )
+
+
+@pytest.mark.paid
+@pytest.mark.prerelease
+@pytest.mark.parametrize("model_name, provider", PRERELEASE_MULTIMODAL_TRACE_MODELS)
+async def test_multimodal_trace_survives_save_to_file(
+    tmp_path, mock_file_factory, model_name, provider
+):
+    """The full flow, end to end: a real image reaches a real model, and the image
+    part is still on disk when the run is read back."""
+    task = build_multimodal_task(tmp_path)
+    image_path = mock_file_factory(MockFileFactoryMimeType.PNG)
+    image_message = build_image_message(image_path, ModelProviderName(provider))
+
+    adapter = adapter_for_task(task, run_config(model_name, provider))
+    run = await adapter.invoke(
+        input="What animal is in the image?",
+        prior_trace=[image_message],
+    )
+
+    # The model answered from the image, so the image really was sent.
+    assert any(term in run.output.output.lower() for term in IMAGE_ANSWER_TERMS), (
+        f"model did not describe the image. Response: {run.output.output}"
+    )
+
+    # invoke() saved the run (autosave_runs defaults on, and the task has a path).
+    assert run.path is not None, "run was not saved - nothing to read back"
+    reloaded = TaskRun.load_from_file(run.path)
+
+    assert reloaded.trace is not None
+    assert image_part_of(reloaded.trace[0]) == image_message["content"][1]
+    assert image_part_of(reloaded.trace[0])["image_url"]["url"].startswith(
+        "data:image/png;base64,"
+    )
+
+
+@pytest.mark.paid
+async def test_multimodal_trace_survives_a_second_turn_and_a_second_save(
+    tmp_path, mock_file_factory
+):
+    """The original bug lost some roles' content only on the *second* write, so one
+    save proving correct was never enough.
+
+    A second turn is how that happens in practice: the stored trace is loaded, seeded
+    back in as `prior_trace`, extended by a new exchange, and saved again. The image
+    part has to survive both writes, and the model has to still see it on turn two.
+    """
+    model_name, provider = PRERELEASE_MULTIMODAL_TRACE_MODELS[0]
+    task = build_multimodal_task(tmp_path)
+    image_path = mock_file_factory(MockFileFactoryMimeType.PNG)
+    image_message = build_image_message(image_path, ModelProviderName(provider))
+
+    adapter = adapter_for_task(task, run_config(model_name, provider))
+    first_run = await adapter.invoke(
+        input="What animal is in the image?",
+        prior_trace=[image_message],
+    )
+    assert first_run.path is not None
+    first_trace = TaskRun.load_from_file(first_run.path).trace
+    assert first_trace is not None
+
+    second_run = await adapter.invoke(
+        input="What colors is it? Name the animal again in your answer.",
+        prior_trace=list(first_trace),
+    )
+
+    # Turn two still had the image: the model names the animal without being told it.
+    assert any(
+        term in second_run.output.output.lower() for term in IMAGE_ANSWER_TERMS
+    ), f"model lost the image on the second turn. Response: {second_run.output.output}"
+
+    assert second_run.path is not None
+    reloaded = TaskRun.load_from_file(second_run.path)
+    assert reloaded.trace is not None
+    assert image_part_of(reloaded.trace[0]) == image_message["content"][1]
+
+    # And saving the loaded run again does not empty it either.
+    resaved = reloaded.mutable_copy()
+    resaved.save_to_file()
+    assert resaved.path is not None
+    assert (
+        image_part_of(TaskRun.load_from_file(resaved.path).trace[0])
+        == (image_message["content"][1])
+    )

--- a/libs/core/kiln_ai/adapters/model_adapters/test_multimodal_trace_paid.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_multimodal_trace_paid.py
@@ -42,6 +42,21 @@ from kiln_ai.utils.open_ai_types import (
 # content list cannot.
 IMAGE_ANSWER_TERMS = ["parrot", "bird", "macaw"]
 
+# The pair the second-turn test runs against, named rather than indexed into the
+# whitelist: reordering that list must not silently move this coverage - the only
+# two-write coverage there is - to a different provider.
+SECOND_TURN_MODEL = ("gpt_4o", ModelProviderName.openai.value)
+
+
+# The instruction the model actually gets. It is seeded as a system message in the
+# prior trace rather than set on the task: `build_chat_formatter` short-circuits to
+# `MultiturnFormatter` whenever `prior_trace` is set, and that formatter sends the
+# prior trace and nothing else - no task instruction, no prompt builder.
+SYSTEM_INSTRUCTION = (
+    "You describe images. Answer the user's question about the image they sent, in "
+    "one short sentence."
+)
+
 
 def build_multimodal_task(tmp_path: Path) -> datamodel.Task:
     project = datamodel.Project(name="test", path=tmp_path / "test.kiln")
@@ -50,10 +65,7 @@ def build_multimodal_task(tmp_path: Path) -> datamodel.Task:
     task = datamodel.Task(
         parent=project,
         name="describe the image",
-        instruction=(
-            "You describe images. Answer the user's question about the image they "
-            "sent, in one short sentence."
-        ),
+        instruction=SYSTEM_INSTRUCTION,
     )
     task.save_to_file()
     return task
@@ -74,6 +86,17 @@ def build_image_message(
     }
 
 
+def build_prior_trace(
+    image_message: ChatCompletionUserMessageParamWrapper,
+) -> list[ChatCompletionMessageParam]:
+    """What the model is sent: the instruction, then the multimodal message. The
+    image message is second, so `trace[1]` is the one to read back."""
+    return [
+        {"role": "system", "content": SYSTEM_INSTRUCTION},
+        image_message,
+    ]
+
+
 def image_part_of(message: ChatCompletionMessageParam) -> dict:
     content = message["content"]
     assert isinstance(content, list), (
@@ -85,6 +108,8 @@ def image_part_of(message: ChatCompletionMessageParam) -> dict:
 
 
 def run_config(model_name: str, provider: str) -> KilnAgentRunConfigProperties:
+    # prompt_id is required by KilnAgentRunConfigProperties but unused on this path:
+    # a run with a prior_trace never reaches the prompt builder. See SYSTEM_INSTRUCTION.
     return KilnAgentRunConfigProperties(
         model_name=model_name,
         model_provider_name=ModelProviderName(provider),
@@ -108,7 +133,7 @@ async def test_multimodal_trace_survives_save_to_file(
     adapter = adapter_for_task(task, run_config(model_name, provider))
     run = await adapter.invoke(
         input="What animal is in the image?",
-        prior_trace=[image_message],
+        prior_trace=build_prior_trace(image_message),
     )
 
     # The model answered from the image, so the image really was sent.
@@ -121,8 +146,8 @@ async def test_multimodal_trace_survives_save_to_file(
     reloaded = TaskRun.load_from_file(run.path)
 
     assert reloaded.trace is not None
-    assert image_part_of(reloaded.trace[0]) == image_message["content"][1]
-    assert image_part_of(reloaded.trace[0])["image_url"]["url"].startswith(
+    assert image_part_of(reloaded.trace[1]) == image_message["content"][1]
+    assert image_part_of(reloaded.trace[1])["image_url"]["url"].startswith(
         "data:image/png;base64,"
     )
 
@@ -138,7 +163,7 @@ async def test_multimodal_trace_survives_a_second_turn_and_a_second_save(
     back in as `prior_trace`, extended by a new exchange, and saved again. The image
     part has to survive both writes, and the model has to still see it on turn two.
     """
-    model_name, provider = PRERELEASE_MULTIMODAL_TRACE_MODELS[0]
+    model_name, provider = SECOND_TURN_MODEL
     task = build_multimodal_task(tmp_path)
     image_path = mock_file_factory(MockFileFactoryMimeType.PNG)
     image_message = build_image_message(image_path, ModelProviderName(provider))
@@ -146,7 +171,7 @@ async def test_multimodal_trace_survives_a_second_turn_and_a_second_save(
     adapter = adapter_for_task(task, run_config(model_name, provider))
     first_run = await adapter.invoke(
         input="What animal is in the image?",
-        prior_trace=[image_message],
+        prior_trace=build_prior_trace(image_message),
     )
     assert first_run.path is not None
     first_trace = TaskRun.load_from_file(first_run.path).trace
@@ -165,7 +190,7 @@ async def test_multimodal_trace_survives_a_second_turn_and_a_second_save(
     assert second_run.path is not None
     reloaded = TaskRun.load_from_file(second_run.path)
     assert reloaded.trace is not None
-    assert image_part_of(reloaded.trace[0]) == image_message["content"][1]
+    assert image_part_of(reloaded.trace[1]) == image_message["content"][1]
 
     # And saving the loaded run again does not empty it either.
     resaved = reloaded.mutable_copy()
@@ -173,7 +198,7 @@ async def test_multimodal_trace_survives_a_second_turn_and_a_second_save(
     assert resaved.path is not None
     resaved_trace = TaskRun.load_from_file(resaved.path).trace
     assert resaved_trace is not None
-    assert image_part_of(resaved_trace[0]) == image_message["content"][1]
+    assert image_part_of(resaved_trace[1]) == image_message["content"][1]
 
 
 @pytest.mark.parametrize("model_name, provider", PRERELEASE_MULTIMODAL_TRACE_MODELS)
@@ -198,3 +223,9 @@ def test_whitelist_entries_are_multimodal(model_name, provider):
     assert KilnMimeType.PNG.value in (model_provider.multimodal_mime_types or []), (
         f"{model_name} on {provider} no longer accepts {KilnMimeType.PNG.value}"
     )
+
+
+def test_second_turn_model_is_on_the_whitelist():
+    """`SECOND_TURN_MODEL` is named directly, so nothing else would keep it in step
+    with the whitelist - or give it the multimodal guard above."""
+    assert SECOND_TURN_MODEL in PRERELEASE_MULTIMODAL_TRACE_MODELS

--- a/libs/core/kiln_ai/adapters/model_adapters/test_multimodal_trace_paid.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_multimodal_trace_paid.py
@@ -20,10 +20,15 @@ import pytest
 from kiln_ai import datamodel
 from kiln_ai.adapters.adapter_registry import adapter_for_task
 from kiln_ai.adapters.extractors.litellm_extractor import encode_file_litellm_format
+from kiln_ai.adapters.ml_model_list import built_in_models_from_provider
 from kiln_ai.adapters.pytest_prerelease_whitelist import (
     PRERELEASE_MULTIMODAL_TRACE_MODELS,
 )
-from kiln_ai.datamodel.datamodel_enums import ModelProviderName, StructuredOutputMode
+from kiln_ai.datamodel.datamodel_enums import (
+    KilnMimeType,
+    ModelProviderName,
+    StructuredOutputMode,
+)
 from kiln_ai.datamodel.run_config import KilnAgentRunConfigProperties
 from kiln_ai.datamodel.task_run import TaskRun
 from kiln_ai.pytest_mock_files import MockFileFactoryMimeType
@@ -166,7 +171,30 @@ async def test_multimodal_trace_survives_a_second_turn_and_a_second_save(
     resaved = reloaded.mutable_copy()
     resaved.save_to_file()
     assert resaved.path is not None
-    assert (
-        image_part_of(TaskRun.load_from_file(resaved.path).trace[0])
-        == (image_message["content"][1])
+    resaved_trace = TaskRun.load_from_file(resaved.path).trace
+    assert resaved_trace is not None
+    assert image_part_of(resaved_trace[0]) == image_message["content"][1]
+
+
+@pytest.mark.parametrize("model_name, provider", PRERELEASE_MULTIMODAL_TRACE_MODELS)
+def test_whitelist_entries_are_multimodal(model_name, provider):
+    """Guard the whitelist itself, in ordinary CI rather than a paid run.
+
+    Every entry above has to be a model that can actually receive a PNG. If one
+    stops being multimodal - or the slug is retired - the paid tests would fail
+    against the live provider and read as a regression in the trace round trip,
+    which is the thing they exist to check. This fails first, and says why.
+    """
+    model_provider = built_in_models_from_provider(
+        ModelProviderName(provider), model_name
+    )
+
+    assert model_provider is not None, (
+        f"{model_name} has no {provider} provider in ml_model_list.py"
+    )
+    assert model_provider.multimodal_capable, (
+        f"{model_name} on {provider} is no longer multimodal_capable"
+    )
+    assert KilnMimeType.PNG.value in (model_provider.multimodal_mime_types or []), (
+        f"{model_name} on {provider} no longer accepts {KilnMimeType.PNG.value}"
     )

--- a/libs/core/kiln_ai/adapters/pytest_prerelease_whitelist.py
+++ b/libs/core/kiln_ai/adapters/pytest_prerelease_whitelist.py
@@ -49,6 +49,16 @@ PRERELEASE_EXTRACTION_MODELS: list[tuple[str, str]] = [
     ("gemini_3_flash", ModelProviderName.gemini_api.value),
 ]
 
+# (model_name, provider_name) — used by the multimodal trace round-trip prerelease
+# smoke test. Every entry must be multimodal_capable in ml_model_list.py with
+# image/png in its multimodal_mime_types: the test sends a real image in the trace
+# and asserts the image part is still on disk after the run is saved.
+PRERELEASE_MULTIMODAL_TRACE_MODELS: list[tuple[str, str]] = [
+    ("gpt_4o", ModelProviderName.openai.value),
+    ("claude_sonnet_4_6", ModelProviderName.anthropic.value),
+    ("gemini_3_flash", ModelProviderName.gemini_api.value),
+]
+
 # Subset of mime types to exercise in the prerelease extraction smoke test.
 # The full paid test sweeps all 13 mime types per model — too slow for prerelease.
 # This covers one example per major content category.

--- a/libs/core/kiln_ai/adapters/pytest_prerelease_whitelist.py
+++ b/libs/core/kiln_ai/adapters/pytest_prerelease_whitelist.py
@@ -53,6 +53,12 @@ PRERELEASE_EXTRACTION_MODELS: list[tuple[str, str]] = [
 # smoke test. Every entry must be multimodal_capable in ml_model_list.py with
 # image/png in its multimodal_mime_types: the test sends a real image in the trace
 # and asserts the image part is still on disk after the run is saved.
+#
+# The entries match PRERELEASE_EXTRACTION_MODELS today, and the list is still separate
+# on purpose: extraction goes through the extractor and needs a model that reads
+# documents, while this goes through the chat adapter and needs one that takes an image
+# in a chat message. Re-pin them independently — a model can stop being right for one
+# and stay right for the other.
 PRERELEASE_MULTIMODAL_TRACE_MODELS: list[tuple[str, str]] = [
     ("gpt_4o", ModelProviderName.openai.value),
     ("claude_sonnet_4_6", ModelProviderName.anthropic.value),

--- a/libs/core/kiln_ai/adapters/test_errors.py
+++ b/libs/core/kiln_ai/adapters/test_errors.py
@@ -270,3 +270,62 @@ class TestErrorWithTrace:
     def test_trace_defaults_to_none(self):
         err = ErrorWithTrace(message="m", error_type="E")
         assert err.trace is None
+
+    def test_materializes_a_lazy_content(self):
+        """A failed run's partial trace is the only record of what happened, so it
+        needs the same guard `TaskRun.trace` has - see `materialize_lazy_content`.
+        """
+        err = ErrorWithTrace(
+            message="boom",
+            error_type="RuntimeError",
+            trace=[
+                {
+                    "role": "user",
+                    "content": (p for p in [{"type": "text", "text": "GEN"}]),
+                }
+            ],  # type: ignore[arg-type]
+        )
+
+        assert err.trace is not None
+        assert err.trace[0]["content"] == [{"type": "text", "text": "GEN"}]
+
+    def test_materializes_a_lazy_content_assigned_after_construction(self):
+        """`validate_assignment` is what makes the `Trace` annotation mean something
+        on a field that is also written to directly."""
+        err = ErrorWithTrace(message="boom", error_type="RuntimeError")
+
+        err.trace = [
+            {"role": "user", "content": (p for p in [{"type": "text", "text": "GEN"}])}
+        ]  # type: ignore[assignment]
+
+        assert err.trace is not None
+        assert err.trace[0]["content"] == [{"type": "text", "text": "GEN"}]
+        assert err.model_dump(mode="json")["trace"][0]["content"] == [
+            {"type": "text", "text": "GEN"}
+        ]
+
+    def test_accepts_a_partial_trace_holding_a_content_part_the_sdk_union_rejects(self):
+        """This model is constructed *inside* the KilnRunError handler, so a
+        ValidationError here replaces the real error message with pydantic noise and
+        loses the partial trace as well. It has to accept whatever the run built -
+        including the `video_url` part Kiln's own file encoder emits for OpenRouter.
+        """
+        trace = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "data:video/mp4;base64,AAAA"},
+                    }
+                ],
+            }
+        ]
+
+        err = ErrorWithTrace(
+            message="downstream failure",
+            error_type="RuntimeError",
+            trace=trace,  # type: ignore[arg-type]
+        )
+
+        assert err.model_dump(mode="json")["trace"] == trace

--- a/libs/core/kiln_ai/datamodel/task_run.py
+++ b/libs/core/kiln_ai/datamodel/task_run.py
@@ -10,7 +10,7 @@ from kiln_ai.datamodel.json_schema import validate_schema_with_value_error
 from kiln_ai.datamodel.strict_mode import strict_mode
 from kiln_ai.datamodel.task_output import DataSource, TaskOutput
 from kiln_ai.utils.open_ai_types import (
-    ChatCompletionMessageParam,
+    Trace,
     trace_has_pending_client_tool_calls,
 )
 from kiln_ai.utils.usage import MessageUsage as MessageUsage
@@ -106,7 +106,7 @@ class TaskRun(
             "cost fields equal those of `usage`."
         ),
     )
-    trace: list[ChatCompletionMessageParam] | None = Field(
+    trace: Trace | None = Field(
         default=None,
         description="The trace of the task run in OpenAI format. This is the list of messages that were sent to/from the model.",
     )

--- a/libs/core/kiln_ai/utils/open_ai_types.py
+++ b/libs/core/kiln_ai/utils/open_ai_types.py
@@ -1,13 +1,24 @@
 """
 Wrapper for OpenAI types to make them compatible with Pydantic.
 
-Pydantic doesn't support Iterable[T] well, so we use List[T] instead for tool_calls,
+Pydantic doesn't support Iterable[T] well, so we use List[T] instead for every
+Iterable[T] field the OpenAI SDK declares: tool_calls, and the list-of-parts form
+of content on every role that allows it.
 https://github.com/pydantic/pydantic/issues/9541
 
-Otherwise we are using OpenAI SDK types directly.
+Pydantic validates an Iterable[T] field into a single-use ValidatorIterator rather
+than a list. Serializing reads it, and a read empties it, so a list-valued content
+would be written to disk as `content: []` - silently, and permanently. List[T]
+materializes at validation time instead, which also makes the message deep-copyable
+(a ValidatorIterator cannot be pickled).
+
+The wrappers below exist only to make that substitution; every other field matches
+the OpenAI SDK type of the same name, plus the Kiln-only fields in
+KILN_ONLY_MESSAGE_FIELDS.
 """
 
 from typing import (
+    Annotated,
     Any,
     Iterable,
     List,
@@ -18,29 +29,93 @@ from typing import (
 )
 
 from openai.types.chat import (
+    ChatCompletionContentPartParam,
     ChatCompletionContentPartTextParam,
-    ChatCompletionDeveloperMessageParam,
     ChatCompletionFunctionMessageParam,
     ChatCompletionMessageToolCallParam,
-    ChatCompletionSystemMessageParam,
-    ChatCompletionUserMessageParam,
 )
 from openai.types.chat.chat_completion_assistant_message_param import (
     Audio,
     ContentArrayOfContentPart,
     FunctionCall,
 )
-from pydantic import TypeAdapter
+from pydantic import BeforeValidator, TypeAdapter
 from typing_extensions import Required, TypedDict
 
 from kiln_ai.utils.usage import MessageUsage
+
+
+class ChatCompletionDeveloperMessageParamWrapper(TypedDict, total=False):
+    """
+    Almost exact copy of ChatCompletionDeveloperMessageParam, with one change:
+    List[T] instead of Iterable[T] for content. Addresses pydantic issue.
+    https://github.com/pydantic/pydantic/issues/9541
+    """
+
+    content: Required[Union[str, List[ChatCompletionContentPartTextParam]]]
+    """The contents of the developer message."""
+
+    role: Required[Literal["developer"]]
+    """The role of the messages author, in this case `developer`."""
+
+    name: str
+    """An optional name for the participant.
+
+    Provides the model information to differentiate between participants of the same
+    role.
+    """
+
+
+class ChatCompletionSystemMessageParamWrapper(TypedDict, total=False):
+    """
+    Almost exact copy of ChatCompletionSystemMessageParam, with one change:
+    List[T] instead of Iterable[T] for content. Addresses pydantic issue.
+    https://github.com/pydantic/pydantic/issues/9541
+    """
+
+    content: Required[Union[str, List[ChatCompletionContentPartTextParam]]]
+    """The contents of the system message."""
+
+    role: Required[Literal["system"]]
+    """The role of the messages author, in this case `system`."""
+
+    name: str
+    """An optional name for the participant.
+
+    Provides the model information to differentiate between participants of the same
+    role.
+    """
+
+
+class ChatCompletionUserMessageParamWrapper(TypedDict, total=False):
+    """
+    Almost exact copy of ChatCompletionUserMessageParam, with one change:
+    List[T] instead of Iterable[T] for content. Addresses pydantic issue.
+    https://github.com/pydantic/pydantic/issues/9541
+
+    This is the multimodal message type: its content parts include images, audio
+    and files, not only text.
+    """
+
+    content: Required[Union[str, List[ChatCompletionContentPartParam]]]
+    """The contents of the user message."""
+
+    role: Required[Literal["user"]]
+    """The role of the messages author, in this case `user`."""
+
+    name: str
+    """An optional name for the participant.
+
+    Provides the model information to differentiate between participants of the same
+    role.
+    """
 
 
 class ChatCompletionAssistantMessageParamWrapper(TypedDict, total=False):
     """
     Almost exact copy of ChatCompletionAssistantMessageParam, but two changes.
 
-    First change: List[T] instead of Iterable[T] for tool_calls. Addresses pydantic issue.
+    First change: List[T] instead of Iterable[T] for tool_calls and content. Addresses pydantic issue.
     https://github.com/pydantic/pydantic/issues/9541
 
     Second change: Add reasoning_content to the message. A LiteLLM property for reasoning data.
@@ -55,7 +130,7 @@ class ChatCompletionAssistantMessageParamWrapper(TypedDict, total=False):
     [Learn more](https://platform.openai.com/docs/guides/audio).
     """
 
-    content: Union[str, Iterable[ContentArrayOfContentPart], None]
+    content: Union[str, List[ContentArrayOfContentPart], None]
     """The contents of the assistant message.
 
     Required unless `tool_calls` or `function_call` is specified.
@@ -101,7 +176,7 @@ class ChatCompletionAssistantMessageParamWrapper(TypedDict, total=False):
 
 
 class ChatCompletionToolMessageParamWrapper(TypedDict, total=False):
-    content: Required[Union[str, Iterable[ChatCompletionContentPartTextParam]]]
+    content: Required[Union[str, List[ChatCompletionContentPartTextParam]]]
     """The contents of the tool message."""
 
     role: Required[Literal["tool"]]
@@ -124,9 +199,9 @@ class ChatCompletionToolMessageParamWrapper(TypedDict, total=False):
 
 
 ChatCompletionMessageParam: TypeAlias = Union[
-    ChatCompletionDeveloperMessageParam,
-    ChatCompletionSystemMessageParam,
-    ChatCompletionUserMessageParam,
+    ChatCompletionDeveloperMessageParamWrapper,
+    ChatCompletionSystemMessageParamWrapper,
+    ChatCompletionUserMessageParamWrapper,
     ChatCompletionAssistantMessageParamWrapper,
     ChatCompletionToolMessageParamWrapper,
     ChatCompletionFunctionMessageParam,
@@ -165,49 +240,54 @@ def sanitize_messages_for_provider(messages: Iterable[Any]) -> list[Any]:
     return sanitized
 
 
+def materialize_lazy_content(trace: Any) -> Any:
+    """Normalize a lazily-iterable ``content`` to a list, in front of union validation.
+
+    The wrappers declare ``content`` as ``List[T]``, so a list arrives whole. A caller
+    can still hand over any other iterable - a generator, a ``map`` object - and that
+    is where pydantic's smart union bites: it tries its members in order, and the
+    members whose role does not match still drain the iterator before they fail. By the
+    time the matching member runs there is nothing left to read, and the message
+    validates to ``content: []`` - silently, with the parts gone. Draining it here,
+    once, is what makes that safe.
+
+    Scoped to ``content`` deliberately, and it needs to stay that way. Iterating a
+    pydantic model yields its ``(name, value)`` pairs, so a walk over "any iterable
+    value" would turn a message's ``usage`` into a list of pairs.
+
+    Returns copies: the caller's own messages are never mutated. Anything that is not
+    a list of dicts passes through untouched, for pydantic to reject with its own error.
+    """
+    if not isinstance(trace, list):
+        return trace
+
+    materialized: list[Any] = []
+    for message in trace:
+        content = message.get("content") if isinstance(message, dict) else None
+        if (
+            content is not None
+            and not isinstance(content, (str, bytes, list, dict))
+            and isinstance(content, Iterable)
+        ):
+            message = {**message, "content": list(content)}
+        materialized.append(message)
+    return materialized
+
+
+Trace: TypeAlias = Annotated[
+    list[ChatCompletionMessageParam], BeforeValidator(materialize_lazy_content)
+]
+"""A trace as a pydantic model should declare it.
+
+Use this, not a bare ``list[ChatCompletionMessageParam]``: the validator is what
+stops a lazily-iterable ``content`` from being drained to nothing by the union - see
+:func:`materialize_lazy_content`.
+"""
+
+
 _trace_adapter: TypeAdapter[list[ChatCompletionMessageParam]] = TypeAdapter(
     list[ChatCompletionMessageParam]
 )
-
-
-def _materialize_lazy_content(trace: Iterable[Any]) -> None:
-    """Replace each message's lazily-validated `content` with the list it yields.
-
-    Pydantic validates the wrappers' ``Iterable[...]``-typed fields into a lazy,
-    single-use ``ValidatorIterator``. Serializing reads it, and a read empties it, so
-    without this a trace would serialize correctly once and as ``content: []`` every
-    time after - and any ``save_to_file`` on the same object would persist the empty
-    version. The read is unavoidable; writing the result back in place is what makes
-    it harmless.
-
-    Scoped to ``content`` deliberately, and it needs to stay that way. ``content`` is
-    the only ``Iterable[...]``-typed field across all six union members (``tool_calls``
-    is a ``List``, which pydantic materializes eagerly). Widening this to "any iterable
-    value" would also sweep in ``usage`` - and iterating a pydantic model yields its
-    ``(name, value)`` pairs, so a ``MessageUsage`` would serialize as a list of pairs.
-
-    Takes ``Iterable[Any]``, the same structural shape
-    :func:`sanitize_messages_for_provider` uses - though for a different reason: that
-    one is loose because its callers really do pass heterogeneous values, while here
-    the sole caller passes a precise ``list[ChatCompletionMessageParam]`` and the
-    ``Any`` exists only to make the write expressible. One union member declares
-    ``content`` as ``str | None`` (the function role), so no tighter signature type
-    checks, and ``typing.cast`` is banned repo-wide. The guard below still means only
-    a message actually holding a lazy iterator is ever written to.
-
-    One side effect, not a defect: a lazy ``content`` matched the union's ``generator``
-    branch, so ``TaskRun.model_dump_json`` emitted no warning for it. A materialized
-    ``list`` matches neither ``str`` nor ``generator``, so each later dump of the same
-    object emits one ``PydanticSerializationUnexpectedValue`` warning. The bytes
-    written are unchanged - this is stderr noise only.
-    """
-    for message in trace:
-        if not isinstance(message, dict):
-            continue
-        content = message.get("content")
-        if content is None or isinstance(content, (str, bytes, list, dict)):
-            continue
-        message["content"] = list(content)
 
 
 def serialize_trace(trace: list[ChatCompletionMessageParam]) -> str:
@@ -218,16 +298,11 @@ def serialize_trace(trace: list[ChatCompletionMessageParam]) -> str:
     TaskRun is loaded back off disk), and the stdlib encoder cannot serialize it.
     For an otherwise-plain trace this returns byte-for-byte what `json.dumps(...,
     indent=2, ensure_ascii=False)` returned, so stored traces render unchanged.
-
-    Normalizes a lazily-validated `content` to a plain list in place first, so that
-    serializing is repeatable and leaves the trace intact for whoever holds it - see
-    :func:`_materialize_lazy_content`.
     """
-    _materialize_lazy_content(trace)
-    # warnings=False: every message with a key the wrappers don't declare, a
-    # list-valued `content`, or a `Usage` in the `usage` slot fails to match a
-    # union member and emits a six-line serializer warning - on every message, on
-    # every eval-results request. The mismatch is not a defect: pydantic then falls
+    # warnings=False: every message with a key the wrappers don't declare or a
+    # `Usage` in the `usage` slot fails to match a union member and emits a
+    # six-line serializer warning - on every message, on every eval-results
+    # request. The mismatch is not a defect: pydantic then falls
     # back to duck-typed inference, which is exactly what keeps the output
     # byte-identical to the `json.dumps` this replaced. Silencing it loses no signal
     # a test wouldn't catch first - TestSerializeTrace pins that parity, including

--- a/libs/core/kiln_ai/utils/open_ai_types.py
+++ b/libs/core/kiln_ai/utils/open_ai_types.py
@@ -353,12 +353,15 @@ def materialize_lazy_content(trace: Any) -> Any:
 
 def _materialize_lazy_content_before_serializing(
     trace: Any, handler: SerializerFunctionWrapHandler
-) -> list["ChatCompletionMessageParam"]:
+) -> list[ChatCompletionMessageParam]:
     """Materialize, then hand over to pydantic's own serializer for this field.
 
-    The return annotation is load-bearing: without it pydantic types the field's
-    serialization schema as ``Any``, and every OpenAPI response carrying a trace
-    degrades to ``unknown``.
+    The return annotation is load-bearing twice over. Without it pydantic types the
+    field's serialization schema as ``Any``, and every OpenAPI response carrying a
+    trace degrades to ``unknown``. And it has to be the type itself, not a string:
+    python 3.10 resolves a forward reference here against the namespace of the model
+    that uses `Trace`, not this module's, so a quoted name leaves `TaskRun` undefined
+    unless that model also imports it.
     """
     return handler(materialize_lazy_content(trace))
 

--- a/libs/core/kiln_ai/utils/open_ai_types.py
+++ b/libs/core/kiln_ai/utils/open_ai_types.py
@@ -1,25 +1,38 @@
 """
 Wrapper for OpenAI types to make them compatible with Pydantic.
 
-Pydantic doesn't support Iterable[T] well, so we use List[T] instead for every
-Iterable[T] field the OpenAI SDK declares: tool_calls, and the list-of-parts form
-of content on every role that allows it.
-https://github.com/pydantic/pydantic/issues/9541
+A trace is a record of what happened, and a store of a record must never reject or
+quietly rewrite what it is handed. Two substitutions serve that, both on `content`:
 
-Pydantic validates an Iterable[T] field into a single-use ValidatorIterator rather
-than a list. Serializing reads it, and a read empties it, so a list-valued content
-would be written to disk as `content: []` - silently, and permanently. List[T]
-materializes at validation time instead, which also makes the message deep-copyable
-(a ValidatorIterator cannot be pickled).
+1. `List[T]`, not `Iterable[T]` - https://github.com/pydantic/pydantic/issues/9541
+   Pydantic validates an `Iterable[T]` field into a single-use ValidatorIterator
+   rather than a list. Serializing reads it, and a read empties it, so a list-valued
+   content would be written to disk as `content: []` - silently, and permanently.
+   `List[T]` materializes at validation time instead, which also makes the message
+   deep-copyable (a ValidatorIterator cannot be pickled).
 
-The wrappers below exist only to make that substitution; every other field matches
-the OpenAI SDK type of the same name, plus the Kiln-only fields in
-KILN_ONLY_MESSAGE_FIELDS.
+2. `ContentPart` (a plain dict), not the OpenAI SDK's content-part unions. The SDK
+   unions are a closed set, and closing the set at a save boundary turns data we
+   cannot parse into data we destroy - see `ContentPart` for what that cost.
+
+Every other field matches the OpenAI SDK type of the same name, with three
+exceptions:
+
+- The Kiln-only fields in `KILN_ONLY_MESSAGE_FIELDS`, which are stripped before
+  messages go to a provider.
+- `reasoning_content` on the assistant message, which is deliberately *not* in that
+  frozenset: it is a LiteLLM field that is sent back to the provider on the next
+  call, so stripping it would drop reasoning state mid-conversation.
+- `tool_calls` on the assistant message, still `List[ChatCompletionMessageToolCallParam]`
+  (function calls only) while the SDK has widened to function-or-custom. Pre-existing
+  and narrower than `ContentPart`; a custom tool call fails validation here.
 """
 
+from collections.abc import Mapping, MutableMapping
 from typing import (
     Annotated,
     Any,
+    Dict,
     Iterable,
     List,
     Literal,
@@ -29,30 +42,42 @@ from typing import (
 )
 
 from openai.types.chat import (
-    ChatCompletionContentPartParam,
-    ChatCompletionContentPartTextParam,
     ChatCompletionFunctionMessageParam,
     ChatCompletionMessageToolCallParam,
 )
 from openai.types.chat.chat_completion_assistant_message_param import (
     Audio,
-    ContentArrayOfContentPart,
     FunctionCall,
 )
-from pydantic import BeforeValidator, TypeAdapter
+from pydantic import BaseModel, BeforeValidator, TypeAdapter, WrapSerializer
+from pydantic.functional_serializers import SerializerFunctionWrapHandler
 from typing_extensions import Required, TypedDict
 
 from kiln_ai.utils.usage import MessageUsage
 
+ContentPart: TypeAlias = Dict[str, Any]
+"""One part of a list-valued message `content`: a text part, an image, an audio clip,
+a file, a provider-specific block.
+
+Deliberately a plain dict rather than the OpenAI SDK's part unions. Those unions are a
+closed set, and every provider extends it: Kiln's own `encode_file_litellm_format`
+emits `video_url` blocks and `input_audio` blocks whose `format` is `ogg`, neither of
+which the SDK union admits, and LiteLLM's `format` hint on an image and Anthropic's
+`cache_control` are extra keys inside parts the SDK does admit. Validating against the
+closed set rejects the first pair outright - failing the save of a run the model has
+already been paid for, and making any stored run holding one permanently unloadable -
+and silently strips the second pair. A part is stored exactly as it was handed over.
+"""
+
 
 class ChatCompletionDeveloperMessageParamWrapper(TypedDict, total=False):
-    """
-    Almost exact copy of ChatCompletionDeveloperMessageParam, with one change:
-    List[T] instead of Iterable[T] for content. Addresses pydantic issue.
-    https://github.com/pydantic/pydantic/issues/9541
+    """A developer message in a trace.
+
+    Almost an exact copy of the OpenAI SDK's ChatCompletionDeveloperMessageParam;
+    only the type of `content` differs. See this module's docstring for why.
     """
 
-    content: Required[Union[str, List[ChatCompletionContentPartTextParam]]]
+    content: Required[Union[str, List[ContentPart]]]
     """The contents of the developer message."""
 
     role: Required[Literal["developer"]]
@@ -67,13 +92,13 @@ class ChatCompletionDeveloperMessageParamWrapper(TypedDict, total=False):
 
 
 class ChatCompletionSystemMessageParamWrapper(TypedDict, total=False):
-    """
-    Almost exact copy of ChatCompletionSystemMessageParam, with one change:
-    List[T] instead of Iterable[T] for content. Addresses pydantic issue.
-    https://github.com/pydantic/pydantic/issues/9541
+    """A system message in a trace.
+
+    Almost an exact copy of the OpenAI SDK's ChatCompletionSystemMessageParam;
+    only the type of `content` differs. See this module's docstring for why.
     """
 
-    content: Required[Union[str, List[ChatCompletionContentPartTextParam]]]
+    content: Required[Union[str, List[ContentPart]]]
     """The contents of the system message."""
 
     role: Required[Literal["system"]]
@@ -88,16 +113,16 @@ class ChatCompletionSystemMessageParamWrapper(TypedDict, total=False):
 
 
 class ChatCompletionUserMessageParamWrapper(TypedDict, total=False):
-    """
-    Almost exact copy of ChatCompletionUserMessageParam, with one change:
-    List[T] instead of Iterable[T] for content. Addresses pydantic issue.
-    https://github.com/pydantic/pydantic/issues/9541
+    """A user message in a trace.
+
+    Almost an exact copy of the OpenAI SDK's ChatCompletionUserMessageParam; only
+    the type of `content` differs. See this module's docstring for why.
 
     This is the multimodal message type: its content parts include images, audio
     and files, not only text.
     """
 
-    content: Required[Union[str, List[ChatCompletionContentPartParam]]]
+    content: Required[Union[str, List[ContentPart]]]
     """The contents of the user message."""
 
     role: Required[Literal["user"]]
@@ -112,13 +137,12 @@ class ChatCompletionUserMessageParamWrapper(TypedDict, total=False):
 
 
 class ChatCompletionAssistantMessageParamWrapper(TypedDict, total=False):
-    """
-    Almost exact copy of ChatCompletionAssistantMessageParam, but two changes.
+    """An assistant message in a trace.
 
-    First change: List[T] instead of Iterable[T] for tool_calls and content. Addresses pydantic issue.
-    https://github.com/pydantic/pydantic/issues/9541
-
-    Second change: Add reasoning_content to the message. A LiteLLM property for reasoning data.
+    Almost a copy of the OpenAI SDK's ChatCompletionAssistantMessageParam, with the
+    `content` and `tool_calls` type changes described in this module's docstring, and
+    three added fields: `reasoning_content` (sent on to the provider), plus
+    `latency_ms` and `usage` (Kiln-only, stripped before the message is sent).
     """
 
     role: Required[Literal["assistant"]]
@@ -130,7 +154,7 @@ class ChatCompletionAssistantMessageParamWrapper(TypedDict, total=False):
     [Learn more](https://platform.openai.com/docs/guides/audio).
     """
 
-    content: Union[str, List[ContentArrayOfContentPart], None]
+    content: Union[str, List[ContentPart], None]
     """The contents of the assistant message.
 
     Required unless `tool_calls` or `function_call` is specified.
@@ -176,7 +200,14 @@ class ChatCompletionAssistantMessageParamWrapper(TypedDict, total=False):
 
 
 class ChatCompletionToolMessageParamWrapper(TypedDict, total=False):
-    content: Required[Union[str, List[ChatCompletionContentPartTextParam]]]
+    """A tool-result message in a trace.
+
+    Almost a copy of the OpenAI SDK's ChatCompletionToolMessageParam, with the
+    `content` type change described in this module's docstring, and the Kiln-only
+    fields below - all of them stripped before the message is sent to a provider.
+    """
+
+    content: Required[Union[str, List[ContentPart]]]
     """The contents of the tool message."""
 
     role: Required[Literal["tool"]]
@@ -240,6 +271,35 @@ def sanitize_messages_for_provider(messages: Iterable[Any]) -> list[Any]:
     return sanitized
 
 
+_RE_READABLE_TYPES: tuple[type, ...] = (
+    str,
+    bytes,
+    bytearray,
+    memoryview,
+    list,
+    tuple,
+    set,
+    frozenset,
+    Mapping,
+    BaseModel,
+)
+"""Types that must not be treated as a lazy iterable.
+
+Two groups. The first (list, tuple, set, ...) can be read as many times as you like,
+so there is nothing to rescue. The second is the dangerous one: a str, a bytes-like
+object, a Mapping and a pydantic BaseModel are all iterable, and iterating them
+yields something that is *not* their content - characters, ints, keys, and
+``(name, value)`` pairs respectively. Draining one would not preserve the value, it
+would replace it with a mangled one.
+"""
+
+
+def _is_lazy_iterable(value: Any) -> bool:
+    """True if reading ``value`` consumes it, so it must be materialized before
+    anything else gets a chance to read it. See `_RE_READABLE_TYPES`."""
+    return isinstance(value, Iterable) and not isinstance(value, _RE_READABLE_TYPES)
+
+
 def materialize_lazy_content(trace: Any) -> Any:
     """Normalize a lazily-iterable ``content`` to a list, in front of union validation.
 
@@ -249,39 +309,76 @@ def materialize_lazy_content(trace: Any) -> Any:
     members whose role does not match still drain the iterator before they fail. By the
     time the matching member runs there is nothing left to read, and the message
     validates to ``content: []`` - silently, with the parts gone. Draining it here,
-    once, is what makes that safe.
+    once, is what makes that safe. The trace container itself gets the same treatment:
+    pydantic accepts a tuple or a generator for a ``list[T]`` field, so a lazy container
+    would otherwise carry its lazy messages straight past this guard.
 
     Scoped to ``content`` deliberately, and it needs to stay that way. Iterating a
     pydantic model yields its ``(name, value)`` pairs, so a walk over "any iterable
     value" would turn a message's ``usage`` into a list of pairs.
 
-    Returns copies: the caller's own messages are never mutated. Anything that is not
-    a list of dicts passes through untouched, for pydantic to reject with its own error.
+    Writes the materialized list back into the caller's message when it can, rather
+    than into a copy. Draining a generator is destructive either way, so a copy would
+    leave the caller holding a spent one: validate or serialize the same trace twice
+    and the second pass sees ``content: []``. Normalizing in place is what makes those
+    repeatable. Anything with no lazy content is passed through untouched, including
+    values pydantic should reject with its own error message.
     """
     if not isinstance(trace, list):
-        return trace
+        # Pydantic lax mode accepts any of these for a `list[T]` field, so the walk
+        # below has to reach the messages inside them. Everything else is passed
+        # through for pydantic to reject with its own error message.
+        if isinstance(trace, Iterable) and not isinstance(
+            trace, (str, bytes, bytearray, memoryview, Mapping, BaseModel)
+        ):
+            trace = list(trace)
+        else:
+            return trace
 
     materialized: list[Any] = []
     for message in trace:
-        content = message.get("content") if isinstance(message, dict) else None
-        if (
-            content is not None
-            and not isinstance(content, (str, bytes, list, dict))
-            and isinstance(content, Iterable)
-        ):
-            message = {**message, "content": list(content)}
+        if isinstance(message, Mapping):
+            content = message.get("content")
+            if _is_lazy_iterable(content):
+                if isinstance(message, MutableMapping):
+                    message["content"] = list(content)
+                else:
+                    # A read-only Mapping (MappingProxyType, ...) cannot be normalized
+                    # in place. Copying it is still better than letting the union drain
+                    # it, even though the caller keeps the spent iterator.
+                    message = {**message, "content": list(content)}
         materialized.append(message)
     return materialized
 
 
+def _materialize_lazy_content_before_serializing(
+    trace: Any, handler: SerializerFunctionWrapHandler
+) -> list["ChatCompletionMessageParam"]:
+    """Materialize, then hand over to pydantic's own serializer for this field.
+
+    The return annotation is load-bearing: without it pydantic types the field's
+    serialization schema as ``Any``, and every OpenAPI response carrying a trace
+    degrades to ``unknown``.
+    """
+    return handler(materialize_lazy_content(trace))
+
+
 Trace: TypeAlias = Annotated[
-    list[ChatCompletionMessageParam], BeforeValidator(materialize_lazy_content)
+    list[ChatCompletionMessageParam],
+    BeforeValidator(materialize_lazy_content),
+    WrapSerializer(_materialize_lazy_content_before_serializing),
 ]
 """A trace as a pydantic model should declare it.
 
-Use this, not a bare ``list[ChatCompletionMessageParam]``: the validator is what
-stops a lazily-iterable ``content`` from being drained to nothing by the union - see
+Use this, not a bare ``list[ChatCompletionMessageParam]``: the two guards are what
+stop a lazily-iterable ``content`` from being drained to nothing - see
 :func:`materialize_lazy_content`.
+
+Validation covers a trace passed to the constructor or assigned to the field (given
+``validate_assignment``). Serialization covers what validation cannot see: appending
+a message to an already-validated trace list in place runs no validator at all, so
+without the second guard the first save would write the message and every save after
+it would write ``content: []``.
 """
 
 
@@ -308,7 +405,14 @@ def serialize_trace(trace: list[ChatCompletionMessageParam]) -> str:
     # a test wouldn't catch first - TestSerializeTrace pins that parity, including
     # the unknown-key and unknown-role cases that rely on the fallback, so a pydantic
     # upgrade that tightened union serialization fails there rather than in a log.
-    return _trace_adapter.dump_json(trace, indent=2, warnings=False).decode()
+    #
+    # materialize_lazy_content first: `dump_json` runs serializers, not validators, so
+    # the `Trace` alias does not protect a trace that has not been through a model.
+    # Without it a lazy `content` is drained by the serializer and this function is
+    # destructive - correct on the first call, `content: []` on the second.
+    return _trace_adapter.dump_json(
+        materialize_lazy_content(trace), indent=2, warnings=False
+    ).decode()
 
 
 def trace_has_pending_client_tool_calls(

--- a/libs/core/kiln_ai/utils/test_open_ai_types.py
+++ b/libs/core/kiln_ai/utils/test_open_ai_types.py
@@ -2,7 +2,9 @@
 
 import copy
 import json
-from typing import ClassVar, get_args, get_origin
+from collections import UserDict
+from types import MappingProxyType
+from typing import ClassVar, get_args, get_origin, get_type_hints
 
 import pytest
 from openai.types.chat import (
@@ -24,7 +26,6 @@ from openai.types.chat import (
     ChatCompletionUserMessageParam as OpenAIChatCompletionUserMessageParam,
 )
 
-from kiln_ai.adapters.errors import ErrorWithTrace
 from kiln_ai.datamodel.task_output import TaskOutput
 from kiln_ai.datamodel.task_run import TaskRun
 from kiln_ai.utils.open_ai_types import (
@@ -44,99 +45,76 @@ from kiln_ai.utils.open_ai_types import (
 )
 from kiln_ai.utils.usage import MessageUsage
 
-
-def test_assistant_message_param_properties_match():
-    """
-    Test that ChatCompletionAssistantMessageParamWrapper has all the same properties
-    as OpenAI's ChatCompletionAssistantMessageParam, except for the known tool_calls type difference.
-
-    This will catch any changes to the OpenAI types that we haven't updated our wrapper for.
-    """
-    # Get annotations for both types
-    openai_annotations = OpenAIChatCompletionAssistantMessageParam.__annotations__
-    kiln_annotations = ChatCompletionAssistantMessageParamWrapper.__annotations__
-
-    # Check that both have the same property names
-    openai_properties = set(openai_annotations.keys())
-    kiln_properties = set(kiln_annotations.keys())
-
-    # Reasoning content is an added property. Confirm it's there and remove it from the comparison.
-    assert "reasoning_content" in kiln_properties, "Kiln should have reasoning_content"
-    kiln_properties.remove("reasoning_content")
-
-    # latency_ms is a Kiln-added property for LLM call timing. Confirm it's there and remove it.
-    assert "latency_ms" in kiln_properties, "Kiln should have latency_ms"
-    kiln_properties.remove("latency_ms")
-
-    # usage is a Kiln-added property for per-LLM-call token usage and cost.
-    assert "usage" in kiln_properties, "Kiln should have usage"
-    kiln_properties.remove("usage")
-
-    assert openai_properties == kiln_properties, (
-        f"Property names don't match. "
-        f"OpenAI has: {openai_properties}, "
-        f"Kiln has: {kiln_properties}, "
-        f"Missing from Kiln: {openai_properties - kiln_properties}, "
-        f"Extra in Kiln: {kiln_properties - openai_properties}"
-    )
-
-
-def test_tool_message_param_properties_match():
-    """
-    Test that ChatCompletionToolMessageParamWrapper has all the same properties
-    as OpenAI's ChatCompletionToolMessageParam, plus the kiln_task_tool_data property.
-
-    This will catch any changes to the OpenAI types that we haven't updated our wrapper for.
-    """
-    # Get annotations for both types
-    openai_annotations = OpenAIChatCompletionToolMessageParam.__annotations__
-    kiln_annotations = ChatCompletionToolMessageParamWrapper.__annotations__
-
-    # Check that both have the same property names
-    openai_properties = set(openai_annotations.keys())
-    kiln_properties = set(kiln_annotations.keys())
-
-    kiln_extra_properties = {"kiln_task_tool_data", "is_error", "error_message"}
-    for prop in kiln_extra_properties:
-        assert prop in kiln_properties, f"Kiln should have {prop}"
-        kiln_properties.remove(prop)
-
-    assert openai_properties == kiln_properties, (
-        f"Property names don't match. "
-        f"OpenAI has: {openai_properties}, "
-        f"Kiln has: {kiln_properties}, "
-        f"Missing from Kiln: {openai_properties - kiln_properties}, "
-        f"Extra in Kiln: {kiln_properties - openai_properties}"
-    )
+# Fields whose type deliberately differs from the OpenAI SDK type of the same name.
+# `content` on every role, and `tool_calls` on the assistant - see the module docstring
+# of kiln_ai.utils.open_ai_types for what each substitution buys.
+WRAPPER_TYPE_EXEMPTIONS = {"content", "tool_calls"}
 
 
 @pytest.mark.parametrize(
-    "kiln_type, openai_type",
+    "kiln_type, openai_type, kiln_only_fields",
     [
         (
             ChatCompletionDeveloperMessageParamWrapper,
             OpenAIChatCompletionDeveloperMessageParam,
+            set(),
         ),
         (
             ChatCompletionSystemMessageParamWrapper,
             OpenAIChatCompletionSystemMessageParam,
+            set(),
         ),
         (
             ChatCompletionUserMessageParamWrapper,
             OpenAIChatCompletionUserMessageParam,
+            set(),
+        ),
+        (
+            ChatCompletionAssistantMessageParamWrapper,
+            OpenAIChatCompletionAssistantMessageParam,
+            {"reasoning_content", "latency_ms", "usage"},
+        ),
+        (
+            ChatCompletionToolMessageParamWrapper,
+            OpenAIChatCompletionToolMessageParam,
+            {"kiln_task_tool_data", "is_error", "error_message"},
         ),
     ],
 )
-def test_content_only_wrappers_properties_match(kiln_type, openai_type):
-    """These three wrappers add nothing - they exist only to swap Iterable[T] for
-    List[T] on content. Any property the OpenAI type grows must be copied over.
+def test_wrappers_match_the_openai_sdk_type_they_copy(
+    kiln_type, openai_type, kiln_only_fields
+):
+    """The wrappers are hand-copied from the OpenAI SDK types, so they can drift from
+    them: `openai` is pinned with no upper bound, and a stored trace is validated
+    against whatever version is installed.
+
+    Resolved types, not just property names. A comparison of names alone would pass
+    while the SDK flipped a field from Required to optional or changed a Literal, and
+    with `content` now materialized at validation such a drift shows up as a stored
+    run that will not load, rather than as a degradation.
     """
-    assert set(openai_type.__annotations__.keys()) == set(
-        kiln_type.__annotations__.keys()
-    ), (
+    openai_hints = get_type_hints(openai_type, include_extras=True)
+    kiln_hints = get_type_hints(kiln_type, include_extras=True)
+
+    for field in kiln_only_fields:
+        assert field in kiln_hints, f"{kiln_type.__name__} should have {field}"
+        del kiln_hints[field]
+
+    assert set(openai_hints) == set(kiln_hints), (
         f"Property names don't match between {kiln_type.__name__} and "
-        f"{openai_type.__name__}."
+        f"{openai_type.__name__}. "
+        f"Missing from Kiln: {set(openai_hints) - set(kiln_hints)}, "
+        f"Extra in Kiln: {set(kiln_hints) - set(openai_hints)}"
     )
+
+    for name, openai_annotation in openai_hints.items():
+        if name in WRAPPER_TYPE_EXEMPTIONS:
+            continue
+        assert kiln_hints[name] == openai_annotation, (
+            f"{kiln_type.__name__}.{name} is {kiln_hints[name]}, but "
+            f"{openai_type.__name__}.{name} is now {openai_annotation}. Copy the "
+            "change over, or add the field to WRAPPER_TYPE_EXEMPTIONS with a reason."
+        )
 
 
 def test_no_union_member_declares_an_iterable_content():
@@ -645,6 +623,22 @@ class TestSerializeTrace:
         assert serialized["usage"]["input_tokens"] == 4
         assert serialized["usage"]["cost"] == 0.01
 
+    def test_serializing_a_trace_twice_returns_the_same_json(self):
+        """This is a public function taking a plain list, so it also gets traces that
+        never went through a model. `dump_json` runs serializers, not validators, so
+        the `Trace` alias does not reach here: without materializing first, the
+        serializer drains a lazy content and the second call returns `content: []`.
+        """
+        trace = [
+            {"role": "user", "content": (p for p in [{"type": "text", "text": "KEEP"}])}
+        ]
+
+        first = serialize_trace(trace)  # type: ignore[arg-type]
+        second = serialize_trace(trace)  # type: ignore[arg-type]
+
+        assert json.loads(first)[0]["content"] == [{"type": "text", "text": "KEEP"}]
+        assert first == second
+
 
 class TestListValuedContentRoundTrip:
     """A message's `content` can be a list of parts instead of a string - that is
@@ -808,6 +802,145 @@ class TestListValuedContentRoundTrip:
 
         assert caller_messages == self.LIST_CONTENT_MESSAGES
 
+    def test_a_message_appended_to_the_trace_in_place_survives_both_saves(
+        self, tmp_path
+    ):
+        """`validate_assignment` fires when the field is rebound, not when the list it
+        holds is mutated, so an appended message reaches the serializer unvalidated.
+        The first save used to write it and every save after it wrote `content: []`.
+        """
+        task_run = self._task_run(tmp_path, [{"role": "user", "content": "hello"}])
+
+        assert task_run.trace is not None
+        task_run.trace.append(
+            {"role": "user", "content": (p for p in [{"type": "text", "text": "GEN"}])}
+        )
+        task_run.save_to_file()
+        first = json.loads(task_run.path.read_text(encoding="utf-8"))["trace"]
+        task_run.save_to_file()
+        second = json.loads(task_run.path.read_text(encoding="utf-8"))["trace"]
+
+        assert first == second
+        assert second[1]["content"] == [{"type": "text", "text": "GEN"}]
+
+    @pytest.mark.parametrize(
+        "container",
+        [tuple, lambda messages: (m for m in messages)],
+        ids=["tuple", "generator"],
+    )
+    def test_a_lazy_trace_container_does_not_smuggle_a_lazy_content_past(
+        self, tmp_path, container
+    ):
+        """Pydantic accepts a tuple or a generator for the `list[T]` trace field, so
+        the container is a way in for exactly the content this guards against."""
+        task_run = self._task_run(
+            tmp_path,
+            container(
+                [
+                    {
+                        "role": "user",
+                        "content": (p for p in [{"type": "text", "text": "GEN"}]),
+                    }
+                ]
+            ),
+        )
+
+        assert task_run.trace is not None
+        assert task_run.trace[0]["content"] == [{"type": "text", "text": "GEN"}]
+
+
+class TestContentPartsAreStoredAsHandedOver:
+    """A trace is a record of what happened. Every provider extends the OpenAI content
+    part set, so validating a part against the SDK's closed union means a part we
+    cannot parse is a part we destroy - either by refusing the save outright, after
+    the model has been paid for, or by dropping a key we did not expect.
+
+    `ContentPart` is a plain dict for that reason. These pin the shapes that made it
+    necessary - all of them produced by Kiln itself, in `encode_file_litellm_format`
+    or by the providers it talks to.
+    """
+
+    @pytest.mark.parametrize(
+        "role, part",
+        [
+            # encode_file_litellm_format emits this for video on OpenRouter.
+            (
+                "user",
+                {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AA"}},
+            ),
+            # ...and this for audio/ogg. The SDK's InputAudio.format is wav or mp3.
+            (
+                "user",
+                {"type": "input_audio", "input_audio": {"data": "AA", "format": "ogg"}},
+            ),
+            # LiteLLM's explicit image type hint: an extra key inside a part the SDK
+            # does declare, so this one used to be dropped rather than rejected.
+            (
+                "user",
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,aGk=",
+                        "format": "image/png",
+                    },
+                },
+            ),
+            # Anthropic prompt caching, same shape of loss.
+            ("user", {"type": "text", "text": "hi", "cache_control": {"type": "e"}}),
+            # The assistant's list content is narrower still in the SDK - text or a
+            # refusal - so a reasoning block from a thinking model does not fit.
+            ("assistant", {"type": "thinking", "thinking": "step one"}),
+            ("tool", {"type": "text", "text": "ok", "annotations": []}),
+        ],
+        ids=[
+            "video_url",
+            "input_audio_ogg",
+            "image_url_format_hint",
+            "text_cache_control",
+            "assistant_thinking_block",
+            "tool_extra_key",
+        ],
+    )
+    def test_a_part_the_openai_union_does_not_admit_round_trips_whole(
+        self, tmp_path, role, part
+    ):
+        message = {"role": role, "content": [part]}
+        if role == "tool":
+            message["tool_call_id"] = "c1"
+
+        task_run = TaskRun(
+            path=tmp_path / "task_run.kiln",
+            input="in",
+            output=TaskOutput(output="out"),
+            trace=[message],
+        )
+        task_run.save_to_file()
+        reloaded = TaskRun.load_from_file(task_run.path)
+
+        assert reloaded.trace is not None
+        assert reloaded.trace[0]["content"] == [part]
+
+    def test_a_stored_run_holding_an_unknown_part_still_loads(self, tmp_path):
+        """The worst outcome of a closed part set is not the failed save, it is the
+        file already on disk: `load_from_file` raising makes one run poison the whole
+        task's run list, which is read with `error_on_first=True`.
+        """
+        path = tmp_path / "task_run.kiln"
+        task_run = TaskRun(
+            path=path,
+            input="in",
+            output=TaskOutput(output="out"),
+            trace=[
+                {
+                    "role": "user",
+                    "content": [{"type": "something_new", "payload": {"a": 1}}],
+                }
+            ],
+        )
+        task_run.save_to_file()
+
+        assert TaskRun.load_from_file(path).trace == task_run.trace
+
 
 class TestMaterializeLazyContent:
     """The guardrail in front of union validation. A caller can pass any iterable as
@@ -847,47 +980,97 @@ class TestMaterializeLazyContent:
 
         assert materialize_lazy_content(trace)[0]["usage"] is usage
 
-    def test_the_callers_message_is_not_mutated(self):
+    def test_the_callers_message_is_normalized_in_place(self):
+        """Draining a generator is destructive whether or not the message is copied,
+        so copying would leave the caller holding a spent one. Writing the list back
+        is what makes a second pass over the same trace return the same thing.
+        """
         message = {
             "role": "user",
             "content": (p for p in [{"type": "text", "text": "G"}]),
         }
         trace = [message]
 
-        result = materialize_lazy_content(trace)
+        first = materialize_lazy_content(trace)
+        second = materialize_lazy_content(trace)
 
-        assert result[0] is not message
-        assert trace[0] is message
+        assert (
+            first
+            == second
+            == [{"role": "user", "content": [{"type": "text", "text": "G"}]}]
+        )
+        assert message["content"] == [{"type": "text", "text": "G"}]
+
+    def test_a_read_only_mapping_message_is_copied_instead(self):
+        """A MappingProxyType cannot be written to. Copying it still beats letting the
+        union drain the generator."""
+        message = MappingProxyType(
+            {"role": "user", "content": (p for p in [{"type": "text", "text": "G"}])}
+        )
+
+        assert materialize_lazy_content([message]) == [
+            {"role": "user", "content": [{"type": "text", "text": "G"}]}
+        ]
 
     def test_a_none_content_passes_through(self):
         trace = [{"role": "assistant", "content": None, "tool_calls": []}]
 
         assert materialize_lazy_content(trace) == trace
 
-    @pytest.mark.parametrize("value", [None, "not a list", 42, {"role": "user"}])
-    def test_a_non_list_passes_through_for_pydantic_to_reject(self, value):
+    @pytest.mark.parametrize("value", [None, "not a list", 42, b"bytes"])
+    def test_a_value_that_is_not_a_trace_passes_through_for_pydantic_to_reject(
+        self, value
+    ):
         """Bad input is pydantic's to complain about, with its own error message."""
         assert materialize_lazy_content(value) is value
+
+    @pytest.mark.parametrize(
+        "container",
+        [
+            lambda messages: tuple(messages),
+            lambda messages: (m for m in messages),
+            lambda messages: map(lambda m: m, messages),
+        ],
+        ids=["tuple", "generator", "map"],
+    )
+    def test_a_lazy_container_is_walked_too(self, container):
+        """Pydantic lax mode accepts a tuple or a generator for a `list[T]` field, so
+        a guard that only looked inside a real `list` would let those carry their lazy
+        content straight past it.
+        """
+        messages = [
+            {"role": "user", "content": (p for p in [{"type": "text", "text": "GEN"}])}
+        ]
+
+        assert materialize_lazy_content(container(messages)) == [
+            {"role": "user", "content": [{"type": "text", "text": "GEN"}]}
+        ]
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            MappingProxyType({"type": "text", "text": "hi"}),
+            UserDict({"type": "text", "text": "hi"}),
+            MessageUsage(input_tokens=4),
+            bytearray(b"hi"),
+            memoryview(b"hi"),
+        ],
+        ids=["mappingproxy", "userdict", "pydantic_model", "bytearray", "memoryview"],
+    )
+    def test_an_iterable_that_does_not_iterate_to_its_own_content_is_left_alone(
+        self, content
+    ):
+        """Every one of these is `Iterable`, and iterating it yields something that is
+        not its value: keys, `(name, value)` pairs, ints. Draining one would replace
+        the caller's value with a mangled one, and the union error that followed would
+        report the mangled value rather than what was passed in.
+        """
+        result = materialize_lazy_content([{"role": "user", "content": content}])
+
+        assert result[0]["content"] is content
 
     def test_a_non_dict_message_passes_through(self):
         """Traces transiently hold LiteLLM Message objects, not only dicts."""
         message = MessageUsage(input_tokens=1)
 
         assert materialize_lazy_content([message]) == [message]
-
-
-def test_error_with_trace_materializes_lazy_content():
-    """`ErrorWithTrace` carries the partial trace of a failed run back to the client.
-    A failed run's trace is the only record of what happened, so it needs the same
-    guard `TaskRun.trace` has.
-    """
-    error = ErrorWithTrace(
-        message="boom",
-        error_type="RuntimeError",
-        trace=[
-            {"role": "user", "content": (p for p in [{"type": "text", "text": "GEN"}])}
-        ],
-    )
-
-    assert error.trace is not None
-    assert error.trace[0]["content"] == [{"type": "text", "text": "GEN"}]

--- a/libs/core/kiln_ai/utils/test_open_ai_types.py
+++ b/libs/core/kiln_ai/utils/test_open_ai_types.py
@@ -1,25 +1,40 @@
 """Tests for OpenAI types wrapper to ensure compatibility."""
 
+import copy
 import json
-from typing import get_args, get_origin
+from typing import ClassVar, get_args, get_origin
 
 import pytest
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam as OpenAIChatCompletionAssistantMessageParam,
 )
 from openai.types.chat import (
+    ChatCompletionDeveloperMessageParam as OpenAIChatCompletionDeveloperMessageParam,
+)
+from openai.types.chat import (
     ChatCompletionMessageParam as OpenAIChatCompletionMessageParam,
+)
+from openai.types.chat import (
+    ChatCompletionSystemMessageParam as OpenAIChatCompletionSystemMessageParam,
 )
 from openai.types.chat import (
     ChatCompletionToolMessageParam as OpenAIChatCompletionToolMessageParam,
 )
+from openai.types.chat import (
+    ChatCompletionUserMessageParam as OpenAIChatCompletionUserMessageParam,
+)
 
+from kiln_ai.adapters.errors import ErrorWithTrace
 from kiln_ai.datamodel.task_output import TaskOutput
 from kiln_ai.datamodel.task_run import TaskRun
 from kiln_ai.utils.open_ai_types import (
     KILN_ONLY_MESSAGE_FIELDS,
     ChatCompletionAssistantMessageParamWrapper,
+    ChatCompletionDeveloperMessageParamWrapper,
+    ChatCompletionSystemMessageParamWrapper,
     ChatCompletionToolMessageParamWrapper,
+    ChatCompletionUserMessageParamWrapper,
+    materialize_lazy_content,
     sanitize_messages_for_provider,
     serialize_trace,
     trace_has_pending_client_tool_calls,
@@ -95,6 +110,49 @@ def test_tool_message_param_properties_match():
     )
 
 
+@pytest.mark.parametrize(
+    "kiln_type, openai_type",
+    [
+        (
+            ChatCompletionDeveloperMessageParamWrapper,
+            OpenAIChatCompletionDeveloperMessageParam,
+        ),
+        (
+            ChatCompletionSystemMessageParamWrapper,
+            OpenAIChatCompletionSystemMessageParam,
+        ),
+        (
+            ChatCompletionUserMessageParamWrapper,
+            OpenAIChatCompletionUserMessageParam,
+        ),
+    ],
+)
+def test_content_only_wrappers_properties_match(kiln_type, openai_type):
+    """These three wrappers add nothing - they exist only to swap Iterable[T] for
+    List[T] on content. Any property the OpenAI type grows must be copied over.
+    """
+    assert set(openai_type.__annotations__.keys()) == set(
+        kiln_type.__annotations__.keys()
+    ), (
+        f"Property names don't match between {kiln_type.__name__} and "
+        f"{openai_type.__name__}."
+    )
+
+
+def test_no_union_member_declares_an_iterable_content():
+    """The whole point of the wrappers. An Iterable[T] content validates into a
+    single-use ValidatorIterator, which serializes to `[]` once read - see
+    TestListValuedContentRoundTrip.
+    """
+    for member in get_args(KilnChatCompletionMessageParam):
+        content_type = member.__annotations__.get("content")
+        assert content_type is not None
+        assert "Iterable" not in str(content_type), (
+            f"{member.__name__}.content is declared as {content_type}. Use List[T], "
+            "not Iterable[T] - pydantic cannot round-trip an Iterable[T]."
+        )
+
+
 def test_chat_completion_message_param_union_compatibility():
     """
     Test that our ChatCompletionMessageParam union contains the same types as OpenAI's,
@@ -120,13 +178,21 @@ def test_chat_completion_message_param_union_compatibility():
     openai_type_names = {arg.__name__ for arg in openai_union_args}
     kiln_type_names = {arg.__name__ for arg in kiln_union_args}
 
-    # Expected differences: OpenAI has ChatCompletionAssistantMessageParam and ChatCompletionToolMessageParam,
-    # Kiln has ChatCompletionAssistantMessageParamWrapper and ChatCompletionToolMessageParamWrapper
+    # Expected differences: every role whose content can be a list of parts is a Kiln
+    # wrapper, because the OpenAI type declares that content as Iterable[T] and pydantic
+    # cannot round-trip an Iterable[T]. Only the function role, whose content is a plain
+    # string, is used directly.
     expected_openai_only = {
+        "ChatCompletionDeveloperMessageParam",
+        "ChatCompletionSystemMessageParam",
+        "ChatCompletionUserMessageParam",
         "ChatCompletionAssistantMessageParam",
         "ChatCompletionToolMessageParam",
     }
     expected_kiln_only = {
+        "ChatCompletionDeveloperMessageParamWrapper",
+        "ChatCompletionSystemMessageParamWrapper",
+        "ChatCompletionUserMessageParamWrapper",
         "ChatCompletionAssistantMessageParamWrapper",
         "ChatCompletionToolMessageParamWrapper",
     }
@@ -144,9 +210,6 @@ def test_chat_completion_message_param_union_compatibility():
     # All other types should be identical
     common_types = openai_type_names & kiln_type_names
     expected_common_types = {
-        "ChatCompletionDeveloperMessageParam",
-        "ChatCompletionSystemMessageParam",
-        "ChatCompletionUserMessageParam",
         "ChatCompletionFunctionMessageParam",
     }
 
@@ -541,12 +604,8 @@ class TestSerializeTrace:
         )
 
     def test_a_list_valued_content_survives_being_serialized(self):
-        """Serializing must not damage the trace it was handed.
-
-        Pydantic validates a list-valued `content` into a single-use
-        `ValidatorIterator`, and reading it empties it. Without the materializing
-        walk this serialized correctly once and as `content: []` forever after,
-        and a `save_to_file` on the same object persisted the empty version.
+        """Serializing must not damage the trace it was handed, and must be
+        repeatable - the second read has to say what the first one said.
         """
         task_run = TaskRun(
             input="in",
@@ -563,21 +622,14 @@ class TestSerializeTrace:
         assert second == first
         # And the trace is still intact for whoever else holds it - the failure mode
         # here was a persisted `content: []`, not just a bad second read.
-        #
-        # This dump prints a `PydanticSerializationUnexpectedValue` warning, which is
-        # expected, not a defect: a materialized list matches neither the `str` nor the
-        # `generator` branch of the union the way the lazy iterator did. The bytes it
-        # writes are what this asserts, and they are correct.
         assert json.loads(task_run.model_dump_json())["trace"][0]["content"] == [
             {"text": "KEEP", "type": "text"}
         ]
 
-    def test_materializing_content_leaves_a_usage_model_alone(self):
-        """The walk is scoped to `content` and must not be generalized.
-
-        A pydantic model is iterable - it yields `(name, value)` pairs - so a walk
-        over "any iterable value" would turn `usage` into a list of pairs. This is
-        the test that catches that.
+    def test_a_list_valued_content_and_a_usage_model_coexist(self):
+        """A list-valued `content` and a `MessageUsage` are both non-plain values on
+        the same message, and they serialize differently: content is a list of parts,
+        usage is a model dumped to an object. Neither may be mistaken for the other.
         """
         trace: list[KilnChatCompletionMessageParam] = [
             {
@@ -592,3 +644,250 @@ class TestSerializeTrace:
         assert serialized["content"] == [{"text": "hi", "type": "text"}]
         assert serialized["usage"]["input_tokens"] == 4
         assert serialized["usage"]["cost"] == 0.01
+
+
+class TestListValuedContentRoundTrip:
+    """A message's `content` can be a list of parts instead of a string - that is
+    how a multimodal message (text plus an image, audio or a file) is expressed.
+
+    Every role that allows it declared that content as `Iterable[T]`, which pydantic
+    validates into a single-use `ValidatorIterator`. Serializing reads it, a read
+    empties it, and `save_to_file` then wrote `content: []` to disk with no error and
+    no warning. These pin that a list-valued content survives the model layer whole:
+    to disk, back off disk, and through a copy.
+    """
+
+    LIST_CONTENT_MESSAGES: ClassVar[list[KilnChatCompletionMessageParam]] = [
+        {"role": "developer", "content": [{"type": "text", "text": "DEV"}]},
+        {"role": "system", "content": [{"type": "text", "text": "SYS"}]},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "USER"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,aGk="},
+                },
+            ],
+        },
+        {"role": "assistant", "content": [{"type": "text", "text": "ASST"}]},
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": [{"type": "text", "text": "TOOL"}],
+        },
+    ]
+
+    def _task_run(self, tmp_path, messages):
+        return TaskRun(
+            path=tmp_path / "task_run.kiln",
+            input="in",
+            output=TaskOutput(output="out"),
+            trace=list(messages),
+        )
+
+    def test_validation_produces_a_list_not_a_lazy_iterator(self, tmp_path):
+        """The root cause, pinned directly. Everything below follows from this."""
+        task_run = self._task_run(tmp_path, self.LIST_CONTENT_MESSAGES)
+
+        assert task_run.trace is not None
+        for message in task_run.trace:
+            assert isinstance(message["content"], list), (
+                f"{message['role']} content is a {type(message['content']).__name__}"
+            )
+
+    def test_every_role_survives_save_and_load(self, tmp_path):
+        task_run = self._task_run(tmp_path, self.LIST_CONTENT_MESSAGES)
+
+        task_run.save_to_file()
+        loaded = TaskRun.load_from_file(task_run.path)
+
+        assert loaded.trace is not None
+        assert len(loaded.trace) == len(self.LIST_CONTENT_MESSAGES)
+        for loaded_message, original in zip(loaded.trace, self.LIST_CONTENT_MESSAGES):
+            assert loaded_message["content"] == original["content"], (
+                f"{original['role']} content did not survive the round trip"
+            )
+
+    def test_the_image_part_of_a_multimodal_message_survives(self, tmp_path):
+        """The case this protects in practice: an image part is not recoverable from
+        anywhere else once it is dropped."""
+        task_run = self._task_run(
+            tmp_path, [m for m in self.LIST_CONTENT_MESSAGES if m["role"] == "user"]
+        )
+
+        task_run.save_to_file()
+        loaded = TaskRun.load_from_file(task_run.path)
+
+        assert loaded.trace is not None
+        assert loaded.trace[0]["content"][1] == {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,aGk="},
+        }
+
+    def test_a_second_save_of_the_same_object_writes_the_same_content(self, tmp_path):
+        """The original bug lost the content on the *second* write for some roles, so
+        one save proving correct was never enough."""
+        task_run = self._task_run(tmp_path, self.LIST_CONTENT_MESSAGES)
+
+        task_run.save_to_file()
+        first = task_run.path.read_text(encoding="utf-8")
+        task_run.save_to_file()
+        second = task_run.path.read_text(encoding="utf-8")
+
+        assert json.loads(first)["trace"] == json.loads(second)["trace"]
+        assert json.loads(second)["trace"][0]["content"] == [
+            {"type": "text", "text": "DEV"}
+        ]
+
+    def test_a_loaded_run_can_be_saved_again_without_loss(self, tmp_path):
+        """Load and re-save is what a repair or a tag edit does to a stored run."""
+        task_run = self._task_run(tmp_path, self.LIST_CONTENT_MESSAGES)
+        task_run.save_to_file()
+
+        loaded = TaskRun.load_from_file(task_run.path).mutable_copy()
+        loaded.save_to_file()
+        reloaded = TaskRun.load_from_file(task_run.path)
+
+        assert reloaded.trace is not None
+        for message, original in zip(reloaded.trace, self.LIST_CONTENT_MESSAGES):
+            assert message["content"] == original["content"]
+
+    def test_mutable_copy_does_not_raise(self, tmp_path):
+        """`mutable_copy` deep-copies, and a `ValidatorIterator` cannot be pickled -
+        so a list-valued content used to raise `TypeError` here.
+        """
+        task_run = self._task_run(tmp_path, self.LIST_CONTENT_MESSAGES)
+
+        copied = task_run.mutable_copy()
+
+        assert copied.trace is not None
+        assert copied.trace[2]["content"] == self.LIST_CONTENT_MESSAGES[2]["content"]
+
+    def test_a_generator_content_is_materialized_at_validation(self, tmp_path):
+        """A library caller can pass any iterable, not only a list. Validation must
+        drain it there and then, while the values are still readable."""
+        task_run = self._task_run(
+            tmp_path,
+            [
+                {
+                    "role": "user",
+                    "content": (p for p in [{"type": "text", "text": "GEN"}]),
+                }
+            ],
+        )
+
+        task_run.save_to_file()
+        loaded = TaskRun.load_from_file(task_run.path)
+
+        assert loaded.trace is not None
+        assert loaded.trace[0]["content"] == [{"type": "text", "text": "GEN"}]
+
+    def test_a_string_content_is_left_a_string(self, tmp_path):
+        """The common case, and the one every stored trace holds today."""
+        task_run = self._task_run(
+            tmp_path,
+            [
+                {"role": "user", "content": "plain"},
+                {"role": "assistant", "content": "also plain"},
+            ],
+        )
+
+        task_run.save_to_file()
+        loaded = TaskRun.load_from_file(task_run.path)
+
+        assert loaded.trace is not None
+        assert loaded.trace[0]["content"] == "plain"
+        assert loaded.trace[1]["content"] == "also plain"
+
+    def test_the_trace_the_caller_handed_over_is_not_consumed(self, tmp_path):
+        """Validation must not empty the caller's own list as a side effect."""
+        caller_messages = copy.deepcopy(self.LIST_CONTENT_MESSAGES)
+
+        self._task_run(tmp_path, caller_messages).save_to_file()
+
+        assert caller_messages == self.LIST_CONTENT_MESSAGES
+
+
+class TestMaterializeLazyContent:
+    """The guardrail in front of union validation. A caller can pass any iterable as
+    `content`; pydantic's smart union drains it on the members that do not match the
+    role, so the matching member sees an empty iterator. This drains it first instead.
+    """
+
+    def test_a_generator_becomes_a_list(self):
+        trace = [
+            {"role": "user", "content": (p for p in [{"type": "text", "text": "GEN"}])}
+        ]
+
+        assert materialize_lazy_content(trace) == [
+            {"role": "user", "content": [{"type": "text", "text": "GEN"}]}
+        ]
+
+    def test_a_list_is_left_alone(self):
+        trace = [{"role": "user", "content": [{"type": "text", "text": "LIST"}]}]
+
+        assert materialize_lazy_content(trace) == trace
+
+    def test_a_string_is_not_split_into_characters(self):
+        """A string is iterable too. Treating it as one would be the worst outcome
+        here - `"hi"` would become `["h", "i"]`.
+        """
+        assert materialize_lazy_content([{"role": "user", "content": "hi"}]) == [
+            {"role": "user", "content": "hi"}
+        ]
+
+    def test_a_usage_model_is_left_alone(self):
+        """The walk is scoped to `content` and must not be generalized. A pydantic
+        model is iterable - it yields `(name, value)` pairs - so a walk over "any
+        iterable value" would turn `usage` into a list of pairs.
+        """
+        usage = MessageUsage(input_tokens=4, cost=0.01)
+        trace = [{"role": "assistant", "content": "hi", "usage": usage}]
+
+        assert materialize_lazy_content(trace)[0]["usage"] is usage
+
+    def test_the_callers_message_is_not_mutated(self):
+        message = {
+            "role": "user",
+            "content": (p for p in [{"type": "text", "text": "G"}]),
+        }
+        trace = [message]
+
+        result = materialize_lazy_content(trace)
+
+        assert result[0] is not message
+        assert trace[0] is message
+
+    def test_a_none_content_passes_through(self):
+        trace = [{"role": "assistant", "content": None, "tool_calls": []}]
+
+        assert materialize_lazy_content(trace) == trace
+
+    @pytest.mark.parametrize("value", [None, "not a list", 42, {"role": "user"}])
+    def test_a_non_list_passes_through_for_pydantic_to_reject(self, value):
+        """Bad input is pydantic's to complain about, with its own error message."""
+        assert materialize_lazy_content(value) is value
+
+    def test_a_non_dict_message_passes_through(self):
+        """Traces transiently hold LiteLLM Message objects, not only dicts."""
+        message = MessageUsage(input_tokens=1)
+
+        assert materialize_lazy_content([message]) == [message]
+
+
+def test_error_with_trace_materializes_lazy_content():
+    """`ErrorWithTrace` carries the partial trace of a failed run back to the client.
+    A failed run's trace is the only record of what happened, so it needs the same
+    guard `TaskRun.trace` has.
+    """
+    error = ErrorWithTrace(
+        message="boom",
+        error_type="RuntimeError",
+        trace=[
+            {"role": "user", "content": (p for p in [{"type": "text", "text": "GEN"}])}
+        ],
+    )
+
+    assert error.trace is not None
+    assert error.trace[0]["content"] == [{"type": "text", "text": "GEN"}]


### PR DESCRIPTION
Fixes [KIL-790](https://linear.app/kiln-ai/issue/KIL-790/taskruntrace-silently-drops-list-valued-message-content-on-save). Related: https://github.com/Kiln-AI/kiln_server/pull/283

## The bug

A message's `content` can be a list of parts instead of a string — that is how a multimodal message (text plus an image, audio or a file) is expressed. Every role that allows it declared that content as `Iterable[T]`, and pydantic validates an `Iterable[T]` field into a single-use `ValidatorIterator`. Serializing reads it, a read empties it, and `save_to_file` wrote `content: []` to disk. No exception, no warning, no recovery — and that list is the only copy of the image, so nothing else in a `TaskRun` can restore it.

```
dump 1: system=[]  developer=ok  user=[]  assistant=ok  tool=[]
dump 2: system=[]  developer=[]  user=[]  assistant=[]  tool=[]
```

The ticket named three roles. It is actually five — `system` and `developer` are SDK types with the same `Iterable` content. Only `function`, whose content is a plain string, was safe. The dump-1/dump-2 asymmetry is not role semantics, just which union member the smart-union matcher consumed while discriminating.

**Blast radius today: latent.** Every path that builds a persisted trace uses string content (`_build_single_turn_trace` json-dumps non-text input, `litellm_message_to_trace_message` takes a string from LiteLLM, the chat formatter's messages are typed `Optional[str]`, `data_gen_api` passes strings). The one place that builds a real list of parts — [`litellm_extractor.py:352`](https://github.com/Kiln-AI/Kiln/blob/main/libs/core/kiln_ai/adapters/extractors/litellm_extractor.py#L352) — sends it straight to the model and never builds a trace. This becomes live data loss the moment a multimodal message reaches a saved trace.

## The fix

**1. `List[T]` instead of `Iterable[T]` for content on every role.** Assistant and tool were already Kiln wrappers. Developer, system and user needed wrappers of their own, following the existing pattern. Only `function` still uses the OpenAI SDK type directly.

**2. `materialize_lazy_content`, a `BeforeValidator` in front of the union.** `List[T]` alone is not enough: a caller can pass any iterable, and pydantic's smart union drains it on the members whose role does not match — so the matching member sees an empty iterator and validates to `content: []` again. Draining it once, up front, closes that. The new `Trace` alias binds the list type and the validator together; use it rather than a bare `list[ChatCompletionMessageParam]` on any model that holds a trace. Applied to `TaskRun.trace` and `ErrorWithTrace.trace`.

**3. `_materialize_lazy_content` inside `serialize_trace` is removed.** It defused this at one serialization boundary (e50a39e). With content materialized at validation and `validate_assignment=True` on the base model, it can no longer see a lazy value — both of its callers pass validated model fields. The tests below cover what it was protecting.

## Tests

`test_open_ai_types.py` goes from 24 to 49 tests: save → load for all five roles, a second save of the same object, `mutable_copy` (a `ValidatorIterator` cannot be pickled, so this used to raise), a generator input, and that a string content stays a string. Reverting the types to `Iterable` fails nine of them.

Two new `@pytest.mark.paid` tests in `test_multimodal_trace_paid.py` run the whole path against real providers — a real PNG goes to a real multimodal model, the answer proves the model received it, and the image part is read back off disk after the run is saved:

| Test | Markers | Coverage |
|---|---|---|
| `test_multimodal_trace_survives_save_to_file` | `paid`, `prerelease` | gpt_4o / claude_sonnet_4_6 / gemini_3_flash |
| `test_multimodal_trace_survives_a_second_turn_and_a_second_save` | `paid` | two turns, two saves — the failure mode that only showed on the second write |

Both were run against the live APIs; all four cases pass. The round-trip test is wired into the prerelease set via a new `PRERELEASE_MULTIMODAL_TRACE_MODELS` whitelist, with rows added to the prerelease skill's coverage table and pin sweep.

## Notes for review

- The wrapper renames change the OpenAPI component names, so `api_schema.d.ts` is regenerated and `types.ts` updated. Shapes are unchanged — the diff there is names only.
- The vendored server API client under `app/desktop/studio_server/api_client/` is deliberately untouched. It tracks the deployed api.kiln.tech spec and is regenerated in its own PR (#1716).
- No migration: this protects new writes. Any trace already flattened to `content: []` is unrecoverable, but per the blast-radius analysis there should be none.

`uv run ./checks.sh --agent-mode` passes.
