### PR TITLE
Revert nltk 3.10.3 bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2312,7 +2312,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.10.3"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2321,9 +2321,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

`Test Count And Coverage` went red on main at `25d1b9a` after the dependency batch landed. The cause is the nltk bump in #1742.

nltk 3.10.3 added a path-security guard that refuses to open any corpus file with more than one hard link (CWE-59). llama_index ships its stopwords corpus inside `site-packages`, and uv installs by hard-linking from its cache on Linux, so the file arrives with `st_nlink=2` and nltk rejects it:

```
PermissionError: Security Violation [pathsec.open]: refusing multiply-linked file
'.../llama_index/core/_static/nltk_cache/corpora/stopwords/english' (st_nlink=2);
a hardlink can point at an outside-root inode (CWE-59)
```

That failed `test_fixed_window_chunker_concrete_chunker`. Every other workflow stayed green, including the full suite on Python 3.10 through 3.13 — `Test Count And Coverage` is the only job that runs the tests serially (`-n0`), and the guard only trips there.

## What this does

Reverts the merge of #1742, putting nltk back to 3.10.0 in `uv.lock`. Nothing else changes.

## Trade-off

This gives back the CVE-2026-12252 / CVE-2026-12841 fixes that shipped in 3.10.3. That is a real cost, taken deliberately to get main green now rather than leave trunk red while the upstream conflict is worked out.

## Follow-ups

- The nltk / llama_index hard-link conflict is unresolved and will come back the next time Dependabot opens this bump. Re-landing needs it fixed first.
- Worth investigating separately: `test_count.yml` still runs `coverage run -m pytest ... -n0`, the pattern #1742's failure depends on. `coverage.yml` moved off it to `pytest --cov` under xdist. Bringing the two in line may remove the serial-only exposure entirely.

## Priority

Medium. Trunk is red on one job; the library itself is unaffected and the other ten workflows are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6NC2nGHWRxyHeo81YkWch