### PR TITLE
Git import: null project descriptions scan as blank instead of failing

### DIFF
--- a/app/desktop/git_sync/clone.py
+++ b/app/desktop/git_sync/clone.py
@@ -505,9 +505,12 @@ def scan_for_projects(clone_path: Path) -> list[dict[str, str]]:
         project_id = ""
         try:
             data = json.loads(kiln_file.read_text())
-            name = data.get("name", "")
-            description = data.get("description", "")
-            project_id = data.get("id", "")
+            # These fields can be present but null: that is what gets written for
+            # a value that was never set. `or ""` covers null, missing and empty
+            # alike, where a get() default would only cover missing.
+            name = data.get("name") or ""
+            description = data.get("description") or ""
+            project_id = data.get("id") or ""
         except Exception:
             pass
 

--- a/app/desktop/git_sync/git_sync_api.py
+++ b/app/desktop/git_sync/git_sync_api.py
@@ -4,7 +4,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi import Path as FastAPIPath
@@ -23,7 +23,7 @@ from kiln_server.project_api import (
     project_from_id,
 )
 from kiln_server.utils.agent_checks import DENY_AGENT
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.desktop.git_sync.clone import (
     clone_repo,
@@ -277,9 +277,19 @@ class ProjectInfo(BaseModel):
     """Metadata about a discovered Kiln project."""
 
     path: str = Field(description="Relative path to the project.kiln file.")
-    name: str = Field(description="Project name from the project file.")
-    description: str = Field(description="Project description from the project file.")
+    name: str = Field(default="", description="Project name from the project file.")
+    description: str = Field(
+        default="", description="Project description from the project file."
+    )
     id: str = Field(default="", description="Unique project identifier.")
+
+    # These three are display-only, and they come from project files we did not
+    # write. A null in any one of them used to fail validation for the whole
+    # scanned list, hiding every valid project in the repo, so treat it as blank.
+    @field_validator("name", "description", "id", mode="before")
+    @classmethod
+    def _blank_if_none(cls, value: Any) -> Any:
+        return "" if value is None else value
 
 
 class ScanProjectsResponse(BaseModel):

--- a/app/desktop/git_sync/test_clone.py
+++ b/app/desktop/git_sync/test_clone.py
@@ -277,6 +277,19 @@ class TestScanForProjects:
         assert len(results) == 1
         assert results[0]["id"] == ""
 
+    def test_null_fields_become_empty_strings(self, tmp_path: Path):
+        # A project file written without these values set carries an explicit
+        # null rather than omitting the key.
+        project_data = {"name": None, "description": None, "id": None}
+        (tmp_path / "project.kiln").write_text(json.dumps(project_data))
+
+        results = scan_for_projects(tmp_path)
+        assert len(results) == 1
+        assert results[0]["description"] == ""
+        assert results[0]["id"] == ""
+        # A project with no usable name falls back to its path.
+        assert results[0]["name"] == "project.kiln"
+
     def test_results_sorted_by_path(self, tmp_path: Path):
         for name in ["c_proj", "a_proj", "b_proj"]:
             d = tmp_path / name

--- a/app/desktop/git_sync/test_git_sync_api.py
+++ b/app/desktop/git_sync/test_git_sync_api.py
@@ -7,8 +7,9 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from kiln_ai.utils.config import Config
 from kiln_ai.utils.project_utils import DuplicateProjectError
+from pydantic import ValidationError
 
-from app.desktop.git_sync.git_sync_api import connect_git_sync_api
+from app.desktop.git_sync.git_sync_api import ProjectInfo, connect_git_sync_api
 
 
 @pytest.fixture
@@ -318,6 +319,18 @@ class TestTestWriteAccess:
         assert data["auth_required"] is True
 
 
+class TestProjectInfo:
+    def test_null_display_fields_are_coerced_to_blank(self):
+        info = ProjectInfo(path="project.kiln", name=None, description=None, id=None)
+        assert info.name == ""
+        assert info.description == ""
+        assert info.id == ""
+
+    def test_path_is_still_required(self):
+        with pytest.raises(ValidationError):
+            ProjectInfo(name="x", description="y", id="z")
+
+
 class TestScanProjects:
     def test_finds_projects(self, api_client, tmp_path):
         clone_dir = tmp_path / "kiln_clone_abc"
@@ -362,6 +375,37 @@ class TestScanProjects:
                 json={"clone_path": "/nonexistent/path"},
             )
         assert resp.status_code == 400
+
+    def test_one_null_description_still_returns_every_project(
+        self, api_client, tmp_path
+    ):
+        # A single project file with a null description used to fail validation
+        # for the whole list, so no project in the repo could be imported.
+        clone_dir = tmp_path / "kiln_clone_abc"
+        clone_dir.mkdir()
+        nested = clone_dir / "nested"
+        nested.mkdir()
+        (clone_dir / "project.kiln").write_text(
+            json.dumps({"name": "Good", "description": "desc", "id": "proj_good"})
+        )
+        (nested / "project.kiln").write_text(
+            json.dumps({"name": "Null Desc", "description": None, "id": "proj_null"})
+        )
+
+        with patch(
+            "app.desktop.git_sync.git_sync_api.default_project_path",
+            return_value=str(tmp_path),
+        ):
+            resp = api_client.post(
+                "/api/git_sync/scan_projects",
+                json={"clone_path": str(clone_dir)},
+            )
+
+        assert resp.status_code == 200
+        projects = resp.json()["projects"]
+        assert sorted(p["name"] for p in projects) == ["Good", "Null Desc"]
+        by_id = {p["id"]: p for p in projects}
+        assert by_id["proj_null"]["description"] == ""
 
 
 class TestSaveAndGetConfig:

--- a/app/web_ui/src/lib/api_schema.d.ts
+++ b/app/web_ui/src/lib/api_schema.d.ts
@@ -9310,11 +9310,13 @@ export interface components {
             /**
              * Name
              * @description Project name from the project file.
+             * @default
              */
             name: string;
             /**
              * Description
              * @description Project description from the project file.
+             * @default
              */
             description: string;
             /**


### PR DESCRIPTION
## What does this PR do?

Treats a project's name, description and id as blank when they arrive as null, so one project file can't block importing the rest of the repo.

### Why

`Project.description` is `str | None` — null is a legal value, and it's what gets written for a description that was never set. The import scan assumed otherwise. It reads project files as raw JSON rather than loading them as `Project`, pulled the value with `data.get("description", "")` — a default that only covers a missing key, not a null one — and handed the result to `ProjectInfo.description`, typed as a required non-nullable `str`.

So two contracts disagreed, and a file that was valid to write was invalid to read. Since the scan validates everything it finds as a single list, one null made every project in the repo unimportable — with an error ("Description: Input should be a valid string") naming no file, no project and no step. Found on a repo with 13 projects, 12 of them fine.

To be clear about what this is not: we aren't relaxing validation to accept broken data. The file was always valid. `ProjectInfo` was simply typed more strictly than the datamodel it describes, and this brings the reader back in line with the contract that already exists.

### The win

These fields are display-only and come from files we didn't write, so a null should read as blank rather than hide twelve valid projects next to it. Fixed at both layers: the scan coerces, and `ProjectInfo` no longer rejects a null. `id` had the same latent exposure and is covered too.

Nothing changes on the write side. Null stays legal, because every project file already on disk with one has to keep loading.

## Checklists

- [x] Tests have been run locally and passed
- [x] New tests have been added to any work in /lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)
