### PR TITLE
Reuse MCP sessions without running a task

### DIFF
--- a/app/desktop/studio_server/code_tool_api.py
+++ b/app/desktop/studio_server/code_tool_api.py
@@ -10,14 +10,9 @@ from kiln_ai.adapters.eval.v2_eval_code_eval import has_add_code_trust
 from kiln_ai.datamodel.code_tool import CodeTool
 from kiln_ai.datamodel.json_schema import validate_schema_with_value_error
 from kiln_ai.datamodel.tool_id import ToolId
-from kiln_ai.run_context import (
-    clear_agent_run_id,
-    generate_agent_run_id,
-    set_agent_run_id,
-)
 from kiln_ai.tools.base_tool import ToolCallContext
 from kiln_ai.tools.code_tool import ChildOutcome, PythonCodeTool
-from kiln_ai.tools.mcp_session_manager import MCPSessionManager
+from kiln_ai.tools.mcp_session_manager import mcp_session_scope
 from kiln_ai.tools.sandbox_bridge import ToolCallLogEntry
 from kiln_server.project_api import project_from_id
 from kiln_server.utils.agent_checks.policy import (
@@ -298,9 +293,7 @@ def connect_code_tool_api(app: FastAPI):
             raise HTTPException(status_code=400, detail=str(e))
 
         tool_call_log: list[ToolCallLogEntry] = []
-        run_id = generate_agent_run_id()
-        set_agent_run_id(run_id)
-        try:
+        async with mcp_session_scope():
             tool = PythonCodeTool(
                 transient_tool,
                 project,
@@ -311,11 +304,6 @@ def connect_code_tool_api(app: FastAPI):
                 ToolCallContext(allow_saving=False), request.params
             )
             return _outcome_to_test_response(outcome, tool_call_log)
-        finally:
-            try:
-                await MCPSessionManager.shared().cleanup_session(run_id)
-            finally:
-                clear_agent_run_id()
 
     @app.get(
         "/api/projects/{project_id}/code_tools",

--- a/app/desktop/studio_server/test_code_tool_api.py
+++ b/app/desktop/studio_server/test_code_tool_api.py
@@ -445,11 +445,9 @@ class TestTestCodeTool:
             ),
             patch(TRUST_PATCH, return_value=True),
             patch(
-                "app.desktop.studio_server.code_tool_api.MCPSessionManager"
+                "kiln_ai.tools.mcp_session_manager.MCPSessionManager"
             ) as mock_manager_cls,
-            patch(
-                "app.desktop.studio_server.code_tool_api.clear_agent_run_id"
-            ) as mock_clear,
+            patch("kiln_ai.tools.mcp_session_manager.clear_agent_run_id") as mock_clear,
         ):
             mock_manager_cls.shared.return_value.cleanup_session = cleanup_mock
             response = client.post(
@@ -473,11 +471,9 @@ class TestTestCodeTool:
             ),
             patch(TRUST_PATCH, return_value=True),
             patch(
-                "app.desktop.studio_server.code_tool_api.MCPSessionManager"
+                "kiln_ai.tools.mcp_session_manager.MCPSessionManager"
             ) as mock_manager_cls,
