### PR TITLE
Reject duplicate skill names at run config creation; surface save errors on the run page

### DIFF
--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any, Dict, List, Set, Tuple, Type, TypeVar
 
 from fastapi import FastAPI, HTTPException, Path, Query, Request
 from fastapi.responses import StreamingResponse
+from kiln_ai.adapters.adapter_registry import load_skills_from_tool_ids
 from kiln_ai.adapters.eval.base_eval import (
     DEFAULT_SYSTEM_PROMPT,
     build_default_llm_judge_prompt,
@@ -1376,6 +1377,35 @@ def compute_score_summary(
     )
 
 
+def validate_unique_skill_names(
+    task: Task, run_config_properties: RunConfigProperties
+) -> None:
+    """Reject a run config attaching two skills that share a name.
+
+    Skill names may repeat across a project (coexisting versions), but the
+    agent's skill tool loads skills by name, so within one run config each
+    attached skill must resolve to a unique name.
+    """
+    if not isinstance(run_config_properties, KilnAgentRunConfigProperties):
+        return
+    tools_config = run_config_properties.tools_config
+    if tools_config is None or not tools_config.tools:
+        return
+    skills = load_skills_from_tool_ids(task, tools_config.tools)
+    names = [skill.name for skill in skills.values()]
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    if duplicates:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Multiple selected skills share the same name: "
+                f"{', '.join(duplicates)}. Skills are loaded by name at "
+                "runtime, so each skill attached to a run config must have "
+                "a unique name."
+            ),
+        )
+
+
 def connect_evals_api(app: FastAPI):
     @app.post(
         "/api/projects/{project_id}/tasks/{task_id}/create_evaluator",
@@ -1670,6 +1700,7 @@ def connect_evals_api(app: FastAPI):
     ) -> TaskRunConfig:
         task = task_from_id(project_id, task_id)
         name = request.name or generate_memorable_name()
+        validate_unique_skill_names(task, request.run_config_properties)
 
         parent_project = task.parent_project()
         if parent_project is None:

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -7001,3 +7001,52 @@ async def test_create_evaluator_rejects_empty_output_scores(
         },
     )
     assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_task_run_config_rejects_duplicate_skill_names(
+    client, mock_task_from_id, mock_task
+):
+    from kiln_ai.datamodel.skill import Skill
+
+    mock_task_from_id.return_value = mock_task
+    project = mock_task.parent_project()
+    duplicate_ids = []
+    for _ in range(2):
+        skill = Skill(name="dup-skill", description="d", parent=project)
+        skill.save_to_file()
+        skill.save_skill_md("# body")
+        duplicate_ids.append(skill.id)
+    unique = Skill(name="unique-skill", description="d", parent=project)
+    unique.save_to_file()
+    unique.save_skill_md("# body")
+
+    def request_body(skill_ids):
+        return {
+            "name": "RC",
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "structured_output_mode": "json_schema",
+                "tools_config": {
+                    "tools": [f"kiln_tool::skill::{i}" for i in skill_ids]
+                },
+            },
+        }
+
+    # Two versions sharing a name in one run config: rejected (skills are
+    # loaded by name at runtime, one would shadow the other).
+    response = client.post(
+        "/api/projects/project1/tasks/task1/run_configs",
+        json=request_body(duplicate_ids),
+    )
+    assert response.status_code == 422
+    assert "same name" in response.text
+
+    # Distinct names: accepted.
+    response = client.post(
+        "/api/projects/project1/tasks/task1/run_configs",
+        json=request_body([duplicate_ids[0], unique.id]),
+    )
+    assert response.status_code == 200

--- a/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/saved_run_configs_dropdown.svelte
@@ -343,10 +343,13 @@
     }
     try {
       inline_action_loading = true
+      save_config_error = null
       const saved_run_config = await save_new_run_config()
       if (saved_run_config.id) {
         selected_run_config_id = saved_run_config.id
       }
+    } catch (e) {
+      save_config_error = createKilnError(e)
     } finally {
       inline_action_loading = false
     }


### PR DESCRIPTION
## What does this PR do?

Two small, related fixes around run configs and skills:

1. **Fail fast on duplicate skill names in a run config.** The agent loads skills by name at runtime, so a run config attaching two same-named skills fails only when it's used (the adapter raises). `POST /api/projects/{p}/tasks/{t}/run_configs` now validates up front and returns a 422 naming the colliding skills — the user finds out at creation, with a clear message, instead of at inference time. The runtime check remains as backstop for configs created outside the API.
2. **Surface save errors from the run page's "Save current options" action.** Its handler was `try/finally` with no `catch`, so any failed save spun briefly and silently did nothing. The component already declared and rendered `save_config_error`; the handler now sets it (and clears it on the next attempt), so server errors — including the new 422 — display under the Run Configuration dropdown.

### Manual testing

Verified on this branch against a live dev server:

- **API — `validate_unique_skill_names` kicks in:** `POST /run_configs` with two same-named skills attached → `HTTP 422` with body `{"message":"Multiple selected skills share the same name: ticket-api. Skills are loaded by name at runtime, so each skill attached to a run config must have a unique name."}`. Same request with a single skill → `HTTP 200`.
- **UI — error path:** selected two same-named skills in the run page's Skills dropdown, clicked "Save current options" → the 422 message renders under Run Configuration (previously: nothing happened).
- **UI — recovery:** deselected one, saved again → error clears, the new config ("Ruffled Putter") is created and selected, and the inline action flips to "Set as task default".

<details>
<summary><b>Screenshots</b> (captured on this branch; hosted on the <code>claude/run-config-validation-assets</code> branch — never merge it, safe to delete after this PR closes)</summary>

**Skills selector allows picking two same-named skills (versions of one skill):**

![skills selector](https://raw.githubusercontent.com/Kiln-AI/Kiln/37f375fe853489c3ad30901c131747614fc60a3e/screenshots/skills_selector.png)

**Save current options with both selected — the validation error is now shown:**

![save error](https://raw.githubusercontent.com/Kiln-AI/Kiln/37f375fe853489c3ad30901c131747614fc60a3e/screenshots/save_error.png)

**After deselecting one — save succeeds, error cleared:**

![save success](https://raw.githubusercontent.com/Kiln-AI/Kiln/37f375fe853489c3ad30901c131747614fc60a3e/screenshots/save_success.png)

</details>

## Related Issues

None.

## Contributor License Agreement

_Left for the PR author to complete._

## Checklists

- [x] Tests have been run locally and passed (`checks.sh` green)
- [x] New tests have been added to any work in /lib (endpoint test covering reject + accept cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hr8tm9wQRGYZyTPpcy1kr