### PR TITLE
models: add Qwen 3.8 Flash

### DIFF
--- a/libs/core/kiln_ai/adapters/ml_model_list.py
+++ b/libs/core/kiln_ai/adapters/ml_model_list.py
@@ -216,6 +216,7 @@ class ModelName(str, Enum):
     qwen_3p5_27b = "qwen_3p5_27b"
     qwen_3p5_35b_a3b = "qwen_3p5_35b_a3b"
     qwen_3p8_2p4t_a95b = "qwen_3p8_2p4t_a95b"
+    qwen_3p8_flash = "qwen_3p8_flash"
     qwen_3p8_27b = "qwen_3p8_27b"
     qwen_3p7_flash = "qwen_3p7_flash"
     qwen_3p7_plus = "qwen_3p7_plus"
@@ -6075,6 +6076,35 @@ built_in_models: List[KilnModel] = [
                 structured_output_mode=StructuredOutputMode.json_instructions,
                 supports_data_gen=True,
                 supports_function_calling=True,
+            ),
+        ],
+    ),
+    # Qwen 3.8 Flash
+    KilnModel(
+        family=ModelFamily.qwen,
+        name=ModelName.qwen_3p8_flash,
+        friendly_name="Qwen 3.8 Flash",
+        providers=[
+            KilnModelProvider(
+                name=ModelProviderName.openrouter,
+                model_id="qwen/qwen3.8-flash",
+                structured_output_mode=StructuredOutputMode.json_instruction_and_object,
+                supports_data_gen=True,
+                supports_function_calling=True,
+                supports_doc_extraction=True,
+                supports_vision=True,
+                multimodal_capable=True,
+                multimodal_mime_types=[
+                    KilnMimeType.JPG,
+                    KilnMimeType.PNG,
+                    KilnMimeType.PDF,
+                    KilnMimeType.TXT,
+                    KilnMimeType.MD,
+                    # video
+                    KilnMimeType.MP4,
+                    KilnMimeType.MOV,
+                ],
+                multimodal_requires_pdf_as_image=True,
             ),
         ],
     ),


### PR DESCRIPTION
## What does this PR do?

Adds Qwen 3.8 Flash as a single-provider OpenRouter entry (`qwen/qwen3.8-flash`), cloned from the Qwen 3.7 Flash configuration: multimodal (image + video) input, function calling, doc extraction, and `json_instruction_and_object` structured output. Placed between Qwen 3.8 2.4T A95B and Qwen 3.8 27B per the family ordering rules.

Test Results

The slug was verified against the OpenRouter API (modality `text+image+video->text`, matching the flags). The initial smoke test passed on the first attempt. However, the full suite runs collided with launch-day congestion on Alibaba's upstream pool: OpenRouter returned HTTP 429 `"qwen/qwen3.8-flash is temporarily rate-limited upstream"` (`limit_source: upstream_provider_shared_pool`) on a random subset of requests in every run. The suite was run five times (12 workers, 4 workers, fully serial, and two serial retries of the remaining failures, the last after a 7-minute back-off). Across all runs, **every single failure was that identical upstream 429 — zero config errors, zero 400s, zero content/assertion failures.**

Which tests passed was random per run, consistent with shared-pool congestion rather than any config problem. 15 of the 19 runnable tests passed at least once (8 more are configured skips). The 4 marked ⚠️ below never got a clean run — all are multi-request tests (COT builders, tools, LLM-as-judge issue several sequential calls), so they had the highest odds of drawing at least one 429. No `KilnMimeType` was removed: the failing extraction cases were 429s, not 400 rejections, and every configured MIME type (PDF, PNG, JPEG, MP4, MOV) passed in at least one run. These should be re-run once upstream capacity stabilizes; `max_parallel_requests` was deliberately not set since the predecessor (Qwen 3.7 Flash) doesn't set it and the limit is flagged as temporary.

Qwen 3.8 Flash (openrouter):
- 15 passed (best-of across runs), 8 skipped (unconfigured MIME types / passthrough / no logprobs), 4 blocked by transient upstream 429s
- No real failures: every failed attempt across all five runs was the same OpenRouter 429 "temporarily rate-limited upstream" (Alibaba shared pool)

---
Qwen 3.8 Flash (openrouter):
✅ test_data_gen_all_models_providers[qwen_3p8_flash-openrouter]
✅ test_data_gen_sample_all_models_providers[qwen_3p8_flash-openrouter]
✅ test_data_gen_sample_all_models_providers_with_structured_output[qwen_3p8_flash-openrouter]
✅ test_all_built_in_models_structured_output[qwen_3p8_flash-openrouter]
✅ test_all_built_in_models_structured_input[qwen_3p8_flash-openrouter]
✅ test_structured_input_cot_prompt_builder[qwen_3p8_flash-openrouter]
✅ test_all_models_providers_plaintext[qwen_3p8_flash-openrouter]
✅ test_supports_vision_is_coherent[qwen_3p8_flash-openrouter]
✅ test_provider_bad_request[qwen_3p8_flash-openrouter]
✅ test_extract_document_success[application/pdf-text_probe0-qwen_3p8_flash-openrouter]
✅ test_extract_document_success[image/png-text_probe5-qwen_3p8_flash-openrouter]
✅ test_extract_document_success[image/jpeg-text_probe6-qwen_3p8_flash-openrouter]
✅ test_extract_document_success[image/jpeg-text_probe7-qwen_3p8_flash-openrouter]
✅ test_extract_document_success[video/mp4-text_probe8-qwen_3p8_flash-openrouter]
✅ test_extract_document_success[video/quicktime-text_probe9-qwen_3p8_flash-openrouter]
⚠️ test_all_built_in_models_llm_as_judge[qwen_3p8_flash-openrouter] — upstream 429 (Alibaba shared pool) on all 5 attempts; no non-429 error ever seen
⚠️ test_structured_output_cot_prompt_builder[qwen_3p8_flash-openrouter] — upstream 429 on all 5 attempts
⚠️ test_cot_prompt_builder[qwen_3p8_flash-openrouter] — upstream 429 on all 5 attempts
⚠️ test_tools_all_built_in_models[qwen_3p8_flash-openrouter] — upstream 429 on all 5 attempts

Skipped (configured, expected):
- test_extract_document_success[audio/mpeg|audio/wav|audio/ogg|text/csv|text/html] — model not configured for these MIME types
- test_extract_document_success[text/markdown|text/plain] — passthrough
- test_all_built_in_models_logprobs_geval — model does not support logprobs

## Checklists

- [X] Tests have been run locally and passed (see caveat above: 4 tests blocked by transient upstream 429s, no real failures)
- [X] New tests have been added to any work in /lib (N/A — model list entry only, covered by existing parametrized paid tests)
