### PR TITLE
fix: restrict call_kiln_api to API paths

### DIFF
--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -275,9 +275,13 @@ def _disallowed_path_message(url_path: str) -> str:
         and not looks_like_a_file
     )
     hint = f" Did you mean '/api{path_only}'?" if suggest else ""
+    # Name the exceptions. The rule alone reads as "/ping is impossible",
+    # which would stop a caller retrying the one path that does work.
+    exceptions = ", ".join(f"'{path}'" for path in sorted(ALLOWED_EXACT_PATHS))
     return (
-        f"url_path must start with '{API_PATH_PREFIX}'. Got: '{url_path}'."
-        f"{hint} Correct paths are in the endpoint documentation."
+        f"url_path must start with '{API_PATH_PREFIX}', or be exactly "
+        f"{exceptions}. Got: '{url_path}'.{hint} "
+        "Correct paths are in the endpoint documentation."
     )
 
 

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -265,16 +265,23 @@ def _disallowed_path_message(url_path: str) -> str:
             "endpoint documentation."
         )
 
-    # Suggest the prefixed form only where it could plausibly be the fix. A
-    # dot in the final segment means a filename, not an endpoint, and
-    # "/api/openapi.json" is no more callable than "/openapi.json".
-    looks_like_a_file = "." in path_only.rsplit("/", 1)[-1]
-    suggest = (
-        not path_only.startswith("/api")
-        and path_only not in _NON_API_PATHS
-        and not looks_like_a_file
-    )
-    hint = f" Did you mean '/api{path_only}'?" if suggest else ""
+    # A near miss on an exact allowed path — a trailing slash, say — is
+    # corrected to that path. Prefixing it instead would name a second wrong
+    # call: '/api/ping/' is no more a route than '/ping/' is.
+    near_miss = path_only.rstrip("/")
+    if near_miss in ALLOWED_EXACT_PATHS:
+        hint = f" Did you mean '{near_miss}'?"
+    else:
+        # Suggest the prefixed form only where it could plausibly be the fix.
+        # A dot in the final segment means a filename, not an endpoint, and
+        # "/api/openapi.json" is no more callable than "/openapi.json".
+        looks_like_a_file = "." in path_only.rsplit("/", 1)[-1]
+        suggest = (
+            not path_only.startswith("/api")
+            and path_only not in _NON_API_PATHS
+            and not looks_like_a_file
+        )
+        hint = f" Did you mean '/api{path_only}'?" if suggest else ""
     # Name the exceptions. The rule alone reads as "/ping is impossible",
     # which would stop a caller retrying the one path that does work.
     exceptions = ", ".join(f"'{path}'" for path in sorted(ALLOWED_EXACT_PATHS))

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import Any
+from urllib.parse import unquote
 
 import httpx
 import jq
@@ -211,18 +212,52 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
         return ToolCallResult(output=json.dumps(result, ensure_ascii=False))
 
 
-def _is_allowed_path(url_path: str) -> bool:
-    """True when url_path addresses the Kiln REST API rather than the web app.
+def _path_without_query(url_path: str) -> str:
+    """The path portion alone.
 
