### PR TITLE
Allow tool name duplicates within a project; validate collisions per run config and show display names in pickers

### DIFF
--- a/app/desktop/studio_server/code_tool_api.py
+++ b/app/desktop/studio_server/code_tool_api.py
@@ -19,6 +19,7 @@ from kiln_ai.tools.base_tool import ToolCallContext
 from kiln_ai.tools.code_tool import ChildOutcome, PythonCodeTool
 from kiln_ai.tools.mcp_session_manager import MCPSessionManager
 from kiln_ai.tools.sandbox_bridge import ToolCallLogEntry
+from kiln_ai.tools.tool_registry import validate_unique_allowlist_tool_names
 from kiln_server.project_api import project_from_id
 from kiln_server.utils.agent_checks.policy import (
     ALLOW_AGENT,
@@ -226,6 +227,7 @@ def connect_code_tool_api(app: FastAPI):
             return CodeToolCreateResponse(not_trusted=True)
 
         try:
+            await validate_unique_allowlist_tool_names(request.tool_allowlist, project)
             code_tool = CodeTool(
                 name=request.name,
                 description=request.description,

--- a/app/desktop/studio_server/code_tool_api.py
+++ b/app/desktop/studio_server/code_tool_api.py
@@ -225,17 +225,6 @@ def connect_code_tool_api(app: FastAPI):
         if not has_add_code_trust(str(project.path)):
             return CodeToolCreateResponse(not_trusted=True)
 
-        existing = project.code_tools(readonly=True)
-        for ct in existing:
-            if (
-                not ct.is_archived
-                and ct.tool_function_name == request.tool_function_name
-            ):
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"A non-archived code tool with function name '{request.tool_function_name}' already exists.",
-                )
-
         try:
             code_tool = CodeTool(
                 name=request.name,

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any, Dict, List, Set, Tuple, Type, TypeVar
 
 from fastapi import FastAPI, HTTPException, Path, Query, Request
 from fastapi.responses import StreamingResponse
-from kiln_ai.adapters.adapter_registry import load_skills_from_tool_ids
+from kiln_ai.adapters.adapter_registry import validate_run_config_tool_names
 from kiln_ai.adapters.eval.base_eval import (
     DEFAULT_SYSTEM_PROMPT,
     build_default_llm_judge_prompt,
@@ -1377,33 +1377,20 @@ def compute_score_summary(
     )
 
 
-def validate_unique_skill_names(
+async def validate_run_config_tools(
     task: Task, run_config_properties: RunConfigProperties
 ) -> None:
-    """Reject a run config attaching two skills that share a name.
+    """Reject a run config whose tools or skills would collide at runtime.
 
-    Skill names may repeat across a project (coexisting versions), but the
-    agent's skill tool loads skills by name, so within one run config each
-    attached skill must resolve to a unique name.
+    Tool and skill names may repeat across a project, but within one run
+    config every tool must expose a unique function name and every skill a
+    unique skill name. Run configs are immutable, so validating here catches
+    every collision that would otherwise fail at inference time.
     """
-    if not isinstance(run_config_properties, KilnAgentRunConfigProperties):
-        return
-    tools_config = run_config_properties.tools_config
-    if tools_config is None or not tools_config.tools:
-        return
-    skills = load_skills_from_tool_ids(task, tools_config.tools)
-    names = [skill.name for skill in skills.values()]
-    duplicates = sorted({n for n in names if names.count(n) > 1})
-    if duplicates:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                "Multiple selected skills share the same name: "
-                f"{', '.join(duplicates)}. Skills are loaded by name at "
-                "runtime, so each skill attached to a run config must have "
-                "a unique name."
-            ),
-        )
+    try:
+        await validate_run_config_tool_names(task, run_config_properties)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
 
 
 def connect_evals_api(app: FastAPI):
@@ -1700,7 +1687,7 @@ def connect_evals_api(app: FastAPI):
     ) -> TaskRunConfig:
         task = task_from_id(project_id, task_id)
         name = request.name or generate_memorable_name()
-        validate_unique_skill_names(task, request.run_config_properties)
+        await validate_run_config_tools(task, request.run_config_properties)
 
         parent_project = task.parent_project()
         if parent_project is None:

--- a/app/desktop/studio_server/eval_api.py
+++ b/app/desktop/studio_server/eval_api.py
@@ -1384,8 +1384,9 @@ async def validate_run_config_tools(
 
     Tool and skill names may repeat across a project, but within one run
     config every tool must expose a unique function name and every skill a
-    unique skill name. Run configs are immutable, so validating here catches
-    every collision that would otherwise fail at inference time.
+    unique skill name. Validating here catches collisions at selection time,
+    instead of at inference time; the runtime check remains the backstop for
+    tools renamed after the run config was created.
     """
     try:
         await validate_run_config_tool_names(task, run_config_properties)

--- a/app/desktop/studio_server/test_code_tool_api.py
+++ b/app/desktop/studio_server/test_code_tool_api.py
@@ -117,7 +117,7 @@ class TestCreateCodeTool:
         assert result["not_trusted"] is True
         assert result["id"] is None
 
-    def test_create_uniqueness_conflict(
+    def test_create_allows_duplicate_function_names(
         self,
         client,
         test_project,
@@ -125,25 +125,8 @@ class TestCreateCodeTool:
         saved_code_tool,
         create_request,
     ):
-        create_request["tool_function_name"] = saved_code_tool.tool_function_name
-        with patch(TRUST_PATCH, return_value=True):
-            response = client.post(
-                f"/api/projects/{test_project.id}/code_tools",
-                json=create_request,
-            )
-        assert response.status_code == 400
-        assert "already exists" in response.json()["message"]
-
-    def test_create_allows_duplicate_when_archived(
-        self,
-        client,
-        test_project,
-        mock_project_from_id,
-        saved_code_tool,
-        create_request,
-    ):
-        saved_code_tool.is_archived = True
-        saved_code_tool.save_to_file()
+        # Duplicate function names are allowed within a project; collisions are
+        # rejected per run config at run config creation time instead.
         create_request["tool_function_name"] = saved_code_tool.tool_function_name
         with patch(TRUST_PATCH, return_value=True):
             response = client.post(
@@ -151,6 +134,7 @@ class TestCreateCodeTool:
                 json=create_request,
             )
         assert response.status_code == 200
+        assert response.json()["id"] is not None
 
     def test_create_validation_error(self, client, test_project, mock_project_from_id):
         with patch(TRUST_PATCH, return_value=True):

--- a/app/desktop/studio_server/test_code_tool_api.py
+++ b/app/desktop/studio_server/test_code_tool_api.py
@@ -136,6 +136,42 @@ class TestCreateCodeTool:
         assert response.status_code == 200
         assert response.json()["id"] is not None
 
+    def test_create_rejects_ambiguous_allowlist(
+        self, client, test_project, mock_project_from_id, create_request
+    ):
+        # Two allowlisted tools sharing a function name would make calls from
+        # sandboxed code ambiguous: rejected at creation.
+        allowlisted = []
+        for _ in range(2):
+            ct = CodeTool(
+                name="dup_tool",
+                tool_function_name="dup_tool",
+                tool_description="d",
+                parameters_schema=SIMPLE_SCHEMA,
+                code=SIMPLE_CODE,
+                parent=test_project,
+            )
+            ct.save_to_file()
+            allowlisted.append(f"kiln_tool::code::{ct.id}")
+
+        create_request["tool_allowlist"] = allowlisted
+        with patch(TRUST_PATCH, return_value=True):
+            response = client.post(
+                f"/api/projects/{test_project.id}/code_tools",
+                json=create_request,
+            )
+        assert response.status_code == 400
+        assert "share the same function name: dup_tool" in response.json()["message"]
+
+        # A single one of them is fine.
+        create_request["tool_allowlist"] = allowlisted[:1]
+        with patch(TRUST_PATCH, return_value=True):
+            response = client.post(
+                f"/api/projects/{test_project.id}/code_tools",
+                json=create_request,
+            )
+        assert response.status_code == 200
+
     def test_create_validation_error(self, client, test_project, mock_project_from_id):
         with patch(TRUST_PATCH, return_value=True):
             response = client.post(

--- a/app/desktop/studio_server/test_code_tool_api.py
+++ b/app/desktop/studio_server/test_code_tool_api.py
@@ -552,6 +552,31 @@ class TestAvailableToolsCodeGroup:
         assert len(tools) == 1
         assert tools[0]["name"] == "my_tool"
 
+    def test_serves_display_name_and_function_name(
+        self, client, test_project, mock_project_from_id
+    ):
+        # name carries the user-facing display name, function_name the
+        # callable name — distinct values so a regression can't hide behind
+        # a fixture where they coincide.
+        ct = CodeTool(
+            name="My Fancy Tool",
+            tool_function_name="my_fancy_tool",
+            tool_description="Does something",
+            parameters_schema=SIMPLE_SCHEMA,
+            code=SIMPLE_CODE,
+            parent=test_project,
+        )
+        ct.save_to_file()
+
+        response = client.get(f"/api/projects/{test_project.id}/available_tools")
+        assert response.status_code == 200
+        tool_sets = response.json()
+        code_sets = [ts for ts in tool_sets if ts["type"] == "code"]
+        assert len(code_sets) == 1
+        [tool] = code_sets[0]["tools"]
+        assert tool["name"] == "My Fancy Tool"
+        assert tool["function_name"] == "my_fancy_tool"
+
     def test_excludes_archived_code_tools(
         self, client, test_project, mock_project_from_id, saved_code_tool
     ):

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -7042,7 +7042,7 @@ async def test_create_task_run_config_rejects_duplicate_skill_names(
         json=request_body(duplicate_ids),
     )
     assert response.status_code == 422
-    assert "same name" in response.text
+    assert "Duplicate skill name 'dup-skill'" in response.text
 
     # Distinct names: accepted.
     response = client.post(
@@ -7050,3 +7050,108 @@ async def test_create_task_run_config_rejects_duplicate_skill_names(
         json=request_body([duplicate_ids[0], unique.id]),
     )
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_create_task_run_config_rejects_duplicate_tool_function_names(
+    client, mock_task_from_id, mock_task
+):
+    from kiln_ai.datamodel.code_tool import CodeTool
+
+    mock_task_from_id.return_value = mock_task
+    project = mock_task.parent_project()
+
+    def make_code_tool(function_name: str) -> CodeTool:
+        code_tool = CodeTool(
+            name=function_name,
+            tool_function_name=function_name,
+            tool_description="d",
+            parameters_schema={"type": "object", "properties": {}},
+            code="def run() -> str:\n    return 'ok'\n",
+            parent=project,
+        )
+        code_tool.save_to_file()
+        return code_tool
+
+    dup_a = make_code_tool("dup_tool")
+    dup_b = make_code_tool("dup_tool")
+    unique = make_code_tool("unique_tool")
+
+    def request_body(tool_ids):
+        return {
+            "name": "RC",
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "structured_output_mode": "json_schema",
+                "tools_config": {"tools": tool_ids},
+            },
+        }
+
+    # Two tools resolving to the same function name in one run config: rejected.
+    response = client.post(
+        "/api/projects/project1/tasks/task1/run_configs",
+        json=request_body(
+            [f"kiln_tool::code::{dup_a.id}", f"kiln_tool::code::{dup_b.id}"]
+        ),
+    )
+    assert response.status_code == 422
+    assert "share the same function name: dup_tool" in response.text
+
+    # Distinct function names: accepted.
+    response = client.post(
+        "/api/projects/project1/tasks/task1/run_configs",
+        json=request_body(
+            [f"kiln_tool::code::{dup_a.id}", f"kiln_tool::code::{unique.id}"]
+        ),
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_create_task_run_config_rejects_tool_colliding_with_skill_loader(
+    client, mock_task_from_id, mock_task
+):
+    from kiln_ai.datamodel.code_tool import CodeTool
+    from kiln_ai.datamodel.skill import Skill
+
+    mock_task_from_id.return_value = mock_task
+    project = mock_task.parent_project()
+
+    code_tool = CodeTool(
+        name="skill",
+        tool_function_name="skill",
+        tool_description="d",
+        parameters_schema={"type": "object", "properties": {}},
+        code="def run() -> str:\n    return 'ok'\n",
+        parent=project,
+    )
+    code_tool.save_to_file()
+    skill = Skill(name="my-skill", description="d", parent=project)
+    skill.save_to_file()
+    skill.save_skill_md("# body")
+
+    # A tool named "skill" collides with the skill loader tool when skills are
+    # attached: rejected with a hint about the reserved name.
+    response = client.post(
+        "/api/projects/project1/tasks/task1/run_configs",
+        json={
+            "name": "RC",
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "structured_output_mode": "json_schema",
+                "tools_config": {
+                    "tools": [
+                        f"kiln_tool::code::{code_tool.id}",
+                        f"kiln_tool::skill::{skill.id}",
+                    ]
+                },
+            },
+        },
+    )
+    assert response.status_code == 422
+    assert "share the same function name: skill" in response.text
+    assert "reserved" in response.text

--- a/app/desktop/studio_server/test_eval_api.py
+++ b/app/desktop/studio_server/test_eval_api.py
@@ -7155,3 +7155,29 @@ async def test_create_task_run_config_rejects_tool_colliding_with_skill_loader(
     assert response.status_code == 422
     assert "share the same function name: skill" in response.text
     assert "reserved" in response.text
+
+
+@pytest.mark.asyncio
+async def test_create_task_run_config_rejects_missing_skill(
+    client, mock_task_from_id, mock_task
+):
+    mock_task_from_id.return_value = mock_task
+
+    # A run config referencing a skill that doesn't exist in the project (e.g.
+    # deleted) is rejected at creation instead of failing at runtime.
+    response = client.post(
+        "/api/projects/project1/tasks/task1/run_configs",
+        json={
+            "name": "RC",
+            "run_config_properties": {
+                "model_name": "gpt-4o",
+                "model_provider_name": "openai",
+                "prompt_id": "simple_chain_of_thought_prompt_builder",
+                "structured_output_mode": "json_schema",
+                "tools_config": {"tools": ["kiln_tool::skill::missing_id"]},
+            },
+        },
+    )
+    assert response.status_code == 422
+    assert "not found in the project: missing_id" in response.text
+    assert len(mock_task.run_configs()) == 0

--- a/app/desktop/studio_server/test_tool_api.py
+++ b/app/desktop/studio_server/test_tool_api.py
@@ -3679,32 +3679,29 @@ async def test_get_available_tools_with_rag_configs(client, test_project):
             rag_set = next(s for s in result if s["set_name"] == "Search Tools (RAG)")
             assert len(rag_set["tools"]) == 2
 
-            # Verify RAG tool details
+            # Verify RAG tool details: name is the display name, function_name
+            # the callable tool name.
             tool_names = [tool["name"] for tool in rag_set["tools"]]
 
-            assert "test_rag_config_1" in tool_names
-            assert "test_rag_config_2" in tool_names
+            assert "Test RAG Config 1" in tool_names
+            assert "Test RAG Config 2" in tool_names
 
             # Verify tool IDs are properly formatted
             for tool in rag_set["tools"]:
                 assert tool["id"].startswith("kiln_tool::rag::")
 
-            # Find specific tools and check their descriptions
+            # Find specific tools and check their fields
             config1_tool = next(
-                t for t in rag_set["tools"] if t["name"] == "test_rag_config_1"
+                t for t in rag_set["tools"] if t["name"] == "Test RAG Config 1"
             )
-            assert (
-                config1_tool["description"]
-                == "Test RAG Config 1: First test RAG configuration"
-            )
+            assert config1_tool["function_name"] == "test_rag_config_1"
+            assert config1_tool["description"] == "First test RAG configuration"
 
             config2_tool = next(
-                t for t in rag_set["tools"] if t["name"] == "test_rag_config_2"
+                t for t in rag_set["tools"] if t["name"] == "Test RAG Config 2"
             )
-            assert (
-                config2_tool["description"]
-                == "Test RAG Config 2: Second test RAG configuration"
-            )
+            assert config2_tool["function_name"] == "test_rag_config_2"
+            assert config2_tool["description"] == "Second test RAG configuration"
 
 
 async def test_get_available_tools_with_rag_and_mcp(client, test_project):
@@ -3914,7 +3911,8 @@ async def test_available_tools_excludes_archived_rag_and_kiln_task_tools(
 
         # Only the active RAG config should be present
         assert len(rag_set["tools"]) == 1
-        assert rag_set["tools"][0]["name"] == "active_rag"
+        assert rag_set["tools"][0]["name"] == "Active RAG"
+        assert rag_set["tools"][0]["function_name"] == "active_rag"
 
         # Only the active kiln task tool should be present
         assert len(kiln_task_set["tools"]) == 1

--- a/app/desktop/studio_server/tool_api.py
+++ b/app/desktop/studio_server/tool_api.py
@@ -179,6 +179,9 @@ class ExternalToolServerApiDescription(BaseModel):
 
 
 class ToolApiDescription(BaseModel):
+    """A tool as shown in pickers: name is the user-facing display name,
+    function_name the callable name the model sees (they often coincide)."""
+
     id: ToolId
     name: str
     description: str | None
@@ -333,8 +336,8 @@ def connect_tool_servers_api(app: FastAPI):
             tools = [
                 ToolApiDescription(
                     id=build_rag_tool_id(rag_config.id),
-                    name=rag_config.tool_name,
-                    description=f"{rag_config.name}: {rag_config.tool_description}",
+                    name=rag_config.name,
+                    description=rag_config.tool_description,
                     function_name=rag_config.tool_name,
                 )
                 for rag_config in rag_configs
@@ -462,7 +465,7 @@ def connect_tool_servers_api(app: FastAPI):
             code_tool_items = [
                 ToolApiDescription(
                     id=build_code_tool_id(ct.id),
-                    name=ct.tool_function_name,
+                    name=ct.name,
                     description=ct.tool_description,
                     function_name=ct.tool_function_name,
                 )

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -11948,7 +11948,11 @@ export interface components {
             /** Unacceptable Examples */
             unacceptable_examples?: string;
         };
-        /** ToolApiDescription */
+        /**
+         * ToolApiDescription
+         * @description A tool as shown in pickers: name is the user-facing display name,
+         *     function_name the callable name the model sees (they often coincide).
+         */
         ToolApiDescription: {
             /** Id */
             id: string;

--- a/app/web_ui/src/lib/stores/tools_store.test.ts
+++ b/app/web_ui/src/lib/stores/tools_store.test.ts
@@ -7,6 +7,7 @@ import {
   kiln_task_tool_server_id,
   split_tool_and_skill_ids,
   tool_display_name,
+  tool_qualifier_id,
 } from "./tools_store"
 
 describe("tools_store", () => {
@@ -137,7 +138,32 @@ describe("tools_store", () => {
         expect(tool_display_name(summarize_tool, new Set())).toBe("summarize")
       })
 
-      it("leaves non-Kiln-task tools alone, since their group already names them", () => {
+      it("qualifies ambiguous code and search tools with their embedded id", () => {
+        expect(
+          tool_display_name(
+            {
+              id: "kiln_tool::code::333",
+              name: "Summarize",
+              description: null,
+              function_name: "summarize",
+            },
+            new Set(["Summarize"]),
+          ),
+        ).toBe("Summarize (333)")
+        expect(
+          tool_display_name(
+            {
+              id: "kiln_tool::rag::444",
+              name: "Docs Search",
+              description: null,
+              function_name: "docs_search",
+            },
+            new Set(["Docs Search"]),
+          ),
+        ).toBe("Docs Search (444)")
+      })
+
+      it("leaves MCP tools alone, since their group already names them", () => {
         expect(
           tool_display_name(
             {
@@ -148,6 +174,21 @@ describe("tools_store", () => {
             new Set(["summarize"]),
           ),
         ).toBe("summarize")
+      })
+    })
+
+    describe("tool_qualifier_id", () => {
+      it("returns the embedded id for kiln task, code, and search tools", () => {
+        expect(tool_qualifier_id("kiln_task::111")).toBe("111")
+        expect(tool_qualifier_id("kiln_tool::code::333")).toBe("333")
+        expect(tool_qualifier_id("kiln_tool::rag::444")).toBe("444")
+      })
+
+      it("returns null for other tool types and empty ids", () => {
+        expect(tool_qualifier_id("mcp::local::456::read")).toBe(null)
+        expect(tool_qualifier_id("kiln_tool::add_numbers")).toBe(null)
+        expect(tool_qualifier_id("kiln_tool::skill::555")).toBe(null)
+        expect(tool_qualifier_id("kiln_tool::code::")).toBe(null)
       })
     })
 

--- a/app/web_ui/src/lib/stores/tools_store.test.ts
+++ b/app/web_ui/src/lib/stores/tools_store.test.ts
@@ -178,16 +178,16 @@ describe("tools_store", () => {
     })
 
     describe("tool_qualifier_id", () => {
-      it("returns the embedded id for kiln task, code, and search tools", () => {
+      it("returns the embedded id for kiln task, code, search, and skill tools", () => {
         expect(tool_qualifier_id("kiln_task::111")).toBe("111")
         expect(tool_qualifier_id("kiln_tool::code::333")).toBe("333")
         expect(tool_qualifier_id("kiln_tool::rag::444")).toBe("444")
+        expect(tool_qualifier_id("kiln_tool::skill::555")).toBe("555")
       })
 
       it("returns null for other tool types and empty ids", () => {
         expect(tool_qualifier_id("mcp::local::456::read")).toBe(null)
         expect(tool_qualifier_id("kiln_tool::add_numbers")).toBe(null)
-        expect(tool_qualifier_id("kiln_tool::skill::555")).toBe(null)
         expect(tool_qualifier_id("kiln_tool::code::")).toBe(null)
       })
     })

--- a/app/web_ui/src/lib/stores/tools_store.ts
+++ b/app/web_ui/src/lib/stores/tools_store.ts
@@ -134,14 +134,15 @@ export function duplicate_tool_names(
 
 // What to call a tool wherever it is listed for a user.
 //
-// Nothing stops two Kiln task tools from carrying the same name and description --
-// the create form defaults the name to the task's, so two run configs of one task
-// collide by default -- which leaves them indistinguishable in a list or a picker.
-// An ambiguous one is qualified by its tool server id, the same id shown on its
-// detail page and in that page's URL, so the user has something to match against.
+// Nothing stops two Kiln task tools, code tools, or search tools from carrying
+// the same name and description -- duplicates are allowed within a project, and
+// the Kiln task create form even defaults the name to the task's -- which leaves
+// them indistinguishable in a list or a picker. An ambiguous one is qualified by
+// the id inside its tool id, the same id shown on its detail page and in that
+// page's URL, so the user has something to match against.
 //
-// Only Kiln task tools earn the qualifier: MCP tools are already grouped under
-// their server, and search and code tools show their function name as a badge.
+// MCP tools never earn the qualifier: they are already grouped under their
+// server, and their id's tail is the tool name itself, not an id.
 export function tool_display_name(
   tool: ToolApiDescription,
   duplicate_names: Set<string>,
@@ -149,11 +150,28 @@ export function tool_display_name(
   if (!duplicate_names.has(tool.name)) {
     return tool.name
   }
-  const tool_server_id = kiln_task_tool_server_id(tool.id)
-  return tool_server_id ? `${tool.name} (${tool_server_id})` : tool.name
+  const qualifier_id = tool_qualifier_id(tool.id)
+  return qualifier_id ? `${tool.name} (${qualifier_id})` : tool.name
+}
+
+// The persistent-object id inside a Kiln task, code, or search tool id -- the id
+// that disambiguates same-named tools of these types. Null for every other type.
+export function tool_qualifier_id(tool_id: string): string | null {
+  for (const prefix of [
+    KILN_TASK_TOOL_ID_PREFIX,
+    CODE_TOOL_ID_PREFIX,
+    RAG_TOOL_ID_PREFIX,
+  ]) {
+    if (tool_id.startsWith(prefix)) {
+      return tool_id.slice(prefix.length) || null
+    }
+  }
+  return null
 }
 
 const KILN_TASK_TOOL_ID_PREFIX = "kiln_task::"
+const CODE_TOOL_ID_PREFIX = "kiln_tool::code::"
+const RAG_TOOL_ID_PREFIX = "kiln_tool::rag::"
 
 // The tool server id inside a Kiln task tool id, or null for every other tool type.
 export function kiln_task_tool_server_id(tool_id: string): string | null {

--- a/app/web_ui/src/lib/stores/tools_store.ts
+++ b/app/web_ui/src/lib/stores/tools_store.ts
@@ -141,7 +141,7 @@ export function duplicate_tool_names(
 // detail page and in that page's URL, so the user has something to match against.
 //
 // Only Kiln task tools earn the qualifier: MCP tools are already grouped under
-// their server, and search tools name their RAG config in their description.
+// their server, and search and code tools show their function name as a badge.
 export function tool_display_name(
   tool: ToolApiDescription,
   duplicate_names: Set<string>,

--- a/app/web_ui/src/lib/stores/tools_store.ts
+++ b/app/web_ui/src/lib/stores/tools_store.ts
@@ -134,12 +134,12 @@ export function duplicate_tool_names(
 
 // What to call a tool wherever it is listed for a user.
 //
-// Nothing stops two Kiln task tools, code tools, or search tools from carrying
-// the same name and description -- duplicates are allowed within a project, and
-// the Kiln task create form even defaults the name to the task's -- which leaves
-// them indistinguishable in a list or a picker. An ambiguous one is qualified by
-// the id inside its tool id, the same id shown on its detail page and in that
-// page's URL, so the user has something to match against.
+// Nothing stops two Kiln task tools, code tools, search tools, or skills from
+// carrying the same name and description -- duplicates are allowed within a
+// project, and the Kiln task create form even defaults the name to the task's --
+// which leaves them indistinguishable in a list or a picker. An ambiguous one is
+// qualified by the id inside its tool id, the same id shown on its detail page
+// and in that page's URL, so the user has something to match against.
 //
 // MCP tools never earn the qualifier: they are already grouped under their
 // server, and their id's tail is the tool name itself, not an id.
@@ -154,13 +154,15 @@ export function tool_display_name(
   return qualifier_id ? `${tool.name} (${qualifier_id})` : tool.name
 }
 
-// The persistent-object id inside a Kiln task, code, or search tool id -- the id
-// that disambiguates same-named tools of these types. Null for every other type.
+// The persistent-object id inside a Kiln task, code, search, or skill tool id --
+// the id that disambiguates same-named tools of these types. Null for every
+// other type.
 export function tool_qualifier_id(tool_id: string): string | null {
   for (const prefix of [
     KILN_TASK_TOOL_ID_PREFIX,
     CODE_TOOL_ID_PREFIX,
     RAG_TOOL_ID_PREFIX,
+    SKILL_TOOL_ID_PREFIX,
   ]) {
     if (tool_id.startsWith(prefix)) {
       return tool_id.slice(prefix.length) || null

--- a/app/web_ui/src/lib/ui/fancy_select.svelte
+++ b/app/web_ui/src/lib/ui/fancy_select.svelte
@@ -729,7 +729,7 @@
                       <div class="flex-grow">
                         {item.label}
                       </div>
-                      {#if item.badge}
+                      {#if item.badge && item.badge_placement !== "below"}
                         <div
                           class="badge badge-sm text-xs {item.badge.length <= 2
                             ? 'rounded-full w-5 h-5'
@@ -741,6 +741,18 @@
                         </div>
                       {/if}
                     </div>
+                    {#if item.badge && item.badge_placement === "below"}
+                      <div class="w-full">
+                        <div
+                          class="badge badge-sm text-xs px-2 {item.badge_color ===
+                          'primary'
+                            ? 'badge-primary'
+                            : 'badge-ghost'}"
+                        >
+                          {item.badge}
+                        </div>
+                      </div>
+                    {/if}
                     {#if item.description}
                       <div
                         class="text-xs font-medium text-base-content/40 w-full line-clamp-3 whitespace-pre-line"

--- a/app/web_ui/src/lib/ui/fancy_select.svelte
+++ b/app/web_ui/src/lib/ui/fancy_select.svelte
@@ -520,6 +520,17 @@
       }
     }
   }
+
+  // One source of truth for badge sizing/color, shared by the inline and
+  // below-label placements so they can't drift apart.
+  function badge_classes(
+    badge: string,
+    badge_color: string | undefined,
+  ): string {
+    const shape = badge.length <= 2 ? "rounded-full w-5 h-5" : "px-2"
+    const color = badge_color === "primary" ? "badge-primary" : "badge-ghost"
+    return `badge badge-sm text-xs ${shape} ${color}`
+  }
 </script>
 
 <div class="dropdown w-full relative">
@@ -731,11 +742,7 @@
                       </div>
                       {#if item.badge && item.badge_placement !== "below"}
                         <div
-                          class="badge badge-sm text-xs {item.badge.length <= 2
-                            ? 'rounded-full w-5 h-5'
-                            : 'px-2'} {item.badge_color === 'primary'
-                            ? 'badge-primary'
-                            : 'badge-ghost'}"
+                          class={badge_classes(item.badge, item.badge_color)}
                         >
                           {item.badge}
                         </div>
@@ -744,10 +751,7 @@
                     {#if item.badge && item.badge_placement === "below"}
                       <div class="w-full">
                         <div
-                          class="badge badge-sm text-xs px-2 {item.badge_color ===
-                          'primary'
-                            ? 'badge-primary'
-                            : 'badge-ghost'}"
+                          class={badge_classes(item.badge, item.badge_color)}
                         >
                           {item.badge}
                         </div>

--- a/app/web_ui/src/lib/ui/fancy_select_types.ts
+++ b/app/web_ui/src/lib/ui/fancy_select_types.ts
@@ -11,6 +11,10 @@ export type Option = {
   badge?: string
   // Defaults to ghost if not specified
   badge_color?: "primary"
+  // "below" renders the badge on its own row under the label instead of beside
+  // it — for long badges (e.g. function names) that would cramp the label.
+  // Defaults to inline.
+  badge_placement?: "below"
   disabled?: boolean
   hide_check?: boolean
 }

--- a/app/web_ui/src/lib/ui/run_config_component/skills_selector.svelte
+++ b/app/web_ui/src/lib/ui/run_config_component/skills_selector.svelte
@@ -8,6 +8,10 @@
     skills_store,
     skills_store_initialized,
   } from "$lib/stores/skills_store"
+  import {
+    duplicate_tool_names,
+    tool_display_name,
+  } from "$lib/stores/tools_store"
   import { goto } from "$app/navigation"
   import type { SkillsSelectorSettings } from "./skills_selector_settings"
 
@@ -182,10 +186,15 @@
     )
 
     if (skill_sets.length > 0) {
+      // Skill names may repeat across a project (coexisting versions), so an
+      // ambiguous one is qualified by its id — otherwise the rows are
+      // indistinguishable and the duplicate-name rejection at save has no
+      // row to point at.
+      const duplicate_names = duplicate_tool_names(skill_sets)
       const skill_options = skill_sets.flatMap((ts) =>
         ts.tools.map((tool) => ({
           value: tool.id,
-          label: tool.name,
+          label: tool_display_name(tool, duplicate_names),
           description: tool.description ? tool.description.trim() : undefined,
           disabled: resolved.mandatory_skills
             ? resolved.mandatory_skills.includes(tool.id)

--- a/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
@@ -101,8 +101,14 @@ describe("build_tool_option_groups labelling", () => {
   it("selects tool ids by default", () => {
     const [option] = all_options(build_tool_option_groups([mcp_set]))
     expect(option.value).toBe("mcp::remote::demo::search_docs")
-    // The function name is not the value here, so it is not worth a badge.
+    // Function name matches the label, so repeating it as a badge is noise.
     expect(option.badge).toBeUndefined()
+  })
+
+  it("badges the function name in id pickers when it differs from the label", () => {
+    const [option] = all_options(build_tool_option_groups([kiln_task_set]))
+    expect(option.label).toBe("Summarize")
+    expect(option.badge).toBe("summarize")
   })
 })
 

--- a/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
@@ -109,6 +109,8 @@ describe("build_tool_option_groups labelling", () => {
     const [option] = all_options(build_tool_option_groups([kiln_task_set]))
     expect(option.label).toBe("Summarize")
     expect(option.badge).toBe("summarize")
+    // Function names are long: rendered under the label, not beside it.
+    expect(option.badge_placement).toBe("below")
   })
 })
 

--- a/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tool_options.test.ts
@@ -51,6 +51,21 @@ const kiln_task_set: ToolSetApiDescription = {
   ],
 }
 
+// Real divergence case: the server sends the display name in `name` and the
+// callable name in `function_name` for code (and search) tools.
+const code_set: ToolSetApiDescription = {
+  type: "code",
+  set_name: "Code Tools",
+  tools: [
+    {
+      id: "kiln_tool::code::333",
+      name: "Summarizer",
+      description: "Summarize the input",
+      function_name: "summarize",
+    },
+  ],
+}
+
 const colliding_kiln_task_set: ToolSetApiDescription = {
   type: "kiln_task",
   set_name: "Kiln Tasks as Tools",
@@ -106,8 +121,8 @@ describe("build_tool_option_groups labelling", () => {
   })
 
   it("badges the function name in id pickers when it differs from the label", () => {
-    const [option] = all_options(build_tool_option_groups([kiln_task_set]))
-    expect(option.label).toBe("Summarize")
+    const [option] = all_options(build_tool_option_groups([code_set]))
+    expect(option.label).toBe("Summarizer")
     expect(option.badge).toBe("summarize")
     // Function names are long: rendered under the label, not beside it.
     expect(option.badge_placement).toBe("below")

--- a/app/web_ui/src/lib/ui/run_config_component/tool_options.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tool_options.ts
@@ -108,8 +108,10 @@ function tool_option(
     description: description ? description : undefined,
     // Only when it differs from the label: repeating the name as a badge is noise,
     // but a function name that differs from the display name is what the model
-    // actually calls, and has to be visible.
+    // actually calls, and has to be visible. Function names are long, so the
+    // badge goes under the label rather than cramping it.
     badge: function_name !== tool.name ? function_name : undefined,
+    badge_placement: "below",
     disabled: option_disabled ? option_disabled(tool, tool_set) : false,
   }
 }

--- a/app/web_ui/src/lib/ui/run_config_component/tool_options.ts
+++ b/app/web_ui/src/lib/ui/run_config_component/tool_options.ts
@@ -106,13 +106,10 @@ function tool_option(
     value: value_field === "function_name" ? function_name : tool.id,
     label: tool_display_name(tool, duplicate_names),
     description: description ? description : undefined,
-    // Only when the selected value isn't already the label: repeating the name as a
-    // badge is noise, but a function name that differs from the display name is the
-    // value being picked, and has to be visible.
-    badge:
-      value_field === "function_name" && function_name !== tool.name
-        ? function_name
-        : undefined,
+    // Only when it differs from the label: repeating the name as a badge is noise,
+    // but a function name that differs from the display name is what the model
+    // actually calls, and has to be visible.
+    badge: function_name !== tool.name ? function_name : undefined,
     disabled: option_disabled ? option_disabled(tool, tool_set) : false,
   }
 }

--- a/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth_data_guidance_datamodel.ts
+++ b/app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth_data_guidance_datamodel.ts
@@ -1128,11 +1128,15 @@ When generating ${task_type}, use these guidelines to create test cases that are
 
     if (!project_tools) return null
 
-    // Search through all tool sets to find the tool
+    // Search through all tool sets to find the tool. The template needs the
+    // callable function name the eval judge targets, not the display name.
     for (const tool_set of project_tools) {
       const tool = tool_set.tools.find((t) => t.id === tool_id)
       if (tool) {
-        return { name: tool.name, description: tool.description }
+        return {
+          name: tool.function_name ?? tool.name,
+          description: tool.description,
+        }
       }
     }
 

--- a/app/web_ui/src/routes/(app)/tools/[project_id]/add_tools/code_tool/+page.svelte
+++ b/app/web_ui/src/routes/(app)/tools/[project_id]/add_tools/code_tool/+page.svelte
@@ -181,8 +181,9 @@
     test_panel_has_tested = false
   }
 
-  // Resolve the display name (which is the function name for code tools) from the
-  // available_tools store so the import comment uses the real function name.
+  // Resolve the callable function name (available_tools carries it in
+  // function_name, separate from the display name) so the import comment
+  // matches what the sandbox dispatches on.
   function resolve_tool_function_name(tool_id: string): string {
     const tool_sets = $available_tools[project_id]
     if (!tool_sets) return tool_id

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -86,9 +86,9 @@ async def validate_run_config_tool_names(
 
     Resolves every attached tool and skill, raising ValueError when a
     referenced skill does not exist or two tools share a name (see
-    assemble_unique_agent_tools). Run configs and skills are immutable, so
-    validating at creation time catches every collision that would otherwise
-    surface as a runtime failure.
+    assemble_unique_agent_tools). Catches collisions at selection time; the
+    runtime check remains the backstop for tools renamed after the run config
+    was created.
     """
     if run_config_properties.type != "kiln_agent":
         return

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -4,6 +4,7 @@ from kiln_ai.adapters.model_adapters.base_adapter import (
     AdapterConfig,
     BaseAdapter,
     SkillsDict,
+    assemble_unique_agent_tools,
 )
 from kiln_ai.adapters.model_adapters.litellm_adapter import (
     LiteLlmAdapter,
@@ -63,6 +64,26 @@ def load_skills_for_task(
     if tool_config is None or tool_config.tools is None:
         return {}
     return load_skills_from_tool_ids(task, tool_config.tools)
+
+
+async def validate_run_config_tool_names(
+    task: datamodel.Task,
+    run_config_properties: RunConfigProperties,
+) -> None:
+    """Reject a run config whose tools would collide at runtime.
+
+    Resolves every attached tool and skill and raises ValueError when two share
+    a name (see assemble_unique_agent_tools). Run configs and skills are
+    immutable, so validating at creation time catches every collision that
+    would otherwise surface as a runtime failure.
+    """
+    if run_config_properties.type != "kiln_agent":
+        return
+    tools_config = as_kiln_agent_run_config(run_config_properties).tools_config
+    if tools_config is None or not tools_config.tools:
+        return
+    skills = load_skills_from_tool_ids(task, tools_config.tools)
+    await assemble_unique_agent_tools(task, tools_config.tools, list(skills.values()))
 
 
 def litellm_core_provider_config(

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -30,11 +30,13 @@ from kiln_ai.utils.exhaustive_error import raise_exhaustive_enum_error
 def load_skills_from_tool_ids(
     task: datamodel.Task,
     tool_ids: list[str],
+    require_all: bool = False,
 ) -> SkillsDict:
     """Load Skill objects for any skill tool IDs in the given list.
 
     Performs a single directory scan of the parent project to resolve all
-    referenced skills at once.
+    referenced skills at once. Unresolvable skill IDs are silently dropped
+    unless require_all is set, in which case they raise ValueError.
     """
     skill_ids = {
         skill_id_from_tool_id(tid)
@@ -44,9 +46,19 @@ def load_skills_from_tool_ids(
     if not skill_ids:
         return {}
     project = task.parent_project()
-    if project is None:
-        return {}
-    return Skill.from_ids_and_parent_path(skill_ids, project.path)
+    skills = (
+        Skill.from_ids_and_parent_path(skill_ids, project.path)
+        if project is not None
+        else {}
+    )
+    if require_all:
+        missing_skill_ids = sorted(skill_ids - set(skills.keys()))
+        if missing_skill_ids:
+            raise ValueError(
+                "Skill(s) referenced in run config not found in the project: "
+                f"{', '.join(missing_skill_ids)}"
+            )
+    return skills
 
 
 def load_skills_for_task(
@@ -83,18 +95,7 @@ async def validate_run_config_tool_names(
     tools_config = as_kiln_agent_run_config(run_config_properties).tools_config
     if tools_config is None or not tools_config.tools:
         return
-    skills = load_skills_from_tool_ids(task, tools_config.tools)
-    requested_skill_ids = {
-        skill_id_from_tool_id(tid)
-        for tid in tools_config.tools
-        if tid.startswith(SKILL_TOOL_ID_PREFIX)
-    }
-    missing_skill_ids = sorted(requested_skill_ids - set(skills.keys()))
-    if missing_skill_ids:
-        raise ValueError(
-            "Skill(s) referenced in run config not found in the project: "
-            f"{', '.join(missing_skill_ids)}"
-        )
+    skills = load_skills_from_tool_ids(task, tools_config.tools, require_all=True)
     await assemble_unique_agent_tools(task, tools_config.tools, list(skills.values()))
 
 

--- a/libs/core/kiln_ai/adapters/adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/adapter_registry.py
@@ -70,12 +70,13 @@ async def validate_run_config_tool_names(
     task: datamodel.Task,
     run_config_properties: RunConfigProperties,
 ) -> None:
-    """Reject a run config whose tools would collide at runtime.
+    """Reject a run config whose tools would fail at runtime.
 
-    Resolves every attached tool and skill and raises ValueError when two share
-    a name (see assemble_unique_agent_tools). Run configs and skills are
-    immutable, so validating at creation time catches every collision that
-    would otherwise surface as a runtime failure.
+    Resolves every attached tool and skill, raising ValueError when a
+    referenced skill does not exist or two tools share a name (see
+    assemble_unique_agent_tools). Run configs and skills are immutable, so
+    validating at creation time catches every collision that would otherwise
+    surface as a runtime failure.
     """
     if run_config_properties.type != "kiln_agent":
         return
@@ -83,6 +84,17 @@ async def validate_run_config_tool_names(
     if tools_config is None or not tools_config.tools:
         return
     skills = load_skills_from_tool_ids(task, tools_config.tools)
+    requested_skill_ids = {
+        skill_id_from_tool_id(tid)
+        for tid in tools_config.tools
+        if tid.startswith(SKILL_TOOL_ID_PREFIX)
+    }
+    missing_skill_ids = sorted(requested_skill_ids - set(skills.keys()))
+    if missing_skill_ids:
+        raise ValueError(
+            "Skill(s) referenced in run config not found in the project: "
+            f"{', '.join(missing_skill_ids)}"
+        )
     await assemble_unique_agent_tools(task, tools_config.tools, list(skills.values()))
 
 

--- a/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
@@ -845,9 +845,10 @@ async def assemble_unique_agent_tools(
     Names may repeat across a project, but within one run config every tool the
     model sees must have a unique function name (and every attached skill a
     unique skill name — skills are loaded by name through the single "skill"
-    tool). Shared by the runtime adapter and creation-time validation of run
-    configs; run configs are immutable, so a config that passes at creation
-    cannot collide later.
+    tool). Shared by creation-time validation of run configs, which catches
+    collisions at selection time, and by the runtime adapter, which stays the
+    backstop for configs whose tools were renamed after creation (e.g. via
+    edit_kiln_task_tool) or that were created outside the API.
     """
     non_skill_tool_ids = [
         tid for tid in tool_ids if not tid.startswith(SKILL_TOOL_ID_PREFIX)

--- a/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/base_adapter.py
@@ -832,32 +832,58 @@ class BaseAdapter(metaclass=ABCMeta):
         if tool_config is None or tool_config.tools is None:
             return []
 
-        non_skill_tool_ids = [
-            tid for tid in tool_config.tools if not tid.startswith(SKILL_TOOL_ID_PREFIX)
-        ]
+        return await assemble_unique_agent_tools(
+            self.task, tool_config.tools, self._resolve_skills()
+        )
 
-        tools: list[KilnToolInterface] = [
-            tool_from_id(tool_id, self.task) for tool_id in non_skill_tool_ids
-        ]
 
-        skills = self._resolve_skills()
-        if skills:
-            seen_names: set[str] = set()
-            for skill in skills:
-                if skill.name in seen_names:
-                    raise ValueError(
-                        f"Duplicate skill name '{skill.name}'. Each skill must have a unique name."
-                    )
-                seen_names.add(skill.name)
-            tools.append(SkillTool(f"{SKILL_TOOL_ID_PREFIX}_combined", skills))
+async def assemble_unique_agent_tools(
+    task: Task, tool_ids: list[str], skills: list[Skill]
+) -> list[KilnToolInterface]:
+    """Resolve a run config's tool IDs into tool instances, rejecting name collisions.
 
-        tool_names = [await tool.name() for tool in tools]
-        if len(tool_names) != len(set(tool_names)):
-            raise ValueError(
-                "Each tool must have a unique name. Either de-select the duplicate tools, or modify their names to describe their unique purpose. Model will struggle if tools do not have descriptive names and tool execution will be undefined."
+    Names may repeat across a project, but within one run config every tool the
+    model sees must have a unique function name (and every attached skill a
+    unique skill name — skills are loaded by name through the single "skill"
+    tool). Shared by the runtime adapter and creation-time validation of run
+    configs; run configs are immutable, so a config that passes at creation
+    cannot collide later.
+    """
+    non_skill_tool_ids = [
+        tid for tid in tool_ids if not tid.startswith(SKILL_TOOL_ID_PREFIX)
+    ]
+
+    tools: list[KilnToolInterface] = [
+        tool_from_id(tool_id, task) for tool_id in non_skill_tool_ids
+    ]
+
+    if skills:
+        seen_names: set[str] = set()
+        for skill in skills:
+            if skill.name in seen_names:
+                raise ValueError(
+                    f"Duplicate skill name '{skill.name}'. Each skill must have a unique name."
+                )
+            seen_names.add(skill.name)
+        tools.append(SkillTool(f"{SKILL_TOOL_ID_PREFIX}_combined", skills))
+
+    tool_names = [await tool.name() for tool in tools]
+    if len(tool_names) != len(set(tool_names)):
+        duplicates = sorted({n for n in tool_names if tool_names.count(n) > 1})
+        message = (
+            f"Multiple selected tools share the same function name: {', '.join(duplicates)}. "
+            "Each tool must have a unique name. Either de-select the duplicate tools, or "
+            "modify their names to describe their unique purpose. The model will struggle "
+            "if tools do not have descriptive names and tool execution will be undefined."
+        )
+        if skills and "skill" in duplicates:
+            message += (
+                " The name 'skill' is reserved for the tool that loads skills, "
+                "so no other tool may use it while skills are selected."
             )
+        raise ValueError(message)
 
-        return tools
+    return tools
 
 
 class OpenAIStreamResult:

--- a/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
+++ b/libs/core/kiln_ai/adapters/model_adapters/test_base_adapter.py
@@ -16,6 +16,7 @@ from kiln_ai.adapters.model_adapters.base_adapter import (
     AdapterConfig,
     BaseAdapter,
     RunOutput,
+    assemble_unique_agent_tools,
 )
 from kiln_ai.adapters.model_adapters.stream_events import (
     AiSdkEventType,
@@ -1005,8 +1006,52 @@ async def test_available_tools_duplicate_names_raises_error(base_project):
         mock_tool_from_id.side_effect = [mock_tool1, mock_tool2]
 
         # Should raise ValueError when tools have duplicate names
-        with pytest.raises(ValueError, match="Each tool must have a unique name"):
+        with pytest.raises(
+            ValueError, match="share the same function name: duplicate_name"
+        ):
             await adapter.available_tools()
+
+
+async def test_assemble_unique_agent_tools_lists_colliding_names(base_project):
+    task = Task(name="test_task", instruction="test_instruction", parent=base_project)
+
+    def mock_tool(name: str) -> KilnToolInterface:
+        tool = MagicMock(spec=KilnToolInterface)
+        tool.name = AsyncMock(return_value=name)
+        return tool
+
+    with patch(
+        "kiln_ai.adapters.model_adapters.base_adapter.tool_from_id"
+    ) as mock_tool_from_id:
+        mock_tool_from_id.side_effect = [
+            mock_tool("dup_a"),
+            mock_tool("dup_a"),
+            mock_tool("dup_b"),
+            mock_tool("dup_b"),
+        ]
+        with pytest.raises(
+            ValueError, match="share the same function name: dup_a, dup_b"
+        ):
+            await assemble_unique_agent_tools(
+                task, ["id_1", "id_2", "id_3", "id_4"], []
+            )
+
+
+async def test_assemble_unique_agent_tools_reserved_skill_name(base_project):
+    task = Task(name="test_task", instruction="test_instruction", parent=base_project)
+    skill = Skill(name="my-skill", description="d", parent=base_project)
+
+    tool_named_skill = MagicMock(spec=KilnToolInterface)
+    tool_named_skill.name = AsyncMock(return_value="skill")
+
+    with patch(
+        "kiln_ai.adapters.model_adapters.base_adapter.tool_from_id",
+        return_value=tool_named_skill,
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            await assemble_unique_agent_tools(task, ["id_1"], [skill])
+    assert "share the same function name: skill" in str(exc_info.value)
+    assert "reserved" in str(exc_info.value)
 
 
 async def test_custom_prompt_builder(base_task):

--- a/libs/core/kiln_ai/adapters/test_adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/test_adapter_registry.py
@@ -4,7 +4,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 from kiln_ai import datamodel
-from kiln_ai.adapters.adapter_registry import adapter_for_task, load_skills_for_task
+from kiln_ai.adapters.adapter_registry import (
+    adapter_for_task,
+    load_skills_for_task,
+    validate_run_config_tool_names,
+)
 from kiln_ai.adapters.ml_model_list import ModelProviderName
 from kiln_ai.adapters.model_adapters.base_adapter import AdapterConfig
 from kiln_ai.adapters.model_adapters.litellm_adapter import (
@@ -17,6 +21,7 @@ from kiln_ai.adapters.provider_tools import (
     LiteLlmCoreConfig,
     lite_llm_core_config_for_provider,
 )
+from kiln_ai.datamodel.code_tool import CodeTool
 from kiln_ai.datamodel.datamodel_enums import StructuredOutputMode
 from kiln_ai.datamodel.run_config import (
     KilnAgentRunConfigProperties,
@@ -1106,3 +1111,113 @@ class TestLoadSkillsForTask:
         assert set(result.keys()) == {skill_a.id, skill_b.id}
         assert result[skill_a.id].name == "skill-a"
         assert result[skill_b.id].name == "skill-b"
+
+
+class TestValidateRunConfigToolNames:
+    @pytest.fixture
+    def _agent_config(self):
+        def _make(**overrides) -> KilnAgentRunConfigProperties:
+            defaults = dict(
+                model_name="gpt-4o",
+                model_provider_name="openai",
+                prompt_id="simple_prompt_builder",
+                structured_output_mode="json_schema",
+            )
+            defaults.update(overrides)
+            return KilnAgentRunConfigProperties(**defaults)
+
+        return _make
+
+    @pytest.fixture
+    def project_task(self, tmp_path):
+        project = datamodel.Project(name="test_project", path=tmp_path / "project.kiln")
+        project.save_to_file()
+        task = datamodel.Task(
+            name="test_task", instruction="do something", parent=project
+        )
+        task.save_to_file()
+        return project, task
+
+    def _make_code_tool(self, project, function_name: str) -> CodeTool:
+        code_tool = CodeTool(
+            name=function_name,
+            tool_function_name=function_name,
+            tool_description="d",
+            parameters_schema={"type": "object", "properties": {}},
+            code="def run() -> str:\n    return 'ok'\n",
+            parent=project,
+        )
+        code_tool.save_to_file()
+        return code_tool
+
+    async def test_noop_for_mcp_run_config(self, basic_task):
+        run_config = McpRunConfigProperties(
+            tool_reference=MCPToolReference(tool_id="mcp::local::s::t"),
+        )
+        await validate_run_config_tool_names(basic_task, run_config)
+
+    async def test_noop_without_tools(self, basic_task, _agent_config):
+        await validate_run_config_tool_names(basic_task, _agent_config())
+        await validate_run_config_tool_names(
+            basic_task, _agent_config(tools_config=ToolsRunConfig(tools=[]))
+        )
+
+    async def test_accepts_unique_names(self, project_task, _agent_config):
+        project, task = project_task
+        tool_a = self._make_code_tool(project, "tool_a")
+        tool_b = self._make_code_tool(project, "tool_b")
+        skill = Skill(name="my-skill", description="d", parent=project)
+        skill.save_to_file()
+        skill.save_skill_md("body")
+
+        rc = _agent_config(
+            tools_config=ToolsRunConfig(
+                tools=[
+                    f"kiln_tool::code::{tool_a.id}",
+                    f"kiln_tool::code::{tool_b.id}",
+                    f"kiln_tool::skill::{skill.id}",
+                ]
+            )
+        )
+        await validate_run_config_tool_names(task, rc)
+
+    async def test_rejects_duplicate_function_names(self, project_task, _agent_config):
+        project, task = project_task
+        dup_a = self._make_code_tool(project, "dup_tool")
+        dup_b = self._make_code_tool(project, "dup_tool")
+
+        rc = _agent_config(
+            tools_config=ToolsRunConfig(
+                tools=[
+                    f"kiln_tool::code::{dup_a.id}",
+                    f"kiln_tool::code::{dup_b.id}",
+                ]
+            )
+        )
+        with pytest.raises(ValueError, match="share the same function name: dup_tool"):
+            await validate_run_config_tool_names(task, rc)
+
+    async def test_rejects_duplicate_skill_names(self, project_task, _agent_config):
+        project, task = project_task
+        skill_ids = []
+        for _ in range(2):
+            skill = Skill(name="dup-skill", description="d", parent=project)
+            skill.save_to_file()
+            skill.save_skill_md("body")
+            skill_ids.append(skill.id)
+
+        rc = _agent_config(
+            tools_config=ToolsRunConfig(
+                tools=[f"kiln_tool::skill::{sid}" for sid in skill_ids]
+            )
+        )
+        with pytest.raises(ValueError, match="Duplicate skill name 'dup-skill'"):
+            await validate_run_config_tool_names(task, rc)
+
+    async def test_rejects_unresolvable_tool_id(self, project_task, _agent_config):
+        _, task = project_task
+        rc = _agent_config(
+            tools_config=ToolsRunConfig(tools=["kiln_tool::code::missing_id"])
+        )
+        with pytest.raises(ValueError, match="Code tool not found"):
+            await validate_run_config_tool_names(task, rc)

--- a/libs/core/kiln_ai/adapters/test_adapter_registry.py
+++ b/libs/core/kiln_ai/adapters/test_adapter_registry.py
@@ -1221,3 +1221,11 @@ class TestValidateRunConfigToolNames:
         )
         with pytest.raises(ValueError, match="Code tool not found"):
             await validate_run_config_tool_names(task, rc)
+
+    async def test_rejects_missing_skill_id(self, project_task, _agent_config):
+        _, task = project_task
+        rc = _agent_config(
+            tools_config=ToolsRunConfig(tools=["kiln_tool::skill::missing_id"])
+        )
+        with pytest.raises(ValueError, match="not found in the project: missing_id"):
+            await validate_run_config_tool_names(task, rc)

--- a/libs/core/kiln_ai/tools/test_tool_registry.py
+++ b/libs/core/kiln_ai/tools/test_tool_registry.py
@@ -956,3 +956,42 @@ class TestValidateUniqueAllowlistToolNames:
                 [f"kiln_tool::code::{dup_a.id}", f"kiln_tool::code::{dup_b.id}"],
                 project,
             )
+
+    async def test_tolerates_mcp_only_collisions(self, project):
+        # MCP tool names come from the servers and can't be renamed in Kiln,
+        # so a collision only among MCP tools is left to the sandbox bridge's
+        # call-time error rather than blocking creation.
+        server_a = ExternalToolServer(
+            name="server_a",
+            type=ToolServerType.remote_mcp,
+            properties={"server_url": "https://a.example.com", "is_archived": False},
+            parent=project,
+        )
+        server_a.save_to_file()
+        server_b = ExternalToolServer(
+            name="server_b",
+            type=ToolServerType.remote_mcp,
+            properties={"server_url": "https://b.example.com", "is_archived": False},
+            parent=project,
+        )
+        server_b.save_to_file()
+
+        await validate_unique_allowlist_tool_names(
+            [
+                f"mcp::remote::{server_a.id}::search",
+                f"mcp::remote::{server_b.id}::search",
+            ],
+            project,
+        )
+
+        # A Kiln-owned tool joining the collision is fixable by renaming it,
+        # so that still rejects.
+        code_tool = self._make_code_tool(project, "search")
+        with pytest.raises(ValueError, match="share the same function name: search"):
+            await validate_unique_allowlist_tool_names(
+                [
+                    f"mcp::remote::{server_a.id}::search",
+                    f"kiln_tool::code::{code_tool.id}",
+                ],
+                project,
+            )

--- a/libs/core/kiln_ai/tools/test_tool_registry.py
+++ b/libs/core/kiln_ai/tools/test_tool_registry.py
@@ -32,6 +32,7 @@ from kiln_ai.tools.tool_registry import (
     tool_definitions_from_ids,
     tool_from_id,
     tool_from_id_and_project,
+    validate_unique_allowlist_tool_names,
 )
 
 
@@ -915,3 +916,43 @@ class TestCodeToolRegistry:
     def test_code_tool_no_project_raises(self):
         with pytest.raises(ValueError, match="Requires a parent project"):
             tool_from_id_and_project("kiln_tool::code::12345")
+
+
+class TestValidateUniqueAllowlistToolNames:
+    def _make_code_tool(self, project, function_name):
+        from kiln_ai.datamodel.code_tool import CodeTool
+
+        ct = CodeTool(
+            name=function_name,
+            tool_function_name=function_name,
+            tool_description="d",
+            parameters_schema={"type": "object", "properties": {}},
+            code="def run() -> str:\n    return 'ok'\n",
+            parent=project,
+        )
+        ct.save_to_file()
+        return ct
+
+    @pytest.fixture
+    def project(self, tmp_path):
+        project = Project(name="test_proj", path=tmp_path / "project.kiln")
+        project.save_to_file()
+        return project
+
+    async def test_accepts_unique_and_empty(self, project):
+        tool_a = self._make_code_tool(project, "tool_a")
+        tool_b = self._make_code_tool(project, "tool_b")
+        await validate_unique_allowlist_tool_names([], project)
+        await validate_unique_allowlist_tool_names(
+            [f"kiln_tool::code::{tool_a.id}", f"kiln_tool::code::{tool_b.id}"],
+            project,
+        )
+
+    async def test_rejects_duplicate_function_names(self, project):
+        dup_a = self._make_code_tool(project, "dup_tool")
+        dup_b = self._make_code_tool(project, "dup_tool")
+        with pytest.raises(ValueError, match="share the same function name: dup_tool"):
+            await validate_unique_allowlist_tool_names(
+                [f"kiln_tool::code::{dup_a.id}", f"kiln_tool::code::{dup_b.id}"],
+                project,
+            )

--- a/libs/core/kiln_ai/tools/tool_registry.py
+++ b/libs/core/kiln_ai/tools/tool_registry.py
@@ -180,6 +180,33 @@ def tool_from_id(tool_id: str, task: Task | None = None) -> KilnToolInterface:
     return tool_from_id_and_project(tool_id, project=project, task=task)
 
 
+async def validate_unique_allowlist_tool_names(
+    tool_allowlist: list[str],
+    project: Project,
+    task: Task | None = None,
+) -> None:
+    """Reject a tool allowlist whose tools would collide on their dispatch name.
+
+    Tool names may repeat across a project, but sandboxed code calls
+    allowlisted tools by name (see sandbox_bridge.name_map), so an allowlist
+    carrying two tools with the same function name would make those calls
+    ambiguous. Raises ValueError naming the colliding function names. The
+    sandbox bridge's call-time ambiguity error remains the backstop, since
+    tools can be renamed after the allowlist is saved.
+    """
+    names = [
+        await tool_from_id_and_project(tool_id, project=project, task=task).name()
+        for tool_id in tool_allowlist
+    ]
+    duplicates = sorted({n for n in names if names.count(n) > 1})
+    if duplicates:
+        raise ValueError(
+            f"Multiple allowlisted tools share the same function name: "
+            f"{', '.join(duplicates)}. Tools are called by name from sandboxed "
+            "code, so each tool in the allowlist must have a unique name."
+        )
+
+
 async def tool_definitions_from_ids(
     tool_ids: list[str], task: Task | None = None
 ) -> list[ToolCallDefinition]:

--- a/libs/core/kiln_ai/tools/tool_registry.py
+++ b/libs/core/kiln_ai/tools/tool_registry.py
@@ -190,15 +190,25 @@ async def validate_unique_allowlist_tool_names(
     Tool names may repeat across a project, but sandboxed code calls
     allowlisted tools by name (see sandbox_bridge.name_map), so an allowlist
     carrying two tools with the same function name would make those calls
-    ambiguous. Raises ValueError naming the colliding function names. The
-    sandbox bridge's call-time ambiguity error remains the backstop, since
+    ambiguous. Raises ValueError naming the colliding function names.
+
+    A collision only among MCP tools is tolerated: their names come from the
+    servers and cannot be renamed in Kiln, so rejecting would leave the user
+    no fix short of dropping a server's tools entirely. The sandbox bridge's
+    call-time ambiguity error remains the backstop — for those, and because
     tools can be renamed after the allowlist is saved.
     """
-    names = [
-        await tool_from_id_and_project(tool_id, project=project, task=task).name()
-        for tool_id in tool_allowlist
-    ]
-    duplicates = sorted({n for n in names if names.count(n) > 1})
+    carriers: dict[str, list[str]] = {}
+    for tool_id in tool_allowlist:
+        name = await tool_from_id_and_project(
+            tool_id, project=project, task=task
+        ).name()
+        carriers.setdefault(name, []).append(tool_id)
+    duplicates = sorted(
+        name
+        for name, tool_ids in carriers.items()
+        if len(tool_ids) > 1 and not all(is_mcp_tool_id(tid) for tid in tool_ids)
+    )
     if duplicates:
         raise ValueError(
             f"Multiple allowlisted tools share the same function name: "


### PR DESCRIPTION
## What does this PR do?

TLDR - we incorrectly prevent tools using the same tool_name within a project, but we need to in order to be able to create multiple version of the same tool. Display name and description can differ; but `tool_name` is passed to the model and should be constant across iterations.

-----

Implements KIL-800, building on #1735 (this PR targets that branch and generalizes its skill-only validation — merge #1735 first, or merge this into it, either order works since we don't squash).

**1. Tool name duplicates are allowed within a project; collisions are rejected per run config.**

- Removed the only project-level collision check: `create_code_tool` no longer rejects a duplicate `tool_function_name` among the project's code tools.
- `POST .../run_configs` now validates *all* attached tools, not just skills: every tool id is resolved and the run config is rejected with a 422 when two tools share a function name (or two skills share a skill name, or a referenced skill no longer exists). Users find out at save, with a message naming the colliding tools, instead of at inference time.
- The runtime assembly + duplicate check moved out of `BaseAdapter.available_tools()` into a shared module-level `assemble_unique_agent_tools()`, reused by the new `validate_run_config_tool_names()` in `adapter_registry`. Creation-time validation catches collisions at selection time; runtime remains the backstop for pre-existing configs and for tools renamed after creation (e.g. `edit_kiln_task_tool`), and the two checks can't drift. The error lists the colliding function names, with a hint when a tool collides with the reserved `skill` loader name. Side benefit: a run config referencing a deleted tool now 422s at creation too.
- Code-tool creation validates its `tool_allowlist` the same way: two allowlisted tools sharing a dispatch name would make sandboxed calls ambiguous, so creation rejects that up front — except when the collision is only among MCP tools, whose names come from the servers and can't be renamed in Kiln (there the sandbox bridge's precise call-time error remains the backstop, as it does for code evals' allowlists, which live in the nested eval-config properties union).

**2. The Tools &amp; Search dropdown shows display names.**

With duplicates allowed, `tool_name` alone can't distinguish tools. `/available_tools` now serves the user-facing display name in `name` (RAG tools: the rag config's name instead of its snake_case `tool_name`; code tools: `CodeTool.name` instead of `tool_function_name`), with the callable name still in `function_name`. Pickers show the function name as a badge under the label whenever it differs (long badges cramped the label when inline). The RAG description drops its now-redundant `"{name}: "` prefix. Duplicate display names get an `(id)` qualifier — previously Kiln task tools only, now code tools, RAG tools, and skills (in the Skills picker) too, so the 422 always has a distinguishable row to point at.

### Manual testing

Verified in the browser against a live dev server, with two Kiln task tools sharing the name `triage_ticket` (creating the duplicate pair itself exercised "duplicates allowed within a project"):

<b>Screenshots</b> (hosted on the <code>claude/tool-name-duplicates-assets</code> branch — never merge it, safe to delete after this PR closes)

**Tools &amp; Search shows display names — "Support Policy Search" with its `support_policy_search` function-name badge underneath — and both same-named tools:**

![tools dropdown](https://raw.githubusercontent.com/Kiln-AI/Kiln/f78f01d2ff954e7425f5aefa86b377156919e4da/screenshots/tools_dropdown.png)

**Save current options with both `triage_ticket` tools selected — 422 shown under Run Configuration:**

![save error](https://raw.githubusercontent.com/Kiln-AI/Kiln/704c5d0065d09211258bb75705adedb360fa1af6/screenshots/save_error.png)

**After deselecting one and adding the (distinctly named) search tool — save succeeds, error cleared, no false positive:**

![save success](https://raw.githubusercontent.com/Kiln-AI/Kiln/704c5d0065d09211258bb75705adedb360fa1af6/screenshots/save_success.png)

## Related Issues

[KIL-800](https://linear.app/kiln-ai/issue/KIL-800/allow-tool-name-duplicates-within-a-project-scope-collision-check-to). Builds on #1735.

## Contributor License Agreement

_Left for the PR author to complete._

## Checklists

- [x] Tests have been run locally and passed (`checks.sh` green)
- [x] New tests have been added to any work in /lib (`assemble_unique_agent_tools`, `validate_run_config_tool_names`, and `validate_unique_allowlist_tool_names` tests, incl. MCP-only vs mixed collisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MraYsBCR3R1eV2xcmgHK1c