### PR TITLE
Raise a clear error for malformed global chunk IDs

### DIFF
--- a/libs/core/kiln_ai/utils/rag_utils.py
+++ b/libs/core/kiln_ai/utils/rag_utils.py
@@ -9,8 +9,21 @@ def global_chunk_id(document_id: str, chunk_idx: int) -> str:
 
 
 def split_global_chunk_id(global_chunk_id: str) -> Tuple[str, int]:
-    document_id, chunk_idx = global_chunk_id.split("::")
-    return document_id, int(chunk_idx)
+    parts = global_chunk_id.split("::")
+    if len(parts) != 2:
+        raise ValueError(
+            f"Invalid global chunk ID '{global_chunk_id}'. Expected exactly one "
+            "'::' separator, in the format 'document_id::chunk_idx'."
+        )
+
+    document_id, chunk_idx = parts
+    try:
+        return document_id, int(chunk_idx)
+    except ValueError:
+        raise ValueError(
+            f"Invalid global chunk ID '{global_chunk_id}'. The chunk index "
+            f"'{chunk_idx}' is not an integer."
+        ) from None
 
 
 def convert_search_results_to_rerank_input(

--- a/libs/core/kiln_ai/utils/test_rag_utils.py
+++ b/libs/core/kiln_ai/utils/test_rag_utils.py
@@ -57,13 +57,31 @@ class TestSplitGlobalChunkId:
         assert doc_id == original_doc_id
         assert chunk_idx == original_chunk_idx
 
-    def test_split_invalid_format_raises_error(self):
-        with pytest.raises(ValueError):
-            split_global_chunk_id("invalid_format")
+    @pytest.mark.parametrize(
+        "invalid_id",
+        [
+            "invalid_format",
+            "",
+            "doc::with::colons::0",
+            "doc::with::colons",
+        ],
+    )
+    def test_split_wrong_separator_count_raises_error(self, invalid_id):
+        with pytest.raises(ValueError, match="Expected exactly one '::' separator"):
+            split_global_chunk_id(invalid_id)
 
-    def test_split_invalid_chunk_idx_raises_error(self):
-        with pytest.raises(ValueError):
-            split_global_chunk_id("doc123::not_a_number")
+    @pytest.mark.parametrize(
+        "invalid_chunk_idx",
+        ["not_a_number", "", "1.5", "0x5"],
+    )
+    def test_split_non_integer_chunk_idx_raises_error(self, invalid_chunk_idx):
+        with pytest.raises(ValueError, match="is not an integer"):
+            split_global_chunk_id(f"doc123::{invalid_chunk_idx}")
+
+    def test_split_error_message_includes_offending_id(self):
+        with pytest.raises(ValueError) as exc_info:
+            split_global_chunk_id("doc::with::colons::0")
+        assert "doc::with::colons::0" in str(exc_info.value)
 
 
 class TestConvertSearchResultsToRerankInput:


### PR DESCRIPTION
## What does this PR do?

`split_global_chunk_id` unpacked `split("::")` straight into two variables, so any malformed input surfaced as `ValueError: not enough values to unpack` or `invalid literal for int()` — neither of which names the actual problem.

This validates the scheme explicitly and raises an error that includes the offending ID:

```python
parts = global_chunk_id.split("::")
if len(parts) != 2:
    raise ValueError(
        f"Invalid global chunk ID '{global_chunk_id}'. Expected exactly one "
        "'::' separator, in the format 'document_id::chunk_idx'."
    )

document_id, chunk_idx = parts
try:
    return document_id, int(chunk_idx)
except ValueError:
    raise ValueError(
        f"Invalid global chunk ID '{global_chunk_id}'. The chunk index "
        f"'{chunk_idx}' is not an integer."
    ) from None
```

### Why strict, and not `rsplit`

The scheme is exactly one `::` separator. `document_id` is a Kiln model ID (a 12 digit numeric string from `generate_model_id`) and `chunk_idx` is an `int`, so neither half can contain the separator. An ID with more than one separator means something upstream is broken, and the right response is to throw — switching to `rsplit("::", 1)` would instead parse such an ID "successfully" into a `document_id` that does not exist, turning a loud crash into a silent wrong lookup in the RAG path.

### Why the error message is worth the lines

The only caller is `libs/core/kiln_ai/tools/rag_tools.py:182`, which parses `result.document.id` — a string that has round-tripped through a third-party reranker API. Kiln generates the ID, but an external provider hands it back, so a provider that truncates, reorders or fabricates an ID is the one realistic source of malformed input here. "The reranker returned an ID we never sent" is a much better starting point for that investigation than a bare unpacking error.

Parse-side only: `global_chunk_id()` is left as-is, since its inputs come straight from Kiln models.

### Tests

Reworked the two existing `pytest.raises(ValueError)` cases in `test_rag_utils.py` into parametrized tests that assert the new messages, and added coverage for the multi-separator case and for the offending ID appearing in the message.

## Related Issues

Addresses the underlying concern in #1524 and supersedes #1525. Note that the specific bug those describe is not reachable: `document_id` is always a 12 digit numeric Kiln model ID, so it cannot contain `::`. This change is about the error message quality, not a live crash.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

---
_Generated by [Claude Code](https://claude.ai/code/session_01JV8mJexrQvDjQXYzaMa5yg)_