-    The query string is ignored here: a url_path carrying one is rejected by
-    its own check, and stripping it first keeps this error about the path.
+    The query string is ignored by the path checks: a url_path carrying one is
+    rejected by its own check, and stripping it first keeps those errors about
+    the path.
     """
-    path_only = url_path.split("?", 1)[0].split("#", 1)[0]
+    return url_path.split("?", 1)[0].split("#", 1)[0]
+
+
+def _has_dot_segment(path_only: str) -> bool:
+    """True when any segment is '.' or '..', encoded or not.
+
+    A prefix check alone is not enough, because the string we validate is not
+    the path that gets sent. httpx resolves dot segments, so '/api/../docs'
+    leaves as '/docs' and '/api/a/../../openapi.json' leaves as
+    '/openapi.json' — both past a guard that only looked at the '/api/' at the
+    front.
+
+    Segments are decoded one at a time rather than decoding the whole path,
+    so an encoded '%2e%2e' is caught while an encoded slash inside a single
+    segment does not split into new ones (httpx leaves those encoded too).
+    """
+    return any(unquote(segment) in {".", ".."} for segment in path_only.split("/"))
+
+
+def _is_allowed_path(url_path: str) -> bool:
+    """True when url_path addresses the Kiln REST API rather than the web app."""
+    path_only = _path_without_query(url_path)
+    if _has_dot_segment(path_only):
+        return False
     return path_only in ALLOWED_EXACT_PATHS or path_only.startswith(API_PATH_PREFIX)
 
 
 def _disallowed_path_message(url_path: str) -> str:
-    path_only = url_path.split("?", 1)[0].split("#", 1)[0]
+    path_only = _path_without_query(url_path)
+    if _has_dot_segment(path_only):
+        # A separate message: "must start with /api/" reads as nonsense for a
+        # path that plainly does start with it.
+        return (
+            "url_path must not contain '.' or '..' path segments, encoded or "
+            f"not. Got: '{url_path}'. Such a path is resolved before it is "
+            "sent, so it can land outside the API — '/api/../docs' is sent as "
+            "'/docs'. Write the full path instead. Correct paths are in the "
+            "endpoint documentation."
+        )
     last_segment = path_only.rsplit("/", 1)[-1]
     # Suggest the prefixed form only where it could plausibly be the fix.
     # Offering "/api/openapi.json" would send the model somewhere just as wrong.

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -65,7 +65,7 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
                 },
                 "url_path": {
                     "type": "string",
-                    "description": "API path, starting with '/api/'. No query string — pass query args via query_params. Correct paths are in the endpoint documentation.",
+                    "description": "API path with no query string — pass query args via query_params. Correct paths are in the endpoint documentation.",
                 },
                 "query_params": {
                     "type": "object",

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -65,7 +65,7 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
                 },
                 "url_path": {
                     "type": "string",
-                    "description": "API path, starting with '/api/' (only '/ping' is allowed outside it). No query string — pass query args via query_params. Web app routes and doc routes such as '/openapi.json' or '/docs' are rejected. Correct paths are in the endpoint documentation.",
+                    "description": "API path, starting with '/api/'. No query string — pass query args via query_params. Correct paths are in the endpoint documentation.",
                 },
                 "query_params": {
                     "type": "object",
@@ -232,10 +232,17 @@ def _has_dot_segment(path_only: str) -> bool:
     front.
 
     Segments are decoded one at a time rather than decoding the whole path,
-    so an encoded '%2e%2e' is caught while an encoded slash inside a single
-    segment does not split into new ones (httpx leaves those encoded too).
+    then split again on any slash the decoding revealed. That catches an
+    encoded '%2e%2e', and an encoded slash used to hide one ('%2e%2e%2f'),
+    without treating an encoded slash as a separator in its own right — httpx
+    leaves those encoded, so '/api/x%2Fy' is one segment and stays under
+    '/api/'.
     """
-    return any(unquote(segment) in {".", ".."} for segment in path_only.split("/"))
+    return any(
+        part in {".", ".."}
+        for segment in path_only.split("/")
+        for part in unquote(segment).split("/")
+    )
 
 
 def _is_allowed_path(url_path: str) -> bool:
@@ -253,27 +260,24 @@ def _disallowed_path_message(url_path: str) -> str:
         # path that plainly does start with it.
         return (
             "url_path must not contain '.' or '..' path segments, encoded or "
-            f"not. Got: '{url_path}'. Such a path is resolved before it is "
-            "sent, so it can land outside the API — '/api/../docs' is sent as "
-            "'/docs'. Write the full path instead. Correct paths are in the "
+            f"not — they resolve elsewhere before the request is sent. Got: "
+            f"'{url_path}'. Write the full path. Correct paths are in the "
             "endpoint documentation."
         )
-    last_segment = path_only.rsplit("/", 1)[-1]
-    # Suggest the prefixed form only where it could plausibly be the fix.
-    # Offering "/api/openapi.json" would send the model somewhere just as wrong.
+
+    # Suggest the prefixed form only where it could plausibly be the fix. A
+    # dot in the final segment means a filename, not an endpoint, and
+    # "/api/openapi.json" is no more callable than "/openapi.json".
+    looks_like_a_file = "." in path_only.rsplit("/", 1)[-1]
     suggest = (
         not path_only.startswith("/api")
         and path_only not in _NON_API_PATHS
-        and "." not in last_segment
+        and not looks_like_a_file
     )
     hint = f" Did you mean '/api{path_only}'?" if suggest else ""
     return (
-        f"url_path must start with '{API_PATH_PREFIX}', or be exactly "
-        f"{', '.join(sorted(ALLOWED_EXACT_PATHS))}. Got: '{url_path}'.{hint} "
-        "This tool reaches the Kiln REST API only. Web app routes and the "
-        "server's own doc routes (/openapi.json, /docs) are not callable, and "
-        "return a web page rather than an API response. Correct paths are in "
-        "the endpoint documentation."
+        f"url_path must start with '{API_PATH_PREFIX}'. Got: '{url_path}'."
+        f"{hint} Correct paths are in the endpoint documentation."
     )
 
 

--- a/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/kiln_api_call_tool.py
@@ -22,6 +22,15 @@ READ_TIMEOUT_SECONDS = 900.0
 # body will then stream for a long time.
 CONNECT_TIMEOUT_SECONDS = 30.0
 
