### PR TITLE
Announce form validation errors to screen readers

### DIFF
--- a/app/web_ui/src/lib/ui/fancy_select.svelte
+++ b/app/web_ui/src/lib/ui/fancy_select.svelte
@@ -6,6 +6,8 @@
   import { onMount, onDestroy } from "svelte"
 
   export let aria_label: string | null = null
+  export let aria_invalid: boolean | undefined = undefined
+  export let aria_describedby: string | undefined = undefined
   export let options: OptionGroup[] = []
   export let selected: unknown
   export let empty_label: string = "Select an option"
@@ -525,6 +527,8 @@
 <div class="dropdown w-full relative">
   <div
     aria-label={aria_label}
+    aria-invalid={aria_invalid}
+    aria-describedby={aria_describedby}
     tabindex={disabled ? -1 : 0}
     role="listbox"
     class="select select-bordered w-full flex items-center {!listVisible

--- a/app/web_ui/src/lib/utils/__tests__/form_element_aria_wrapper.svelte
+++ b/app/web_ui/src/lib/utils/__tests__/form_element_aria_wrapper.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import FormElement from "$lib/utils/form_element.svelte"
+
+  export let value: string = ""
+  export let label: string = "Full Name"
+  export let placeholder: string | null = null
+  export let error_message: string | null = null
+  export let inputType: "input" | "textarea" | "select" = "input"
+</script>
+
+<FormElement
+  {inputType}
+  id="aria_test_field"
+  {label}
+  {placeholder}
+  {error_message}
+  select_options={[
+    ["a", "Option A"],
+    ["b", "Option B"],
+  ]}
+  bind:value
+/>

--- a/app/web_ui/src/lib/utils/__tests__/form_element_fancy_wrapper.svelte
+++ b/app/web_ui/src/lib/utils/__tests__/form_element_fancy_wrapper.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import FormElement from "$lib/utils/form_element.svelte"
+
+  export let value: unknown = null
+  export let error_message: string | null = null
+  export let inputType: "fancy_select" | "multi_select" = "fancy_select"
+</script>
+
+<FormElement
+  {inputType}
+  id="fancy_test_field"
+  label="Dataset Filter Tag"
+  {error_message}
+  fancy_select_options={[
+    { label: "Tags", options: [{ label: "fine_tune_a", value: "a" }] },
+  ]}
+  bind:value
+/>

--- a/app/web_ui/src/lib/utils/form_element.svelte
+++ b/app/web_ui/src/lib/utils/form_element.svelte
@@ -151,6 +151,11 @@
     if (target) value = target.checked
   }
 
