### PR TITLE
Deprecate three model provider entries that are dead upstream

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -4172,6 +4172,7 @@ built_in_models: List[KilnModel] = [
                 supports_structured_output=True,
                 supports_data_gen=True,
                 model_id="llama-3.3-70b-versatile",
+                deprecated=True,
                 supports_function_calling=False,
             ),
             KilnModelProvider(
@@ -4483,6 +4484,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.groq,
                 model_id="llama-3.1-8b-instant",
+                deprecated=True,
                 supports_function_calling=False,
             ),
             KilnModelProvider(
@@ -8327,6 +8329,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.cerebras,
                 model_id="zai-glm-4.7",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_schema,
                 reasoning_capable=True,
             ),

--- a/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
+++ b/libs/core/kiln_ai/adapters/test_prompt_adaptors.py
@@ -34,7 +34,7 @@ def get_all_models_and_providers():
 async def test_groq(tmp_path):
     if os.getenv("GROQ_API_KEY") is None:
         pytest.skip("GROQ_API_KEY not set")
-    await run_simple_test(tmp_path, "llama_3_3_70b", "groq")
+    await run_simple_test(tmp_path, "gpt_oss_20b", "groq")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Marks three `KilnModelProvider` entries as `deprecated=True`. Each was verified unreachable by calling the live provider API on 2026-08-24.

| Model | Provider | `model_id` | Error |
|---|---|---|---|
| `llama_3_3_70b` | Groq | `llama-3.3-70b-versatile` | `model_not_found` — "The model `llama-3.3-70b-versatile` does not exist or you do not have access to it." |
| `llama_3_1_8b` | Groq | `llama-3.1-8b-instant` | `model_not_found` — "The model `llama-3.1-8b-instant` does not exist or you do not have access to it." |
| `glm_4_7` | Cerebras | `zai-glm-4.7` | `model_archived` — "Model zai-glm-4.7 is archived and unavailable for the organization." |

`deprecated` is a per-provider field, so the other providers for these models (OpenRouter, Ollama, Bedrock, Fireworks) are untouched and still selectable.

Cerebras `gpt-oss-120b` was deliberately left alone. The same test account gets `payment_required` for it rather than `model_archived`, which means the model still exists and the account simply has no quota — an account problem, not a dead model. That contrast is also what confirms the `zai-glm-4.7` archive error is about the model itself.

No models were added, removed, or re-ided.