+# The base URL is the server root, and that server also hosts the web app and
+# FastAPI's own doc routes. So a mistyped path does not 404 as JSON — it returns
+# a web page, and thousands of tokens of HTML land in the model's context. Every
+# Kiln API route lives under /api/ apart from /ping, so hold the tool to that.
+API_PATH_PREFIX = "/api/"
+ALLOWED_EXACT_PATHS = frozenset({"/ping"})
+# Paths that a "did you mean /api<path>?" hint would only mislead on.
+_NON_API_PATHS = frozenset({"/", "/docs", "/redoc", "/scalar"})
+
 
 class KilnApiCallTool(KilnTool):
     """Tool for making HTTP requests to the Kiln API server."""
@@ -55,7 +64,7 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
                 },
                 "url_path": {
                     "type": "string",
-                    "description": "API path with no query string — pass query args via query_params. Correct paths are in the endpoint documentation.",
+                    "description": "API path, starting with '/api/' (only '/ping' is allowed outside it). No query string — pass query args via query_params. Web app routes and doc routes such as '/openapi.json' or '/docs' are rejected. Correct paths are in the endpoint documentation.",
                 },
                 "query_params": {
                     "type": "object",
@@ -104,6 +113,9 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
 
         if not url_path.startswith("/"):
             raise ValueError(f"url_path must start with '/', got: {url_path}")
+
+        if not _is_allowed_path(url_path):
+            raise ValueError(_disallowed_path_message(url_path))
 
         if "?" in url_path or "#" in url_path:
             raise ValueError(
@@ -197,6 +209,37 @@ For SSE endpoints (text/event-stream), the tool consumes the stream until it clo
 
         result = {"status_code": status_code, "body": response_body}
         return ToolCallResult(output=json.dumps(result, ensure_ascii=False))
+
+
+def _is_allowed_path(url_path: str) -> bool:
+    """True when url_path addresses the Kiln REST API rather than the web app.
+
+    The query string is ignored here: a url_path carrying one is rejected by
+    its own check, and stripping it first keeps this error about the path.
+    """
+    path_only = url_path.split("?", 1)[0].split("#", 1)[0]
+    return path_only in ALLOWED_EXACT_PATHS or path_only.startswith(API_PATH_PREFIX)
+
+
+def _disallowed_path_message(url_path: str) -> str:
+    path_only = url_path.split("?", 1)[0].split("#", 1)[0]
+    last_segment = path_only.rsplit("/", 1)[-1]
+    # Suggest the prefixed form only where it could plausibly be the fix.
+    # Offering "/api/openapi.json" would send the model somewhere just as wrong.
+    suggest = (
+        not path_only.startswith("/api")
+        and path_only not in _NON_API_PATHS
+        and "." not in last_segment
+    )
+    hint = f" Did you mean '/api{path_only}'?" if suggest else ""
+    return (
+        f"url_path must start with '{API_PATH_PREFIX}', or be exactly "
+        f"{', '.join(sorted(ALLOWED_EXACT_PATHS))}. Got: '{url_path}'.{hint} "
+        "This tool reaches the Kiln REST API only. Web app routes and the "
+        "server's own doc routes (/openapi.json, /docs) are not callable, and "
+        "return a web page rather than an API response. Correct paths are in "
+        "the endpoint documentation."
+    )
 
 
 async def _consume_sse(response: httpx.Response) -> int:

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -10,6 +10,7 @@ import respx
 from kiln_ai.datamodel.tool_id import KilnBuiltInToolId
 from kiln_ai.tools.base_tool import ToolCallContext
 from kiln_ai.tools.built_in_tools.kiln_api_call_tool import (
+    ALLOWED_EXACT_PATHS,
     CONNECT_TIMEOUT_SECONDS,
     READ_TIMEOUT_SECONDS,
     KilnApiCallTool,
@@ -966,6 +967,15 @@ class TestErrorMessageShape:
         assert "Did you mean '/api/projects/123'?" in message
         assert "openapi.json" not in message
         assert "/docs" not in message
+
+    @pytest.mark.asyncio
+    async def test_prefix_error_names_the_allowed_exceptions(self, tool):
+        """The rule alone reads as '/ping is impossible'. Name what works."""
+        with pytest.raises(ValueError) as exc_info:
+            await tool.run(method="GET", url_path="/projects/123")
+        message = str(exc_info.value)
+        for allowed in ALLOWED_EXACT_PATHS:
+            assert allowed in message
 
     @pytest.mark.asyncio
     async def test_no_suggestion_for_something_that_looks_like_a_file(self, tool):

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -983,3 +983,25 @@ class TestErrorMessageShape:
         with pytest.raises(ValueError) as exc_info:
             await tool.run(method="GET", url_path="/_app/immutable/start.js")
         assert "Did you mean" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("url_path", ["/ping/", "/ping//"])
+    async def test_near_miss_on_an_exact_path_is_corrected_to_that_path(
+        self, url_path, tool
+    ):
+        """A trailing slash gets '/ping', not '/api/ping/'.
+
+        Prefixing a near miss names a second wrong call rather than the fix.
+        """
+        with pytest.raises(ValueError) as exc_info:
+            await tool.run(method="GET", url_path=url_path)
+        message = str(exc_info.value)
+        assert "Did you mean '/ping'?" in message
+        assert "/api/ping" not in message
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_unknown_path_still_gets_the_prefix_hint(self, tool):
+        """'/pings' is not a near miss, it is just wrong. Treat it normally."""
+        with pytest.raises(ValueError) as exc_info:
+            await tool.run(method="GET", url_path="/pings")
+        assert "Did you mean '/api/pings'?" in str(exc_info.value)

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -899,6 +899,9 @@ class TestDotSegments:
             "/api/%2e%2e/docs",
             "/api/%2E%2E/docs",
             "/api/%2e/docs",
+            # An encoded slash used to hide a dot segment inside one segment.
+            "/api/%2e%2e%2fdocs",
+            "/api/%2e%2e%2Fopenapi.json",
         ],
     )
     async def test_dot_segments_rejected(self, url_path, tool):
@@ -950,3 +953,23 @@ class TestDotSegments:
             )
             result = await tool.run(method="GET", url_path="/api/files/report..txt")
             assert json.loads(result.output)["status_code"] == 200
