### PR TITLE
Repoint three dead prerelease chat pins at live models

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -9081,6 +9081,7 @@ built_in_models: List[KilnModel] = [
             KilnModelProvider(
                 name=ModelProviderName.together_ai,
                 model_id="MiniMaxAI/MiniMax-M2.7",
+                deprecated=True,
                 structured_output_mode=StructuredOutputMode.json_instruction_and_object,
                 reasoning_capable=True,
                 supports_data_gen=True,

--- a/libs/core/kiln_ai/adapters/pytest_prerelease_whitelist.py
+++ b/libs/core/kiln_ai/adapters/pytest_prerelease_whitelist.py
@@ -24,9 +24,9 @@ PRERELEASE_CHAT_MODELS: list[tuple[str, str]] = [
     ("gemini_3_flash", ModelProviderName.gemini_api.value),
     ("claude_sonnet_4_6", ModelProviderName.openrouter.value),
     ("gpt_5_4_mini", ModelProviderName.openrouter.value),
-    ("llama_3_3_70b", ModelProviderName.groq.value),
-    ("qwen_3p6_plus", ModelProviderName.fireworks_ai.value),
-    ("minimax_m2_7", ModelProviderName.together_ai.value),
+    ("gpt_oss_20b", ModelProviderName.groq.value),
+    ("qwen_3p7_plus", ModelProviderName.fireworks_ai.value),
+    ("deepseek_4_flash", ModelProviderName.together_ai.value),
 ]
 
 # (model_name, provider_name) — used by the embedding prerelease smoke tests


### PR DESCRIPTION
## What

`PRERELEASE_CHAT_MODELS` was left behind by #1726, which deprecated dead provider entries in `ml_model_list.py` and repointed `test_groq`, but did not sweep the whitelist. This repoints the stale pins and deprecates one provider entry that turned out to be unreachable.

| Provider | Was | Now | Why |
|---|---|---|---|
| `groq` | `llama_3_3_70b` | `gpt_oss_20b` | Groq has exactly two live entries (`gpt_oss_120b`, `gpt_oss_20b`). `gpt_oss_20b` is the cheaper one and is already what `test_groq` uses after #1726, so the two stay consistent. |
| `fireworks_ai` | `qwen_3p6_plus` | `qwen_3p7_plus` | Direct same-family, same-tier successor, one version newer. Keeps Qwen coverage and the list's "latest small/cheap" bias. Deliberately **not** `qwen_3p8_2p4t_a95b` — newer, but the 2.4T-param max tier, against the cost bias. |
| `together_ai` | `minimax_m2_7` | `deepseek_4_flash` | Together no longer serves M2.7 serverless. `deepseek_4_flash` is the small/fast tier and adds a family the chat list did not otherwise cover. |

The `together_ai` provider entry for `minimax_m2_7` is also marked `deprecated=True` in `ml_model_list.py`. Together returns:

> Unable to access non-serverless model MiniMaxAI/MiniMax-M2.7 ... create and start a new dedicated endpoint

Three other Together models (`deepseek_4_flash`, `glm_5_2`, `llama_3_3_70b`) answer fine on the same key, so this is the model, not the credentials. **Only the `together_ai` entry is deprecated** — the OpenRouter and Fireworks entries for M2.7 are still live and untouched.

## Evidence

Each replacement was driven through the repo's own `run_simple_test` helper against the real provider, and each returned a correct answer (the helper asserts `"64" in output`):

```
LIVE_OK   gpt_oss_20b      @ groq
LIVE_OK   qwen_3p7_plus    @ fireworks_ai
LIVE_OK   deepseek_4_flash @ together_ai
```

All ten entries in `PRERELEASE_CHAT_MODELS` now resolve `OK` (non-deprecated, provider present). `uv run ./checks.sh --agent-mode` passes.

## Sweep of the other whitelists

Swept `PRERELEASE_EMBEDDING_MODELS`, `PRERELEASE_EXTRACTION_MODELS`, and `PRERELEASE_THINKING_MODELS`. All entries are live; no changes needed. (`PRERELEASE_MULTIMODAL_TRACE_MODELS` does not exist in this file.)

Note that embedding entries must be resolved against `built_in_embedding_models_from_provider`, not `built_in_models_from_provider` — the latter reports every embedding pin as `NO_PROVIDER`, which is a false alarm.

## Known follow-ups, not fixed here

1. **`test_prompt_caching.py` hardcodes the same dead model.** `test_prompt_caching_cache_hit[fireworks_ai/qwen_3p6_plus]` is `@pytest.mark.prerelease` and 404s (`Model not found, inaccessible, and/or not deployed`). Same one-line fix as the whitelist (`qwen_3p6_plus` → `qwen_3p7_plus`), deliberately left out to keep this PR to whitelist + model-list only. Tracked for a separate PR.

2. **`PRERELEASE_CHAT_MODELS` has no test consumers.** Nothing imports it — the only references are in `.agents/skills/kiln-prerelease-check/SKILL.md`. Its docstring claims it is "used by the litellm adapter prerelease smoke tests that exercise basic completion / structured output / tool calling", but no such sibling smoke test exists, unlike the embedding/extraction/thinking lists which are genuinely parametrized over. So these pins going stale is currently invisible to CI. Worth deciding whether to add the missing smoke test or correct the docstring.

3. `test_thinking_level_reasoning_content_prerelease_smoke[gemini_api-gemini_3_flash-medium]` failed once in the full run and passed on isolated re-run — flaky, not stale.

4. The two `vertex-semantic_ranker_*` reranker failures in the prerelease run are unrelated to model pins and pre-date this branch.