-            patch(
-                "app.desktop.studio_server.code_tool_api.clear_agent_run_id"
-            ) as mock_clear,
+            patch("kiln_ai.tools.mcp_session_manager.clear_agent_run_id") as mock_clear,
         ):
             mock_manager_cls.shared.return_value.cleanup_session = cleanup_mock
             response = error_client.post(

--- a/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
@@ -54,16 +54,8 @@ from kiln_ai.datamodel.run_config import (
 from kiln_ai.datamodel.skill import Skill
 from kiln_ai.datamodel.task import RunConfigProperties
 from kiln_ai.datamodel.tool_id import SKILL_TOOL_ID_PREFIX, skill_id_from_tool_id
-
-# Import agent run context for run lifecycle management
-from kiln_ai.run_context import (
-    clear_agent_run_id,
-    generate_agent_run_id,
-    get_agent_run_id,
-    set_agent_run_id,
-)
 from kiln_ai.tools import KilnToolInterface
-from kiln_ai.tools.mcp_session_manager import MCPSessionManager
+from kiln_ai.tools.mcp_session_manager import mcp_session_scope
 from kiln_ai.tools.skill_tool import SkillTool
 from kiln_ai.tools.tool_registry import tool_from_id
 from kiln_ai.utils.config import Config
@@ -373,25 +365,10 @@ class BaseAdapter(metaclass=ABCMeta):
         prior_trace: list[ChatCompletionMessageParam] | None = None,
         parent_task_run: TaskRun | None = None,
     ) -> Tuple[TaskRun, RunOutput]:
-        # Determine if this is the root agent (no existing run context)
-        is_root_agent = get_agent_run_id() is None
-
-        if is_root_agent:
-            run_id = generate_agent_run_id()
-            set_agent_run_id(run_id)
-
-        try:
+        async with mcp_session_scope():
             return await self._run_returning_run_output(
                 input, input_source, prior_trace, parent_task_run
             )
-        finally:
-            if is_root_agent:
-                try:
-                    run_id = get_agent_run_id()
-                    if run_id:
-                        await MCPSessionManager.shared().cleanup_session(run_id)
-                finally:
-                    clear_agent_run_id()
 
     def invoke_openai_stream(
         self,
@@ -896,11 +873,7 @@ class OpenAIStreamResult:
 
     async def __aiter__(self) -> AsyncIterator[ModelResponseStream]:
         self._task_run = None
-        is_root_agent = get_agent_run_id() is None
-        if is_root_agent:
-            set_agent_run_id(generate_agent_run_id())
-
-        try:
+        async with mcp_session_scope():
             adapter_stream = self._adapter._prepare_stream(
                 self._input, self._prior_trace
             )
@@ -912,14 +885,6 @@ class OpenAIStreamResult:
             self._task_run = self._adapter._finalize_stream(
                 adapter_stream, self._input, self._input_source, self._parent_task_run
             )
-        finally:
-            if is_root_agent:
-                try:
-                    run_id = get_agent_run_id()
-                    if run_id:
-                        await MCPSessionManager.shared().cleanup_session(run_id)
-                finally:
-                    clear_agent_run_id()
 
 
 class AiSdkStreamResult:
@@ -959,11 +924,7 @@ class AiSdkStreamResult:
 
     async def __aiter__(self) -> AsyncIterator[AiSdkStreamEvent]:
         self._task_run = None
-        is_root_agent = get_agent_run_id() is None
-        if is_root_agent:
-            set_agent_run_id(generate_agent_run_id())
-
-        try:
+        async with mcp_session_scope():
             adapter_stream = self._adapter._prepare_stream(
                 self._input, self._prior_trace
             )
@@ -1003,11 +964,3 @@ class AiSdkStreamResult:
             else:
                 for ai_event in converter.finalize():
                     yield ai_event
-        finally:
-            if is_root_agent:
-                try:
-                    run_id = get_agent_run_id()
-                    if run_id:
-                        await MCPSessionManager.shared().cleanup_session(run_id)
-                finally:
-                    clear_agent_run_id()

--- a/libs/core/kiln_ai/adapters/model_adapters/mcp_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/mcp_adapter.py
@@ -13,13 +13,7 @@ from kiln_ai.datamodel.json_schema import (
 )
 from kiln_ai.datamodel.run_config import McpRunConfigProperties
 from kiln_ai.datamodel.task import RunConfigProperties
-from kiln_ai.run_context import (
-    clear_agent_run_id,
-    generate_agent_run_id,
-    get_agent_run_id,
-    set_agent_run_id,
-)
-from kiln_ai.tools.mcp_session_manager import MCPSessionManager
+from kiln_ai.tools.mcp_session_manager import mcp_session_scope
 from kiln_ai.tools.tool_registry import tool_from_id
 from kiln_ai.utils.config import Config
 from kiln_ai.utils.open_ai_types import (
@@ -114,7 +108,10 @@ class MCPAdapter(BaseAdapter):
     ) -> Tuple[TaskRun, RunOutput]:
         """
         Runs the task and returns both the persisted TaskRun and raw RunOutput.
-        If this call is the root of a run, it creates an agent run context, ensures MCP tool calls have a valid session scope, and cleans up the session/context on completion.
+        The run executes inside an MCP session scope, so the tool call has a
+        valid session to reuse. If this call opened the scope, the sessions it
+        opened are cleaned up on completion; nested inside a caller's scope,
+        that caller owns the teardown.
         """
         if prior_trace or parent_task_run is not None:
             raise NotImplementedError(
@@ -122,24 +119,10 @@ class MCPAdapter(BaseAdapter):
                 "MCP tools are single-turn and do not maintain conversation state."
             )
 
-        is_root_agent = get_agent_run_id() is None
-
-        if is_root_agent:
-            run_id = generate_agent_run_id()
-            set_agent_run_id(run_id)
-
-        try:
+        async with mcp_session_scope():
             return await self._run_and_validate_output(
                 input, input_source, parent_task_run
             )
-        finally:
-            if is_root_agent:
-                try:
-                    run_id = get_agent_run_id()
-                    if run_id:
-                        await MCPSessionManager.shared().cleanup_session(run_id)
-                finally:
-                    clear_agent_run_id()
 
     async def _run_and_validate_output(
         self,

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -1296,7 +1296,7 @@ class TestAgentRunContextLifecycle:
                 "kiln_ai.adapters.model_adapters.base_adapter.request_formatter_from_id"
             ),
             patch(
-                "kiln_ai.adapters.model_adapters.base_adapter.MCPSessionManager"
+                "kiln_ai.tools.mcp_session_manager.MCPSessionManager"
             ) as mock_manager_class,
         ):
             mock_parser_factory.return_value = parser
@@ -1310,10 +1310,92 @@ class TestAgentRunContextLifecycle:
             # cleanup_session should have been called
             mock_manager.cleanup_session.assert_called_once()
             # The run ID should be a string that starts with "run_"
-            call_args = mock_manager.cleanup_session.call_args
-            assert call_args is not None
-            run_id = call_args[0][0] if call_args[0] else call_args[1]["run_id"]
+            run_id = mock_manager.cleanup_session.call_args[0][0]
             assert run_id.startswith("run_")
+
+    @staticmethod
+    def _fake_adapter_stream():
+        """A one-chunk stand-in for the model stream, so these tests exercise
+        the session scope around iteration rather than a real model path."""
+
+        class FakeAdapterStream:
+            async def __aiter__(self):
+                yield ModelResponseStream(
+                    id="test",
+                    choices=[
+                        StreamingChoices(
+                            index=0,
+                            delta=Delta(content="hi"),
+                            finish_reason=None,
+                        )
+                    ],
+                )
+
+        return FakeAdapterStream()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_session_called_after_openai_stream(
+        self, adapter, clear_context
+    ):
+        """The streaming path opens the same session scope as invoke, so a
+        consumed stream must close its sessions and release the run id too."""
+        from kiln_ai.run_context import get_agent_run_id
+
+        with (
+            patch.object(
+                adapter, "_prepare_stream", return_value=self._fake_adapter_stream()
+            ),
+            patch.object(
+                adapter, "_finalize_stream", return_value=MagicMock(spec=TaskRun)
+            ),
+            patch(
+                "kiln_ai.tools.mcp_session_manager.MCPSessionManager"
+            ) as mock_manager_class,
+        ):
+            mock_manager = MagicMock()
+            mock_manager_class.shared.return_value = mock_manager
+            mock_manager.cleanup_session = AsyncMock()
+
+            async for _chunk in adapter.invoke_openai_stream("test input"):
+                pass
+
+            mock_manager.cleanup_session.assert_called_once()
+            run_id = mock_manager.cleanup_session.call_args[0][0]
+            assert run_id.startswith("run_")
+            assert get_agent_run_id() is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_session_called_after_ai_sdk_stream(
+        self, adapter, clear_context
+    ):
+        """Same guarantee for the AI SDK stream: it owns a scope of its own."""
+        from kiln_ai.run_context import get_agent_run_id
+
+        finalized_run = MagicMock(spec=TaskRun)
+        # Pins the finish branch: a bare mock is truthy here, which would
+        # silently route the stream down the tool-calls-pending path instead.
+        finalized_run.is_toolcall_pending = False
+
+        with (
+            patch.object(
+                adapter, "_prepare_stream", return_value=self._fake_adapter_stream()
+            ),
+            patch.object(adapter, "_finalize_stream", return_value=finalized_run),
+            patch(
+                "kiln_ai.tools.mcp_session_manager.MCPSessionManager"
+            ) as mock_manager_class,
+        ):
+            mock_manager = MagicMock()
+            mock_manager_class.shared.return_value = mock_manager
+            mock_manager.cleanup_session = AsyncMock()
+
+            async for _event in adapter.invoke_ai_sdk_stream("test input"):
+                pass
+
+            mock_manager.cleanup_session.assert_called_once()
+            run_id = mock_manager.cleanup_session.call_args[0][0]
+            assert run_id.startswith("run_")
+            assert get_agent_run_id() is None
 
 
 class TestStreamMethods:

--- a/libs/core/kiln_ai/tools/mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/mcp_session_manager.py
@@ -16,6 +16,12 @@ from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.exceptions import McpError
 
 from kiln_ai.datamodel.external_tool_server import ExternalToolServer, ToolServerType
+from kiln_ai.run_context import (
+    clear_agent_run_id,
+    generate_agent_run_id,
+    get_agent_run_id,
+    set_agent_run_id,
+)
 from kiln_ai.utils.config import Config
 from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 
@@ -117,7 +123,8 @@ class MCPSessionManager:
     async def cleanup_session(self, session_id: str) -> None:
         """Close all MCP sessions associated with a session ID.
 
-        Called by the root agent's finally block when the agent run completes.
+        Called by `mcp_session_scope` when the scope that owns the id exits.
+        Nothing else reaps these sessions, so a skipped call leaks them.
 
         Args:
             session_id: The session ID to clean up
@@ -499,6 +506,40 @@ class MCPSessionManager:
     def clear_shell_path_cache(self):
         """Clear the cached shell path. Typically used when adding a new tool, which might have just been installed."""
         self._shell_path = None
+
+
+@asynccontextmanager
+async def mcp_session_scope() -> AsyncGenerator[None, None]:
+    """Run a block under an agent run id so MCP tool calls inside it share
+    cached sessions, and close those sessions when the block exits.
+
+    Nesting joins the enclosing scope and does nothing on exit: the sessions
+    belong to whoever opened it and may still be in use when the inner block
+    finishes.
+
+    Otherwise this scope owns the run id it creates, and cleanup runs on both
+    success and exception. Cleanup targets that local id rather than re-reading
+    the context, so code inside the block cannot redirect the teardown by
+    setting its own id. The manager has no reaper, so a session whose cleanup
+    is skipped stays open (with any stdio subprocess) until the process exits.
+
+    Sessions leave anyio cancel scopes open on the task that created them, so a
+    scope must open and close on one task — do not gather across it. See the
+    LIFO-close comment in `cleanup_session`.
+    """
+    if get_agent_run_id() is not None:
+        yield
+        return
+
+    run_id = generate_agent_run_id()
+    set_agent_run_id(run_id)
+    try:
+        yield
+    finally:
+        try:
+            await MCPSessionManager.shared().cleanup_session(run_id)
+        finally:
+            clear_agent_run_id()
 
 
 def build_mcp_session_cache_key(server_id: str | None, session_id: str) -> str:

--- a/libs/core/kiln_ai/tools/test_mcp_session_manager.py
+++ b/libs/core/kiln_ai/tools/test_mcp_session_manager.py
@@ -12,11 +12,17 @@ from kiln_ai.datamodel.external_tool_server import (
     ExternalToolServer,
     ToolServerType,
 )
+from kiln_ai.run_context import (
+    clear_agent_run_id,
+    get_agent_run_id,
+    set_agent_run_id,
+)
 from kiln_ai.tools.mcp_session_manager import (
     MCP_SESSION_CACHE_KEY_DELIMITER,
     KilnMCPError,
     MCPSessionManager,
     build_mcp_session_cache_key,
+    mcp_session_scope,
     parse_mcp_session_cache_session_id,
 )
 from kiln_ai.utils.config import MCP_SECRETS_KEY
@@ -1963,6 +1969,84 @@ class TestMCPSessionCaching:
             assert all(r is mock_session_instance for r in results)
             assert creation_count > 1, "Delay should cause multiple creation attempts"
             assert len(manager._session_cache) == 1
+
+
+class TestMCPSessionScope:
+    """Unit tests for the mcp_session_scope context manager."""
+
+    @pytest.fixture
+    def clear_context(self):
+        """Clear the agent run context before and after each test."""
+        clear_agent_run_id()
+        yield
+        clear_agent_run_id()
+
+    @pytest.fixture
+    def cleanup_mock(self):
+        """Replace the session manager the scope tears down with, so tests can
+        see which run id cleanup was aimed at without opening real sessions."""
+        mock = AsyncMock()
+        with patch(
+            "kiln_ai.tools.mcp_session_manager.MCPSessionManager"
+        ) as mock_manager_class:
+            mock_manager_class.shared.return_value.cleanup_session = mock
+            yield mock
+
+    @pytest.mark.asyncio
+    async def test_sets_run_id_and_cleans_up_on_success(
+        self, clear_context, cleanup_mock
+    ):
+        async with mcp_session_scope():
+            run_id = get_agent_run_id()
+            assert run_id is not None
+            assert run_id.startswith("run_")
+
+        cleanup_mock.assert_called_once_with(run_id)
+        assert get_agent_run_id() is None
+
+    @pytest.mark.asyncio
+    async def test_cleans_up_when_body_raises(self, clear_context, cleanup_mock):
+        run_id = None
+
+        with pytest.raises(ValueError, match="boom"):
+            async with mcp_session_scope():
+                run_id = get_agent_run_id()
+                raise ValueError("boom")
+
+        # Guards the sentinel: without this a scope that never set an id would
+        # satisfy the cleanup assert below with None.
+        assert run_id is not None
+        cleanup_mock.assert_called_once_with(run_id)
+        assert get_agent_run_id() is None
+
+    @pytest.mark.asyncio
+    async def test_nested_scope_does_not_own_sessions(
+        self, clear_context, cleanup_mock
+    ):
+        """Inside an open scope the sessions belong to whoever opened it, so a
+        nested scope must not tear them down or release the run id."""
+        set_agent_run_id("caller_run_id")
+
+        async with mcp_session_scope():
+            assert get_agent_run_id() == "caller_run_id"
+
+        cleanup_mock.assert_not_called()
+        assert get_agent_run_id() == "caller_run_id"
+
+    @pytest.mark.asyncio
+    async def test_cleanup_targets_the_id_the_scope_created(
+        self, clear_context, cleanup_mock
+    ):
+        """Cleanup uses the id this scope created, not the current context
+        value, so code inside the block cannot redirect the teardown and leak
+        the sessions it actually opened."""
+        async with mcp_session_scope():
+            created_run_id = get_agent_run_id()
+            set_agent_run_id("hijacked")
+
+        assert created_run_id is not None
+        cleanup_mock.assert_called_once_with(created_run_id)
+        assert get_agent_run_id() is None
 
 
 class TestMCPSessionCacheKeyHelpers:


### PR DESCRIPTION
## What does this PR do?

Promotes Kiln's MCP session-scoping idiom into a first-class API: `mcp_session_scope()`, an async context manager that gives any code block MCP session reuse without needing a task run in flight.

### Why

We found the gap during the eval builder v2 work. MCP session reuse is keyed off the agent run id, and only task execution sets it — so any code outside a run pays a fresh connect, initialize, and teardown per tool call. The spec builder describes a task's tools to the copilot before any run exists: a task with 4 tools on one local MCP server spawns that server 4 times per request, when one connection has all the answers. The code tool test-run endpoint hit the same wall earlier and worked around it by hand-rolling a run id plus cleanup. That workaround is now copy-pasted at five sites, and every copy risks leaking the server subprocess until app restart if cleanup is missed, since the session manager has no reaper.

There is no user-visible bug today and nothing here is ship-blocking. It is prevention for a class of latency and leak problems that has now bitten twice.

### The win

A small, contained change with real benefit. The helper puts the idiom in one place: it joins an open scope without owning its teardown, otherwise it creates a run id and guarantees cleanup on success and exception, keyed to the id it created. The five hand-rolled sites now use it with no behavior change, and new tests cover the helper's guarantees directly and pin cleanup at each migrated site.

The benefit going forward: any code that needs MCP access gets session reuse (one connection per server instead of one per tool) and guaranteed cleanup with a single line, instead of invoking a task or re-implementing the idiom — first up, the eval builder's capability collection, which shaves the per-tool server spawns off every copilot request.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)