+
+
+class TestErrorMessageShape:
+    @pytest.mark.asyncio
+    async def test_prefix_error_names_only_the_rule_and_the_fix(self, tool):
+        """No lecture about routes the caller was never asking for."""
+        with pytest.raises(ValueError) as exc_info:
+            await tool.run(method="GET", url_path="/projects/123")
+        message = str(exc_info.value)
+        assert "must start with '/api/'" in message
+        assert "Did you mean '/api/projects/123'?" in message
+        assert "openapi.json" not in message
+        assert "/docs" not in message
+
+    @pytest.mark.asyncio
+    async def test_no_suggestion_for_something_that_looks_like_a_file(self, tool):
+        """A dot in the last segment means a filename, not an endpoint."""
+        with pytest.raises(ValueError) as exc_info:
+            await tool.run(method="GET", url_path="/_app/immutable/start.js")
+        assert "Did you mean" not in str(exc_info.value)

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -30,10 +30,10 @@ class TestRunCallingConvention:
         # Mirrors LiteLlmAdapter.process_tool_calls: context passed positionally,
         # call args expanded as keywords.
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, json={"ok": True})
             )
-            args = {"method": "GET", "url_path": "/test"}
+            args = {"method": "GET", "url_path": "/api/test"}
             result = await tool.run(ToolCallContext(allow_saving=False), **args)
             assert json.loads(result.output)["status_code"] == 200
 
@@ -41,10 +41,10 @@ class TestRunCallingConvention:
     async def test_run_without_context(self, tool):
         # Mirrors studio_server.chat.stream_session.execute_tool: tool.run(**args).
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, json={"ok": True})
             )
-            result = await tool.run(method="GET", url_path="/test")
+            result = await tool.run(method="GET", url_path="/api/test")
             assert json.loads(result.output)["status_code"] == 200
 
     @pytest.mark.asyncio
@@ -52,10 +52,10 @@ class TestRunCallingConvention:
         # jq_filter must still bind as a keyword-only arg when context is passed
         # positionally — i.e. the adapter convention with the full set of args.
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, json={"name": "v", "extra": 1})
             )
-            args = {"method": "GET", "url_path": "/test", "jq_filter": ".name"}
+            args = {"method": "GET", "url_path": "/api/test", "jq_filter": ".name"}
             result = await tool.run(ToolCallContext(allow_saving=False), **args)
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
@@ -78,15 +78,15 @@ class TestInputValidation:
     @pytest.mark.asyncio
     async def test_invalid_method(self, tool):
         with pytest.raises(ValueError, match="Invalid method 'INVALID'"):
-            await tool.run(method="INVALID", url_path="/test")
+            await tool.run(method="INVALID", url_path="/api/test")
 
     @pytest.mark.asyncio
     async def test_method_case_insensitive(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, json={"ok": True})
             )
-            result = await tool.run(method="get", url_path="/test")
+            result = await tool.run(method="get", url_path="/api/test")
             assert "status_code" in json.loads(result.output)
 
     @pytest.mark.asyncio
