### PR TITLE
Run test count and coverage on dependency PRs

### DIFF
--- a/.github/workflows/test_count.yml
+++ b/.github/workflows/test_count.yml
@@ -4,6 +4,17 @@ on:
   push:
     branches:
       - main # Adjust this if your main branch has a different name
+  # Also run on PRs that change dependencies. The library coverage step runs the suite
+  # serially, so it exercises code paths the parallel jobs don't, and it has caught a
+  # dependency bump that every other check passed. Running only on push meant that
+  # breakage surfaced after the merge landed. Path-filtered to keep it off unrelated PRs.
+  pull_request:
+    paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
+      - 'app/web_ui/package-lock.json'
+      - 'app/web_ui/package.json'
+      - '.github/workflows/test_count.yml'
 
 jobs:
   count_tests:
@@ -53,6 +64,9 @@ jobs:
           echo "TOTAL_TEST_COUNT=$TOTAL_TEST_COUNT" >> $GITHUB_ENV
 
       - name: Create test count badge
+        # The badges report main's numbers, so only publish from the push-to-main run.
+        # PR runs also have no gist secret when they come from a fork.
+        if: github.event_name == 'push'
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_SECRET }}
@@ -70,6 +84,9 @@ jobs:
           echo "TOTAL_LIB_COVERAGE=$TOTAL_LIB_COVERAGE" >> $GITHUB_ENV
 
       - name: Create coverage badge
+        # The badges report main's numbers, so only publish from the push-to-main run.
+        # PR runs also have no gist secret when they come from a fork.
+        if: github.event_name == 'push'
         uses: schneegans/dynamic-badges-action@v1.7.0
         with:
           auth: ${{ secrets.GIST_SECRET }}


### PR DESCRIPTION
## What does this PR do?

Run the Test Count And Coverage job on PRs that change dependencies, instead of only on push to main.

#1742 (Bump nltk from 3.10.0 to 3.10.3) passed every check on its PR and turned main red once it merged, and we reverted it in #1762 (Revert nltk 3.10.3 bump). This job is the one that caught it, and it had never run on the PR. It was scoped to `branches: [main]` while the other test workflows run on any branch push.

* The last two steps write the test count and coverage numbers into a gist that the README badges read. Those badges should only ever show main, so those steps now only run on push. They would also fail on Dependabot PRs, which don't get repo secrets.
* The trigger matches on changed files, not on Dependabot being the author. Of the last 40 PRs, 12 touched dependency files and 2 of those were ours.
* The workflow file is in the path filter, so future changes to it are self testing.
* Adds about 4 to 5 minutes on roughly 30% of PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6NC2nGHWRxyHeo81YkWch