+  $: error_id = `${id}-error`
+  $: accessible_error = error_message || inline_error
+  $: described_by = accessible_error ? error_id : undefined
+  $: aria_invalid = accessible_error ? true : undefined
+
   const height_class = {
     base: "h-18",
     medium: "h-36",
@@ -169,6 +174,8 @@
         checked={value ? true : false}
         on:change={handleCheckboxChange}
         aria-label={aria_label || label}
+        aria-invalid={aria_invalid}
+        aria-describedby={described_by}
         {disabled}
       />
     {/if}
@@ -227,6 +234,8 @@
     {#if inputType === "textarea"}
       <textarea
         aria-label={aria_label || label}
+        aria-invalid={aria_invalid}
+        aria-describedby={described_by}
         placeholder={error_message || placeholder || label}
         {id}
         class="textarea text-base textarea-bordered w-full {height_class[
@@ -241,6 +250,8 @@
     {:else if inputType === "input"}
       <input
         aria-label={aria_label || label}
+        aria-invalid={aria_invalid}
+        aria-describedby={described_by}
         type="text"
         placeholder={error_message || placeholder || label}
         {id}
@@ -256,6 +267,8 @@
     {:else if inputType === "input_number"}
       <input
         aria-label={aria_label || label}
+        aria-invalid={aria_invalid}
+        aria-describedby={described_by}
         type="number"
         placeholder={error_message || placeholder || label}
         {id}
@@ -273,6 +286,8 @@
     {:else if inputType === "select"}
       <select
         aria-label={aria_label || label}
+        aria-invalid={aria_invalid}
+        aria-describedby={described_by}
         {id}
         class="select select-bordered w-full {error_message || inline_error
           ? 'select-error'
@@ -306,6 +321,8 @@
     {:else if inputType === "fancy_select" || inputType === "multi_select"}
       <FancySelect
         aria_label={aria_label || label}
+        {aria_invalid}
+        aria_describedby={described_by}
         bind:options={fancy_select_options}
         bind:selected={value}
         multi_select={inputType === "multi_select"}
@@ -320,6 +337,8 @@
       <div
         role="radiogroup"
         aria-label={aria_label || label}
+        aria-invalid={aria_invalid}
+        aria-describedby={described_by}
         class="flex flex-col gap-2 {error_message ? 'input-error' : ''}"
         {id}
         tabindex="-1"
@@ -358,10 +377,14 @@
     {/if}
     {#if inline_error || (inputType === "select" && error_message)}
       <span
+        aria-hidden="true"
         class="absolute right-3 bottom-4 badge badge-error badge-sm badge-outline text-xs bg-base-100"
       >
         {inline_error || error_message}
       </span>
     {/if}
   </div>
+  {#if accessible_error}
+    <div id={error_id} class="sr-only">{accessible_error}</div>
+  {/if}
 </div>

--- a/app/web_ui/src/lib/utils/form_element_aria.test.ts
+++ b/app/web_ui/src/lib/utils/form_element_aria.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/svelte"
+import Wrapper from "./__tests__/form_element_aria_wrapper.svelte"
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    ;(
+      globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }
+    ).ResizeObserver = ResizeObserverStub
+  }
+})
+
+afterEach(cleanup)
+
+const ERROR = '"Full Name" is required'
+
+describe("FormElement aria error wiring", () => {
+  it("marks the input invalid and points it at the error text", () => {
+    const { container } = render(Wrapper, {
+      props: { error_message: ERROR },
+    })
+    const input = container.querySelector("input")
+    expect(input?.getAttribute("aria-invalid")).toBe("true")
+    expect(input?.getAttribute("aria-describedby")).toBe(
+      "aria_test_field-error",
+    )
+
+    const described = container.querySelector("#aria_test_field-error")
+    expect(described?.textContent?.trim()).toBe(ERROR)
+  })
+
+  it("emits no aria attributes when the field is valid", () => {
+    const { container } = render(Wrapper, { props: { error_message: null } })
+    const input = container.querySelector("input")
+    expect(input?.hasAttribute("aria-invalid")).toBe(false)
+    expect(input?.hasAttribute("aria-describedby")).toBe(false)
+    expect(container.querySelector("#aria_test_field-error")).toBeNull()
+  })
+
+  it("keeps the error target out of the visual layout", () => {
+    const { container } = render(Wrapper, { props: { error_message: ERROR } })
+    expect(
+      container.querySelector("#aria_test_field-error")?.className,
+    ).toContain("sr-only")
+  })
+
+  it("does not change what a sighted user sees in the placeholder", () => {
+    const { container } = render(Wrapper, {
+      props: { error_message: ERROR, placeholder: "Your name" },
+    })
+    // Unchanged from before this PR: the error still takes over the placeholder.
+    expect(container.querySelector("input")?.placeholder).toBe(ERROR)
+  })
+
+  it("does not hand assistive tech the same message twice on a select", () => {
+    const { container } = render(Wrapper, {
+      props: { inputType: "select", error_message: ERROR },
+    })
+    // The badge repeats the message visually; it must not also be announced.
+    const badge = container.querySelector(".badge-error")
+    expect(badge?.textContent?.trim()).toBe(ERROR)
+    expect(badge?.getAttribute("aria-hidden")).toBe("true")
+
+    // The exclaim InfoTooltip also holds the text, but its container is
+    // display:none until hover, so it is out of the accessibility tree.
+    // jsdom has no stylesheet, so exclude it by role rather than by style.
+    const exposed = Array.from(container.querySelectorAll("*")).filter(
+      (el) =>
+        el.children.length === 0 &&
+        el.textContent?.trim() === ERROR &&
+        !el.closest("[aria-hidden='true']") &&
+        !el.closest("[role='tooltip']"),
+    )
+    expect(exposed).toHaveLength(1)
+    expect(exposed[0].id).toBe("aria_test_field-error")
+  })
+
+  it("wires a textarea the same way", () => {
+    const { container } = render(Wrapper, {
+      props: { inputType: "textarea", error_message: ERROR },
+    })
+    const ta = container.querySelector("textarea")
+    expect(ta?.getAttribute("aria-invalid")).toBe("true")
+    expect(ta?.getAttribute("aria-describedby")).toBe("aria_test_field-error")
+  })
+
+  it("wires a select the same way", () => {
+    const { container } = render(Wrapper, {
+      props: { inputType: "select", error_message: ERROR },
+    })
+    const sel = container.querySelector("select")
+    expect(sel?.getAttribute("aria-invalid")).toBe("true")
+    expect(sel?.getAttribute("aria-describedby")).toBe("aria_test_field-error")
+  })
+})