@@ -97,22 +97,22 @@ class TestInputValidation:
     @pytest.mark.asyncio
     async def test_body_with_get(self, tool):
         with pytest.raises(ValueError, match="body parameter not allowed with GET"):
-            await tool.run(method="GET", url_path="/test", body="data")
+            await tool.run(method="GET", url_path="/api/test", body="data")
 
     @pytest.mark.asyncio
     async def test_body_with_delete(self, tool):
         with pytest.raises(ValueError, match="body parameter not allowed with DELETE"):
-            await tool.run(method="DELETE", url_path="/test", body="data")
+            await tool.run(method="DELETE", url_path="/api/test", body="data")
 
     @pytest.mark.asyncio
     async def test_url_path_with_query_string_rejected(self, tool):
         with pytest.raises(ValueError, match="must not contain a query string"):
-            await tool.run(method="GET", url_path="/test?foo=bar")
+            await tool.run(method="GET", url_path="/api/test?foo=bar")
 
     @pytest.mark.asyncio
     async def test_url_path_with_fragment_rejected(self, tool):
         with pytest.raises(ValueError, match="query string or fragment"):
-            await tool.run(method="GET", url_path="/test#section")
+            await tool.run(method="GET", url_path="/api/test#section")
 
 
 class TestQueryParams:
@@ -266,10 +266,12 @@ class TestJqFilter:
     @pytest.mark.asyncio
     async def test_jq_filter_on_success(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, json={"name": "test-value"})
             )
-            result = await tool.run(method="GET", url_path="/test", jq_filter=".name")
+            result = await tool.run(
+                method="GET", url_path="/api/test", jq_filter=".name"
+            )
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
             assert parsed["body"] == "test-value"
@@ -293,11 +295,11 @@ class TestJqFilter:
     @pytest.mark.asyncio
     async def test_jq_filter_extracts_array(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, json={"items": [{"id": 1}, {"id": 2}]})
             )
             result = await tool.run(
-                method="GET", url_path="/test", jq_filter=".items[] | .id"
+                method="GET", url_path="/api/test", jq_filter=".items[] | .id"
             )
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
@@ -306,10 +308,12 @@ class TestJqFilter:
     @pytest.mark.asyncio
     async def test_jq_filter_not_applied_on_error(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(404, json={"error": "not found"})
             )
-            result = await tool.run(method="GET", url_path="/test", jq_filter=".name")
+            result = await tool.run(
+                method="GET", url_path="/api/test", jq_filter=".name"
+            )
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 404
             assert "error" in parsed["body"]
@@ -317,10 +321,12 @@ class TestJqFilter:
     @pytest.mark.asyncio
     async def test_jq_filter_on_500(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(500, text="Internal Server Error")
             )
-            result = await tool.run(method="GET", url_path="/test", jq_filter=".name")
+            result = await tool.run(
+                method="GET", url_path="/api/test", jq_filter=".name"
+            )
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 500
             assert parsed["body"] == "Internal Server Error"
@@ -330,88 +336,92 @@ class TestJqErrors:
     @pytest.mark.asyncio
     async def test_invalid_jq_syntax(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, json={"name": "test"})
             )
             with pytest.raises(ValueError, match="jq filter error"):
-                await tool.run(method="GET", url_path="/test", jq_filter=".[invalid")
+                await tool.run(
+                    method="GET", url_path="/api/test", jq_filter=".[invalid"
+                )
 
     @pytest.mark.asyncio
     async def test_jq_runtime_error(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, json={"value": 10})
             )
             with pytest.raises(ValueError, match="jq filter error"):
-                await tool.run(method="GET", url_path="/test", jq_filter=".value / 0")
+                await tool.run(
+                    method="GET", url_path="/api/test", jq_filter=".value / 0"
+                )
 
     @pytest.mark.asyncio
     async def test_jq_on_non_json_response(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, text="not json")
             )
             with pytest.raises(ValueError, match="Response is not valid JSON"):
-                await tool.run(method="GET", url_path="/test", jq_filter=".name")
+                await tool.run(method="GET", url_path="/api/test", jq_filter=".name")
 
 
 class TestHttpErrors:
     @pytest.mark.asyncio
     async def test_connection_refused(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 side_effect=httpx.ConnectError("connection refused")
             )
             with pytest.raises(
                 ConnectionError,
-                match=r"^Could not connect to server for /test$",
+                match=r"^Could not connect to server for /api/test$",
             ):
-                await tool.run(method="GET", url_path="/test")
+                await tool.run(method="GET", url_path="/api/test")
 
     @pytest.mark.asyncio
     async def test_read_timeout_reports_read_bound(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 side_effect=httpx.ReadTimeout("timeout")
             )
             with pytest.raises(
                 TimeoutError,
-                match=rf"Request to /test timed out after {READ_TIMEOUT_SECONDS}s",
+                match=rf"Request to /api/test timed out after {READ_TIMEOUT_SECONDS}s",
             ):
-                await tool.run(method="GET", url_path="/test")
+                await tool.run(method="GET", url_path="/api/test")
 
     @pytest.mark.asyncio
     async def test_read_timeout_on_post(self, tool):
         with respx.mock:
-            respx.post("http://test-server:8757/test").mock(
+            respx.post("http://test-server:8757/api/test").mock(
                 side_effect=httpx.ReadTimeout("timeout")
             )
             with pytest.raises(
                 TimeoutError, match=rf"timed out after {READ_TIMEOUT_SECONDS}s"
             ):
-                await tool.run(method="POST", url_path="/test", body="{}")
+                await tool.run(method="POST", url_path="/api/test", body="{}")
 
     @pytest.mark.asyncio
     async def test_connect_timeout_reports_connect_bound(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 side_effect=httpx.ConnectTimeout("timeout")
             )
             with pytest.raises(
                 TimeoutError,
-                match=rf"Request to /test timed out after {CONNECT_TIMEOUT_SECONDS}s",
+                match=rf"Request to /api/test timed out after {CONNECT_TIMEOUT_SECONDS}s",
             ):
-                await tool.run(method="GET", url_path="/test")
+                await tool.run(method="GET", url_path="/api/test")
 
 
 class TestResponseConstruction:
     @pytest.mark.asyncio
     async def test_output_is_valid_json(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(200, json={"data": "value"})
             )
-            result = await tool.run(method="GET", url_path="/test")
+            result = await tool.run(method="GET", url_path="/api/test")
             parsed = json.loads(result.output)
             assert "status_code" in parsed
             assert "body" in parsed
@@ -419,10 +429,10 @@ class TestResponseConstruction:
     @pytest.mark.asyncio
     async def test_status_code_is_integer(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(201, json={})
             )
-            result = await tool.run(method="GET", url_path="/test")
+            result = await tool.run(method="GET", url_path="/api/test")
             parsed = json.loads(result.output)
             assert isinstance(parsed["status_code"], int)
             assert parsed["status_code"] == 201
@@ -454,10 +464,10 @@ class TestResponseConstruction:
     @pytest.mark.asyncio
     async def test_non_json_response_body_stays_plain_string(self, tool):
         with respx.mock:
-            respx.get("http://test-server:8757/test").mock(
+            respx.get("http://test-server:8757/api/test").mock(
                 return_value=httpx.Response(500, text="Internal Server Error")
             )
-            result = await tool.run(method="GET", url_path="/test")
+            result = await tool.run(method="GET", url_path="/api/test")
             parsed = json.loads(result.output)
             assert parsed["body"] == "Internal Server Error"
 
@@ -465,10 +475,10 @@ class TestResponseConstruction:
     async def test_error_json_response_body_is_object(self, tool):
         err = {"error": "not found", "code": 404}
         with respx.mock:
-            respx.get("http://test-server:8757/missing").mock(
+            respx.get("http://test-server:8757/api/missing").mock(
                 return_value=httpx.Response(404, json=err)
             )
-            result = await tool.run(method="GET", url_path="/missing")
+            result = await tool.run(method="GET", url_path="/api/missing")
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 404
             assert parsed["body"] == err
@@ -777,7 +787,92 @@ class TestSSEReadTimeout:
 
         async with _sse_test_server(handler) as base_url:
             tool = KilnApiCallTool(api_base_url=base_url)
-            result = await tool.run(method="GET", url_path="/stream")
+            result = await tool.run(method="GET", url_path="/api/stream")
             parsed = json.loads(result.output)
             assert parsed["status_code"] == 200
             assert parsed["body"]["event_count"] == 8
+
+
+class TestPathAllowlist:
+    """The tool reaches the API only.
+
+    The base URL is the server root, which also serves the web app and the
+    server's own doc routes. A mistyped path used to return a web page, and
+    thousands of tokens of HTML landed in the model's context.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url_path",
+        [
+            "/openapi.json",
+            "/docs",
+            "/redoc",
+            "/scalar",
+            "/",
+            "/settings",
+            "/projects/123/tasks",
+            "/_app/immutable/entry/start.js",
+            "/apifoo",
+            "/api",
+        ],
+    )
+    async def test_non_api_paths_rejected(self, url_path, tool):
+        with pytest.raises(ValueError, match="url_path must start with '/api/'"):
+            await tool.run(method="GET", url_path=url_path)
+
+    @pytest.mark.asyncio
+    async def test_rejection_happens_before_any_request(self, tool):
+        """No HTTP call is made, so no page can reach the context."""
+        with respx.mock:
+            route = respx.get("http://test-server:8757/openapi.json").mock(
+                return_value=httpx.Response(200, json={"openapi": "3.1.0"})
+            )
+            with pytest.raises(ValueError):
+                await tool.run(method="GET", url_path="/openapi.json")
+            assert not route.called
+
+    @pytest.mark.asyncio
+    async def test_ping_allowed(self, tool):
+        """The one real route outside /api/. Agents use it as a readiness check."""
+        with respx.mock:
+            respx.get("http://test-server:8757/ping").mock(
+                return_value=httpx.Response(200, json="pong")
+            )
+            result = await tool.run(method="GET", url_path="/ping")
+            assert json.loads(result.output)["status_code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_api_path_allowed(self, tool):
+        with respx.mock:
+            respx.get("http://test-server:8757/api/projects").mock(
+                return_value=httpx.Response(200, json=[])
+            )
+            result = await tool.run(method="GET", url_path="/api/projects")
+            assert json.loads(result.output)["status_code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_dropped_prefix_gets_a_suggestion(self, tool):
+        """The most common model error, so name the fix rather than the rule."""
+        with pytest.raises(ValueError, match=r"Did you mean '/api/projects/123'\?"):
+            await tool.run(method="GET", url_path="/projects/123")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("url_path", ["/openapi.json", "/docs", "/"])
+    async def test_no_misleading_suggestion_for_non_api_routes(self, url_path, tool):
+        """'/api/openapi.json' is not a route either. Do not send it there."""
+        with pytest.raises(ValueError) as exc_info:
+            await tool.run(method="GET", url_path=url_path)
+        assert "Did you mean" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_missing_slash_error_still_wins(self, tool):
+        """The more basic error is reported first."""
+        with pytest.raises(ValueError, match="url_path must start with '/'"):
+            await tool.run(method="GET", url_path="api/projects")
+
+    @pytest.mark.asyncio
+    async def test_path_checked_ignoring_query_string(self, tool):
+        """A bad prefix is reported as such, not as a query string problem."""
+        with pytest.raises(ValueError, match="url_path must start with '/api/'"):
+            await tool.run(method="GET", url_path="/projects?id=1")

--- a/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
+++ b/libs/core/kiln_ai/tools/built_in_tools/test_kiln_api_call_tool.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import json
+import re
 
 import httpx
 import pytest
@@ -876,3 +877,76 @@ class TestPathAllowlist:
         """A bad prefix is reported as such, not as a query string problem."""
         with pytest.raises(ValueError, match="url_path must start with '/api/'"):
             await tool.run(method="GET", url_path="/projects?id=1")
+
+
+class TestDotSegments:
+    """A prefix check alone is not enough.
+
+    The string validated is not the path sent. httpx resolves dot segments, so
+    a path that starts with /api/ can leave as something else entirely.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url_path",
+        [
+            "/api/../docs",
+            "/api/../openapi.json",
+            "/api/a/../../openapi.json",
+            "/api/./docs",
+            # Percent-encoded forms. httpx leaves these encoded in the request
+            # target, so whether they escape depends on who decodes them.
+            "/api/%2e%2e/docs",
+            "/api/%2E%2E/docs",
+            "/api/%2e/docs",
+        ],
+    )
+    async def test_dot_segments_rejected(self, url_path, tool):
+        with pytest.raises(ValueError, match=re.escape("must not contain '.' or '..'")):
+            await tool.run(method="GET", url_path=url_path)
+
+    @pytest.mark.asyncio
+    async def test_dot_segment_error_does_not_claim_a_missing_prefix(self, tool):
+        """These paths do start with /api/. Saying otherwise reads as nonsense."""
+        with pytest.raises(ValueError) as exc_info:
+            await tool.run(method="GET", url_path="/api/../docs")
+        assert "must start with '/api/'" not in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "url_path, sent_path",
+        [
+            ("/api/../docs", "/docs"),
+            ("/api/a/../../openapi.json", "/openapi.json"),
+        ],
+    )
+    def test_httpx_really_would_have_sent_these_elsewhere(self, url_path, sent_path):
+        """Pins the reason the rule exists, not just the rule.
+
+        If httpx ever stopped resolving dot segments this would fail, and the
+        guard above could be reconsidered rather than cargo-culted.
+        """
+        assert httpx.URL(f"http://test-server:8757{url_path}").path == sent_path
+
+    @pytest.mark.asyncio
+    async def test_encoded_slash_inside_a_segment_is_still_allowed(self, tool):
+        """Decoding whole paths would split this into segments and over-reject.
+
+        httpx keeps %2F encoded, so it never becomes a separator, and the path
+        stays under /api/.
+        """
+        with respx.mock:
+            respx.get("http://test-server:8757/api/%2Foutside").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            result = await tool.run(method="GET", url_path="/api/%2Foutside")
+            assert json.loads(result.output)["status_code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_dots_inside_a_segment_are_not_dot_segments(self, tool):
+        """Only a whole segment of '.' or '..' is traversal."""
+        with respx.mock:
+            respx.get("http://test-server:8757/api/files/report..txt").mock(
+                return_value=httpx.Response(200, json={"ok": True})
+            )
+            result = await tool.run(method="GET", url_path="/api/files/report..txt")
+            assert json.loads(result.output)["status_code"] == 200


### PR DESCRIPTION
## What does this PR do?

`call_kiln_api` builds its URL from the server root, and that server serves more than the API: the SvelteKit web app is mounted at `/`, and FastAPI's own `/docs`, `/redoc` and `/openapi.json` answer too.

`url_path` was validated for a leading slash and nothing else. So a mistyped path did not come back as a JSON 404. It came back as a web page, and the model got thousands of tokens of HTML in its context instead of an error it could act on.

`url_path` must now start with `/api/`, or be exactly `/ping`.

That pair is not a new rule. Every production route already lives under `/api/` apart from `/ping`, and `test_all_routes_have_tags` already uses exactly that pair as its definition of an API route.

## Rejected, with a reason the model can act on

Where the fix is obvious, the error names it:

```
url_path must start with '/api/', or be exactly '/ping'. Got: '/projects/123'.
Did you mean '/api/projects/123'? Correct paths are in the endpoint documentation.
```

The exceptions are listed from `ALLOWED_EXACT_PATHS` rather than hardcoded, so the message cannot drift from the guard. Stating the rule alone would read as "`/ping` is impossible", which would stop a caller retrying the one path outside `/api/` that does work.

Where the fix is not obvious, the error does not guess. `/api/openapi.json` is no more callable than `/openapi.json`, so a doc or asset route gets the rule and a pointer to the endpoint documentation, not a misleading suggestion. A dot in the final segment is read as a filename and suppresses the hint for the same reason.

A near miss on an exact allowed path is corrected to that path: `/ping/` is told `Did you mean '/ping'?`, not `/api/ping/`, which would just be a second wrong call. A genuinely unknown path like `/pings` is not a near miss and keeps the ordinary prefix hint.

## Dot segments

A prefix check on the string we are handed is not a check on the path that gets sent. httpx resolves dot segments, so a path starting with `/api/` could leave as something else:

```
/api/../docs                -> /docs
/api/a/../../openapi.json   -> /openapi.json
```

The second is the exact payload this guard exists to stop. Percent-encoded forms (`%2e%2e`, `%2E%2E`) are left encoded by httpx, so whether they escape depends on who decodes them downstream; they are rejected too, as is a dot segment hidden behind an encoded slash (`%2e%2e%2f`).

Segments are decoded one at a time and split again on any slash the decoding revealed, rather than decoding the whole path at once. So an encoded slash is not a separator in its own right — httpx keeps those encoded, and `/api/x%2Fy` stays one segment under `/api/`.

Dot segments get their own error message. Telling the caller a path "must start with `/api/`" reads as nonsense when it plainly does.

A test pins httpx's normalisation, so the reason for the rule is checked rather than just the rule.

## Why this is worth a guard rather than a doc line

The instruction already exists in agent prompts, and agents still get it wrong. In one internal optimisation loop, 34 recorded traces have a `<!doctype html>` body sitting in an agent's context, and 21 calls fetched `/openapi.json` despite a prompt line that forbids exactly that.

Two things caused it: a dropped `/api` prefix, and a wrong path segment. Both are ordinary model slips, and neither is fixable by asking more firmly.

## Notes

- The rejection happens before the HTTP call, so no page is fetched at all.
- The `url_path` parameter description is untouched. A caller asking for an endpoint is not wondering about web app routes, and the guard states the rule when a call breaks it. The tool file diff is purely additive.
- The check ignores any query string when deciding, so a path with both problems reports the prefix, not the query string.
- No response size cap. That would truncate the file downloads this tool is meant to serve, such as document and dataset downloads.
- Existing tests used `/test` as a path. They now use `/api/test`.

## The same guard, twice

`api_mcp` in the experiments repo holds a duplicated copy of this tool — it imports only the `KilnTool` base class and repeats the body, so it never picked any of this up. It had the same hole, including the dot-segment one, and Kiln-AI/experiments#28 ports this guard across verbatim.

That PR is where the field evidence above comes from. It is independent of this one, so the two can merge in either order; the copy is what should go, eventually.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