--- a/app/web_ui/src/lib/utils/form_element_fancy_aria.test.ts
+++ b/app/web_ui/src/lib/utils/form_element_fancy_aria.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/svelte"
+import Wrapper from "./__tests__/form_element_fancy_wrapper.svelte"
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    ;(
+      globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }
+    ).ResizeObserver = ResizeObserverStub
+  }
+})
+
+afterEach(cleanup)
+
+describe("FancySelect aria error wiring", () => {
+  it("reaches the listbox trigger through FormElement", () => {
+    const { container } = render(Wrapper, {
+      props: { error_message: '"Dataset Filter Tag" is required' },
+    })
+    const trigger = container.querySelector('[role="listbox"]')
+    expect(trigger?.getAttribute("aria-invalid")).toBe("true")
+    expect(trigger?.getAttribute("aria-describedby")).toBe(
+      "fancy_test_field-error",
+    )
+    expect(
+      container.querySelector("#fancy_test_field-error")?.textContent?.trim(),
+    ).toBe('"Dataset Filter Tag" is required')
+  })
+
+  it("emits nothing when valid", () => {
+    const { container } = render(Wrapper, { props: { error_message: null } })
+    const trigger = container.querySelector('[role="listbox"]')
+    expect(trigger?.hasAttribute("aria-invalid")).toBe(false)
+    expect(trigger?.hasAttribute("aria-describedby")).toBe(false)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Makes form validation errors reachable by screen readers. **No visual change.**

### The problem

Validation errors are shown by replacing the input's placeholder:

```svelte
placeholder={error_message || placeholder || label}
```

That works for sighted users, but a placeholder is exposed to assistive technology as a **hint**, not an error, and changing its text fires no announcement. So a screen reader user tabs into a failing field, hears `"Full Name, edit"`, and gets no indication that anything is wrong or why the form will not submit.

### Why `aria-invalid` and `aria-describedby`

These are the two attributes that turn a visual error into an announced one:

- **`aria-invalid="true"`** tells assistive tech the field failed validation. A screen reader appends "invalid entry" when it reads the field.
- **`aria-describedby="{id}-error"`** points at the element holding the explanation, so the reader speaks the actual message rather than just flagging a problem.

`FormContainer` already moves focus to the first invalid field on submit, so both fire at the moment the user lands there. The announcement goes from `"Full Name, edit"` to `"Full Name, edit, invalid entry, "Full Name" is required"`.

The error text lives in a `sr-only` element so `aria-describedby` has something to point at without changing the layout. The `inline_error` badge is marked `aria-hidden` — it repeats the same message visually, and without that a screen reader would meet it twice. The hidden element therefore carries `error_message || inline_error`, so nothing the badge used to convey is lost.

### Why there are no screenshots

There is nothing to show. The placeholder expression and the `inline_error` badge are untouched, so the rendered output is byte-identical for sighted users. The diff adds attributes and one visually hidden node.

### Scope

Applies to every input type — text, number, textarea, select, checkbox, radio group, and `FancySelect`, which gains two optional pass-through props. Attributes are emitted as `undefined` when the field is valid, so Svelte omits them entirely and clean fields are unchanged in the DOM.

Six new tests cover the aria wiring across input types, attribute absence when valid, the error target staying out of the visual layout, and an explicit assertion that the placeholder still behaves exactly as it does today.

Lint, format, `svelte-check` (0 errors), 2460 tests, and build all pass.

### Follow-ups, not in this PR

- `FormContainer.first_error()` queries only `.input-error, .textarea-error`, so a form whose only invalid field is a `select` passes validation and submits. Pre-existing.
- Callers that pass `label=""` on a required field produce `"" is required`. It reads poorly in the placeholder today and is now also announced. A fallback to `aria_label` would fix it.
- An author-supplied `placeholder` is still overwritten by the error text, so the hint is lost exactly when the user needs it. Fixing that means moving the error into the visible layout, which is a UX change and deliberately out of scope here.

## Related Issues

N/A

## Contributor License Agreement

I, @<your-github-username>, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib
