### PR TITLE
feat(compare): radar scale toggle, hideable usage axes, row renames

### DIFF
--- a/app/web_ui/src/lib/components/chart_no_data.svelte
+++ b/app/web_ui/src/lib/components/chart_no_data.svelte
@@ -1,3 +1,8 @@
+<script lang="ts">
+  export let title: string = "No Data Available"
+  export let message: string = "Create and run evals to see a comparison chart."
+</script>
+
 <div class="flex items-center justify-center h-[300px]">
   <div class="text-center">
     <svg
@@ -13,9 +18,7 @@
         d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
       />
     </svg>
-    <p class="text-lg font-medium">No Data Available</p>
-    <p class="mt-1 text-gray-500">
-      Create and run evals to see a comparison chart.
-    </p>
+    <p class="text-lg font-medium">{title}</p>
+    <p class="mt-1 text-gray-500 max-w-md">{message}</p>
   </div>
 </div>

--- a/app/web_ui/src/lib/components/compare_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_chart.svelte
@@ -15,17 +15,10 @@
   } from "$lib/utils/run_config_formatters"
   import ChartNoData from "./chart_no_data.svelte"
   import { formatLatency } from "$lib/utils/formatters"
-
-  // Type for comparison features (same as parent page)
-  type ComparisonFeature = {
-    category: string
-    items: { label: string; key: string }[]
-    has_default_eval_config: boolean | undefined
-    eval_id: string
-  }
+  import type { ComparisonSection } from "$lib/utils/compare_metric_keys"
 
   // Props
-  export let comparisonFeatures: ComparisonFeature[]
+  export let comparisonFeatures: ComparisonSection[]
   export let getModelValueRaw: (
     modelKey: string | null,
     dataKey: string,

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -96,7 +96,7 @@ Cost, latency and token axes score each run config against the others, so they s
   $: notShownNote =
     omittedAxisCount > 0
       ? `Not shown: ${omittedAxisCount} ${
-          omittedAxisCount === 1 ? "score" : "scores"
+          omittedAxisCount === 1 ? "axis" : "axes"
         } without results for every selected run config. See the table above.`
       : null
 

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -142,7 +142,10 @@ Cost, latency and token axes score each run config against the others, so they s
     }
   }
 
-  function buildLegendSubtext(config: TaskRunConfig): string {
+  function buildLegendSubtext(
+    config: TaskRunConfig,
+    promptList: PromptResponse | null,
+  ): string {
     const parts: string[] = []
     if (isMcpRunConfig(config.run_config_properties)) {
       const toolName =
@@ -151,7 +154,7 @@ Cost, latency and token axes score each run config against the others, so they s
     } else {
       const modelName =
         getRunConfigModelDisplayName(config, model_info) || "Unknown"
-      const promptName = getRunConfigPromptDisplayName(config, prompts)
+      const promptName = getRunConfigPromptDisplayName(config, promptList)
       parts.push(`{sub|Model: ${modelName}}`)
       if (promptName) parts.push(`{sub|Prompt: ${promptName}}`)
       const transformLabel = getRunConfigInputTransformSummaryLabel(config)
@@ -160,16 +163,23 @@ Cost, latency and token axes score each run config against the others, so they s
     return parts.join("\n")
   }
 
-  function buildLegendFormatter(data: RadarChartData): Record<string, string> {
+  function buildLegendFormatter(
+    data: RadarChartData,
+    promptList: PromptResponse | null,
+  ): Record<string, string> {
     const formatter: Record<string, string> = {}
     for (const [name, config] of Object.entries(data.configsBySeriesName)) {
-      formatter[name] = `${name}\n${buildLegendSubtext(config)}`
+      formatter[name] = `${name}\n${buildLegendSubtext(config, promptList)}`
     }
     return formatter
   }
 
   // Build full tooltip HTML for a run config (reused by chart tooltip and legend tooltip)
-  function buildRunConfigTooltip(name: string, data: RadarChartData): string {
+  function buildRunConfigTooltip(
+    name: string,
+    data: RadarChartData,
+    promptList: PromptResponse | null,
+  ): string {
     const config = data.configsBySeriesName[name]
 
     let html = `<div style="font-weight: bold; margin-bottom: 4px;">${escapeHtml(
@@ -184,7 +194,7 @@ Cost, latency and token axes score each run config against the others, so they s
         ? getRunConfigModelDisplayName(config, model_info) || "Unknown"
         : "Unknown"
       const promptName = config
-        ? getRunConfigPromptDisplayName(config, prompts)
+        ? getRunConfigPromptDisplayName(config, promptList)
         : null
       html += `<div>Model: ${escapeHtml(modelName)}</div>`
       if (promptName) {
@@ -226,16 +236,18 @@ Cost, latency and token axes score each run config against the others, so they s
     return html
   }
 
-  function updateChart() {
+  function updateChart(
+    data: RadarChartData,
+    promptList: PromptResponse | null,
+  ) {
     if (!chartInstance) return
 
-    if (!chartData.hasData) {
+    if (!data.hasData) {
       chartInstance.clear()
       return
     }
 
-    const data = chartData
-    const legendFormatter = buildLegendFormatter(data)
+    const legendFormatter = buildLegendFormatter(data, promptList)
 
     // A couple of configs don't need a legend column - centering the radar and
     // dropping the legend underneath buys a much larger plot.
@@ -258,7 +270,7 @@ Cost, latency and token axes score each run config against the others, so they s
           trigger: "item",
           confine: true,
           formatter: (params: { name: string }) =>
-            buildRunConfigTooltip(params.name, data),
+            buildRunConfigTooltip(params.name, data, promptList),
         },
         legend: {
           data: data.legend,
@@ -266,7 +278,7 @@ Cost, latency and token axes score each run config against the others, so they s
           tooltip: {
             show: true,
             formatter: (params: { name: string }) =>
-              buildRunConfigTooltip(params.name, data),
+              buildRunConfigTooltip(params.name, data, promptList),
           },
           textStyle: legendTextStyle,
           ...(compactLayout
@@ -334,9 +346,10 @@ Cost, latency and token axes score each run config against the others, so they s
   }
 
   // Redraw whenever the data changes. prompts reaches the chart only through the
-  // legend and tooltip text, so it is named here to make it a dependency too.
-  $: if (chartInstance && chartData && (prompts || prompts === null)) {
-    updateChart()
+  // legend and tooltip text, so it is an argument rather than something the chart
+  // reads for itself: a reactive statement depends on the identifiers it mentions.
+  $: if (chartInstance) {
+    updateChart(chartData, prompts)
   }
 
   // Svelte action to initialize chart when element is added to DOM
@@ -348,7 +361,7 @@ Cost, latency and token axes score each run config against the others, so they s
     })
     resizeObserver.observe(node)
 
-    updateChart()
+    updateChart(chartData, prompts)
 
     return {
       destroy() {

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -94,17 +94,18 @@ Cost, latency and token axes score each run config against the others, so they s
   $: omittedAxisCount = chartData.omittedKeyCount
 
   $: notShownNote =
-    omittedAxisCount > 0
+    chartData.hasData && omittedAxisCount > 0
       ? `Not shown: ${omittedAxisCount} ${
           omittedAxisCount === 1 ? "axis" : "axes"
         } without results for every selected run config. See the table above.`
       : null
 
-  // When there's nothing to draw, say which of the two reasons it is
-  $: noDataMessage =
-    omittedAxisCount > 0
-      ? `Fewer than ${MIN_RADAR_AXES} axes have a result for every selected run configuration. Run the missing evals, or compare fewer run configurations.`
-      : "Create and run evals to see a comparison chart."
+  // With no eval section there is nothing to show but the usage rows, and the way
+  // out is a new eval. With one, the axes are hidden or unshared, and the way out
+  // is one of three things the user can do from this page.
+  $: noDataMessage = chartData.hasEvalSections
+    ? `A radar chart needs at least ${MIN_RADAR_AXES} axes. Show a hidden row, run the missing evals, or compare fewer run configurations.`
+    : "Create and run evals to see a comparison chart."
 
   function setScale(useAbsolute: boolean) {
     absoluteScale = useAbsolute
@@ -359,10 +360,10 @@ Cost, latency and token axes score each run config against the others, so they s
   }
 </script>
 
-<!-- Radar charts don't really work with <3 items. Counts the usage axes too: they
-     are axes like any other, and a task with one or two eval scores still has a
-     chart worth drawing once cost, latency and tokens are on it. -->
-{#if chartData.candidateAxisCount >= MIN_RADAR_AXES}
+<!-- A table with no rows left has nothing to say about a radar chart, so the card
+     goes with it. One or two rows keep the card, where the empty state can say how
+     to get a third. -->
+{#if chartData.candidateAxisCount > 0}
   <div
     class="bg-white border border-gray-200 rounded-lg p-6 mb-6 h-full flex flex-col"
   >
@@ -406,8 +407,8 @@ Cost, latency and token axes score each run config against the others, so they s
       ></div>
     {:else}
       <ChartNoData
-        title={omittedAxisCount > 0
-          ? "Not Enough Shared Axes"
+        title={chartData.hasEvalSections
+          ? "Not Enough Axes"
           : "No Data Available"}
         message={noDataMessage}
       />

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -103,7 +103,7 @@ Cost, latency and token axes score each run config against the others, so they s
   // When there's nothing to draw, say which of the two reasons it is
   $: noDataMessage =
     omittedAxisCount > 0
-      ? `The selected run configurations share fewer than ${MIN_RADAR_AXES} scores with results. Run the missing evals, or compare fewer run configurations.`
+      ? `Fewer than ${MIN_RADAR_AXES} axes have a result for every selected run configuration. Run the missing evals, or compare fewer run configurations.`
       : "Create and run evals to see a comparison chart."
 
   function setScale(useAbsolute: boolean) {
@@ -407,7 +407,7 @@ Cost, latency and token axes score each run config against the others, so they s
     {:else}
       <ChartNoData
         title={omittedAxisCount > 0
-          ? "Not Enough Shared Scores"
+          ? "Not Enough Shared Axes"
           : "No Data Available"}
         message={noDataMessage}
       />

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -223,7 +223,7 @@ Cost, latency and token axes score each run config against the others, so they s
     })
 
     html += `<div style="font-weight: bold; margin-bottom: 4px; padding-top: 8px;">${
-      trimmedCount > 0 ? "Lowest Scores" : "Values"
+      trimmedCount > 0 ? "Lowest Scores" : "Scores"
     }</div>`
     for (const score of scores) {
       const formatted = score.value === null ? "N/A" : score.value.toFixed(3)
@@ -384,8 +384,8 @@ Cost, latency and token axes score each run config against the others, so they s
       <div class="flex-grow">
         <div class="text-xl font-bold">Radar Chart</div>
         <div class="text-sm text-gray-500 {notShownNote ? '' : 'mb-4'}">
-          Compare the evaluation scores of the run configurations selected
-          above.
+          Compare the run configurations selected above across their eval score,
+          cost, speed and token axes.
         </div>
         {#if notShownNote}
           <div class="text-xs text-gray-400 mt-1 mb-4">{notShownNote}</div>

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -12,16 +12,22 @@
     getRunConfigInputTransformSummaryLabel,
   } from "$lib/utils/run_config_formatters"
   import { formatLatency } from "$lib/utils/formatters"
+  import {
+    buildRadarChartData,
+    plottedRunConfigs,
+    rankTooltipScores,
+    runConfigSeriesName,
+    COST_KEY,
+    LATENCY_KEY,
+    TOTAL_TOKENS_KEY,
+    MIN_RADAR_AXES,
+  } from "$lib/utils/radar_chart_data"
+  import type {
+    ComparisonFeature,
+    RadarChartData,
+  } from "$lib/utils/radar_chart_data"
   import ChartNoData from "$lib/components/chart_no_data.svelte"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
-
-  // Type for comparison features (same as parent page)
-  type ComparisonFeature = {
-    category: string
-    items: { label: string; key: string }[]
-    has_default_eval_config: boolean | undefined
-    eval_id: string
-  }
 
   // Props
   export let comparisonFeatures: ComparisonFeature[]
@@ -38,7 +44,7 @@
   // fall back to the data-relative max.
   export let scoreAxisMaxes: Record<string, number> = {}
   // Display names the user has given rows in the table, by key. They win over the
-  // usage axis names below too, so a renamed cost row is renamed on its axis.
+  // usage axis names too, so a renamed cost row is renamed on its axis.
   export let metricLabels: Record<string, string> = {}
 
   // Axis scaling mode. Relative scales each axis to the best value across the selected
@@ -48,25 +54,6 @@
   // picks a mode, after which their choice sticks.
   let absoluteScale = false
   let userChoseScale = false
-  $: if (!userChoseScale) {
-    absoluteScale = plottedConfigCount <= 1
-  }
-
-  function setScale(useAbsolute: boolean) {
-    absoluteScale = useAbsolute
-    userChoseScale = true
-  }
-
-  // Fallback full-scale max when we don't know the score's type. Most eval scores are
-  // normalized to 0-1, and we only use it when the data actually fits under it.
-  const DEFAULT_ABSOLUTE_MAX = 1
-
-  // Above this many scores the tooltip lists only the weakest ones - the full set is
-  // in the comparison table above.
-  const MAX_TOOLTIP_SCORES = 10
-
-  // Below this many axes there's no shape to read, so there's no chart to draw
-  const MIN_RADAR_AXES = 3
 
   const SCALE_TOOLTIP = `**Relative**: each axis is scaled to the highest value across the selected run configs. Best for spotting differences between configs.
 
@@ -77,119 +64,49 @@ Cost, latency and token axes score each run config against the others, so they s
   // Chart instance
   let chartInstance: echarts.ECharts | null = null
 
-  const COST_KEY = "cost::mean_cost"
-  const LATENCY_KEY = "cost::mean_total_llm_latency_ms"
+  // Held apart from chartData rather than read back out of it: the scale default
+  // below depends on how many configs are plotted, and chartData depends on the
+  // scale. One source, two readers, no cycle.
+  $: plottedConfigs = plottedRunConfigs({
+    comparisonFeatures,
+    runConfigs: run_configs,
+    selectedRunConfigIds,
+    getValue: getModelValueRaw,
+  })
 
-  // Cost, latency and token counts are lower-is-better raw quantities with no
-  // absolute range, so they're scored by position within the selected run configs
-  // (metricToScore) on a shared 0-100 axis. That's a comparison, which means these
-  // axes only carry information when there are at least two configs to compare - and
-  // it's why they stay relative even in Full Scale mode.
-  //
-  // On the chart they're named for the direction that's better, since a bigger value
-  // means less cost / less time / fewer tokens.
-  const USAGE_LABELS: Record<string, string> = {
-    [COST_KEY]: "Cost Efficiency",
-    [LATENCY_KEY]: "Speed",
-    "cost::mean_total_tokens": "Token Efficiency",
-    "cost::mean_input_tokens": "Input Token Efficiency",
-    "cost::mean_output_tokens": "Output Token Efficiency",
+  $: if (!userChoseScale) {
+    absoluteScale = plottedConfigs.length <= 1
   }
 
-  function isLowerIsBetterMetric(key: string): boolean {
-    return key.startsWith("cost::")
-  }
+  $: chartData = buildRadarChartData({
+    comparisonFeatures,
+    plottedConfigs,
+    selectedRunConfigIds,
+    getValue: getModelValueRaw,
+    modelInfo: model_info,
+    scoreAxisMaxes,
+    metricLabels,
+    absoluteScale,
+  })
 
-  // Position of a lower-is-better value within the selected configs, as a 0-100
-  // score. Ties (or a single config) land at 50: no better, no worse.
-  export function metricToScore(
-    cost: number,
-    costs: number[],
-    {
-      padding = 10, // keep endpoints away from 0/100
-      relFull = 0.7, // when (hi-lo)/|hi| reaches this, use full spread (k=1)
-    }: {
-      padding?: number
-      relFull?: number
-    } = {},
-  ): number {
-    const lo = Math.min(...costs)
-    const hi = Math.max(...costs)
+  $: omittedAxisCount = chartData.omittedKeyCount
 
-    const range = hi - lo
-    if (range <= 0) return 50
+  $: notShownNote =
+    omittedAxisCount > 0
+      ? `Not shown: ${omittedAxisCount} ${
+          omittedAxisCount === 1 ? "score" : "scores"
+        } without results for every selected run config. See the table above.`
+      : null
 
-    // 1) range-based normalized position
-    const t = (cost - lo) / range
+  // When there's nothing to draw, say which of the two reasons it is
+  $: noDataMessage =
+    omittedAxisCount > 0
+      ? `The selected run configurations share fewer than ${MIN_RADAR_AXES} scores with results. Run the missing evals, or compare fewer run configurations.`
+      : "Create and run evals to see a comparison chart."
 
-    // 2) raw padded linear score (lower cost = higher score)
-    const raw = padding + (1 - t) * (100 - 2 * padding)
-
-    // 3) compress based on range relative to magnitude ("scale from zero")
-    const scale = Math.max(Math.abs(hi), 1e-12)
-    const relRange = range / scale // e.g. 0.02..0.03 => 0.01/0.03 ≈ 0.33
-    const k = Math.max(0, Math.min(1, relRange / relFull)) // small relRange -> k<1 -> compress
-
-    // 4) mix toward midpoint
-    const score = 50 + k * (raw - 50)
-
-    return Math.max(0, Math.min(100, score))
-  }
-
-  // Eval score keys (the cost section is excluded - its metrics come back as usage
-  // axes below, on their own terms)
-  $: dataKeys = comparisonFeatures
-    .filter((f) => f.eval_id !== "kiln_cost_section")
-    .flatMap((f) => f.items.map((item) => item.key))
-
-  // Usage axes come from the cost section of the table, so hiding a row there with
-  // its x removes the axis here too - one control, where the numbers are.
-  $: visibleUsageKeys = comparisonFeatures
-    .filter((f) => f.eval_id === "kiln_cost_section")
-    .flatMap((f) => f.items.map((item) => item.key))
-
-  // Run configs that will actually be drawn: selected, and with at least one eval
-  // result. A config with nothing to show shouldn't make the chart behave as though
-  // there's something to compare against. Computed here rather than read back out of
-  // generateChartData() so that the scale default below doesn't depend on a value
-  // that itself depends on the scale.
-  $: plottedConfigCount = selectedRunConfigIds.filter(
-    (configId) =>
-      run_configs.some((c) => c.id === configId) &&
-      dataKeys.some((key) => getModelValueRaw(configId, key) !== null),
-  ).length
-
-  $: notShownNote = (() => {
-    const parts: string[] = []
-    if (noResultAxisCount > 0) {
-      parts.push(
-        `${noResultAxisCount} ${
-          noResultAxisCount === 1 ? "score" : "scores"
-        } without results for every selected run config`,
-      )
-    }
-    if (parts.length === 0) return null
-    return `Not shown: ${parts.join(", ")}. See the table above.`
-  })()
-
-  // Get labels for radar indicators
-  function getKeyLabel(dataKey: string): string {
-    if (metricLabels[dataKey]) return metricLabels[dataKey]
-    if (USAGE_LABELS[dataKey]) return USAGE_LABELS[dataKey]
-    for (const feature of comparisonFeatures) {
-      const item = feature.items.find((i) => i.key === dataKey)
-      if (item) return item.label
-    }
-    return dataKey
-  }
-
-  // Get simple display name for the series (used as the internal name/key)
-  function getSeriesDisplayName(config: TaskRunConfig): string {
-    if (config.name) return config.name
-    if (isMcpRunConfig(config.run_config_properties)) {
-      return config.run_config_properties.tool_reference.tool_name ?? "MCP Tool"
-    }
-    return getRunConfigModelDisplayName(config, model_info) ?? "Unknown"
+  function setScale(useAbsolute: boolean) {
+    absoluteScale = useAbsolute
+    userChoseScale = true
   }
 
   // The raw quantity behind a usage axis, in its own units
@@ -210,7 +127,7 @@ Cost, latency and token axes score each run config against the others, so they s
       config?.id ? getModelValueRaw(config.id, key) : null
     const meanCost = raw(COST_KEY)
     const meanLatency = raw(LATENCY_KEY)
-    const meanTotalTokens = raw("cost::mean_total_tokens")
+    const meanTotalTokens = raw(TOTAL_TOKENS_KEY)
     return {
       cost: meanCost === null ? null : formatUsageValue(COST_KEY, meanCost),
       latency:
@@ -220,7 +137,7 @@ Cost, latency and token axes score each run config against the others, so they s
       totalTokens:
         meanTotalTokens === null
           ? null
-          : formatUsageValue("cost::mean_total_tokens", meanTotalTokens),
+          : formatUsageValue(TOTAL_TOKENS_KEY, meanTotalTokens),
     }
   }
 
@@ -247,19 +164,17 @@ Cost, latency and token axes score each run config against the others, so they s
     for (const configId of selectedRunConfigIds) {
       const config = run_configs.find((c) => c.id === configId)
       if (!config) continue
-      const displayName = getSeriesDisplayName(config)
+      const displayName = runConfigSeriesName(config, model_info)
       formatter[displayName] = `${displayName}\n${buildLegendSubtext(config)}`
     }
     return formatter
   }
 
   // Build full tooltip HTML for a run config (reused by chart tooltip and legend tooltip)
-  function buildRunConfigTooltip(
-    name: string,
-    axisMaxes: Record<string, number>,
-    keys: string[],
-  ): string {
-    const config = run_configs.find((c) => getSeriesDisplayName(c) === name)
+  function buildRunConfigTooltip(name: string, data: RadarChartData): string {
+    const config = run_configs.find(
+      (c) => runConfigSeriesName(c, model_info) === name,
+    )
 
     let html = `<div style="font-weight: bold; margin-bottom: 4px;">${name}</div>`
     if (config && isMcpRunConfig(config.run_config_properties)) {
@@ -292,213 +207,41 @@ Cost, latency and token axes score each run config against the others, so they s
       html += `<div>Mean Total Tokens: ${usage.totalTokens}</div>`
     }
 
-    // Eval scores only. The usage axes plot a relative score rather than their raw
-    // quantity, so ranking them against pass rates would compare unlike things -
-    // their real values are listed above instead.
-    const scores = keys
-      .filter((key) => !isLowerIsBetterMetric(key))
-      .map((key) => {
-        const value = config?.id ? getModelValueRaw(config.id, key) : null
-        const max = axisMaxes[key] || 1
-        return {
-          label: getKeyLabel(key),
-          value,
-          // Rank by position on the axis, so scores with different ranges (0-1 vs
-          // 1-5) are comparable. Missing values sort first: "didn't run" is worth
-          // surfacing.
-          position: value === null ? -1 : value / max,
-        }
-      })
-
-    const trimmed = scores.length > MAX_TOOLTIP_SCORES
-    const shown = trimmed
-      ? [...scores]
-          .sort((a, b) => a.position - b.position)
-          .slice(0, MAX_TOOLTIP_SCORES)
-      : scores
+    const { scores, trimmedCount } = rankTooltipScores({
+      keys: data.keys,
+      axisMaxes: data.axisMaxes,
+      axisLabels: data.axisLabels,
+      getValue: (key) => (config?.id ? getModelValueRaw(config.id, key) : null),
+    })
 
     html += `<div style="font-weight: bold; margin-bottom: 4px; padding-top: 8px;">${
-      trimmed ? "Lowest Scores" : "Values"
+      trimmedCount > 0 ? "Lowest Scores" : "Values"
     }</div>`
-    for (const score of shown) {
+    for (const score of scores) {
       const formatted = score.value === null ? "N/A" : score.value.toFixed(3)
       html += `<div>${score.label}: ${formatted}</div>`
     }
-    if (trimmed) {
-      html += `<div style="color: #888; padding-top: 4px;">+${
-        scores.length - shown.length
-      } more in the table above</div>`
+    if (trimmedCount > 0) {
+      html += `<div style="color: #888; padding-top: 4px;">+${trimmedCount} more in the table above</div>`
     }
 
     return html
   }
 
-  // Axis max in "Full Scale" mode: the score's own range when we know it, otherwise
-  // the normalized 0-1 default. Never returns a max below the data, so nothing is
-  // clipped for unbounded (custom) scores or unrecognized score types.
-  function absoluteAxisMax(
-    key: string,
-    rawMax: number,
-    paddedMax: number,
-  ): number {
-    const knownMax = scoreAxisMaxes[key]
-    if (knownMax !== undefined && knownMax >= rawMax) {
-      return knownMax
-    }
-    return rawMax <= DEFAULT_ABSOLUTE_MAX ? DEFAULT_ABSOLUTE_MAX : paddedMax
-  }
-
-  function generateChartData(): {
-    indicators: { name: string; max: number }[]
-    series: { value: (number | null)[]; name: string }[]
-    legend: string[]
-    axisMaxes: Record<string, number>
-    keys: string[]
-    noResultKeyCount: number
-  } {
-    const indicators: { name: string; max: number }[] = []
-    const series: { value: (number | null)[]; name: string }[] = []
-    const legend: string[] = []
-    const axisMaxes: Record<string, number> = {}
-    const empty = {
-      indicators,
-      series,
-      legend,
-      axisMaxes,
-      keys: [] as string[],
-    }
-
-    if (dataKeys.length === 0 || selectedRunConfigIds.length === 0) {
-      return { ...empty, noResultKeyCount: 0 }
-    }
-
-    // Run configs with at least one result. One with nothing to plot is left out
-    // entirely rather than emptying every axis. Same rule as the module-level
-    // plottedConfigCount, which the scale default reads.
-    const plottedConfigs = selectedRunConfigIds
-      .map((configId) => run_configs.find((c) => c.id === configId))
-      .filter((config): config is TaskRunConfig => !!config)
-      .filter((config) =>
-        dataKeys.some(
-          (key) => getModelValueRaw(config.id ?? null, key) !== null,
-        ),
-      )
-
-    const candidateKeys = [...dataKeys, ...visibleUsageKeys]
-
-    // Only scores every plotted config has a result for. ECharts draws a missing
-    // radar value at the center of the chart (radarLayout's getValueMissingPoint),
-    // which is indistinguishable from scoring zero - so an axis one config hasn't
-    // been evaluated on can't be drawn honestly at all. It's left out, and counted
-    // under the chart title instead.
-    const keys = candidateKeys.filter((key) =>
-      plottedConfigs.every(
-        (config) => getModelValueRaw(config.id ?? null, key) !== null,
-      ),
-    )
-    const noResultKeyCount = candidateKeys.length - keys.length
-
-    if (keys.length < MIN_RADAR_AXES) {
-      return { ...empty, noResultKeyCount }
-    }
-
-    // Every value on a usage axis, so each can be scored by its position among them
-    const usageValues: Record<string, number[]> = {}
-    for (const key of keys) {
-      if (!isLowerIsBetterMetric(key)) continue
-      usageValues[key] = plottedConfigs
-        .map((config) => getModelValueRaw(config.id ?? null, key))
-        .filter((value): value is number => value !== null)
-    }
-
-    // Calculate max values for each data key across the plotted run configs
-    for (const key of keys) {
-      if (isLowerIsBetterMetric(key)) {
-        // Already a 0-100 score, in both scale modes
-        axisMaxes[key] = 100
-        continue
-      }
-      let max = 0
-      for (const config of plottedConfigs) {
-        const value = getModelValueRaw(config.id ?? null, key)
-        if (value !== null && value > max) {
-          max = value
-        }
-      }
-      // Add 10% padding to max for better visualization
-      const paddedMax = max > 0 ? max * 1.1 : 1
-      axisMaxes[key] = absoluteScale
-        ? absoluteAxisMax(key, max, paddedMax)
-        : paddedMax
-    }
-
-    for (const key of keys) {
-      indicators.push({
-        name: getKeyLabel(key),
-        max: axisMaxes[key],
-      })
-    }
-
-    // Build series data for each plotted run config. Every one of them has a value
-    // for every key by construction above.
-    for (const config of plottedConfigs) {
-      const values = keys.map((key) => {
-        const rawValue = getModelValueRaw(config.id ?? null, key)
-        if (rawValue === null) return null
-        return isLowerIsBetterMetric(key)
-          ? metricToScore(rawValue, usageValues[key] || [])
-          : rawValue
-      })
-      const name = getSeriesDisplayName(config)
-      legend.push(name)
-      series.push({ value: values, name })
-    }
-
-    return { indicators, series, legend, axisMaxes, keys, noResultKeyCount }
-  }
-
-  // Check if there's data to display (reactive - references every input that can
-  // change what generateChartData() returns)
-  $: chartSummary = (() => {
-    // visibleUsageKeys is referenced so this re-runs when a usage row is hidden
-    if (
-      !dataKeys ||
-      dataKeys.length === 0 ||
-      !selectedRunConfigIds ||
-      !visibleUsageKeys
-    ) {
-      return { hasData: false, noResultKeyCount: 0 }
-    }
-    const { indicators, series, noResultKeyCount } = generateChartData()
-    return {
-      hasData: indicators.length > 0 && series.length > 0,
-      noResultKeyCount,
-    }
-  })()
-  $: hasData = chartSummary.hasData
-  $: noResultAxisCount = chartSummary.noResultKeyCount
-
-  // When there's nothing to draw, say which of the two reasons it is
-  $: noDataMessage =
-    noResultAxisCount > 0
-      ? `The selected run configurations share fewer than ${MIN_RADAR_AXES} scores with results. Run the missing evals, or compare fewer run configurations.`
-      : "Create and run evals to see a comparison chart."
-
   function updateChart() {
     if (!chartInstance) return
 
-    if (!hasData) {
+    if (!chartData.hasData) {
       chartInstance.clear()
       return
     }
 
-    const { indicators, series, legend, axisMaxes, keys } = generateChartData()
-
+    const data = chartData
     const legendFormatter = buildLegendFormatter()
 
     // A couple of configs don't need a legend column - centering the radar and
     // dropping the legend underneath buys a much larger plot.
-    const compactLayout = series.length <= 2
+    const compactLayout = data.series.length <= 2
 
     const legendTextStyle = {
       lineHeight: 16,
@@ -517,15 +260,15 @@ Cost, latency and token axes score each run config against the others, so they s
           trigger: "item",
           confine: true,
           formatter: (params: { name: string }) =>
-            buildRunConfigTooltip(params.name, axisMaxes, keys),
+            buildRunConfigTooltip(params.name, data),
         },
         legend: {
-          data: legend,
+          data: data.legend,
           formatter: (name: string) => legendFormatter[name] || name,
           tooltip: {
             show: true,
             formatter: (params: { name: string }) =>
-              buildRunConfigTooltip(params.name, axisMaxes, keys),
+              buildRunConfigTooltip(params.name, data),
           },
           textStyle: legendTextStyle,
           ...(compactLayout
@@ -543,7 +286,7 @@ Cost, latency and token axes score each run config against the others, so they s
               }),
         },
         radar: {
-          indicator: indicators,
+          indicator: data.indicators,
           center: compactLayout ? ["50%", "46%"] : ["32%", "50%"],
           radius: compactLayout ? "62%" : "85%",
           axisName: {
@@ -574,13 +317,15 @@ Cost, latency and token axes score each run config against the others, so they s
           {
             name: "Eval Scores",
             type: "radar",
-            data: series,
+            data: data.series,
             lineStyle: {
               width: 2,
             },
             symbolSize: 6,
             // Filling one shape makes it readable. Filling several makes mud.
-            ...(series.length === 1 ? { areaStyle: { opacity: 0.2 } } : {}),
+            ...(data.series.length === 1
+              ? { areaStyle: { opacity: 0.2 } }
+              : {}),
           },
         ],
       },
@@ -588,22 +333,9 @@ Cost, latency and token axes score each run config against the others, so they s
     )
   }
 
-  // Named so the reactive block below re-runs when the scaling mode is toggled
-  $: axisScaleMode = absoluteScale ? "absolute" : "relative"
-
-  // Update chart when data changes (model_info and prompts may load async). Every
-  // input that changes what's drawn has to be referenced here, or the chart keeps
-  // showing the previous render.
-  $: if (
-    chartInstance &&
-    comparisonFeatures &&
-    selectedRunConfigIds &&
-    axisScaleMode &&
-    scoreAxisMaxes &&
-    visibleUsageKeys &&
-    (model_info || model_info === null) &&
-    (prompts || prompts === null)
-  ) {
+  // Redraw whenever the data changes. prompts reaches the chart only through the
+  // legend and tooltip text, so it is named here to make it a dependency too.
+  $: if (chartInstance && chartData && (prompts || prompts === null)) {
     updateChart()
   }
 
@@ -631,7 +363,7 @@ Cost, latency and token axes score each run config against the others, so they s
 <!-- Radar charts don't really work with <3 items. Counts the usage axes too: they
      are axes like any other, and a task with one or two eval scores still has a
      chart worth drawing once cost, latency and tokens are on it. -->
-{#if dataKeys.length + visibleUsageKeys.length >= MIN_RADAR_AXES}
+{#if chartData.candidateAxisCount >= MIN_RADAR_AXES}
   <div
     class="bg-white border border-gray-200 rounded-lg p-6 mb-6 h-full flex flex-col"
   >
@@ -668,14 +400,14 @@ Cost, latency and token axes score each run config against the others, so they s
         <InfoTooltip tooltip_text={SCALE_TOOLTIP} position="bottom" />
       </div>
     </div>
-    {#if hasData}
+    {#if chartData.hasData}
       <div
         use:initChart
         class="w-full flex-1 min-h-[500px] xl:min-h-[620px]"
       ></div>
     {:else}
       <ChartNoData
-        title={noResultAxisCount > 0
+        title={omittedAxisCount > 0
           ? "Not Enough Shared Scores"
           : "No Data Available"}
         message={noDataMessage}

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -24,15 +24,13 @@
     rankTooltipScores,
     MIN_RADAR_AXES,
   } from "$lib/utils/radar_chart_data"
-  import type {
-    ComparisonFeature,
-    RadarChartData,
-  } from "$lib/utils/radar_chart_data"
+  import type { RadarChartData } from "$lib/utils/radar_chart_data"
+  import type { ComparisonSection } from "$lib/utils/compare_metric_keys"
   import ChartNoData from "$lib/components/chart_no_data.svelte"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
 
   // Props
-  export let comparisonFeatures: ComparisonFeature[]
+  export let comparisonFeatures: ComparisonSection[]
   export let getModelValueRaw: (
     modelKey: string | null,
     dataKey: string,

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -13,13 +13,15 @@
   } from "$lib/utils/run_config_formatters"
   import { formatLatency } from "$lib/utils/formatters"
   import {
+    COST_KEY,
+    LATENCY_KEY,
+    TOTAL_TOKENS_KEY,
+  } from "$lib/utils/compare_metric_keys"
+  import {
     buildRadarChartData,
     plottedRunConfigs,
     rankTooltipScores,
     runConfigSeriesName,
-    COST_KEY,
-    LATENCY_KEY,
-    TOTAL_TOKENS_KEY,
     MIN_RADAR_AXES,
   } from "$lib/utils/radar_chart_data"
   import type {

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -11,6 +11,7 @@
     getRunConfigPromptDisplayName,
     getRunConfigInputTransformSummaryLabel,
   } from "$lib/utils/run_config_formatters"
+  import { escapeHtml } from "$lib/utils/escape_html"
   import { formatLatency } from "$lib/utils/formatters"
   import {
     COST_KEY,
@@ -178,11 +179,13 @@ Cost, latency and token axes score each run config against the others, so they s
       (c) => runConfigSeriesName(c, model_info) === name,
     )
 
-    let html = `<div style="font-weight: bold; margin-bottom: 4px;">${name}</div>`
+    let html = `<div style="font-weight: bold; margin-bottom: 4px;">${escapeHtml(
+      name,
+    )}</div>`
     if (config && isMcpRunConfig(config.run_config_properties)) {
       const toolName =
         config.run_config_properties.tool_reference.tool_name ?? "MCP Tool"
-      html += `<div>MCP Tool: ${toolName}</div>`
+      html += `<div>MCP Tool: ${escapeHtml(toolName)}</div>`
     } else {
       const modelName = config
         ? getRunConfigModelDisplayName(config, model_info) || "Unknown"
@@ -190,14 +193,14 @@ Cost, latency and token axes score each run config against the others, so they s
       const promptName = config
         ? getRunConfigPromptDisplayName(config, prompts)
         : null
-      html += `<div>Model: ${modelName}</div>`
+      html += `<div>Model: ${escapeHtml(modelName)}</div>`
       if (promptName) {
-        html += `<div>Prompt: ${promptName}</div>`
+        html += `<div>Prompt: ${escapeHtml(promptName)}</div>`
       }
       if (config) {
         const transformLabel = getRunConfigInputTransformSummaryLabel(config)
         if (transformLabel) {
-          html += `<div>Input Transform: ${transformLabel}</div>`
+          html += `<div>Input Transform: ${escapeHtml(transformLabel)}</div>`
         }
       }
     }
@@ -221,7 +224,7 @@ Cost, latency and token axes score each run config against the others, so they s
     }</div>`
     for (const score of scores) {
       const formatted = score.value === null ? "N/A" : score.value.toFixed(3)
-      html += `<div>${score.label}: ${formatted}</div>`
+      html += `<div>${escapeHtml(score.label)}: ${formatted}</div>`
     }
     if (trimmedCount > 0) {
       html += `<div style="color: #888; padding-top: 4px;">+${trimmedCount} more in the table above</div>`

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -22,7 +22,6 @@
     buildRadarChartData,
     plottedRunConfigs,
     rankTooltipScores,
-    runConfigSeriesName,
     MIN_RADAR_AXES,
   } from "$lib/utils/radar_chart_data"
   import type {
@@ -162,22 +161,17 @@ Cost, latency and token axes score each run config against the others, so they s
     return parts.join("\n")
   }
 
-  function buildLegendFormatter(): Record<string, string> {
+  function buildLegendFormatter(data: RadarChartData): Record<string, string> {
     const formatter: Record<string, string> = {}
-    for (const configId of selectedRunConfigIds) {
-      const config = run_configs.find((c) => c.id === configId)
-      if (!config) continue
-      const displayName = runConfigSeriesName(config, model_info)
-      formatter[displayName] = `${displayName}\n${buildLegendSubtext(config)}`
+    for (const [name, config] of Object.entries(data.configsBySeriesName)) {
+      formatter[name] = `${name}\n${buildLegendSubtext(config)}`
     }
     return formatter
   }
 
   // Build full tooltip HTML for a run config (reused by chart tooltip and legend tooltip)
   function buildRunConfigTooltip(name: string, data: RadarChartData): string {
-    const config = run_configs.find(
-      (c) => runConfigSeriesName(c, model_info) === name,
-    )
+    const config = data.configsBySeriesName[name]
 
     let html = `<div style="font-weight: bold; margin-bottom: 4px;">${escapeHtml(
       name,
@@ -242,7 +236,7 @@ Cost, latency and token axes score each run config against the others, so they s
     }
 
     const data = chartData
-    const legendFormatter = buildLegendFormatter()
+    const legendFormatter = buildLegendFormatter(data)
 
     // A couple of configs don't need a legend column - centering the radar and
     // dropping the legend underneath buys a much larger plot.

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -11,7 +11,9 @@
     getRunConfigPromptDisplayName,
     getRunConfigInputTransformSummaryLabel,
   } from "$lib/utils/run_config_formatters"
+  import { formatLatency } from "$lib/utils/formatters"
   import ChartNoData from "$lib/components/chart_no_data.svelte"
+  import InfoTooltip from "$lib/ui/info_tooltip.svelte"
 
   // Type for comparison features (same as parent page)
   type ComparisonFeature = {
@@ -31,19 +33,75 @@
   export let model_info: ProviderModels | null
   export let prompts: PromptResponse | null = null
   export let selectedRunConfigIds: string[]
+  // Full-range maximum for a data key (eg 1 for pass/fail, 5 for 5-star), used by
+  // the "Full Scale" axis mode. Keys without an entry (unbounded custom scores)
+  // fall back to the data-relative max.
+  export let scoreAxisMaxes: Record<string, number> = {}
+  // Display names the user has given rows in the table, by key. They win over the
+  // usage axis names below too, so a renamed cost row is renamed on its axis.
+  export let metricLabels: Record<string, string> = {}
+
+  // Axis scaling mode. Relative scales each axis to the best value across the selected
+  // run configs, which is the better lens for spotting differences between configs.
+  // Full scale uses the score's own range, which is the only readable option when
+  // there's nothing to compare against. Default follows the selection until the user
+  // picks a mode, after which their choice sticks.
+  let absoluteScale = false
+  let userChoseScale = false
+  $: if (!userChoseScale) {
+    absoluteScale = plottedConfigCount <= 1
+  }
+
+  function setScale(useAbsolute: boolean) {
+    absoluteScale = useAbsolute
+    userChoseScale = true
+  }
+
+  // Fallback full-scale max when we don't know the score's type. Most eval scores are
+  // normalized to 0-1, and we only use it when the data actually fits under it.
+  const DEFAULT_ABSOLUTE_MAX = 1
+
+  // Above this many scores the tooltip lists only the weakest ones - the full set is
+  // in the comparison table above.
+  const MAX_TOOLTIP_SCORES = 10
+
+  // Below this many axes there's no shape to read, so there's no chart to draw
+  const MIN_RADAR_AXES = 3
+
+  const SCALE_TOOLTIP = `**Relative**: each axis is scaled to the highest value across the selected run configs. Best for spotting differences between configs.
+
+**Full Scale**: each axis uses the score's own range (0-1 for pass/fail, 1-5 for 5-star). Best when looking at one run config on its own, where there is nothing to compare against.
+
+Cost, latency and token axes score each run config against the others, so they stay relative in both modes. With a single run config there's nothing to compare against and they all sit at the midpoint. Hide one with the x on its row in the table above.`
 
   // Chart instance
   let chartInstance: echarts.ECharts | null = null
 
-  // Keys that should be included in radar chart where lower is better
   const COST_KEY = "cost::mean_cost"
   const LATENCY_KEY = "cost::mean_total_llm_latency_ms"
 
-  // Check if a key is a lower-is-better metric
-  function isLowerIsBetterMetric(key: string): boolean {
-    return key === COST_KEY || key === LATENCY_KEY
+  // Cost, latency and token counts are lower-is-better raw quantities with no
+  // absolute range, so they're scored by position within the selected run configs
+  // (metricToScore) on a shared 0-100 axis. That's a comparison, which means these
+  // axes only carry information when there are at least two configs to compare - and
+  // it's why they stay relative even in Full Scale mode.
+  //
+  // On the chart they're named for the direction that's better, since a bigger value
+  // means less cost / less time / fewer tokens.
+  const USAGE_LABELS: Record<string, string> = {
+    [COST_KEY]: "Cost Efficiency",
+    [LATENCY_KEY]: "Speed",
+    "cost::mean_total_tokens": "Token Efficiency",
+    "cost::mean_input_tokens": "Input Token Efficiency",
+    "cost::mean_output_tokens": "Output Token Efficiency",
   }
 
+  function isLowerIsBetterMetric(key: string): boolean {
+    return key.startsWith("cost::")
+  }
+
+  // Position of a lower-is-better value within the selected configs, as a 0-100
+  // score. Ties (or a single config) land at 50: no better, no worse.
   export function metricToScore(
     cost: number,
     costs: number[],
@@ -78,24 +136,46 @@
     return Math.max(0, Math.min(100, score))
   }
 
-  // Get all data keys: include eval metrics + cost (but exclude token counts)
-  $: dataKeys = [
-    ...comparisonFeatures
-      .filter((f) => f.eval_id !== "kiln_cost_section")
-      .flatMap((f) => f.items.map((item) => item.key)),
-    COST_KEY,
-    LATENCY_KEY,
-  ]
+  // Eval score keys (the cost section is excluded - its metrics come back as usage
+  // axes below, on their own terms)
+  $: dataKeys = comparisonFeatures
+    .filter((f) => f.eval_id !== "kiln_cost_section")
+    .flatMap((f) => f.items.map((item) => item.key))
+
+  // Usage axes come from the cost section of the table, so hiding a row there with
+  // its x removes the axis here too - one control, where the numbers are.
+  $: visibleUsageKeys = comparisonFeatures
+    .filter((f) => f.eval_id === "kiln_cost_section")
+    .flatMap((f) => f.items.map((item) => item.key))
+
+  // Run configs that will actually be drawn: selected, and with at least one eval
+  // result. A config with nothing to show shouldn't make the chart behave as though
+  // there's something to compare against. Computed here rather than read back out of
+  // generateChartData() so that the scale default below doesn't depend on a value
+  // that itself depends on the scale.
+  $: plottedConfigCount = selectedRunConfigIds.filter(
+    (configId) =>
+      run_configs.some((c) => c.id === configId) &&
+      dataKeys.some((key) => getModelValueRaw(configId, key) !== null),
+  ).length
+
+  $: notShownNote = (() => {
+    const parts: string[] = []
+    if (noResultAxisCount > 0) {
+      parts.push(
+        `${noResultAxisCount} ${
+          noResultAxisCount === 1 ? "score" : "scores"
+        } without results for every selected run config`,
+      )
+    }
+    if (parts.length === 0) return null
+    return `Not shown: ${parts.join(", ")}. See the table above.`
+  })()
 
   // Get labels for radar indicators
   function getKeyLabel(dataKey: string): string {
-    // Special handling for lower-is-better metrics
-    if (dataKey === COST_KEY) {
-      return "Cost Efficiency"
-    }
-    if (dataKey === LATENCY_KEY) {
-      return "Speed"
-    }
+    if (metricLabels[dataKey]) return metricLabels[dataKey]
+    if (USAGE_LABELS[dataKey]) return USAGE_LABELS[dataKey]
     for (const feature of comparisonFeatures) {
       const item = feature.items.find((i) => i.key === dataKey)
       if (item) return item.label
@@ -112,19 +192,53 @@
     return getRunConfigModelDisplayName(config, model_info) ?? "Unknown"
   }
 
+  // The raw quantity behind a usage axis, in its own units
+  function formatUsageValue(key: string, value: number | null): string {
+    if (value === null) return "N/A"
+    if (key === COST_KEY) return `$${value.toFixed(6)}`
+    if (key === LATENCY_KEY) return formatLatency(value)
+    return `${Math.round(value).toLocaleString()} tokens`
+  }
+
+  // Mean usage for a config, formatted for display. Null when unavailable.
+  function getUsageSummary(config: TaskRunConfig | undefined): {
+    cost: string | null
+    latency: string | null
+    totalTokens: string | null
+  } {
+    const raw = (key: string) =>
+      config?.id ? getModelValueRaw(config.id, key) : null
+    const meanCost = raw(COST_KEY)
+    const meanLatency = raw(LATENCY_KEY)
+    const meanTotalTokens = raw("cost::mean_total_tokens")
+    return {
+      cost: meanCost === null ? null : formatUsageValue(COST_KEY, meanCost),
+      latency:
+        meanLatency === null
+          ? null
+          : formatUsageValue(LATENCY_KEY, meanLatency),
+      totalTokens:
+        meanTotalTokens === null
+          ? null
+          : formatUsageValue("cost::mean_total_tokens", meanTotalTokens),
+    }
+  }
+
   function buildLegendSubtext(config: TaskRunConfig): string {
+    const parts: string[] = []
     if (isMcpRunConfig(config.run_config_properties)) {
       const toolName =
         config.run_config_properties.tool_reference.tool_name ?? "MCP Tool"
-      return `{sub|Tool: ${toolName}}`
+      parts.push(`{sub|Tool: ${toolName}}`)
+    } else {
+      const modelName =
+        getRunConfigModelDisplayName(config, model_info) || "Unknown"
+      const promptName = getRunConfigPromptDisplayName(config, prompts)
+      parts.push(`{sub|Model: ${modelName}}`)
+      if (promptName) parts.push(`{sub|Prompt: ${promptName}}`)
+      const transformLabel = getRunConfigInputTransformSummaryLabel(config)
+      if (transformLabel) parts.push(`{sub|Input Transform: ${transformLabel}}`)
     }
-    const modelName =
-      getRunConfigModelDisplayName(config, model_info) || "Unknown"
-    const promptName = getRunConfigPromptDisplayName(config, prompts)
-    const parts = [`{sub|Model: ${modelName}}`]
-    if (promptName) parts.push(`{sub|Prompt: ${promptName}}`)
-    const transformLabel = getRunConfigInputTransformSummaryLabel(config)
-    if (transformLabel) parts.push(`{sub|Input Transform: ${transformLabel}}`)
     return parts.join("\n")
   }
 
@@ -142,7 +256,8 @@
   // Build full tooltip HTML for a run config (reused by chart tooltip and legend tooltip)
   function buildRunConfigTooltip(
     name: string,
-    lowerIsBetterValues: Record<string, number[]>,
+    axisMaxes: Record<string, number>,
+    keys: string[],
   ): string {
     const config = run_configs.find((c) => getSeriesDisplayName(c) === name)
 
@@ -169,120 +284,205 @@
         }
       }
     }
-    html += `<div style="font-weight: bold; margin-bottom: 4px; padding-top: 8px;">Values</div>`
 
-    dataKeys.forEach((key) => {
-      const label = getKeyLabel(key)
-      const rawValue = config?.id ? getModelValueRaw(config.id, key) : null
-      if (rawValue === null) {
-        html += `<div>${label}: N/A</div>`
-      } else if (key === COST_KEY) {
-        const displayValue = metricToScore(
-          rawValue,
-          lowerIsBetterValues[key] || [],
-        )
-        html += `<div>${label}: ${displayValue.toFixed(1)} <span style="color: #888;">(Mean Cost: $${rawValue.toFixed(6)})</span></div>`
-      } else if (key === LATENCY_KEY) {
-        const displayValue = metricToScore(
-          rawValue,
-          lowerIsBetterValues[key] || [],
-        )
-        const formatted =
-          rawValue < 1000
-            ? `${Math.round(rawValue)}ms`
-            : `${(rawValue / 1000).toFixed(1)}s`
-        html += `<div>${label}: ${displayValue.toFixed(1)} <span style="color: #888;">(Mean Latency: ${formatted})</span></div>`
-      } else {
-        html += `<div>${label}: ${rawValue.toFixed(3)}</div>`
-      }
-    })
+    const usage = getUsageSummary(config)
+    if (usage.cost) html += `<div>Mean Cost: ${usage.cost}</div>`
+    if (usage.latency) html += `<div>Mean Latency: ${usage.latency}</div>`
+    if (usage.totalTokens) {
+      html += `<div>Mean Total Tokens: ${usage.totalTokens}</div>`
+    }
+
+    // Eval scores only. The usage axes plot a relative score rather than their raw
+    // quantity, so ranking them against pass rates would compare unlike things -
+    // their real values are listed above instead.
+    const scores = keys
+      .filter((key) => !isLowerIsBetterMetric(key))
+      .map((key) => {
+        const value = config?.id ? getModelValueRaw(config.id, key) : null
+        const max = axisMaxes[key] || 1
+        return {
+          label: getKeyLabel(key),
+          value,
+          // Rank by position on the axis, so scores with different ranges (0-1 vs
+          // 1-5) are comparable. Missing values sort first: "didn't run" is worth
+          // surfacing.
+          position: value === null ? -1 : value / max,
+        }
+      })
+
+    const trimmed = scores.length > MAX_TOOLTIP_SCORES
+    const shown = trimmed
+      ? [...scores]
+          .sort((a, b) => a.position - b.position)
+          .slice(0, MAX_TOOLTIP_SCORES)
+      : scores
+
+    html += `<div style="font-weight: bold; margin-bottom: 4px; padding-top: 8px;">${
+      trimmed ? "Lowest Scores" : "Values"
+    }</div>`
+    for (const score of shown) {
+      const formatted = score.value === null ? "N/A" : score.value.toFixed(3)
+      html += `<div>${score.label}: ${formatted}</div>`
+    }
+    if (trimmed) {
+      html += `<div style="color: #888; padding-top: 4px;">+${
+        scores.length - shown.length
+      } more in the table above</div>`
+    }
 
     return html
   }
 
+  // Axis max in "Full Scale" mode: the score's own range when we know it, otherwise
+  // the normalized 0-1 default. Never returns a max below the data, so nothing is
+  // clipped for unbounded (custom) scores or unrecognized score types.
+  function absoluteAxisMax(
+    key: string,
+    rawMax: number,
+    paddedMax: number,
+  ): number {
+    const knownMax = scoreAxisMaxes[key]
+    if (knownMax !== undefined && knownMax >= rawMax) {
+      return knownMax
+    }
+    return rawMax <= DEFAULT_ABSOLUTE_MAX ? DEFAULT_ABSOLUTE_MAX : paddedMax
+  }
+
   function generateChartData(): {
     indicators: { name: string; max: number }[]
-    series: { value: number[]; name: string }[]
+    series: { value: (number | null)[]; name: string }[]
     legend: string[]
-    lowerIsBetterValues: Record<string, number[]>
+    axisMaxes: Record<string, number>
+    keys: string[]
+    noResultKeyCount: number
   } {
     const indicators: { name: string; max: number }[] = []
-    const series: { value: number[]; name: string }[] = []
+    const series: { value: (number | null)[]; name: string }[] = []
     const legend: string[] = []
-    const lowerIsBetterValues: Record<string, number[]> = {}
-
-    if (dataKeys.length === 0 || selectedRunConfigIds.length === 0) {
-      return { indicators, series, legend, lowerIsBetterValues }
+    const axisMaxes: Record<string, number> = {}
+    const empty = {
+      indicators,
+      series,
+      legend,
+      axisMaxes,
+      keys: [] as string[],
     }
 
-    // Calculate max values for each data key across all selected run configs
-    const maxValues: Record<string, number> = {}
+    if (dataKeys.length === 0 || selectedRunConfigIds.length === 0) {
+      return { ...empty, noResultKeyCount: 0 }
+    }
 
-    for (const key of dataKeys) {
+    // Run configs with at least one result. One with nothing to plot is left out
+    // entirely rather than emptying every axis. Same rule as the module-level
+    // plottedConfigCount, which the scale default reads.
+    const plottedConfigs = selectedRunConfigIds
+      .map((configId) => run_configs.find((c) => c.id === configId))
+      .filter((config): config is TaskRunConfig => !!config)
+      .filter((config) =>
+        dataKeys.some(
+          (key) => getModelValueRaw(config.id ?? null, key) !== null,
+        ),
+      )
+
+    const candidateKeys = [...dataKeys, ...visibleUsageKeys]
+
+    // Only scores every plotted config has a result for. ECharts draws a missing
+    // radar value at the center of the chart (radarLayout's getValueMissingPoint),
+    // which is indistinguishable from scoring zero - so an axis one config hasn't
+    // been evaluated on can't be drawn honestly at all. It's left out, and counted
+    // under the chart title instead.
+    const keys = candidateKeys.filter((key) =>
+      plottedConfigs.every(
+        (config) => getModelValueRaw(config.id ?? null, key) !== null,
+      ),
+    )
+    const noResultKeyCount = candidateKeys.length - keys.length
+
+    if (keys.length < MIN_RADAR_AXES) {
+      return { ...empty, noResultKeyCount }
+    }
+
+    // Every value on a usage axis, so each can be scored by its position among them
+    const usageValues: Record<string, number[]> = {}
+    for (const key of keys) {
+      if (!isLowerIsBetterMetric(key)) continue
+      usageValues[key] = plottedConfigs
+        .map((config) => getModelValueRaw(config.id ?? null, key))
+        .filter((value): value is number => value !== null)
+    }
+
+    // Calculate max values for each data key across the plotted run configs
+    for (const key of keys) {
+      if (isLowerIsBetterMetric(key)) {
+        // Already a 0-100 score, in both scale modes
+        axisMaxes[key] = 100
+        continue
+      }
       let max = 0
-      for (const configId of selectedRunConfigIds) {
-        const value = getModelValueRaw(configId, key)
+      for (const config of plottedConfigs) {
+        const value = getModelValueRaw(config.id ?? null, key)
         if (value !== null && value > max) {
           max = value
         }
-        if (value !== null && isLowerIsBetterMetric(key)) {
-          if (!lowerIsBetterValues[key]) lowerIsBetterValues[key] = []
-          lowerIsBetterValues[key].push(value)
-        }
       }
       // Add 10% padding to max for better visualization
-      maxValues[key] = max > 0 ? max * 1.1 : 1
+      const paddedMax = max > 0 ? max * 1.1 : 1
+      axisMaxes[key] = absoluteScale
+        ? absoluteAxisMax(key, max, paddedMax)
+        : paddedMax
     }
 
-    // Build indicators with actual max values (lower-is-better metrics use 0-100 scale)
-    for (const key of dataKeys) {
+    for (const key of keys) {
       indicators.push({
         name: getKeyLabel(key),
-        max: isLowerIsBetterMetric(key) ? 100 : maxValues[key],
+        max: axisMaxes[key],
       })
     }
 
-    // Build series data for each selected run config
-    for (const configId of selectedRunConfigIds) {
-      const config = run_configs.find((c) => c.id === configId)
-      if (!config) continue
-
-      const values: number[] = []
-      let hasAnyValue = false
-
-      for (const key of dataKeys) {
-        const rawValue = getModelValueRaw(configId, key)
-        let displayValue: number
-        if (rawValue === null) {
-          displayValue = 0
-        } else if (isLowerIsBetterMetric(key)) {
-          displayValue = metricToScore(rawValue, lowerIsBetterValues[key] || [])
-        } else {
-          displayValue = rawValue
-        }
-        values.push(displayValue)
-        if (rawValue !== null) hasAnyValue = true
-      }
-
-      // Only include if at least one value is available
-      if (hasAnyValue) {
-        const name = getSeriesDisplayName(config)
-        legend.push(name)
-        series.push({ value: values, name })
-      }
+    // Build series data for each plotted run config. Every one of them has a value
+    // for every key by construction above.
+    for (const config of plottedConfigs) {
+      const values = keys.map((key) => {
+        const rawValue = getModelValueRaw(config.id ?? null, key)
+        if (rawValue === null) return null
+        return isLowerIsBetterMetric(key)
+          ? metricToScore(rawValue, usageValues[key] || [])
+          : rawValue
+      })
+      const name = getSeriesDisplayName(config)
+      legend.push(name)
+      series.push({ value: values, name })
     }
 
-    return { indicators, series, legend, lowerIsBetterValues }
+    return { indicators, series, legend, axisMaxes, keys, noResultKeyCount }
   }
 
-  // Check if there's data to display (reactive, depends on dataKeys and selectedRunConfigIds)
-  $: hasData = (() => {
-    if (!dataKeys || dataKeys.length === 0 || !selectedRunConfigIds) {
-      return false
+  // Check if there's data to display (reactive - references every input that can
+  // change what generateChartData() returns)
+  $: chartSummary = (() => {
+    // visibleUsageKeys is referenced so this re-runs when a usage row is hidden
+    if (
+      !dataKeys ||
+      dataKeys.length === 0 ||
+      !selectedRunConfigIds ||
+      !visibleUsageKeys
+    ) {
+      return { hasData: false, noResultKeyCount: 0 }
     }
-    const { indicators, series } = generateChartData()
-    return indicators.length > 0 && series.length > 0
+    const { indicators, series, noResultKeyCount } = generateChartData()
+    return {
+      hasData: indicators.length > 0 && series.length > 0,
+      noResultKeyCount,
+    }
   })()
+  $: hasData = chartSummary.hasData
+  $: noResultAxisCount = chartSummary.noResultKeyCount
+
+  // When there's nothing to draw, say which of the two reasons it is
+  $: noDataMessage =
+    noResultAxisCount > 0
+      ? `The selected run configurations share fewer than ${MIN_RADAR_AXES} scores with results. Run the missing evals, or compare fewer run configurations.`
+      : "Create and run evals to see a comparison chart."
 
   function updateChart() {
     if (!chartInstance) return
@@ -292,48 +492,67 @@
       return
     }
 
-    const { indicators, series, legend, lowerIsBetterValues } =
-      generateChartData()
+    const { indicators, series, legend, axisMaxes, keys } = generateChartData()
 
     const legendFormatter = buildLegendFormatter()
+
+    // A couple of configs don't need a legend column - centering the radar and
+    // dropping the legend underneath buys a much larger plot.
+    const compactLayout = series.length <= 2
+
+    const legendTextStyle = {
+      lineHeight: 16,
+      rich: {
+        sub: {
+          fontSize: 11,
+          color: "#666",
+          lineHeight: 14,
+        },
+      },
+    }
 
     chartInstance.setOption(
       {
         tooltip: {
           trigger: "item",
+          confine: true,
           formatter: (params: { name: string }) =>
-            buildRunConfigTooltip(params.name, lowerIsBetterValues),
+            buildRunConfigTooltip(params.name, axisMaxes, keys),
         },
         legend: {
           data: legend,
-          orient: "vertical",
-          left: "60%",
-          top: "middle",
-          itemGap: 16,
           formatter: (name: string) => legendFormatter[name] || name,
           tooltip: {
             show: true,
             formatter: (params: { name: string }) =>
-              buildRunConfigTooltip(params.name, lowerIsBetterValues),
+              buildRunConfigTooltip(params.name, axisMaxes, keys),
           },
-          textStyle: {
-            lineHeight: 16,
-            rich: {
-              sub: {
-                fontSize: 11,
-                color: "#666",
-                lineHeight: 14,
-              },
-            },
-          },
+          textStyle: legendTextStyle,
+          ...(compactLayout
+            ? {
+                orient: "horizontal" as const,
+                bottom: 0,
+                left: "center" as const,
+                itemGap: 40,
+              }
+            : {
+                orient: "vertical" as const,
+                left: "60%",
+                top: "middle" as const,
+                itemGap: 16,
+              }),
         },
         radar: {
           indicator: indicators,
-          center: ["32%", "50%"],
-          radius: "85%",
+          center: compactLayout ? ["50%", "46%"] : ["32%", "50%"],
+          radius: compactLayout ? "62%" : "85%",
           axisName: {
             color: "#666",
             fontSize: 12,
+            // Wrap long score names instead of letting neighbours collide
+            width: 110,
+            overflow: "break",
+            lineHeight: 14,
           },
           splitArea: {
             areaStyle: {
@@ -360,6 +579,8 @@
               width: 2,
             },
             symbolSize: 6,
+            // Filling one shape makes it readable. Filling several makes mud.
+            ...(series.length === 1 ? { areaStyle: { opacity: 0.2 } } : {}),
           },
         ],
       },
@@ -367,11 +588,19 @@
     )
   }
 
-  // Update chart when data changes (model_info and prompts may load async)
+  // Named so the reactive block below re-runs when the scaling mode is toggled
+  $: axisScaleMode = absoluteScale ? "absolute" : "relative"
+
+  // Update chart when data changes (model_info and prompts may load async). Every
+  // input that changes what's drawn has to be referenced here, or the chart keeps
+  // showing the previous render.
   $: if (
     chartInstance &&
     comparisonFeatures &&
     selectedRunConfigIds &&
+    axisScaleMode &&
+    scoreAxisMaxes &&
+    visibleUsageKeys &&
     (model_info || model_info === null) &&
     (prompts || prompts === null)
   ) {
@@ -399,19 +628,58 @@
   }
 </script>
 
-<!-- Radar charts don't really work with <3 items -->
-{#if dataKeys.length >= 3}
+<!-- Radar charts don't really work with <3 items. Counts the usage axes too: they
+     are axes like any other, and a task with one or two eval scores still has a
+     chart worth drawing once cost, latency and tokens are on it. -->
+{#if dataKeys.length + visibleUsageKeys.length >= MIN_RADAR_AXES}
   <div
     class="bg-white border border-gray-200 rounded-lg p-6 mb-6 h-full flex flex-col"
   >
-    <div class="text-xl font-bold">Radar Chart</div>
-    <div class="text-sm text-gray-500 mb-4">
-      Compare the evaluation scores of the run configurations selected above.
+    <div class="flex flex-row gap-4 items-start">
+      <div class="flex-grow">
+        <div class="text-xl font-bold">Radar Chart</div>
+        <div class="text-sm text-gray-500 {notShownNote ? '' : 'mb-4'}">
+          Compare the evaluation scores of the run configurations selected
+          above.
+        </div>
+        {#if notShownNote}
+          <div class="text-xs text-gray-400 mt-1 mb-4">{notShownNote}</div>
+        {/if}
+      </div>
+      <div class="flex flex-row gap-1 items-center flex-shrink-0">
+        <div class="join">
+          <button
+            type="button"
+            class="join-item btn btn-sm {absoluteScale ? '' : 'btn-active'}"
+            aria-pressed={!absoluteScale}
+            on:click={() => setScale(false)}
+          >
+            Relative
+          </button>
+          <button
+            type="button"
+            class="join-item btn btn-sm {absoluteScale ? 'btn-active' : ''}"
+            aria-pressed={absoluteScale}
+            on:click={() => setScale(true)}
+          >
+            Full Scale
+          </button>
+        </div>
+        <InfoTooltip tooltip_text={SCALE_TOOLTIP} position="bottom" />
+      </div>
     </div>
     {#if hasData}
-      <div use:initChart class="w-full flex-1 min-h-[400px]"></div>
+      <div
+        use:initChart
+        class="w-full flex-1 min-h-[500px] xl:min-h-[620px]"
+      ></div>
     {:else}
-      <ChartNoData />
+      <ChartNoData
+        title={noResultAxisCount > 0
+          ? "Not Enough Shared Scores"
+          : "No Data Available"}
+        message={noDataMessage}
+      />
     {/if}
   </div>
 {/if}

--- a/app/web_ui/src/lib/components/compare_radar_chart.svelte
+++ b/app/web_ui/src/lib/components/compare_radar_chart.svelte
@@ -287,13 +287,15 @@ Cost, latency and token axes score each run config against the others, so they s
         },
         radar: {
           indicator: data.indicators,
-          center: compactLayout ? ["50%", "46%"] : ["32%", "50%"],
-          radius: compactLayout ? "62%" : "85%",
+          center: compactLayout ? ["50%", "46%"] : ["36%", "50%"],
+          radius: compactLayout ? "62%" : "70%",
           axisName: {
             color: "#666",
             fontSize: 12,
-            // Wrap long score names instead of letting neighbours collide
-            width: 110,
+            // Axis names are drawn outside the plot and wrap rather than collide
+            // with their neighbours, so the centre and radius above have to leave
+            // this much room, plus the name gap, at either edge of the card.
+            width: 90,
             overflow: "break",
             lineHeight: 14,
           },

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -437,7 +437,7 @@ describe("compare radar chart axes", () => {
     expect(axisNames(option)).not.toContain("Speed")
   })
 
-  it("leaves out a usage axis whose row is hidden in the comparison table", async () => {
+  it("only draws the usage rows it is given", async () => {
     const option = await captureOption(fixtures.three_configs)
     expect(axisNames(option)).not.toContain("Input Token Efficiency")
     expect(axisNames(option)).not.toContain("Output Token Efficiency")

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -726,17 +726,62 @@ describe("compare radar chart empty states", () => {
   })
 })
 
-describe("compare radar chart option shape", () => {
-  it("serialises every fixture with its three formatters invoked", async () => {
-    for (const props of Object.values(fixtures)) {
+const OPTION_KEYS = ["legend", "radar", "series", "tooltip"]
+
+// Paths of every value the predicate rejects, named so a failure says where.
+function offendingPaths(
+  value: unknown,
+  reject: (entry: unknown) => boolean,
+  path = "option",
+): string[] {
+  if (reject(value)) return [path]
+  if (Array.isArray(value)) {
+    return value.flatMap((entry, index) =>
+      offendingPaths(entry, reject, `${path}[${index}]`),
+    )
+  }
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>).flatMap(
+      ([key, entry]) => offendingPaths(entry, reject, `${path}.${key}`),
+    )
+  }
+  return []
+}
+
+describe.each(Object.entries(fixtures))(
+  "compare radar chart option shape (%s)",
+  (_name, props) => {
+    it("sets every part of the option, one value per axis, with no gaps", async () => {
       const option = await captureOption(props)
-      const serialised = serialise(option) as {
-        tooltip: { formatter: Record<string, string> }
-        legend: { formatter: Record<string, string> }
+
+      expect(Object.keys(option).sort()).toEqual(OPTION_KEYS)
+
+      const axisCount = option.radar.indicator.length
+      expect(axisCount).toBeGreaterThan(0)
+      for (const series of option.series) {
+        expect(series.data.length).toBeGreaterThan(0)
+        for (const datum of series.data) {
+          expect(datum.value).toHaveLength(axisCount)
+        }
       }
+
       const names = Array.from(new Set(option.legend.data))
-      expect(Object.keys(serialised.tooltip.formatter)).toEqual(names)
-      expect(Object.keys(serialised.legend.formatter)).toEqual(names)
-    }
-  })
-})
+      expect(names.length).toBeGreaterThan(0)
+      for (const name of names) {
+        expect(option.tooltip.formatter({ name })).not.toBe("")
+        expect(option.legend.formatter(name)).not.toBe("")
+        expect(option.legend.tooltip.formatter({ name })).not.toBe("")
+      }
+
+      // An undefined in an echarts option drops a setting without saying so, and a
+      // formatter left behind by serialise() is one the golden dump cannot see.
+      expect(offendingPaths(option, (entry) => entry === undefined)).toEqual([])
+      expect(
+        offendingPaths(
+          serialise(option),
+          (entry) => typeof entry === "function",
+        ),
+      ).toEqual([])
+    })
+  },
+)

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -592,7 +592,7 @@ describe("compare radar chart tooltip", () => {
     expect(html).toContain("<div>Mean Cost: $0.002000</div>")
     expect(html).toContain("<div>Mean Latency: 1.2s</div>")
     expect(html).toContain("<div>Mean Total Tokens: 900 tokens</div>")
-    expect(html).toContain(">Values</div>")
+    expect(html).toContain(">Scores</div>")
     expect(html).toContain("<div>Pass Rate: 0.800</div>")
     expect(html).toContain("<div>Custom Depth: 2.000</div>")
     expect(html).not.toContain("Cost Efficiency:")

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -637,6 +637,37 @@ describe("compare radar chart tooltip", () => {
   })
 })
 
+describe("compare radar chart redraws", () => {
+  it("keeps redrawing whether the prompt list is missing, arrives or goes away", async () => {
+    const { component } = renderChart({
+      ...fixtures.three_configs,
+      prompts: undefined as unknown as PromptResponse | null,
+    })
+    await tick()
+    const drawn = () => setOptionCalls.length
+    expect(drawn()).toBeGreaterThan(0)
+    expect(
+      setOptionCalls[setOptionCalls.length - 1].legend.formatter("Fast Config"),
+    ).not.toContain("Basic (Zero Shot)")
+
+    const afterFirstDraw = drawn()
+    await component.$set({ prompts: PROMPTS })
+    await tick()
+    expect(drawn()).toBeGreaterThan(afterFirstDraw)
+    expect(
+      setOptionCalls[setOptionCalls.length - 1].legend.formatter("Fast Config"),
+    ).toContain("Basic (Zero Shot)")
+
+    const afterPrompts = drawn()
+    await component.$set({
+      prompts: undefined as unknown as PromptResponse | null,
+      scoreAxisMaxes: {},
+    })
+    await tick()
+    expect(drawn()).toBeGreaterThan(afterPrompts)
+  })
+})
+
 describe("compare radar chart scale default", () => {
   it("defaults to full scale for a single run config and to relative scale for several", async () => {
     const one = renderChart(fixtures.single_config)

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -31,6 +31,7 @@ type RadarOption = {
     indicator: Indicator[]
     center: string[]
     radius: string
+    axisName: { width: number }
   }
   series: {
     name: string
@@ -529,8 +530,26 @@ describe("compare radar chart legend", () => {
     expect(option.legend.orient).toBe("vertical")
     expect(option.legend.left).toBe("60%")
     expect(option.legend.top).toBe("middle")
-    expect(option.radar.center).toEqual(["32%", "50%"])
-    expect(option.radar.radius).toBe("85%")
+    expect(option.radar.center).toEqual(["36%", "50%"])
+    expect(option.radar.radius).toBe("70%")
+  })
+
+  it("leaves the left-hand axis names room on the card", async () => {
+    // The plot is at its widest on a 1280px screen, where the card takes its
+    // larger minimum height and echarts sizes the radius from that height.
+    const cardWidth = 928
+    const cardHeight = 620
+    const nameGap = 15
+    for (const props of [fixtures.three_configs, fixtures.two_configs]) {
+      const option = await captureOption(props)
+      const centreX = (parseFloat(option.radar.center[0]) / 100) * cardWidth
+      const radius =
+        (parseFloat(option.radar.radius) / 100) *
+        (Math.min(cardWidth, cardHeight) / 2)
+      expect(centreX - radius).toBeGreaterThan(
+        option.radar.axisName.width + nameGap,
+      )
+    }
   })
 
   it("lays the legend under the chart for two or fewer run configs", async () => {

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -1,0 +1,707 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest"
+import { render, cleanup, fireEvent } from "@testing-library/svelte"
+import { tick } from "svelte"
+import type { TaskRunConfig, ProviderModels, PromptResponse } from "$lib/types"
+
+type Indicator = { name: string; max: number }
+type SeriesDatum = { name: string; value: (number | null)[] }
+
+type RadarOption = {
+  tooltip: {
+    trigger: string
+    confine: boolean
+    formatter: (params: { name: string }) => string
+  }
+  legend: {
+    data: string[]
+    formatter: (name: string) => string
+    tooltip: {
+      show: boolean
+      formatter: (params: { name: string }) => string
+    }
+    textStyle: Record<string, unknown>
+    orient: string
+    itemGap: number
+    bottom?: number
+    top?: string
+    left?: string
+  }
+  radar: {
+    indicator: Indicator[]
+    center: string[]
+    radius: string
+  }
+  series: {
+    name: string
+    type: string
+    data: SeriesDatum[]
+    areaStyle?: { opacity: number }
+  }[]
+}
+
+const { setOptionCalls } = vi.hoisted(() => ({
+  setOptionCalls: [] as RadarOption[],
+}))
+
+vi.mock("echarts", () => ({
+  init: () => ({
+    setOption: (option: RadarOption) => {
+      setOptionCalls.push(option)
+    },
+    clear: () => {},
+    dispose: () => {},
+    resize: () => {},
+  }),
+}))
+
+const CompareRadarChart = (await import("./compare_radar_chart.svelte")).default
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    class ResizeObserverStub {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    ;(
+      globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }
+    ).ResizeObserver = ResizeObserverStub
+  }
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+type ComparisonFeature = {
+  category: string
+  items: { label: string; key: string }[]
+  has_default_eval_config: boolean | undefined
+  eval_id: string
+}
+
+type RadarProps = {
+  comparisonFeatures: ComparisonFeature[]
+  getModelValueRaw: (modelKey: string | null, dataKey: string) => number | null
+  run_configs: TaskRunConfig[]
+  model_info: ProviderModels | null
+  prompts: PromptResponse | null
+  selectedRunConfigIds: string[]
+  scoreAxisMaxes: Record<string, number>
+  metricLabels: Record<string, string>
+}
+
+type ValueTable = Record<string, Record<string, number | null>>
+
+function lookup(values: ValueTable) {
+  return (modelKey: string | null, dataKey: string): number | null => {
+    if (!modelKey) return null
+    const row = values[modelKey]
+    if (!row) return null
+    const value = row[dataKey]
+    return value === undefined ? null : value
+  }
+}
+
+const MODEL_INFO = {
+  models: {
+    gpt_4o: { id: "gpt_4o", name: "GPT 4o" },
+    claude_sonnet: { id: "claude_sonnet", name: "Claude Sonnet" },
+  },
+} as unknown as ProviderModels
+
+const PROMPTS = {
+  prompts: [{ id: "custom_prompt", name: "Detailed Prompt" }],
+  generators: [{ id: "simple_prompt_builder", name: "Basic (Zero Shot)" }],
+} as unknown as PromptResponse
+
+const FAST_CONFIG = {
+  id: "rc_fast",
+  v: 1,
+  name: "Fast Config",
+  model_type: "task_run_config",
+  starred: false,
+  run_config_properties: {
+    type: "kiln_agent",
+    model_name: "gpt_4o",
+    model_provider_name: "openai",
+    prompt_id: "simple_prompt_builder",
+    top_p: 1,
+    temperature: 1,
+    structured_output_mode: "json_schema",
+  },
+} as unknown as TaskRunConfig
+
+const THOROUGH_CONFIG = {
+  id: "rc_thorough",
+  v: 1,
+  name: "Thorough Config",
+  model_type: "task_run_config",
+  starred: false,
+  run_config_properties: {
+    type: "kiln_agent",
+    model_name: "claude_sonnet",
+    model_provider_name: "anthropic",
+    prompt_id: "custom_prompt",
+    top_p: 1,
+    temperature: 1,
+    structured_output_mode: "json_schema",
+    input_transform: { type: "jinja", template: "{{ task_input }}" },
+  },
+} as unknown as TaskRunConfig
+
+const TOOL_CONFIG = {
+  id: "rc_tool",
+  v: 1,
+  name: "",
+  model_type: "task_run_config",
+  starred: false,
+  run_config_properties: {
+    type: "mcp",
+    tool_reference: {
+      tool_id: "mcp::ticketing::route",
+      tool_name: "Ticket Router",
+    },
+  },
+} as unknown as TaskRunConfig
+
+const TWIN_CONFIG = {
+  ...FAST_CONFIG,
+  id: "rc_twin",
+  name: "Fast Config",
+} as unknown as TaskRunConfig
+
+const EVAL_SECTION: ComparisonFeature = {
+  category: "Ticket Quality",
+  eval_id: "eval_1",
+  has_default_eval_config: true,
+  items: [
+    { label: "Pass Rate", key: "eval_1::pass_rate" },
+    { label: "Overall Rating", key: "eval_1::overall_rating" },
+    { label: "Custom Depth", key: "eval_1::custom_depth" },
+  ],
+}
+
+const USAGE_SECTION: ComparisonFeature = {
+  category: "Average Usage, Cost & Latency",
+  eval_id: "kiln_cost_section",
+  has_default_eval_config: undefined,
+  items: [
+    { label: "Total Tokens", key: "cost::mean_total_tokens" },
+    { label: "Cost (USD)", key: "cost::mean_cost" },
+    { label: "Latency", key: "cost::mean_total_llm_latency_ms" },
+  ],
+}
+
+const SCORE_AXIS_MAXES = {
+  "eval_1::pass_rate": 1,
+  "eval_1::overall_rating": 5,
+}
+
+const METRIC_LABELS = {
+  "eval_1::overall_rating": "Answer Quality",
+  "cost::mean_total_llm_latency_ms": "Response Time",
+}
+
+const BASE_VALUES: ValueTable = {
+  rc_fast: {
+    "eval_1::pass_rate": 0.8,
+    "eval_1::overall_rating": 4,
+    "eval_1::custom_depth": 2,
+    "cost::mean_total_tokens": 900,
+    "cost::mean_cost": 0.002,
+    "cost::mean_total_llm_latency_ms": 1200,
+    "cost::mean_input_tokens": 600,
+    "cost::mean_output_tokens": 300,
+  },
+  rc_thorough: {
+    "eval_1::pass_rate": 0.6,
+    "eval_1::overall_rating": 5,
+    "eval_1::custom_depth": 3,
+    "cost::mean_total_tokens": 2100,
+    "cost::mean_cost": 0.006,
+    "cost::mean_total_llm_latency_ms": 3000,
+    "cost::mean_input_tokens": 1500,
+    "cost::mean_output_tokens": 600,
+  },
+  rc_tool: {
+    "eval_1::pass_rate": 1,
+    "eval_1::overall_rating": 3,
+    "eval_1::custom_depth": 1,
+    "cost::mean_total_tokens": 1500,
+    "cost::mean_cost": 0.004,
+    "cost::mean_total_llm_latency_ms": 600,
+    "cost::mean_input_tokens": 1000,
+    "cost::mean_output_tokens": 500,
+  },
+  rc_twin: {
+    "eval_1::pass_rate": 0.5,
+    "eval_1::overall_rating": 2,
+    "eval_1::custom_depth": 1.5,
+    "cost::mean_total_tokens": 4000,
+    "cost::mean_cost": 0.009,
+    "cost::mean_total_llm_latency_ms": 5000,
+  },
+}
+
+const MISSING_VALUES: ValueTable = {
+  ...BASE_VALUES,
+  rc_tool: { ...BASE_VALUES.rc_tool, "eval_1::custom_depth": null },
+}
+
+const MANY_SCORE_KEYS = Array.from(
+  { length: 12 },
+  (_, index) => `eval_1::score_${String(index + 1).padStart(2, "0")}`,
+)
+
+const MANY_SCORE_SECTION: ComparisonFeature = {
+  category: "Ticket Quality",
+  eval_id: "eval_1",
+  has_default_eval_config: true,
+  items: MANY_SCORE_KEYS.map((key, index) => ({
+    key,
+    label: `Score ${String(index + 1).padStart(2, "0")}`,
+  })),
+}
+
+const MANY_SCORE_VALUES: ValueTable = Object.fromEntries(
+  ["rc_fast", "rc_thorough", "rc_tool"].map((configId, configIndex) => [
+    configId,
+    {
+      ...Object.fromEntries(
+        MANY_SCORE_KEYS.map((key, scoreIndex) => [
+          key,
+          0.05 * (scoreIndex + 1) + 0.01 * configIndex,
+        ]),
+      ),
+      "cost::mean_total_tokens": BASE_VALUES[configId][
+        "cost::mean_total_tokens"
+      ] as number,
+      "cost::mean_cost": BASE_VALUES[configId]["cost::mean_cost"] as number,
+      "cost::mean_total_llm_latency_ms": BASE_VALUES[configId][
+        "cost::mean_total_llm_latency_ms"
+      ] as number,
+    },
+  ]),
+)
+
+const three_configs: RadarProps = {
+  comparisonFeatures: [EVAL_SECTION, USAGE_SECTION],
+  getModelValueRaw: lookup(BASE_VALUES),
+  run_configs: [FAST_CONFIG, THOROUGH_CONFIG, TOOL_CONFIG],
+  model_info: MODEL_INFO,
+  prompts: PROMPTS,
+  selectedRunConfigIds: ["rc_fast", "rc_thorough", "rc_tool"],
+  scoreAxisMaxes: SCORE_AXIS_MAXES,
+  metricLabels: METRIC_LABELS,
+}
+
+const missing_result: RadarProps = {
+  ...three_configs,
+  getModelValueRaw: lookup(MISSING_VALUES),
+}
+
+const two_configs: RadarProps = {
+  ...three_configs,
+  selectedRunConfigIds: ["rc_fast", "rc_thorough"],
+}
+
+const single_config: RadarProps = {
+  ...three_configs,
+  selectedRunConfigIds: ["rc_fast"],
+}
+
+const many_scores: RadarProps = {
+  comparisonFeatures: [MANY_SCORE_SECTION, USAGE_SECTION],
+  getModelValueRaw: lookup(MANY_SCORE_VALUES),
+  run_configs: [FAST_CONFIG, THOROUGH_CONFIG, TOOL_CONFIG],
+  model_info: MODEL_INFO,
+  prompts: PROMPTS,
+  selectedRunConfigIds: ["rc_fast", "rc_thorough", "rc_tool"],
+  scoreAxisMaxes: {},
+  metricLabels: {},
+}
+
+const duplicate_names: RadarProps = {
+  ...three_configs,
+  run_configs: [FAST_CONFIG, TWIN_CONFIG],
+  selectedRunConfigIds: ["rc_fast", "rc_twin"],
+}
+
+const fixtures = {
+  three_configs,
+  missing_result,
+  two_configs,
+  single_config,
+  many_scores,
+  duplicate_names,
+}
+
+function renderChart(props: RadarProps) {
+  cleanup()
+  setOptionCalls.length = 0
+  return render(CompareRadarChart, { props })
+}
+
+async function captureOption(
+  props: RadarProps,
+  { fullScale = false }: { fullScale?: boolean } = {},
+): Promise<RadarOption> {
+  const { getByRole } = renderChart(props)
+  await tick()
+  await tick()
+  if (fullScale) {
+    await fireEvent.click(getByRole("button", { name: "Full Scale" }))
+    await tick()
+  }
+  return setOptionCalls[setOptionCalls.length - 1]
+}
+
+function byName(names: string[], render_one: (name: string) => string) {
+  return Object.fromEntries(names.map((name) => [name, render_one(name)]))
+}
+
+function serialise(option: RadarOption): Record<string, unknown> {
+  const names = Array.from(new Set(option.legend.data))
+  const copy = JSON.parse(JSON.stringify(option)) as Record<string, unknown>
+  const tooltip = copy.tooltip as Record<string, unknown>
+  tooltip.formatter = byName(names, (name) =>
+    option.tooltip.formatter({ name }),
+  )
+  const legend = copy.legend as Record<string, unknown>
+  legend.formatter = byName(names, (name) => option.legend.formatter(name))
+  const legendTooltip = legend.tooltip as Record<string, unknown>
+  legendTooltip.formatter = byName(names, (name) =>
+    option.legend.tooltip.formatter({ name }),
+  )
+  return copy
+}
+
+function axisNames(option: RadarOption): string[] {
+  return option.radar.indicator.map((indicator) => indicator.name)
+}
+
+function axisMax(option: RadarOption, name: string): number {
+  const indicator = option.radar.indicator.find((i) => i.name === name)
+  if (!indicator) throw new Error(`no axis named ${name}`)
+  return indicator.max
+}
+
+function valueOn(
+  option: RadarOption,
+  seriesName: string,
+  axisName: string,
+): number | null {
+  const datum = option.series[0].data.find((d) => d.name === seriesName)
+  if (!datum) throw new Error(`no series named ${seriesName}`)
+  const index = axisNames(option).indexOf(axisName)
+  if (index < 0) throw new Error(`no axis named ${axisName}`)
+  return datum.value[index]
+}
+
+function tooltipFor(option: RadarOption, seriesName: string): string {
+  return option.tooltip.formatter({ name: seriesName })
+}
+
+describe("compare radar chart axes", () => {
+  it("lists the eval score axes first and the usage axes after them", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    expect(axisNames(option)).toEqual([
+      "Pass Rate",
+      "Answer Quality",
+      "Custom Depth",
+      "Token Efficiency",
+      "Cost Efficiency",
+      "Response Time",
+    ])
+  })
+
+  it("names usage axes for the direction that is better", async () => {
+    const option = await captureOption(fixtures.many_scores)
+    expect(axisNames(option)).toContain("Token Efficiency")
+    expect(axisNames(option)).toContain("Cost Efficiency")
+    expect(axisNames(option)).toContain("Speed")
+  })
+
+  it("uses the display name the user gave a row, on the axis, in the tooltip, and over the built-in usage name", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    expect(axisNames(option)).toContain("Answer Quality")
+    expect(axisNames(option)).not.toContain("Overall Rating")
+    expect(tooltipFor(option, "Fast Config")).toContain(
+      "<div>Answer Quality: 4.000</div>",
+    )
+    expect(axisNames(option)).toContain("Response Time")
+    expect(axisNames(option)).not.toContain("Speed")
+  })
+
+  it("leaves out a usage axis whose row is hidden in the comparison table", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    expect(axisNames(option)).not.toContain("Input Token Efficiency")
+    expect(axisNames(option)).not.toContain("Output Token Efficiency")
+    expect(option.radar.indicator).toHaveLength(6)
+  })
+
+  it("leaves out a score that any plotted run config has no result for, and counts it under the title", async () => {
+    const option = await captureOption(fixtures.missing_result)
+    expect(axisNames(option)).not.toContain("Custom Depth")
+    expect(option.radar.indicator).toHaveLength(5)
+
+    const { container } = renderChart(fixtures.missing_result)
+    await tick()
+    expect(container.textContent).toContain(
+      "Not shown: 1 score without results for every selected run config. See the table above.",
+    )
+  })
+})
+
+describe("compare radar chart axis maximums", () => {
+  it("pads the highest value in the data by ten percent in relative mode", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    expect(axisMax(option, "Pass Rate")).toBeCloseTo(1.1, 10)
+    expect(axisMax(option, "Answer Quality")).toBeCloseTo(5.5, 10)
+    expect(axisMax(option, "Custom Depth")).toBeCloseTo(3.3, 10)
+  })
+
+  it("uses the score's own range in full scale mode, and the padded data maximum where the range is unknown", async () => {
+    const option = await captureOption(fixtures.three_configs, {
+      fullScale: true,
+    })
+    expect(axisMax(option, "Pass Rate")).toBe(1)
+    expect(axisMax(option, "Answer Quality")).toBe(5)
+    expect(axisMax(option, "Custom Depth")).toBeCloseTo(3.3, 10)
+  })
+
+  it("keeps usage axes on a nought to one hundred scale in both modes", async () => {
+    const relative = await captureOption(fixtures.three_configs)
+    const full = await captureOption(fixtures.three_configs, {
+      fullScale: true,
+    })
+    expect(axisMax(relative, "Cost Efficiency")).toBe(100)
+    expect(axisMax(full, "Cost Efficiency")).toBe(100)
+    expect(axisMax(full, "Response Time")).toBe(100)
+  })
+})
+
+describe("compare radar chart series", () => {
+  it("plots the raw score on an eval axis", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    expect(valueOn(option, "Fast Config", "Pass Rate")).toBe(0.8)
+    expect(valueOn(option, "Thorough Config", "Answer Quality")).toBe(5)
+    expect(valueOn(option, "Ticket Router", "Custom Depth")).toBe(1)
+  })
+
+  it("scores the cheapest and the fastest run config highest on the usage axes", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    const cheapest = valueOn(option, "Fast Config", "Cost Efficiency") ?? 0
+    const dearest = valueOn(option, "Thorough Config", "Cost Efficiency") ?? 0
+    expect(cheapest).toBeGreaterThan(dearest)
+
+    const fastest = valueOn(option, "Ticket Router", "Response Time") ?? 0
+    const slowest = valueOn(option, "Thorough Config", "Response Time") ?? 0
+    expect(fastest).toBeGreaterThan(slowest)
+
+    const fewestTokens = valueOn(option, "Fast Config", "Token Efficiency") ?? 0
+    const mostTokens =
+      valueOn(option, "Thorough Config", "Token Efficiency") ?? 0
+    expect(fewestTokens).toBeGreaterThan(mostTokens)
+  })
+
+  it("puts every usage axis at the midpoint when there is nothing to compare against", async () => {
+    const option = await captureOption(fixtures.single_config)
+    expect(valueOn(option, "Fast Config", "Cost Efficiency")).toBe(50)
+    expect(valueOn(option, "Fast Config", "Response Time")).toBe(50)
+    expect(valueOn(option, "Fast Config", "Token Efficiency")).toBe(50)
+  })
+
+  it("fills the area only when a single run config is plotted", async () => {
+    const one = await captureOption(fixtures.single_config)
+    const several = await captureOption(fixtures.three_configs)
+    expect(one.series[0].areaStyle).toEqual({ opacity: 0.2 })
+    expect(several.series[0].areaStyle).toBeUndefined()
+  })
+})
+
+describe("compare radar chart legend", () => {
+  it("stands the legend beside the chart for more than two run configs", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    expect(option.legend.orient).toBe("vertical")
+    expect(option.legend.left).toBe("60%")
+    expect(option.legend.top).toBe("middle")
+    expect(option.radar.center).toEqual(["32%", "50%"])
+    expect(option.radar.radius).toBe("85%")
+  })
+
+  it("lays the legend under the chart for two or fewer run configs", async () => {
+    const option = await captureOption(fixtures.two_configs)
+    expect(option.legend.orient).toBe("horizontal")
+    expect(option.legend.bottom).toBe(0)
+    expect(option.legend.left).toBe("center")
+    expect(option.radar.center).toEqual(["50%", "46%"])
+    expect(option.radar.radius).toBe("62%")
+  })
+
+  it("writes the model, prompt and input transform under the run config name", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    expect(option.legend.formatter("Fast Config")).toBe(
+      "Fast Config\n{sub|Model: GPT 4o (OpenAI)}\n{sub|Prompt: Basic (Zero Shot)}",
+    )
+    expect(option.legend.formatter("Thorough Config")).toBe(
+      "Thorough Config\n{sub|Model: Claude Sonnet (Anthropic)}\n{sub|Prompt: Detailed Prompt}\n{sub|Input Transform: Custom}",
+    )
+  })
+
+  it("writes the tool name under an MCP run config", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    expect(option.legend.data).toContain("Ticket Router")
+    expect(option.legend.formatter("Ticket Router")).toBe(
+      "Ticket Router\n{sub|Tool: Ticket Router}",
+    )
+    expect(
+      option.legend.tooltip.formatter({ name: "Ticket Router" }),
+    ).toContain("<div>MCP Tool: Ticket Router</div>")
+  })
+})
+
+describe("compare radar chart tooltip", () => {
+  it("lists the run config details and every score when there are ten or fewer", async () => {
+    const option = await captureOption(fixtures.three_configs)
+    const html = tooltipFor(option, "Fast Config")
+    expect(html).toContain("<div>Model: GPT 4o (OpenAI)</div>")
+    expect(html).toContain("<div>Prompt: Basic (Zero Shot)</div>")
+    expect(html).toContain("<div>Mean Cost: $0.002000</div>")
+    expect(html).toContain("<div>Mean Latency: 1.2s</div>")
+    expect(html).toContain("<div>Mean Total Tokens: 900 tokens</div>")
+    expect(html).toContain(">Values</div>")
+    expect(html).toContain("<div>Pass Rate: 0.800</div>")
+    expect(html).toContain("<div>Custom Depth: 2.000</div>")
+    expect(html).not.toContain("Cost Efficiency:")
+    expect(html).not.toContain("Token Efficiency:")
+    expect(html).not.toContain("Response Time:")
+  })
+
+  it("lists only the ten weakest scores and counts the rest when there are more than ten", async () => {
+    const option = await captureOption(fixtures.many_scores)
+    const html = tooltipFor(option, "Fast Config")
+    const lines = html.match(/<div>Score \d\d: /g) ?? []
+    expect(lines).toHaveLength(10)
+    expect(html).toContain(">Lowest Scores</div>")
+    expect(html).toContain("<div>Score 01: 0.050</div>")
+    expect(html).toContain("<div>Score 10: 0.500</div>")
+    expect(html).not.toContain("Score 11:")
+    expect(html).not.toContain("Score 12:")
+    expect(html).toContain("+2 more in the table above")
+  })
+
+  it("currently interpolates the score label unescaped", async () => {
+    const option = await captureOption({
+      ...fixtures.three_configs,
+      metricLabels: { "eval_1::pass_rate": "<b>Boom</b>" },
+    })
+    expect(tooltipFor(option, "Fast Config")).toContain(
+      "<div><b>Boom</b>: 0.800</div>",
+    )
+  })
+
+  it("currently resolves two run configs sharing a name to the first of them", async () => {
+    const option = await captureOption(fixtures.duplicate_names)
+    expect(option.legend.data).toEqual(["Fast Config", "Fast Config"])
+    expect(tooltipFor(option, "Fast Config")).toContain(
+      "<div>Mean Cost: $0.002000</div>",
+    )
+    expect(tooltipFor(option, "Fast Config")).not.toContain("$0.009000")
+  })
+})
+
+describe("compare radar chart scale default", () => {
+  it("defaults to full scale for a single run config and to relative scale for several", async () => {
+    const one = renderChart(fixtures.single_config)
+    await tick()
+    expect(
+      one
+        .getByRole("button", { name: "Full Scale" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true")
+    expect(
+      axisMax(setOptionCalls[setOptionCalls.length - 1], "Pass Rate"),
+    ).toBe(1)
+
+    const several = renderChart(fixtures.three_configs)
+    await tick()
+    expect(
+      several
+        .getByRole("button", { name: "Relative" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true")
+    expect(
+      axisMax(setOptionCalls[setOptionCalls.length - 1], "Pass Rate"),
+    ).toBeCloseTo(1.1, 10)
+  })
+})
+
+describe("compare radar chart empty states", () => {
+  it("draws nothing at all when fewer than three axes could exist", async () => {
+    const { container } = renderChart({
+      ...fixtures.three_configs,
+      comparisonFeatures: [
+        { ...EVAL_SECTION, items: EVAL_SECTION.items.slice(0, 2) },
+      ],
+    })
+    await tick()
+    expect(container.textContent?.trim()).toBe("")
+    expect(setOptionCalls).toHaveLength(0)
+  })
+
+  it("shows the not enough shared scores state when the plotted configs share fewer than three", async () => {
+    const { container } = renderChart({
+      ...fixtures.three_configs,
+      comparisonFeatures: [EVAL_SECTION],
+      getModelValueRaw: lookup({
+        ...BASE_VALUES,
+        rc_tool: {
+          ...BASE_VALUES.rc_tool,
+          "eval_1::overall_rating": null,
+          "eval_1::custom_depth": null,
+        },
+      }),
+    })
+    await tick()
+    expect(container.textContent).toContain("Not Enough Shared Scores")
+    expect(container.textContent).toContain(
+      "The selected run configurations share fewer than 3 scores with results.",
+    )
+    expect(container.textContent).toContain(
+      "Not shown: 2 scores without results for every selected run config.",
+    )
+    expect(setOptionCalls).toHaveLength(0)
+  })
+
+  it("shows the plain no data state when no run config is selected", async () => {
+    const { container } = renderChart({
+      ...fixtures.three_configs,
+      selectedRunConfigIds: [],
+    })
+    await tick()
+    expect(container.textContent).toContain("No Data Available")
+    expect(container.textContent).toContain(
+      "Create and run evals to see a comparison chart.",
+    )
+    expect(container.textContent).not.toContain("Not shown:")
+  })
+})
+
+describe("compare radar chart option shape", () => {
+  it("serialises every fixture with its three formatters invoked", async () => {
+    for (const props of Object.values(fixtures)) {
+      const option = await captureOption(props)
+      const serialised = serialise(option) as {
+        tooltip: { formatter: Record<string, string> }
+        legend: { formatter: Record<string, string> }
+      }
+      const names = Array.from(new Set(option.legend.data))
+      expect(Object.keys(serialised.tooltip.formatter)).toEqual(names)
+      expect(Object.keys(serialised.legend.formatter)).toEqual(names)
+    }
+  })
+})

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -657,7 +657,7 @@ describe("compare radar chart empty states", () => {
     expect(setOptionCalls).toHaveLength(0)
   })
 
-  it("shows the not enough shared scores state when the plotted configs share fewer than three", async () => {
+  it("shows the not enough shared axes state when the plotted configs share fewer than three", async () => {
     const { container } = renderChart({
       ...fixtures.three_configs,
       comparisonFeatures: [EVAL_SECTION],
@@ -671,9 +671,9 @@ describe("compare radar chart empty states", () => {
       }),
     })
     await tick()
-    expect(container.textContent).toContain("Not Enough Shared Scores")
+    expect(container.textContent).toContain("Not Enough Shared Axes")
     expect(container.textContent).toContain(
-      "The selected run configurations share fewer than 3 scores with results.",
+      "Fewer than 3 axes have a result for every selected run configuration.",
     )
     expect(container.textContent).toContain(
       "Not shown: 2 axes without results for every selected run config.",

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -594,14 +594,14 @@ describe("compare radar chart tooltip", () => {
     expect(html).toContain("+2 more in the table above")
   })
 
-  it("currently interpolates the score label unescaped", async () => {
+  it("escapes the score label in the tooltip", async () => {
     const option = await captureOption({
       ...fixtures.three_configs,
       metricLabels: { "eval_1::pass_rate": "<b>Boom</b>" },
     })
-    expect(tooltipFor(option, "Fast Config")).toContain(
-      "<div><b>Boom</b>: 0.800</div>",
-    )
+    const html = tooltipFor(option, "Fast Config")
+    expect(html).toContain("<div>&lt;b&gt;Boom&lt;/b&gt;: 0.800</div>")
+    expect(html).not.toContain("<b>Boom</b>")
   })
 
   it("currently resolves two run configs sharing a name to the first of them", async () => {

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -645,7 +645,17 @@ describe("compare radar chart scale default", () => {
 })
 
 describe("compare radar chart empty states", () => {
-  it("draws nothing at all when fewer than three axes could exist", async () => {
+  it("draws nothing at all when the table has no rows left to offer", async () => {
+    const { container } = renderChart({
+      ...fixtures.three_configs,
+      comparisonFeatures: [],
+    })
+    await tick()
+    expect(container.textContent?.trim()).toBe("")
+    expect(setOptionCalls).toHaveLength(0)
+  })
+
+  it("keeps the card and its empty state when hidden rows leave two axes", async () => {
     const { container } = renderChart({
       ...fixtures.three_configs,
       comparisonFeatures: [
@@ -653,11 +663,15 @@ describe("compare radar chart empty states", () => {
       ],
     })
     await tick()
-    expect(container.textContent?.trim()).toBe("")
+    expect(container.textContent).toContain("Radar Chart")
+    expect(container.textContent).toContain("Not Enough Axes")
+    expect(container.textContent).toContain(
+      "A radar chart needs at least 3 axes. Show a hidden row, run the missing evals, or compare fewer run configurations.",
+    )
     expect(setOptionCalls).toHaveLength(0)
   })
 
-  it("shows the not enough shared axes state when the plotted configs share fewer than three", async () => {
+  it("shows the not enough axes state when the plotted configs share fewer than three", async () => {
     const { container } = renderChart({
       ...fixtures.three_configs,
       comparisonFeatures: [EVAL_SECTION],
@@ -671,20 +685,18 @@ describe("compare radar chart empty states", () => {
       }),
     })
     await tick()
-    expect(container.textContent).toContain("Not Enough Shared Axes")
+    expect(container.textContent).toContain("Not Enough Axes")
     expect(container.textContent).toContain(
-      "Fewer than 3 axes have a result for every selected run configuration.",
+      "A radar chart needs at least 3 axes. Show a hidden row, run the missing evals, or compare fewer run configurations.",
     )
-    expect(container.textContent).toContain(
-      "Not shown: 2 axes without results for every selected run config.",
-    )
+    expect(container.textContent).not.toContain("Not shown:")
     expect(setOptionCalls).toHaveLength(0)
   })
 
-  it("shows the plain no data state when no run config is selected", async () => {
+  it("asks for evals only when the table offers no eval section at all", async () => {
     const { container } = renderChart({
       ...fixtures.three_configs,
-      selectedRunConfigIds: [],
+      comparisonFeatures: [USAGE_SECTION],
     })
     await tick()
     expect(container.textContent).toContain("No Data Available")

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -451,7 +451,7 @@ describe("compare radar chart axes", () => {
     const { container } = renderChart(fixtures.missing_result)
     await tick()
     expect(container.textContent).toContain(
-      "Not shown: 1 score without results for every selected run config. See the table above.",
+      "Not shown: 1 axis without results for every selected run config. See the table above.",
     )
   })
 })
@@ -676,7 +676,7 @@ describe("compare radar chart empty states", () => {
       "The selected run configurations share fewer than 3 scores with results.",
     )
     expect(container.textContent).toContain(
-      "Not shown: 2 scores without results for every selected run config.",
+      "Not shown: 2 axes without results for every selected run config.",
     )
     expect(setOptionCalls).toHaveLength(0)
   })

--- a/app/web_ui/src/lib/components/compare_radar_chart.test.ts
+++ b/app/web_ui/src/lib/components/compare_radar_chart.test.ts
@@ -604,13 +604,17 @@ describe("compare radar chart tooltip", () => {
     expect(html).not.toContain("<b>Boom</b>")
   })
 
-  it("currently resolves two run configs sharing a name to the first of them", async () => {
+  it("keeps two run configs sharing a name apart", async () => {
     const option = await captureOption(fixtures.duplicate_names)
-    expect(option.legend.data).toEqual(["Fast Config", "Fast Config"])
-    expect(tooltipFor(option, "Fast Config")).toContain(
-      "<div>Mean Cost: $0.002000</div>",
-    )
-    expect(tooltipFor(option, "Fast Config")).not.toContain("$0.009000")
+    expect(option.legend.data).toEqual(["Fast Config (1)", "Fast Config (2)"])
+
+    const first = tooltipFor(option, "Fast Config (1)")
+    expect(first).toContain("<div>Mean Cost: $0.002000</div>")
+    expect(first).toContain("<div>Pass Rate: 0.800</div>")
+
+    const second = tooltipFor(option, "Fast Config (2)")
+    expect(second).toContain("<div>Mean Cost: $0.009000</div>")
+    expect(second).toContain("<div>Pass Rate: 0.500</div>")
   })
 })
 

--- a/app/web_ui/src/lib/ui/chat/chat_markdown.svelte
+++ b/app/web_ui/src/lib/ui/chat/chat_markdown.svelte
@@ -2,6 +2,7 @@
   import { Marked, type Token } from "marked"
   import DOMPurify from "dompurify"
   import hljs from "highlight.js/lib/core"
+  import { escapeHtml } from "$lib/utils/escape_html"
   import json from "highlight.js/lib/languages/json"
   import javascript from "highlight.js/lib/languages/javascript"
   import typescript from "highlight.js/lib/languages/typescript"
@@ -18,14 +19,6 @@
   hljs.registerLanguage("bash", bash)
   hljs.registerLanguage("shell", bash)
   hljs.registerLanguage("sh", bash)
-
-  function escapeHtml(s: string): string {
-    return s
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-  }
 
   const md = new Marked({
     gfm: true,

--- a/app/web_ui/src/lib/utils/compare_metric_keys.ts
+++ b/app/web_ui/src/lib/utils/compare_metric_keys.ts
@@ -1,0 +1,50 @@
+// The row keys of the comparison table's usage section, shared by the compare page
+// that builds the table and the radar chart that turns the same rows into axes.
+// Renaming a key in one place without the other would silently drop an axis, so
+// there is one definition of each.
+
+// Section id of the usage rows. Not an eval, so the page skips it wherever it looks
+// up eval data, and the chart scores its rows by position rather than by range.
+export const COST_SECTION_ID = "kiln_cost_section"
+
+const USAGE_KEY_PREFIX = "cost::"
+
+export const INPUT_TOKENS_KEY = `${USAGE_KEY_PREFIX}mean_input_tokens`
+export const OUTPUT_TOKENS_KEY = `${USAGE_KEY_PREFIX}mean_output_tokens`
+export const TOTAL_TOKENS_KEY = `${USAGE_KEY_PREFIX}mean_total_tokens`
+export const COST_KEY = `${USAGE_KEY_PREFIX}mean_cost`
+export const LATENCY_KEY = `${USAGE_KEY_PREFIX}mean_total_llm_latency_ms`
+
+export type UsageMetric = {
+  key: string
+  // Name in the comparison table, above the raw quantity
+  label: string
+  // Name on the radar axis, where a bigger value means less of the quantity
+  axisLabel: string
+}
+
+// In table order, which is also axis order.
+export const USAGE_METRICS: UsageMetric[] = [
+  {
+    key: INPUT_TOKENS_KEY,
+    label: "Input Tokens",
+    axisLabel: "Input Token Efficiency",
+  },
+  {
+    key: OUTPUT_TOKENS_KEY,
+    label: "Output Tokens",
+    axisLabel: "Output Token Efficiency",
+  },
+  {
+    key: TOTAL_TOKENS_KEY,
+    label: "Total Tokens",
+    axisLabel: "Token Efficiency",
+  },
+  { key: COST_KEY, label: "Cost (USD)", axisLabel: "Cost Efficiency" },
+  { key: LATENCY_KEY, label: "Latency", axisLabel: "Speed" },
+]
+
+// Usage rows carry a lower-is-better raw quantity, unlike eval scores.
+export function isUsageMetricKey(key: string): boolean {
+  return key.startsWith(USAGE_KEY_PREFIX)
+}

--- a/app/web_ui/src/lib/utils/compare_metric_keys.ts
+++ b/app/web_ui/src/lib/utils/compare_metric_keys.ts
@@ -1,7 +1,14 @@
-// The row keys of the comparison table's usage section, shared by the compare page
-// that builds the table and the radar chart that turns the same rows into axes.
-// Renaming a key in one place without the other would silently drop an axis, so
-// there is one definition of each.
+// The shape and the row keys of the comparison table, shared by the compare page
+// that builds the table and the charts that turn the same rows into axes. Renaming
+// a key in one place without the other would silently drop an axis, so there is one
+// definition of each.
+
+// One block of the comparison table: an eval's scores, or the usage section.
+export type ComparisonSection = {
+  category: string
+  eval_id: string
+  items: { label: string; key: string }[]
+}
 
 // Section id of the usage rows. Not an eval, so the page skips it wherever it looks
 // up eval data, and the chart scores its rows by position rather than by range.
@@ -9,13 +16,13 @@ export const COST_SECTION_ID = "kiln_cost_section"
 
 const USAGE_KEY_PREFIX = "cost::"
 
-export const INPUT_TOKENS_KEY = `${USAGE_KEY_PREFIX}mean_input_tokens`
-export const OUTPUT_TOKENS_KEY = `${USAGE_KEY_PREFIX}mean_output_tokens`
+const INPUT_TOKENS_KEY = `${USAGE_KEY_PREFIX}mean_input_tokens`
+const OUTPUT_TOKENS_KEY = `${USAGE_KEY_PREFIX}mean_output_tokens`
 export const TOTAL_TOKENS_KEY = `${USAGE_KEY_PREFIX}mean_total_tokens`
 export const COST_KEY = `${USAGE_KEY_PREFIX}mean_cost`
 export const LATENCY_KEY = `${USAGE_KEY_PREFIX}mean_total_llm_latency_ms`
 
-export type UsageMetric = {
+type UsageMetric = {
   key: string
   // Name in the comparison table, above the raw quantity
   label: string

--- a/app/web_ui/src/lib/utils/escape_html.test.ts
+++ b/app/web_ui/src/lib/utils/escape_html.test.ts
@@ -16,4 +16,11 @@ describe("escapeHtml", () => {
       "&quot; onmouseover=&quot;alert(1)",
     )
   })
+
+  it("escapes an apostrophe, which closes a single-quoted attribute", () => {
+    expect(escapeHtml("' onmouseover='alert(1)")).toBe(
+      "&#39; onmouseover=&#39;alert(1)",
+    )
+    expect(escapeHtml("Bob's Eval")).toBe("Bob&#39;s Eval")
+  })
 })

--- a/app/web_ui/src/lib/utils/escape_html.test.ts
+++ b/app/web_ui/src/lib/utils/escape_html.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest"
+import { escapeHtml } from "./escape_html"
+
+describe("escapeHtml", () => {
+  it("turns a tag into text rather than markup", () => {
+    expect(escapeHtml("<b>Boom</b>")).toBe("&lt;b&gt;Boom&lt;/b&gt;")
+  })
+
+  it("escapes the ampersand first, so an escape is not escaped twice", () => {
+    expect(escapeHtml("Cost & Latency")).toBe("Cost &amp; Latency")
+    expect(escapeHtml("&lt;")).toBe("&amp;lt;")
+  })
+
+  it("escapes a quote, which would otherwise close an attribute", () => {
+    expect(escapeHtml('" onmouseover="alert(1)')).toBe(
+      "&quot; onmouseover=&quot;alert(1)",
+    )
+  })
+})

--- a/app/web_ui/src/lib/utils/escape_html.ts
+++ b/app/web_ui/src/lib/utils/escape_html.ts
@@ -9,4 +9,5 @@ export function escapeHtml(value: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
 }

--- a/app/web_ui/src/lib/utils/escape_html.ts
+++ b/app/web_ui/src/lib/utils/escape_html.ts
@@ -1,0 +1,12 @@
+/**
+ * Escape text for interpolation into markup we assemble ourselves. Anything a user
+ * named - an eval score, a run config, a row renamed through the URL - is text, not
+ * markup, and the places that build HTML strings by hand have no other guard.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+}

--- a/app/web_ui/src/lib/utils/radar_chart_data.test.ts
+++ b/app/web_ui/src/lib/utils/radar_chart_data.test.ts
@@ -6,6 +6,7 @@ import {
   metricToScore,
   plottedRunConfigs,
   rankTooltipScores,
+  runConfigSeriesNames,
   sharedAxisKeys,
   splitAxisKeys,
 } from "./radar_chart_data"
@@ -432,5 +433,23 @@ describe("buildRadarChartData", () => {
     const data = chartData({ comparisonFeatures: [USAGE_SECTION] })
     expect(data.hasData).toBe(false)
     expect(data.candidateAxisCount).toBe(3)
+  })
+})
+
+describe("runConfigSeriesNames", () => {
+  it("leaves a name that occurs once exactly as it is", () => {
+    expect(runConfigSeriesNames([FAST, THOROUGH], null)).toEqual([
+      "Fast Config",
+      "Thorough Config",
+    ])
+  })
+
+  it("numbers every occurrence of a name two run configs share", () => {
+    const twin = make_config("rc_twin", "Fast Config")
+    expect(runConfigSeriesNames([FAST, THOROUGH, twin], null)).toEqual([
+      "Fast Config (1)",
+      "Thorough Config",
+      "Fast Config (2)",
+    ])
   })
 })

--- a/app/web_ui/src/lib/utils/radar_chart_data.test.ts
+++ b/app/web_ui/src/lib/utils/radar_chart_data.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect } from "vitest"
+import {
+  axisMaxFor,
+  buildAxisLabels,
+  buildRadarChartData,
+  metricToScore,
+  plottedRunConfigs,
+  rankTooltipScores,
+  sharedAxisKeys,
+  splitAxisKeys,
+} from "./radar_chart_data"
+import type { ComparisonFeature, RadarValueLookup } from "./radar_chart_data"
+import type { TaskRunConfig } from "$lib/types"
+
+function make_config(id: string, name: string): TaskRunConfig {
+  return {
+    id,
+    name,
+    run_config_properties: { type: "kiln_agent" },
+  } as unknown as TaskRunConfig
+}
+
+const FAST = make_config("rc_fast", "Fast Config")
+const THOROUGH = make_config("rc_thorough", "Thorough Config")
+const IDLE = make_config("rc_idle", "Idle Config")
+
+const EVAL_SECTION: ComparisonFeature = {
+  category: "Ticket Quality",
+  eval_id: "eval_1",
+  has_default_eval_config: true,
+  items: [
+    { label: "Pass Rate", key: "eval_1::pass_rate" },
+    { label: "Overall Rating", key: "eval_1::overall_rating" },
+    { label: "Custom Depth", key: "eval_1::custom_depth" },
+  ],
+}
+
+const USAGE_SECTION: ComparisonFeature = {
+  category: "Average Usage, Cost & Latency",
+  eval_id: "kiln_cost_section",
+  has_default_eval_config: undefined,
+  items: [
+    { label: "Cost (USD)", key: "cost::mean_cost" },
+    { label: "Latency", key: "cost::mean_total_llm_latency_ms" },
+    { label: "Total Tokens", key: "cost::mean_total_tokens" },
+  ],
+}
+
+type ValueTable = Record<string, Record<string, number | null>>
+
+const VALUES: ValueTable = {
+  rc_fast: {
+    "eval_1::pass_rate": 0.8,
+    "eval_1::overall_rating": 4,
+    "eval_1::custom_depth": 2,
+    "cost::mean_cost": 0.002,
+    "cost::mean_total_llm_latency_ms": 1200,
+    "cost::mean_total_tokens": 900,
+  },
+  rc_thorough: {
+    "eval_1::pass_rate": 0.6,
+    "eval_1::overall_rating": 5,
+    "eval_1::custom_depth": 3,
+    "cost::mean_cost": 0.006,
+    "cost::mean_total_llm_latency_ms": 3000,
+    "cost::mean_total_tokens": 2100,
+  },
+  rc_idle: {},
+}
+
+function lookup(values: ValueTable): RadarValueLookup {
+  return (modelKey, dataKey) => {
+    if (!modelKey) return null
+    const value = values[modelKey]?.[dataKey]
+    return value === undefined ? null : value
+  }
+}
+
+const getValue = lookup(VALUES)
+
+function chartData(overrides: {
+  comparisonFeatures?: ComparisonFeature[]
+  plottedConfigs?: TaskRunConfig[]
+  selectedRunConfigIds?: string[]
+  getValue?: RadarValueLookup
+  scoreAxisMaxes?: Record<string, number>
+  metricLabels?: Record<string, string>
+  absoluteScale?: boolean
+}) {
+  return buildRadarChartData({
+    comparisonFeatures: [EVAL_SECTION, USAGE_SECTION],
+    plottedConfigs: [FAST, THOROUGH],
+    selectedRunConfigIds: [FAST.id ?? "", THOROUGH.id ?? ""],
+    getValue,
+    modelInfo: null,
+    scoreAxisMaxes: {},
+    metricLabels: {},
+    absoluteScale: false,
+    ...overrides,
+  })
+}
+
+describe("metricToScore", () => {
+  it("lands every run config at the midpoint when they all tie", () => {
+    expect(metricToScore(5, [5, 5, 5])).toBe(50)
+  })
+
+  it("lands a single run config at the midpoint", () => {
+    expect(metricToScore(5, [5])).toBe(50)
+  })
+
+  it("scores the cheapest run config highest and the priciest lowest", () => {
+    expect(metricToScore(1, [1, 100])).toBeCloseTo(90, 10)
+    expect(metricToScore(100, [1, 100])).toBeCloseTo(10, 10)
+  })
+
+  it("compresses toward the midpoint when the spread is small next to the magnitude", () => {
+    const tight = metricToScore(0.02, [0.02, 0.03])
+    expect(tight).toBeGreaterThan(50)
+    expect(tight).toBeLessThan(metricToScore(1, [1, 100]))
+  })
+})
+
+describe("splitAxisKeys", () => {
+  it("separates the usage section's rows from the eval score rows", () => {
+    expect(splitAxisKeys([EVAL_SECTION, USAGE_SECTION])).toEqual({
+      scoreKeys: [
+        "eval_1::pass_rate",
+        "eval_1::overall_rating",
+        "eval_1::custom_depth",
+      ],
+      usageKeys: [
+        "cost::mean_cost",
+        "cost::mean_total_llm_latency_ms",
+        "cost::mean_total_tokens",
+      ],
+    })
+  })
+})
+
+describe("plottedRunConfigs", () => {
+  it("leaves out a run config with no eval result at all", () => {
+    const plotted = plottedRunConfigs({
+      comparisonFeatures: [EVAL_SECTION, USAGE_SECTION],
+      runConfigs: [FAST, THOROUGH, IDLE],
+      selectedRunConfigIds: ["rc_fast", "rc_thorough", "rc_idle"],
+      getValue,
+    })
+    expect(plotted.map((config) => config.id)).toEqual([
+      "rc_fast",
+      "rc_thorough",
+    ])
+  })
+
+  it("keeps a run config with a single eval result", () => {
+    const plotted = plottedRunConfigs({
+      comparisonFeatures: [EVAL_SECTION, USAGE_SECTION],
+      runConfigs: [IDLE],
+      selectedRunConfigIds: ["rc_idle"],
+      getValue: lookup({ rc_idle: { "eval_1::custom_depth": 1 } }),
+    })
+    expect(plotted.map((config) => config.id)).toEqual(["rc_idle"])
+  })
+
+  it("ignores a selected id that matches no run config", () => {
+    const plotted = plottedRunConfigs({
+      comparisonFeatures: [EVAL_SECTION, USAGE_SECTION],
+      runConfigs: [FAST],
+      selectedRunConfigIds: ["rc_gone", "rc_fast"],
+      getValue,
+    })
+    expect(plotted).toEqual([FAST])
+  })
+})
+
+describe("sharedAxisKeys", () => {
+  it("keeps a key only when every plotted run config has a result for it", () => {
+    const values = lookup({
+      ...VALUES,
+      rc_thorough: { ...VALUES.rc_thorough, "eval_1::custom_depth": null },
+    })
+    const { keys } = sharedAxisKeys(
+      ["eval_1::pass_rate", "eval_1::custom_depth"],
+      [FAST, THOROUGH],
+      values,
+    )
+    expect(keys).toEqual(["eval_1::pass_rate"])
+  })
+
+  it("counts the keys it dropped", () => {
+    const { omittedCount } = sharedAxisKeys(
+      ["eval_1::pass_rate", "eval_1::unrun", "eval_1::also_unrun"],
+      [FAST],
+      getValue,
+    )
+    expect(omittedCount).toBe(2)
+  })
+
+  it("ignores a run config that is not being plotted", () => {
+    const { keys, omittedCount } = sharedAxisKeys(
+      ["eval_1::pass_rate", "eval_1::custom_depth"],
+      [FAST],
+      getValue,
+    )
+    expect(keys).toEqual(["eval_1::pass_rate", "eval_1::custom_depth"])
+    expect(omittedCount).toBe(0)
+  })
+})
+
+describe("axisMaxFor", () => {
+  const relative = { absoluteScale: false, scoreAxisMaxes: {} }
+  const fullScale = {
+    absoluteScale: true,
+    scoreAxisMaxes: {
+      "eval_1::pass_rate": 1,
+      "eval_1::overall_rating": 5,
+    },
+  }
+
+  it("pads the highest value in the data by a tenth in relative mode", () => {
+    expect(axisMaxFor("eval_1::pass_rate", 0.8, relative)).toBeCloseTo(0.88, 10)
+    expect(axisMaxFor("eval_1::overall_rating", 5, relative)).toBeCloseTo(
+      5.5,
+      10,
+    )
+  })
+
+  it("uses the score's own range in full scale mode", () => {
+    expect(axisMaxFor("eval_1::pass_rate", 0.8, fullScale)).toBe(1)
+    expect(axisMaxFor("eval_1::overall_rating", 4, fullScale)).toBe(5)
+  })
+
+  it("falls back to the normalized zero to one range when the score's range is unknown", () => {
+    expect(axisMaxFor("eval_1::custom_depth", 0.4, fullScale)).toBe(1)
+  })
+
+  it("never returns a maximum below the data", () => {
+    expect(axisMaxFor("eval_1::custom_depth", 3, fullScale)).toBeCloseTo(
+      3.3,
+      10,
+    )
+    expect(
+      axisMaxFor("eval_1::overall_rating", 7, {
+        ...fullScale,
+        scoreAxisMaxes: { "eval_1::overall_rating": 5 },
+      }),
+    ).toBeCloseTo(7.7, 10)
+  })
+
+  it("gives an axis with no positive value a maximum of one", () => {
+    expect(axisMaxFor("eval_1::custom_depth", 0, relative)).toBe(1)
+  })
+})
+
+describe("buildAxisLabels", () => {
+  it("uses the comparison table's own label for an eval score", () => {
+    const labels = buildAxisLabels([EVAL_SECTION, USAGE_SECTION], {})
+    expect(labels["eval_1::pass_rate"]).toBe("Pass Rate")
+  })
+
+  it("names a usage row for the direction that is better", () => {
+    const labels = buildAxisLabels([EVAL_SECTION, USAGE_SECTION], {})
+    expect(labels["cost::mean_cost"]).toBe("Cost Efficiency")
+    expect(labels["cost::mean_total_llm_latency_ms"]).toBe("Speed")
+  })
+
+  it("prefers the name the user gave the row, over both the table and the usage name", () => {
+    const labels = buildAxisLabels([EVAL_SECTION, USAGE_SECTION], {
+      "eval_1::overall_rating": "Answer Quality",
+      "cost::mean_total_llm_latency_ms": "Response Time",
+    })
+    expect(labels["eval_1::overall_rating"]).toBe("Answer Quality")
+    expect(labels["cost::mean_total_llm_latency_ms"]).toBe("Response Time")
+  })
+})
+
+describe("rankTooltipScores", () => {
+  const manyKeys = Array.from(
+    { length: 12 },
+    (_, index) => `eval_1::score_${String(index + 1).padStart(2, "0")}`,
+  )
+  const manyLabels = Object.fromEntries(
+    manyKeys.map((key, index) => [key, `Score ${index + 1}`]),
+  )
+  const manyMaxes = Object.fromEntries(manyKeys.map((key) => [key, 1]))
+
+  it("keeps every score in axis order when there are ten or fewer", () => {
+    const { scores, trimmedCount } = rankTooltipScores({
+      keys: ["eval_1::overall_rating", "eval_1::pass_rate"],
+      axisMaxes: { "eval_1::overall_rating": 5, "eval_1::pass_rate": 1 },
+      axisLabels: {
+        "eval_1::overall_rating": "Overall Rating",
+        "eval_1::pass_rate": "Pass Rate",
+      },
+      getValue: (key) => getValue("rc_fast", key),
+    })
+    expect(scores).toEqual([
+      { label: "Overall Rating", value: 4 },
+      { label: "Pass Rate", value: 0.8 },
+    ])
+    expect(trimmedCount).toBe(0)
+  })
+
+  it("trims to the ten weakest and reports how many it dropped", () => {
+    const { scores, trimmedCount } = rankTooltipScores({
+      keys: manyKeys,
+      axisMaxes: manyMaxes,
+      axisLabels: manyLabels,
+      getValue: (key) => 0.05 * (manyKeys.indexOf(key) + 1),
+    })
+    expect(trimmedCount).toBe(2)
+    expect(scores.map((score) => score.label)).toEqual([
+      "Score 1",
+      "Score 2",
+      "Score 3",
+      "Score 4",
+      "Score 5",
+      "Score 6",
+      "Score 7",
+      "Score 8",
+      "Score 9",
+      "Score 10",
+    ])
+  })
+
+  it("ranks by position on the axis rather than by raw value", () => {
+    const { scores } = rankTooltipScores({
+      keys: ["eval_1::overall_rating", "eval_1::pass_rate"],
+      axisMaxes: { "eval_1::overall_rating": 5, "eval_1::pass_rate": 1 },
+      axisLabels: {
+        "eval_1::overall_rating": "Overall Rating",
+        "eval_1::pass_rate": "Pass Rate",
+      },
+      getValue: (key) => (key === "eval_1::pass_rate" ? 0.9 : 1),
+      limit: 1,
+    })
+    expect(scores).toEqual([{ label: "Overall Rating", value: 1 }])
+  })
+
+  it("sorts a score with no result first", () => {
+    const { scores } = rankTooltipScores({
+      keys: manyKeys,
+      axisMaxes: manyMaxes,
+      axisLabels: manyLabels,
+      getValue: (key) =>
+        key === "eval_1::score_12" ? null : 0.05 * (manyKeys.indexOf(key) + 1),
+    })
+    expect(scores[0]).toEqual({ label: "Score 12", value: null })
+  })
+
+  it("leaves the usage axes out", () => {
+    const { scores } = rankTooltipScores({
+      keys: ["eval_1::pass_rate", "cost::mean_cost"],
+      axisMaxes: { "eval_1::pass_rate": 1, "cost::mean_cost": 100 },
+      axisLabels: {
+        "eval_1::pass_rate": "Pass Rate",
+        "cost::mean_cost": "Cost Efficiency",
+      },
+      getValue: (key) => getValue("rc_fast", key),
+    })
+    expect(scores.map((score) => score.label)).toEqual(["Pass Rate"])
+  })
+})
+
+describe("buildRadarChartData", () => {
+  it("builds one axis per shared key and one series per plotted run config", () => {
+    const data = chartData({})
+    expect(data.indicators.map((indicator) => indicator.name)).toEqual([
+      "Pass Rate",
+      "Overall Rating",
+      "Custom Depth",
+      "Cost Efficiency",
+      "Speed",
+      "Token Efficiency",
+    ])
+    expect(data.legend).toEqual(["Fast Config", "Thorough Config"])
+    expect(data.hasData).toBe(true)
+    expect(data.omittedKeyCount).toBe(0)
+  })
+
+  it("scores the cheaper and faster run config higher on the usage axes", () => {
+    const data = chartData({})
+    const [fast, thorough] = data.series
+    const costIndex = data.keys.indexOf("cost::mean_cost")
+    const latencyIndex = data.keys.indexOf("cost::mean_total_llm_latency_ms")
+    expect(fast.value[costIndex]).toBeGreaterThan(
+      thorough.value[costIndex] as number,
+    )
+    expect(fast.value[latencyIndex]).toBeGreaterThan(
+      thorough.value[latencyIndex] as number,
+    )
+  })
+
+  it("puts every usage axis at the midpoint for a single run config", () => {
+    const data = chartData({
+      plottedConfigs: [FAST],
+      selectedRunConfigIds: ["rc_fast"],
+    })
+    expect(data.keys.filter((key) => key.startsWith("cost::"))).toHaveLength(3)
+    for (const key of data.keys.filter((k) => k.startsWith("cost::"))) {
+      expect(data.series[0].value[data.keys.indexOf(key)]).toBe(50)
+    }
+  })
+
+  it("has nothing to draw when no run config is selected, but still counts the axes the table could offer", () => {
+    const data = chartData({ plottedConfigs: [], selectedRunConfigIds: [] })
+    expect(data.hasData).toBe(false)
+    expect(data.indicators).toEqual([])
+    expect(data.series).toEqual([])
+    expect(data.omittedKeyCount).toBe(0)
+    expect(data.candidateAxisCount).toBe(6)
+  })
+
+  it("has nothing to draw when the plotted configs share fewer than three keys, and counts what it dropped", () => {
+    const data = chartData({
+      comparisonFeatures: [EVAL_SECTION],
+      getValue: lookup({
+        ...VALUES,
+        rc_thorough: {
+          "eval_1::pass_rate": 0.6,
+          "eval_1::overall_rating": null,
+          "eval_1::custom_depth": null,
+        },
+      }),
+    })
+    expect(data.hasData).toBe(false)
+    expect(data.omittedKeyCount).toBe(2)
+    expect(data.candidateAxisCount).toBe(3)
+  })
+
+  it("has nothing to draw when the table has no eval score rows", () => {
+    const data = chartData({ comparisonFeatures: [USAGE_SECTION] })
+    expect(data.hasData).toBe(false)
+    expect(data.candidateAxisCount).toBe(3)
+  })
+})

--- a/app/web_ui/src/lib/utils/radar_chart_data.test.ts
+++ b/app/web_ui/src/lib/utils/radar_chart_data.test.ts
@@ -10,7 +10,8 @@ import {
   sharedAxisKeys,
   splitAxisKeys,
 } from "./radar_chart_data"
-import type { ComparisonFeature, RadarValueLookup } from "./radar_chart_data"
+import type { RadarValueLookup } from "./radar_chart_data"
+import type { ComparisonSection } from "./compare_metric_keys"
 import type { TaskRunConfig } from "$lib/types"
 
 function make_config(id: string, name: string): TaskRunConfig {
@@ -25,10 +26,9 @@ const FAST = make_config("rc_fast", "Fast Config")
 const THOROUGH = make_config("rc_thorough", "Thorough Config")
 const IDLE = make_config("rc_idle", "Idle Config")
 
-const EVAL_SECTION: ComparisonFeature = {
+const EVAL_SECTION: ComparisonSection = {
   category: "Ticket Quality",
   eval_id: "eval_1",
-  has_default_eval_config: true,
   items: [
     { label: "Pass Rate", key: "eval_1::pass_rate" },
     { label: "Overall Rating", key: "eval_1::overall_rating" },
@@ -36,10 +36,9 @@ const EVAL_SECTION: ComparisonFeature = {
   ],
 }
 
-const USAGE_SECTION: ComparisonFeature = {
+const USAGE_SECTION: ComparisonSection = {
   category: "Average Usage, Cost & Latency",
   eval_id: "kiln_cost_section",
-  has_default_eval_config: undefined,
   items: [
     { label: "Cost (USD)", key: "cost::mean_cost" },
     { label: "Latency", key: "cost::mean_total_llm_latency_ms" },
@@ -80,7 +79,7 @@ function lookup(values: ValueTable): RadarValueLookup {
 const getValue = lookup(VALUES)
 
 function chartData(overrides: {
-  comparisonFeatures?: ComparisonFeature[]
+  comparisonFeatures?: ComparisonSection[]
   plottedConfigs?: TaskRunConfig[]
   selectedRunConfigIds?: string[]
   getValue?: RadarValueLookup

--- a/app/web_ui/src/lib/utils/radar_chart_data.ts
+++ b/app/web_ui/src/lib/utils/radar_chart_data.ts
@@ -42,9 +42,13 @@ export type RadarChartData = {
   // Candidate axes dropped because some plotted config had no result for them.
   omittedKeyCount: number
   axisLabels: Record<string, string>
-  // Axes the table could offer at all, before any filtering. Drives the "is there
-  // a chart worth drawing" gate, so it must not depend on the current selection.
+  // Rows the table is offering as axes, hidden ones already dropped upstream. Zero
+  // of them means there is nothing to put on a card at all.
   candidateAxisCount: number
+  // Whether the table has an eval section at all. A section keeps its place once
+  // every one of its rows is hidden, so this tells a task with no evals apart from
+  // one whose score rows are hidden - they need different advice.
+  hasEvalSections: boolean
   hasData: boolean
 }
 
@@ -341,6 +345,9 @@ export function buildRadarChartData(input: RadarChartInput): RadarChartData {
     omittedKeyCount: 0,
     axisLabels,
     candidateAxisCount: scoreKeys.length + usageKeys.length,
+    hasEvalSections: comparisonFeatures.some(
+      (feature) => feature.eval_id !== COST_SECTION_ID,
+    ),
     hasData: false,
   }
 
@@ -417,6 +424,7 @@ export function buildRadarChartData(input: RadarChartInput): RadarChartData {
     omittedKeyCount: omittedCount,
     axisLabels,
     candidateAxisCount: empty.candidateAxisCount,
+    hasEvalSections: empty.hasEvalSections,
     hasData: indicators.length > 0 && series.length > 0,
   }
 }

--- a/app/web_ui/src/lib/utils/radar_chart_data.ts
+++ b/app/web_ui/src/lib/utils/radar_chart_data.ts
@@ -1,5 +1,10 @@
 import type { ProviderModels, TaskRunConfig } from "$lib/types"
 import { isMcpRunConfig } from "$lib/types"
+import {
+  COST_SECTION_ID,
+  USAGE_METRICS,
+  isUsageMetricKey,
+} from "./compare_metric_keys"
 import { getRunConfigModelDisplayName } from "./run_config_formatters"
 
 // A section of the comparison table: one eval's scores, or the usage section.
@@ -50,14 +55,6 @@ export type RadarChartInput = {
   absoluteScale: boolean
 }
 
-// The comparison table's usage section. Its rows become usage axes rather than
-// eval score axes.
-export const COST_SECTION_ID = "kiln_cost_section"
-
-export const COST_KEY = "cost::mean_cost"
-export const LATENCY_KEY = "cost::mean_total_llm_latency_ms"
-export const TOTAL_TOKENS_KEY = "cost::mean_total_tokens"
-
 // Fallback full-scale max when we don't know the score's type. Most eval scores are
 // normalized to 0-1, and we only use it when the data actually fits under it.
 export const DEFAULT_ABSOLUTE_MAX = 1
@@ -81,17 +78,9 @@ export const MIN_RADAR_AXES = 3
 //
 // On the chart they're named for the direction that's better, since a bigger value
 // means less cost / less time / fewer tokens.
-export const USAGE_LABELS: Record<string, string> = {
-  [COST_KEY]: "Cost Efficiency",
-  [LATENCY_KEY]: "Speed",
-  [TOTAL_TOKENS_KEY]: "Token Efficiency",
-  "cost::mean_input_tokens": "Input Token Efficiency",
-  "cost::mean_output_tokens": "Output Token Efficiency",
-}
-
-export function isLowerIsBetterMetric(key: string): boolean {
-  return key.startsWith("cost::")
-}
+export const USAGE_LABELS: Record<string, string> = Object.fromEntries(
+  USAGE_METRICS.map((metric) => [metric.key, metric.axisLabel]),
+)
 
 /**
  * Position of a lower-is-better value within the selected configs, as a 0-100
@@ -270,7 +259,7 @@ export function rankTooltipScores({
   limit?: number
 }): { scores: TooltipScore[]; trimmedCount: number } {
   const ranked = keys
-    .filter((key) => !isLowerIsBetterMetric(key))
+    .filter((key) => !isUsageMetricKey(key))
     .map((key) => {
       const value = getValue(key)
       const max = axisMaxes[key] || 1
@@ -345,7 +334,7 @@ export function buildRadarChartData(input: RadarChartInput): RadarChartData {
   // Every value on a usage axis, so each can be scored by its position among them
   const usageValues: Record<string, number[]> = {}
   for (const key of keys) {
-    if (!isLowerIsBetterMetric(key)) continue
+    if (!isUsageMetricKey(key)) continue
     usageValues[key] = plottedConfigs
       .map((config) => getValue(config.id ?? null, key))
       .filter((value): value is number => value !== null)
@@ -353,7 +342,7 @@ export function buildRadarChartData(input: RadarChartInput): RadarChartData {
 
   const axisMaxes: Record<string, number> = {}
   for (const key of keys) {
-    if (isLowerIsBetterMetric(key)) {
+    if (isUsageMetricKey(key)) {
       axisMaxes[key] = USAGE_AXIS_MAX
       continue
     }
@@ -377,7 +366,7 @@ export function buildRadarChartData(input: RadarChartInput): RadarChartData {
     value: keys.map((key) => {
       const rawValue = getValue(config.id ?? null, key)
       if (rawValue === null) return null
-      return isLowerIsBetterMetric(key)
+      return isUsageMetricKey(key)
         ? metricToScore(rawValue, usageValues[key] || [])
         : rawValue
     }),

--- a/app/web_ui/src/lib/utils/radar_chart_data.ts
+++ b/app/web_ui/src/lib/utils/radar_chart_data.ts
@@ -33,6 +33,10 @@ export type RadarChartData = {
   // One entry per plotted run config, values in `keys` order.
   series: RadarSeriesDatum[]
   legend: string[]
+  // The run config behind each series name. Echarts hands a formatter the series
+  // name and nothing else, so this is how a tooltip gets back to the config that
+  // drew the shape - by identity, not by display name.
+  configsBySeriesName: Record<string, TaskRunConfig>
   axisMaxes: Record<string, number>
   keys: string[]
   // Candidate axes dropped because some plotted config had no result for them.
@@ -241,6 +245,28 @@ export function runConfigSeriesName(
 }
 
 /**
+ * Series name per run config, in plot order. Echarts keys a series by its name and
+ * two run configs can carry the same one, so every occurrence of a repeated name is
+ * numbered. A name that occurs once is left exactly as it is.
+ */
+export function runConfigSeriesNames(
+  configs: TaskRunConfig[],
+  modelInfo: ProviderModels | null,
+): string[] {
+  const names = configs.map((config) => runConfigSeriesName(config, modelInfo))
+  const totals: Record<string, number> = {}
+  for (const name of names) {
+    totals[name] = (totals[name] ?? 0) + 1
+  }
+  const seen: Record<string, number> = {}
+  return names.map((name) => {
+    if (totals[name] === 1) return name
+    seen[name] = (seen[name] ?? 0) + 1
+    return `${name} (${seen[name]})`
+  })
+}
+
+/**
  * The eval scores a tooltip should list, trimmed to the weakest `limit` of them.
  * The usage axes plot a relative score rather than their raw quantity, so ranking
  * them against pass rates would compare unlike things - they are left out.
@@ -309,6 +335,7 @@ export function buildRadarChartData(input: RadarChartInput): RadarChartData {
     indicators: [],
     series: [],
     legend: [],
+    configsBySeriesName: {},
     axisMaxes: {},
     keys: [],
     omittedKeyCount: 0,
@@ -361,8 +388,10 @@ export function buildRadarChartData(input: RadarChartInput): RadarChartData {
     max: axisMaxes[key],
   }))
 
+  const seriesNames = runConfigSeriesNames(plottedConfigs, modelInfo)
+
   // Every plotted config has a value for every key by construction above.
-  const series = plottedConfigs.map((config) => ({
+  const series = plottedConfigs.map((config, index) => ({
     value: keys.map((key) => {
       const rawValue = getValue(config.id ?? null, key)
       if (rawValue === null) return null
@@ -370,13 +399,19 @@ export function buildRadarChartData(input: RadarChartInput): RadarChartData {
         ? metricToScore(rawValue, usageValues[key] || [])
         : rawValue
     }),
-    name: runConfigSeriesName(config, modelInfo),
+    name: seriesNames[index],
   }))
+
+  const configsBySeriesName: Record<string, TaskRunConfig> = {}
+  plottedConfigs.forEach((config, index) => {
+    configsBySeriesName[seriesNames[index]] = config
+  })
 
   return {
     indicators,
     series,
     legend: series.map((datum) => datum.name),
+    configsBySeriesName,
     axisMaxes,
     keys,
     omittedKeyCount: omittedCount,

--- a/app/web_ui/src/lib/utils/radar_chart_data.ts
+++ b/app/web_ui/src/lib/utils/radar_chart_data.ts
@@ -5,15 +5,8 @@ import {
   USAGE_METRICS,
   isUsageMetricKey,
 } from "./compare_metric_keys"
+import type { ComparisonSection } from "./compare_metric_keys"
 import { getRunConfigModelDisplayName } from "./run_config_formatters"
-
-// A section of the comparison table: one eval's scores, or the usage section.
-export type ComparisonFeature = {
-  category: string
-  items: { label: string; key: string }[]
-  has_default_eval_config: boolean | undefined
-  eval_id: string
-}
 
 // Reads one run config's value for one row of the comparison table.
 export type RadarValueLookup = (
@@ -21,11 +14,11 @@ export type RadarValueLookup = (
   dataKey: string,
 ) => number | null
 
-export type RadarIndicator = { name: string; max: number }
+type RadarIndicator = { name: string; max: number }
 
-export type RadarSeriesDatum = { value: (number | null)[]; name: string }
+type RadarSeriesDatum = { value: (number | null)[]; name: string }
 
-export type TooltipScore = { label: string; value: number | null }
+type TooltipScore = { label: string; value: number | null }
 
 export type RadarChartData = {
   // Axes in plot order, already labelled.
@@ -52,8 +45,8 @@ export type RadarChartData = {
   hasData: boolean
 }
 
-export type RadarChartInput = {
-  comparisonFeatures: ComparisonFeature[]
+type RadarChartInput = {
+  comparisonFeatures: ComparisonSection[]
   plottedConfigs: TaskRunConfig[]
   selectedRunConfigIds: string[]
   getValue: RadarValueLookup
@@ -65,15 +58,15 @@ export type RadarChartInput = {
 
 // Fallback full-scale max when we don't know the score's type. Most eval scores are
 // normalized to 0-1, and we only use it when the data actually fits under it.
-export const DEFAULT_ABSOLUTE_MAX = 1
+const DEFAULT_ABSOLUTE_MAX = 1
 
 // Usage axes carry a 0-100 position score rather than a raw quantity, in both
 // scale modes.
-export const USAGE_AXIS_MAX = 100
+const USAGE_AXIS_MAX = 100
 
 // Above this many scores the tooltip lists only the weakest ones - the full set is
 // in the comparison table above.
-export const MAX_TOOLTIP_SCORES = 10
+const MAX_TOOLTIP_SCORES = 10
 
 // Below this many axes there's no shape to read, so there's no chart to draw
 export const MIN_RADAR_AXES = 3
@@ -86,7 +79,7 @@ export const MIN_RADAR_AXES = 3
 //
 // On the chart they're named for the direction that's better, since a bigger value
 // means less cost / less time / fewer tokens.
-export const USAGE_LABELS: Record<string, string> = Object.fromEntries(
+const USAGE_LABELS: Record<string, string> = Object.fromEntries(
   USAGE_METRICS.map((metric) => [metric.key, metric.axisLabel]),
 )
 
@@ -132,7 +125,7 @@ export function metricToScore(
  * The table's row keys, split into eval score axes and usage axes. Hiding a usage
  * row in the table removes it here too - one control, where the numbers are.
  */
-export function splitAxisKeys(comparisonFeatures: ComparisonFeature[]): {
+export function splitAxisKeys(comparisonFeatures: ComparisonSection[]): {
   scoreKeys: string[]
   usageKeys: string[]
 } {
@@ -158,7 +151,7 @@ export function plottedRunConfigs({
   selectedRunConfigIds,
   getValue,
 }: {
-  comparisonFeatures: ComparisonFeature[]
+  comparisonFeatures: ComparisonSection[]
   runConfigs: TaskRunConfig[]
   selectedRunConfigIds: string[]
   getValue: RadarValueLookup
@@ -219,7 +212,7 @@ export function axisMaxFor(
  * name, then the table's own label, then the raw key.
  */
 export function buildAxisLabels(
-  comparisonFeatures: ComparisonFeature[],
+  comparisonFeatures: ComparisonSection[],
   metricLabels: Record<string, string>,
 ): Record<string, string> {
   const tableLabels: Record<string, string> = {}
@@ -237,7 +230,7 @@ export function buildAxisLabels(
 }
 
 /** The series name of a run config, which is also its legend entry. */
-export function runConfigSeriesName(
+function runConfigSeriesName(
   config: TaskRunConfig,
   modelInfo: ProviderModels | null,
 ): string {
@@ -292,7 +285,7 @@ export function rankTooltipScores({
     .filter((key) => !isUsageMetricKey(key))
     .map((key) => {
       const value = getValue(key)
-      const max = axisMaxes[key] || 1
+      const max = axisMaxes[key] ?? 1
       return {
         label: axisLabels[key] ?? key,
         value,
@@ -403,7 +396,7 @@ export function buildRadarChartData(input: RadarChartInput): RadarChartData {
       const rawValue = getValue(config.id ?? null, key)
       if (rawValue === null) return null
       return isUsageMetricKey(key)
-        ? metricToScore(rawValue, usageValues[key] || [])
+        ? metricToScore(rawValue, usageValues[key])
         : rawValue
     }),
     name: seriesNames[index],

--- a/app/web_ui/src/lib/utils/radar_chart_data.ts
+++ b/app/web_ui/src/lib/utils/radar_chart_data.ts
@@ -1,0 +1,398 @@
+import type { ProviderModels, TaskRunConfig } from "$lib/types"
+import { isMcpRunConfig } from "$lib/types"
+import { getRunConfigModelDisplayName } from "./run_config_formatters"
+
+// A section of the comparison table: one eval's scores, or the usage section.
+export type ComparisonFeature = {
+  category: string
+  items: { label: string; key: string }[]
+  has_default_eval_config: boolean | undefined
+  eval_id: string
+}
+
+// Reads one run config's value for one row of the comparison table.
+export type RadarValueLookup = (
+  modelKey: string | null,
+  dataKey: string,
+) => number | null
+
+export type RadarIndicator = { name: string; max: number }
+
+export type RadarSeriesDatum = { value: (number | null)[]; name: string }
+
+export type TooltipScore = { label: string; value: number | null }
+
+export type RadarChartData = {
+  // Axes in plot order, already labelled.
+  indicators: RadarIndicator[]
+  // One entry per plotted run config, values in `keys` order.
+  series: RadarSeriesDatum[]
+  legend: string[]
+  axisMaxes: Record<string, number>
+  keys: string[]
+  // Candidate axes dropped because some plotted config had no result for them.
+  omittedKeyCount: number
+  axisLabels: Record<string, string>
+  // Axes the table could offer at all, before any filtering. Drives the "is there
+  // a chart worth drawing" gate, so it must not depend on the current selection.
+  candidateAxisCount: number
+  hasData: boolean
+}
+
+export type RadarChartInput = {
+  comparisonFeatures: ComparisonFeature[]
+  plottedConfigs: TaskRunConfig[]
+  selectedRunConfigIds: string[]
+  getValue: RadarValueLookup
+  modelInfo: ProviderModels | null
+  scoreAxisMaxes: Record<string, number>
+  metricLabels: Record<string, string>
+  absoluteScale: boolean
+}
+
+// The comparison table's usage section. Its rows become usage axes rather than
+// eval score axes.
+export const COST_SECTION_ID = "kiln_cost_section"
+
+export const COST_KEY = "cost::mean_cost"
+export const LATENCY_KEY = "cost::mean_total_llm_latency_ms"
+export const TOTAL_TOKENS_KEY = "cost::mean_total_tokens"
+
+// Fallback full-scale max when we don't know the score's type. Most eval scores are
+// normalized to 0-1, and we only use it when the data actually fits under it.
+export const DEFAULT_ABSOLUTE_MAX = 1
+
+// Usage axes carry a 0-100 position score rather than a raw quantity, in both
+// scale modes.
+export const USAGE_AXIS_MAX = 100
+
+// Above this many scores the tooltip lists only the weakest ones - the full set is
+// in the comparison table above.
+export const MAX_TOOLTIP_SCORES = 10
+
+// Below this many axes there's no shape to read, so there's no chart to draw
+export const MIN_RADAR_AXES = 3
+
+// Cost, latency and token counts are lower-is-better raw quantities with no
+// absolute range, so they're scored by position within the selected run configs
+// (metricToScore) on a shared 0-100 axis. That's a comparison, which means these
+// axes only carry information when there are at least two configs to compare - and
+// it's why they stay relative even in Full Scale mode.
+//
+// On the chart they're named for the direction that's better, since a bigger value
+// means less cost / less time / fewer tokens.
+export const USAGE_LABELS: Record<string, string> = {
+  [COST_KEY]: "Cost Efficiency",
+  [LATENCY_KEY]: "Speed",
+  [TOTAL_TOKENS_KEY]: "Token Efficiency",
+  "cost::mean_input_tokens": "Input Token Efficiency",
+  "cost::mean_output_tokens": "Output Token Efficiency",
+}
+
+export function isLowerIsBetterMetric(key: string): boolean {
+  return key.startsWith("cost::")
+}
+
+/**
+ * Position of a lower-is-better value within the selected configs, as a 0-100
+ * score. Ties (or a single config) land at 50: no better, no worse.
+ */
+export function metricToScore(
+  cost: number,
+  costs: number[],
+  {
+    padding = 10, // keep endpoints away from 0/100
+    relFull = 0.7, // when (hi-lo)/|hi| reaches this, use full spread (k=1)
+  }: {
+    padding?: number
+    relFull?: number
+  } = {},
+): number {
+  const lo = Math.min(...costs)
+  const hi = Math.max(...costs)
+
+  const range = hi - lo
+  if (range <= 0) return 50
+
+  // 1) range-based normalized position
+  const t = (cost - lo) / range
+
+  // 2) raw padded linear score (lower cost = higher score)
+  const raw = padding + (1 - t) * (100 - 2 * padding)
+
+  // 3) compress based on range relative to magnitude ("scale from zero")
+  const scale = Math.max(Math.abs(hi), 1e-12)
+  const relRange = range / scale // e.g. 0.02..0.03 => 0.01/0.03 ≈ 0.33
+  const k = Math.max(0, Math.min(1, relRange / relFull)) // small relRange -> k<1 -> compress
+
+  // 4) mix toward midpoint
+  const score = 50 + k * (raw - 50)
+
+  return Math.max(0, Math.min(100, score))
+}
+
+/**
+ * The table's row keys, split into eval score axes and usage axes. Hiding a usage
+ * row in the table removes it here too - one control, where the numbers are.
+ */
+export function splitAxisKeys(comparisonFeatures: ComparisonFeature[]): {
+  scoreKeys: string[]
+  usageKeys: string[]
+} {
+  const scoreKeys: string[] = []
+  const usageKeys: string[] = []
+  for (const feature of comparisonFeatures) {
+    const target = feature.eval_id === COST_SECTION_ID ? usageKeys : scoreKeys
+    for (const item of feature.items) {
+      target.push(item.key)
+    }
+  }
+  return { scoreKeys, usageKeys }
+}
+
+/**
+ * Run configs that will actually be drawn: selected, and with at least one eval
+ * result. One with nothing to plot is left out entirely rather than emptying every
+ * axis.
+ */
+export function plottedRunConfigs({
+  comparisonFeatures,
+  runConfigs,
+  selectedRunConfigIds,
+  getValue,
+}: {
+  comparisonFeatures: ComparisonFeature[]
+  runConfigs: TaskRunConfig[]
+  selectedRunConfigIds: string[]
+  getValue: RadarValueLookup
+}): TaskRunConfig[] {
+  const { scoreKeys } = splitAxisKeys(comparisonFeatures)
+  return selectedRunConfigIds
+    .map((configId) => runConfigs.find((config) => config.id === configId))
+    .filter((config): config is TaskRunConfig => !!config)
+    .filter((config) =>
+      scoreKeys.some((key) => getValue(config.id ?? null, key) !== null),
+    )
+}
+
+/**
+ * The candidate axes every plotted config has a result for, and how many were
+ * dropped. ECharts draws a missing radar value at the center of the chart
+ * (radarLayout's getValueMissingPoint), which is indistinguishable from scoring
+ * zero - so an axis one config hasn't been evaluated on can't be drawn honestly at
+ * all.
+ */
+export function sharedAxisKeys(
+  candidateKeys: string[],
+  plottedConfigs: TaskRunConfig[],
+  getValue: RadarValueLookup,
+): { keys: string[]; omittedCount: number } {
+  const keys = candidateKeys.filter((key) =>
+    plottedConfigs.every((config) => getValue(config.id ?? null, key) !== null),
+  )
+  return { keys, omittedCount: candidateKeys.length - keys.length }
+}
+
+/**
+ * The top of one eval score axis. Relative mode pads the observed maximum; full
+ * scale uses the score's own range when we know it, and never returns a max below
+ * the data, so nothing is clipped for unbounded (custom) or unrecognized scores.
+ */
+export function axisMaxFor(
+  key: string,
+  rawMax: number,
+  {
+    absoluteScale,
+    scoreAxisMaxes,
+  }: { absoluteScale: boolean; scoreAxisMaxes: Record<string, number> },
+): number {
+  const paddedMax = rawMax > 0 ? rawMax * 1.1 : 1
+  if (!absoluteScale) {
+    return paddedMax
+  }
+  const knownMax = scoreAxisMaxes[key]
+  if (knownMax !== undefined && knownMax >= rawMax) {
+    return knownMax
+  }
+  return rawMax <= DEFAULT_ABSOLUTE_MAX ? DEFAULT_ABSOLUTE_MAX : paddedMax
+}
+
+/**
+ * Axis name per row key: the name the user gave the row wins, then the usage axis
+ * name, then the table's own label, then the raw key.
+ */
+export function buildAxisLabels(
+  comparisonFeatures: ComparisonFeature[],
+  metricLabels: Record<string, string>,
+): Record<string, string> {
+  const tableLabels: Record<string, string> = {}
+  for (const feature of comparisonFeatures) {
+    for (const item of feature.items) {
+      if (item.key in tableLabels) continue
+      tableLabels[item.key] = item.label
+    }
+  }
+  const labels: Record<string, string> = {}
+  for (const [key, tableLabel] of Object.entries(tableLabels)) {
+    labels[key] = metricLabels[key] || USAGE_LABELS[key] || tableLabel
+  }
+  return labels
+}
+
+/** The series name of a run config, which is also its legend entry. */
+export function runConfigSeriesName(
+  config: TaskRunConfig,
+  modelInfo: ProviderModels | null,
+): string {
+  if (config.name) return config.name
+  if (isMcpRunConfig(config.run_config_properties)) {
+    return config.run_config_properties.tool_reference.tool_name ?? "MCP Tool"
+  }
+  return getRunConfigModelDisplayName(config, modelInfo) ?? "Unknown"
+}
+
+/**
+ * The eval scores a tooltip should list, trimmed to the weakest `limit` of them.
+ * The usage axes plot a relative score rather than their raw quantity, so ranking
+ * them against pass rates would compare unlike things - they are left out.
+ */
+export function rankTooltipScores({
+  keys,
+  axisMaxes,
+  axisLabels,
+  getValue,
+  limit = MAX_TOOLTIP_SCORES,
+}: {
+  keys: string[]
+  axisMaxes: Record<string, number>
+  axisLabels: Record<string, string>
+  getValue: (key: string) => number | null
+  limit?: number
+}): { scores: TooltipScore[]; trimmedCount: number } {
+  const ranked = keys
+    .filter((key) => !isLowerIsBetterMetric(key))
+    .map((key) => {
+      const value = getValue(key)
+      const max = axisMaxes[key] || 1
+      return {
+        label: axisLabels[key] ?? key,
+        value,
+        // Rank by position on the axis, so scores with different ranges (0-1 vs
+        // 1-5) are comparable. Missing values sort first: "didn't run" is worth
+        // surfacing.
+        position: value === null ? -1 : value / max,
+      }
+    })
+
+  const strip = (entry: (typeof ranked)[number]): TooltipScore => ({
+    label: entry.label,
+    value: entry.value,
+  })
+
+  if (ranked.length <= limit) {
+    return { scores: ranked.map(strip), trimmedCount: 0 }
+  }
+  const shown = [...ranked]
+    .sort((a, b) => a.position - b.position)
+    .slice(0, limit)
+  return {
+    scores: shown.map(strip),
+    trimmedCount: ranked.length - shown.length,
+  }
+}
+
+/** Everything the radar chart draws, derived from the table and the selection. */
+export function buildRadarChartData(input: RadarChartInput): RadarChartData {
+  const {
+    comparisonFeatures,
+    plottedConfigs,
+    selectedRunConfigIds,
+    getValue,
+    modelInfo,
+    scoreAxisMaxes,
+    metricLabels,
+    absoluteScale,
+  } = input
+
+  const { scoreKeys, usageKeys } = splitAxisKeys(comparisonFeatures)
+  const axisLabels = buildAxisLabels(comparisonFeatures, metricLabels)
+  const empty: RadarChartData = {
+    indicators: [],
+    series: [],
+    legend: [],
+    axisMaxes: {},
+    keys: [],
+    omittedKeyCount: 0,
+    axisLabels,
+    candidateAxisCount: scoreKeys.length + usageKeys.length,
+    hasData: false,
+  }
+
+  if (scoreKeys.length === 0 || selectedRunConfigIds.length === 0) {
+    return empty
+  }
+
+  const { keys, omittedCount } = sharedAxisKeys(
+    [...scoreKeys, ...usageKeys],
+    plottedConfigs,
+    getValue,
+  )
+
+  if (keys.length < MIN_RADAR_AXES) {
+    return { ...empty, omittedKeyCount: omittedCount }
+  }
+
+  // Every value on a usage axis, so each can be scored by its position among them
+  const usageValues: Record<string, number[]> = {}
+  for (const key of keys) {
+    if (!isLowerIsBetterMetric(key)) continue
+    usageValues[key] = plottedConfigs
+      .map((config) => getValue(config.id ?? null, key))
+      .filter((value): value is number => value !== null)
+  }
+
+  const axisMaxes: Record<string, number> = {}
+  for (const key of keys) {
+    if (isLowerIsBetterMetric(key)) {
+      axisMaxes[key] = USAGE_AXIS_MAX
+      continue
+    }
+    let rawMax = 0
+    for (const config of plottedConfigs) {
+      const value = getValue(config.id ?? null, key)
+      if (value !== null && value > rawMax) {
+        rawMax = value
+      }
+    }
+    axisMaxes[key] = axisMaxFor(key, rawMax, { absoluteScale, scoreAxisMaxes })
+  }
+
+  const indicators = keys.map((key) => ({
+    name: axisLabels[key] ?? key,
+    max: axisMaxes[key],
+  }))
+
+  // Every plotted config has a value for every key by construction above.
+  const series = plottedConfigs.map((config) => ({
+    value: keys.map((key) => {
+      const rawValue = getValue(config.id ?? null, key)
+      if (rawValue === null) return null
+      return isLowerIsBetterMetric(key)
+        ? metricToScore(rawValue, usageValues[key] || [])
+        : rawValue
+    }),
+    name: runConfigSeriesName(config, modelInfo),
+  }))
+
+  return {
+    indicators,
+    series,
+    legend: series.map((datum) => datum.name),
+    axisMaxes,
+    keys,
+    omittedKeyCount: omittedCount,
+    axisLabels,
+    candidateAxisCount: empty.candidateAxisCount,
+    hasData: indicators.length > 0 && series.length > 0,
+  }
+}

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -35,7 +35,6 @@
     getRunConfigInputTransformSummaryLabel,
   } from "$lib/utils/run_config_formatters"
   import { isKilnAgentRunConfig, isMcpRunConfig } from "$lib/types"
-  import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
   import { prompt_link } from "$lib/utils/link_builder"
   import { tagFromFilterId } from "../spec_utils"
@@ -52,6 +51,7 @@
   } from "$lib/utils/compare_metric_keys"
   import {
     applyMetricLabels,
+    buildScoreAxisMaxes,
     filterVisibleSections,
     listHiddenMetrics,
     parseHiddenListParam,
@@ -528,34 +528,8 @@
     })
   }
 
-  // Full range of each score type. Custom scores are unbounded, so they get no
-  // absolute max and stay on data-relative scaling in the radar chart.
-  function score_type_max(score_type: string): number | null {
-    switch (score_type) {
-      case "five_star":
-        return 5
-      case "pass_fail":
-        return 1
-      case "pass_fail_critical":
-        return 1
-      default:
-        return null
-    }
-  }
-
   // Absolute (full range) max per radar axis key, for the chart's "Full Scale" mode
-  $: scoreAxisMaxes = (() => {
-    const maxes: Record<string, number> = {}
-    for (const [eval_id, evalData] of Object.entries(eval_data_cache)) {
-      for (const score of evalData?.output_scores || []) {
-        const max = score_type_max(score.type)
-        if (max !== null) {
-          maxes[`${eval_id}::${string_to_json_key(score.name)}`] = max
-        }
-      }
-    }
-    return maxes
-  })()
+  $: scoreAxisMaxes = buildScoreAxisMaxes(eval_data_cache)
 
   function generateComparisonFeatures(
     models: (string | null)[],

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -47,6 +47,10 @@
   import FloatingMenu from "$lib/ui/floating_menu.svelte"
   import type { FloatingMenuItem } from "$lib/ui/floating_menu_types"
   import {
+    COST_SECTION_ID,
+    USAGE_METRICS,
+  } from "$lib/utils/compare_metric_keys"
+  import {
     applyMetricLabels,
     filterVisibleSections,
     listHiddenMetrics,
@@ -518,7 +522,7 @@
   // Reactively fetch eval templates for sections
   $: {
     comparisonFeatures.forEach((section) => {
-      if (section.eval_id !== "kiln_cost_section") {
+      if (section.eval_id !== COST_SECTION_ID) {
         fetch_eval_data(section.eval_id)
       }
     })
@@ -611,19 +615,13 @@
     })
 
     // Add Cost section (always last)
-    const costItems = [
-      { label: "Input Tokens", key: "cost::mean_input_tokens" },
-      { label: "Output Tokens", key: "cost::mean_output_tokens" },
-      { label: "Total Tokens", key: "cost::mean_total_tokens" },
-      { label: "Cost (USD)", key: "cost::mean_cost" },
-      { label: "Latency", key: "cost::mean_total_llm_latency_ms" },
-    ]
+    const costItems = USAGE_METRICS.map(({ label, key }) => ({ label, key }))
 
     features.push({
       category: "Average Usage, Cost & Latency",
       items: costItems,
       has_default_eval_config: undefined,
-      eval_id: "kiln_cost_section",
+      eval_id: COST_SECTION_ID,
       spec_id: null,
     })
 
@@ -732,11 +730,7 @@
     modelKey: string | null,
     evalID: string | null,
   ): { n_excluded: number; n_used: number } {
-    if (
-      evalID === "kiln_cost_section" ||
-      !modelKey ||
-      !eval_scores_cache[modelKey]
-    )
+    if (evalID === COST_SECTION_ID || !modelKey || !eval_scores_cache[modelKey])
       return { n_excluded: 0, n_used: 0 }
 
     const evalScores = eval_scores_cache[modelKey]
@@ -757,7 +751,7 @@
     modelKey: string | null,
     evalID: string | null,
   ): number {
-    if (evalID === "kiln_cost_section") return 1.0
+    if (evalID === COST_SECTION_ID) return 1.0
     if (!modelKey || !eval_scores_cache[modelKey]) return 0.0
 
     const evalScores = eval_scores_cache[modelKey]
@@ -779,7 +773,7 @@
     modelKey: string | null,
     evalID: string | null,
   ): string | null | undefined {
-    if (evalID === "kiln_cost_section") return null
+    if (evalID === COST_SECTION_ID) return null
     if (!modelKey || !eval_scores_cache[modelKey]) return null
 
     const evalScores = eval_scores_cache[modelKey]
@@ -1120,7 +1114,7 @@
                   type="button"
                   on:click={() => hideEval(section.eval_id)}
                   class="w-6 h-6 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 transition-colors"
-                  title={section.eval_id === "kiln_cost_section"
+                  title={section.eval_id === COST_SECTION_ID
                     ? "Hide this section"
                     : "Hide this eval"}
                 >

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -35,6 +35,7 @@
     getRunConfigInputTransformSummaryLabel,
   } from "$lib/utils/run_config_formatters"
   import { isKilnAgentRunConfig, isMcpRunConfig } from "$lib/types"
+  import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
   import InfoTooltip from "$lib/ui/info_tooltip.svelte"
   import { prompt_link } from "$lib/utils/link_builder"
   import { tagFromFilterId } from "../spec_utils"
@@ -45,6 +46,15 @@
   import RunEval from "$lib/components/run_eval.svelte"
   import FloatingMenu from "$lib/ui/floating_menu.svelte"
   import type { FloatingMenuItem } from "$lib/ui/floating_menu_types"
+  import {
+    applyMetricLabels,
+    filterVisibleSections,
+    listHiddenMetrics,
+    parseHiddenListParam,
+    parseMetricLabelsParam,
+    withMetricLabel,
+    type MetricLabels,
+  } from "./compare_view"
 
   import { agentInfo } from "$lib/agent"
   $: project_id = $page.params.project_id!
@@ -58,7 +68,10 @@
   // State management
   let columns = 2 // Start with 2 columns
   let selectedModels: (string | null)[] = [null, null] // Track selected model for each column
-  let hiddenEvalIds: string[] = [] // Eval IDs hidden by the user (kiln_cost_section is never hideable)
+  let hiddenEvalIds: string[] = [] // Sections hidden by the user: evals, or the cost section
+  let hiddenMetricKeys: string[] = [] // Individual rows hidden by the user, in any section
+  let metricLabels: MetricLabels = {} // Display names the user has given rows, by row key
+  let renamingMetricKey: string | null = null // Row whose name is being edited, if any
 
   // Run configs state
   let loading_run_configs = true
@@ -101,19 +114,14 @@
     // Initialize selectedModels array with correct length
     selectedModels = new Array(columns).fill(null)
 
-    // Hidden evals can be restored before run configs are loaded - they are just IDs.
-    // Defensive: drop the cost section ID + dedupe in case a hand-edited URL is messy.
-    const urlHidden = urlParams.get("hidden_evals")
-    if (urlHidden) {
-      hiddenEvalIds = [
-        ...new Set(
-          urlHidden
-            .split(",")
-            .map((id) => id.trim())
-            .filter((id) => id.length > 0 && id !== "kiln_cost_section"),
-        ),
-      ]
-    }
+    // Hidden sections and rows can be restored before run configs are loaded - they
+    // are just IDs and keys. Row keys are "<section>::<metric>".
+    hiddenEvalIds = parseHiddenListParam(urlParams.get("hidden_evals"))
+    hiddenMetricKeys = parseHiddenListParam(
+      urlParams.get("hidden_metrics"),
+      (key) => key.includes("::"),
+    )
+    metricLabels = parseMetricLabelsParam(urlParams.get("metric_labels"))
   }
 
   // Restore model selections from URL after data is loaded
@@ -164,13 +172,34 @@
       urlParams.delete("hidden_evals")
     }
 
-    // Use replace to avoid creating new history entries
+    if (hiddenMetricKeys.length > 0) {
+      urlParams.set("hidden_metrics", hiddenMetricKeys.join(","))
+    } else {
+      urlParams.delete("hidden_metrics")
+    }
+
+    if (Object.keys(metricLabels).length > 0) {
+      urlParams.set("metric_labels", JSON.stringify(metricLabels))
+    } else {
+      urlParams.delete("metric_labels")
+    }
+
+    // Use replace to avoid creating new history entries. noScroll/keepFocus because
+    // this only ever records existing UI state in the URL - without them, hiding a
+    // row or adding a column jumps the page back to the top and drops focus.
     const newURL = `${$page.url.pathname}?${urlParams.toString()}`
-    goto(newURL, { replaceState: true })
+    goto(newURL, { replaceState: true, noScroll: true, keepFocus: true })
   }
 
   // Reactive statements to update URL when state changes
-  $: if (!isInitializing && (columns || selectedModels || hiddenEvalIds)) {
+  $: if (
+    !isInitializing &&
+    (columns ||
+      selectedModels ||
+      hiddenEvalIds ||
+      hiddenMetricKeys ||
+      metricLabels)
+  ) {
     updateURL()
   }
 
@@ -350,43 +379,62 @@
     eval_scores_cache,
   )
 
-  // Filter out user-hidden evals (cost section is never hideable). hiddenEvalIds is
-  // passed in as a parameter (rather than read via closure) so that Svelte's reactive
-  // `$:` statements track it as a dependency and re-run when it changes.
-  function filterVisibleFeatures<T extends { eval_id: string }>(
-    features: T[],
-    hidden: string[],
-  ): T[] {
-    if (hidden.length === 0) return features
-    return features.filter(
-      (section) =>
-        section.eval_id === "kiln_cost_section" ||
-        !hidden.includes(section.eval_id),
-    )
-  }
-
-  $: visibleComparisonFeatures = filterVisibleFeatures(
+  // The user's view of the sections: rows carry their display names, then hidden
+  // sections and rows are dropped. Hidden state and names are passed as arguments
+  // (rather than read via closure) so that Svelte's reactive `$:` statements track
+  // them as dependencies and re-run when they change.
+  $: labeledComparisonFeatures = applyMetricLabels(
     comparisonFeatures,
-    hiddenEvalIds,
+    metricLabels,
   )
-  $: visibleChartComparisonFeatures = filterVisibleFeatures(
+  $: labeledChartComparisonFeatures = applyMetricLabels(
     chartComparisonFeatures,
+    metricLabels,
+  )
+  $: visibleComparisonFeatures = filterVisibleSections(
+    labeledComparisonFeatures,
     hiddenEvalIds,
+    hiddenMetricKeys,
+  )
+  $: visibleChartComparisonFeatures = filterVisibleSections(
+    labeledChartComparisonFeatures,
+    hiddenEvalIds,
+    hiddenMetricKeys,
+  )
+
+  // Each row's own name, for the rename field's placeholder and so that typing it
+  // back in drops the override
+  $: originalMetricLabels = Object.fromEntries(
+    chartComparisonFeatures.flatMap((section) =>
+      section.items.map((item) => [item.key, item.label]),
+    ),
+  ) as Record<string, string>
+
+  // Sections whose eval produced no scores at all - as opposed to sections the user
+  // has emptied by hiding every row, which just render as their header
+  $: sectionsWithoutScores = new Set(
+    comparisonFeatures
+      .filter((section) => section.items.length === 0)
+      .map((section) => section.eval_id),
   )
 
   // Names of currently-hidden evals (used for the "show hidden" dropdown).
   // chartComparisonFeatures is built from ALL run configs for the task and is a
   // superset of comparisonFeatures (which only covers selected models), so it
   // alone is enough to resolve display names.
-  $: hiddenEvalsInfo = hiddenEvalIds
-    .filter((id) => id !== "kiln_cost_section")
-    .map((evalId) => {
-      const feature = chartComparisonFeatures.find((s) => s.eval_id === evalId)
-      return { eval_id: evalId, category: feature?.category ?? "Unknown eval" }
-    })
+  $: hiddenEvalsInfo = hiddenEvalIds.map((evalId) => {
+    const feature = chartComparisonFeatures.find((s) => s.eval_id === evalId)
+    return { eval_id: evalId, category: feature?.category ?? "Unknown eval" }
+  })
+
+  // Rows hidden one at a time, for the same dropdown
+  $: hiddenMetricsInfo = listHiddenMetrics(
+    labeledChartComparisonFeatures,
+    hiddenEvalIds,
+    hiddenMetricKeys,
+  )
 
   function hideEval(evalId: string) {
-    if (evalId === "kiln_cost_section") return
     if (hiddenEvalIds.includes(evalId)) return
     hiddenEvalIds = [...hiddenEvalIds, evalId]
   }
@@ -395,19 +443,74 @@
     hiddenEvalIds = hiddenEvalIds.filter((id) => id !== evalId)
   }
 
-  function showAllHiddenEvals() {
-    hiddenEvalIds = []
+  function hideMetric(key: string) {
+    if (hiddenMetricKeys.includes(key)) return
+    hiddenMetricKeys = [...hiddenMetricKeys, key]
   }
 
+  function showMetric(key: string) {
+    hiddenMetricKeys = hiddenMetricKeys.filter((k) => k !== key)
+  }
+
+  function showAllHiddenEvals() {
+    hiddenEvalIds = []
+    hiddenMetricKeys = []
+  }
+
+  function startRename(key: string) {
+    renamingMetricKey = key
+  }
+
+  function commitRename(key: string, name: string) {
+    // The field blurs as it unmounts after Enter or Escape - nothing more to do then
+    if (renamingMetricKey !== key) return
+    metricLabels = withMetricLabel(
+      metricLabels,
+      key,
+      name,
+      originalMetricLabels[key],
+    )
+    renamingMetricKey = null
+  }
+
+  function cancelRename() {
+    renamingMetricKey = null
+  }
+
+  // Focus the rename field as soon as it appears, with its text selected so that
+  // typing replaces the current name
+  function focusAndSelect(node: HTMLInputElement) {
+    node.focus()
+    node.select()
+  }
+
+  $: hiddenCount = hiddenEvalsInfo.length + hiddenMetricsInfo.length
+
   $: hiddenEvalsMenuItems = [
-    { label: "Show Eval", header: true },
-    ...hiddenEvalsInfo.map(
-      (info): FloatingMenuItem => ({
-        label: info.category,
-        onclick: () => showEval(info.eval_id),
-      }),
-    ),
-    ...(hiddenEvalsInfo.length > 1
+    ...(hiddenEvalsInfo.length > 0
+      ? [
+          { label: "Show Eval", header: true },
+          ...hiddenEvalsInfo.map(
+            (info): FloatingMenuItem => ({
+              label: info.category,
+              onclick: () => showEval(info.eval_id),
+            }),
+          ),
+        ]
+      : []),
+    ...(hiddenMetricsInfo.length > 0
+      ? [
+          { label: "Show Metric", header: true },
+          ...hiddenMetricsInfo.map(
+            (info): FloatingMenuItem => ({
+              label: info.label,
+              description: info.section,
+              onclick: () => showMetric(info.key),
+            }),
+          ),
+        ]
+      : []),
+    ...(hiddenCount > 1
       ? [{ label: "Show All", onclick: showAllHiddenEvals }]
       : []),
   ] as FloatingMenuItem[]
@@ -420,6 +523,35 @@
       }
     })
   }
+
+  // Full range of each score type. Custom scores are unbounded, so they get no
+  // absolute max and stay on data-relative scaling in the radar chart.
+  function score_type_max(score_type: string): number | null {
+    switch (score_type) {
+      case "five_star":
+        return 5
+      case "pass_fail":
+        return 1
+      case "pass_fail_critical":
+        return 1
+      default:
+        return null
+    }
+  }
+
+  // Absolute (full range) max per radar axis key, for the chart's "Full Scale" mode
+  $: scoreAxisMaxes = (() => {
+    const maxes: Record<string, number> = {}
+    for (const [eval_id, evalData] of Object.entries(eval_data_cache)) {
+      for (const score of evalData?.output_scores || []) {
+        const max = score_type_max(score.type)
+        if (max !== null) {
+          maxes[`${eval_id}::${string_to_json_key(score.name)}`] = max
+        }
+      }
+    }
+    return maxes
+  })()
 
   function generateComparisonFeatures(
     models: (string | null)[],
@@ -829,7 +961,7 @@
       {:else}
         <!-- Table action buttons - positioned above table on the right -->
         <div class="flex justify-end gap-2 mb-4">
-          {#if hiddenEvalsInfo.length > 0}
+          {#if hiddenCount > 0}
             <div class="hidden-evals-dropdown">
               <FloatingMenu items={hiddenEvalsMenuItems} width="w-72">
                 <button
@@ -837,7 +969,7 @@
                   type="button"
                   class="btn btn-sm btn-outline"
                 >
-                  Hidden Evals ({hiddenEvalsInfo.length})
+                  Hidden ({hiddenCount})
                 </button>
               </FloatingMenu>
             </div>
@@ -870,7 +1002,7 @@
           <!-- Model Selection Header Row -->
           <div
             class="grid border-b border-gray-200 bg-gray-50"
-            style="grid-template-columns: 200px repeat({columns}, 1fr);"
+            style="grid-template-columns: 240px repeat({columns}, 1fr);"
           >
             <div class="px-6 py-4 font-semibold text-gray-900"></div>
             {#each Array(columns) as _, i}
@@ -977,28 +1109,31 @@
             {#each visibleComparisonFeatures as section}
               <!-- Section Header -->
               <div
-                class="bg-gray-50 px-6 py-3 border-b border-gray-200 flex items-center justify-between gap-2"
+                class="bg-gray-50 px-6 py-3 border-b border-gray-200 flex items-center gap-2"
               >
                 <h4
                   class="text-sm font-semibold text-gray-900 uppercase tracking-wide"
                 >
                   {section.category}
                 </h4>
-                {#if section.eval_id !== "kiln_cost_section"}
-                  <button
-                    on:click={() => hideEval(section.eval_id)}
-                    class="w-6 h-6 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 transition-colors"
-                    title="Hide this eval"
-                  >
-                    ✕
-                  </button>
-                {/if}
+                <button
+                  type="button"
+                  on:click={() => hideEval(section.eval_id)}
+                  class="w-6 h-6 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 transition-colors"
+                  title={section.eval_id === "kiln_cost_section"
+                    ? "Hide this section"
+                    : "Hide this eval"}
+                >
+                  ✕
+                </button>
               </div>
 
-              {#if section.items.length == 0}
+              <!-- A section the user has emptied by hiding every row is not an error
+                   state - it just has nothing left to show below its header. -->
+              {#if sectionsWithoutScores.has(section.eval_id)}
                 <div
                   class="grid gap-4 border-b border-gray-100 last:border-b-0"
-                  style="grid-template-columns: 200px repeat(1, 1fr);"
+                  style="grid-template-columns: 240px repeat(1, 1fr);"
                 >
                   <!-- Empty section for visual consistency -->
                   <div
@@ -1038,14 +1173,53 @@
               {#if section.items.length > 0}
                 <div
                   class="grid"
-                  style="grid-template-columns: 200px repeat({columns}, 1fr);"
+                  style="grid-template-columns: 240px repeat({columns}, 1fr);"
                 >
                   {#each section.items as item, item_index}
                     <!-- Feature Label -->
                     <div
-                      class="px-6 py-4 bg-gray-50 font-medium text-gray-700 flex items-center border-b border-gray-100"
+                      class="px-6 py-4 bg-gray-50 font-medium text-gray-700 flex items-center gap-2 border-b border-gray-100"
                     >
-                      {item.label}
+                      {#if renamingMetricKey === item.key}
+                        <!-- Enter or leaving the field saves, Escape cancels, and an
+                             empty name restores the original -->
+                        <input
+                          type="text"
+                          class="input input-sm input-bordered w-full min-w-0 font-medium"
+                          value={item.label}
+                          placeholder={originalMetricLabels[item.key] ??
+                            item.label}
+                          use:focusAndSelect
+                          on:keydown={(e) => {
+                            if (e.key === "Enter") {
+                              commitRename(item.key, e.currentTarget.value)
+                            } else if (e.key === "Escape") {
+                              cancelRename()
+                            }
+                          }}
+                          on:blur={(e) =>
+                            commitRename(item.key, e.currentTarget.value)}
+                        />
+                      {:else}
+                        {item.label}
+                        <!-- Both always visible, matching the section's hide button -->
+                        <button
+                          type="button"
+                          on:click={() => startRename(item.key)}
+                          class="w-6 h-6 shrink-0 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 transition-colors"
+                          title="Rename this metric"
+                        >
+                          ✎
+                        </button>
+                        <button
+                          type="button"
+                          on:click={() => hideMetric(item.key)}
+                          class="w-6 h-6 shrink-0 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 transition-colors"
+                          title="Hide this metric"
+                        >
+                          ✕
+                        </button>
+                      {/if}
                     </div>
 
                     <!-- Model Values -->
@@ -1259,6 +1433,8 @@
               run_configs={current_task_run_configs || []}
               model_info={$model_info}
               selectedRunConfigIds={validSelectedModels}
+              {scoreAxisMaxes}
+              {metricLabels}
               prompts={$prompts_by_task_composite_id[
                 get_task_composite_id(project_id, task_id)
               ] || null}
@@ -1315,18 +1491,33 @@
     color: rgb(17 24 39);
   }
 
-  /* Render a gray "+" prefix on eval rows only. Excludes the header
-     (first-child) and the "Restore All" footer (last-child at position 4+). */
+  /* Render a gray "+" prefix on eval and metric rows only. Excludes the headers
+     (a span, not a button) and the "Show All" footer (last-child at position 4+).
+     A metric row is two lines - name over section - laid out as a flex column, so
+     its "+" goes on the name line rather than on the button, where it would land
+     on a line of its own. */
   .hidden-evals-dropdown
     :global(
       ul.menu
         li:not(:first-child):not(:last-child:nth-child(n + 4))
-        > button::before
+        > button:not(:has(> span))::before
+    ),
+  .hidden-evals-dropdown
+    :global(
+      ul.menu
+        li:not(:first-child):not(:last-child:nth-child(n + 4))
+        > button
+        > span:first-child::before
     ) {
     content: "+";
     color: rgb(107 114 128);
     margin-right: 0.375rem;
     font-weight: 400;
+  }
+
+  /* The section line of a metric row sits under its name, not under the "+" */
+  .hidden-evals-dropdown :global(ul.menu li > button > span + span) {
+    padding-left: 0.95rem;
   }
 
   /* "Restore All" footer styling — gray-500. */

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -1091,6 +1091,7 @@
                   title={section.eval_id === COST_SECTION_ID
                     ? "Hide this section"
                     : "Hide this eval"}
+                  aria-label="Hide {section.category}"
                 >
                   ✕
                 </button>
@@ -1150,13 +1151,17 @@
                     >
                       {#if renamingMetricKey === item.key}
                         <!-- Enter or leaving the field saves, Escape cancels, and an
-                             empty name restores the original -->
+                             empty name restores the original. The name is stored in
+                             the URL, so it is capped at a row heading's worth of
+                             characters. -->
                         <input
                           type="text"
                           class="input input-sm input-bordered w-full min-w-0 font-medium"
                           value={item.label}
                           placeholder={originalMetricLabels[item.key] ??
                             item.label}
+                          maxlength="60"
+                          aria-label="Rename {item.label}"
                           use:focusAndSelect
                           on:keydown={(e) => {
                             if (e.key === "Enter") {
@@ -1176,6 +1181,7 @@
                           on:click={() => startRename(item.key)}
                           class="w-6 h-6 shrink-0 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 transition-colors"
                           title="Rename this metric"
+                          aria-label="Rename {item.label}"
                         >
                           ✎
                         </button>
@@ -1184,6 +1190,7 @@
                           on:click={() => hideMetric(item.key)}
                           class="w-6 h-6 shrink-0 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 transition-colors"
                           title="Hide this metric"
+                          aria-label="Hide {item.label}"
                         >
                           ✕
                         </button>

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/+page.svelte
@@ -72,7 +72,7 @@
   // State management
   let columns = 2 // Start with 2 columns
   let selectedModels: (string | null)[] = [null, null] // Track selected model for each column
-  let hiddenEvalIds: string[] = [] // Sections hidden by the user: evals, or the cost section
+  let hiddenSectionIds: string[] = [] // Sections hidden by the user: evals, or the cost section
   let hiddenMetricKeys: string[] = [] // Individual rows hidden by the user, in any section
   let metricLabels: MetricLabels = {} // Display names the user has given rows, by row key
   let renamingMetricKey: string | null = null // Row whose name is being edited, if any
@@ -119,8 +119,9 @@
     selectedModels = new Array(columns).fill(null)
 
     // Hidden sections and rows can be restored before run configs are loaded - they
-    // are just IDs and keys. Row keys are "<section>::<metric>".
-    hiddenEvalIds = parseHiddenListParam(urlParams.get("hidden_evals"))
+    // are just IDs and keys. Row keys are "<section>::<metric>". The parameter names
+    // are older than the cost section and stay as they are, so links keep working.
+    hiddenSectionIds = parseHiddenListParam(urlParams.get("hidden_evals"))
     hiddenMetricKeys = parseHiddenListParam(
       urlParams.get("hidden_metrics"),
       (key) => key.includes("::"),
@@ -169,9 +170,9 @@
     )
     urlParams.set("models", modelIds.join(","))
 
-    // Update hidden evals (omit param when none are hidden to keep URL clean)
-    if (hiddenEvalIds.length > 0) {
-      urlParams.set("hidden_evals", hiddenEvalIds.join(","))
+    // Omit the param when nothing is hidden, to keep the URL clean
+    if (hiddenSectionIds.length > 0) {
+      urlParams.set("hidden_evals", hiddenSectionIds.join(","))
     } else {
       urlParams.delete("hidden_evals")
     }
@@ -200,7 +201,7 @@
     !isInitializing &&
     (columns ||
       selectedModels ||
-      hiddenEvalIds ||
+      hiddenSectionIds ||
       hiddenMetricKeys ||
       metricLabels)
   ) {
@@ -387,22 +388,22 @@
   // sections and rows are dropped. Hidden state and names are passed as arguments
   // (rather than read via closure) so that Svelte's reactive `$:` statements track
   // them as dependencies and re-run when they change.
-  $: labeledComparisonFeatures = applyMetricLabels(
-    comparisonFeatures,
-    metricLabels,
-  )
   $: labeledChartComparisonFeatures = applyMetricLabels(
     chartComparisonFeatures,
     metricLabels,
   )
   $: visibleComparisonFeatures = filterVisibleSections(
-    labeledComparisonFeatures,
-    hiddenEvalIds,
+    comparisonFeatures,
+    hiddenSectionIds,
     hiddenMetricKeys,
+  )
+  $: labeledComparisonFeatures = applyMetricLabels(
+    visibleComparisonFeatures,
+    metricLabels,
   )
   $: visibleChartComparisonFeatures = filterVisibleSections(
     labeledChartComparisonFeatures,
-    hiddenEvalIds,
+    hiddenSectionIds,
     hiddenMetricKeys,
   )
 
@@ -422,29 +423,32 @@
       .map((section) => section.eval_id),
   )
 
-  // Names of currently-hidden evals (used for the "show hidden" dropdown).
+  // Names of the currently-hidden sections (used for the "show hidden" dropdown).
   // chartComparisonFeatures is built from ALL run configs for the task and is a
   // superset of comparisonFeatures (which only covers selected models), so it
   // alone is enough to resolve display names.
-  $: hiddenEvalsInfo = hiddenEvalIds.map((evalId) => {
-    const feature = chartComparisonFeatures.find((s) => s.eval_id === evalId)
-    return { eval_id: evalId, category: feature?.category ?? "Unknown eval" }
+  $: hiddenSectionsInfo = hiddenSectionIds.map((sectionId) => {
+    const section = chartComparisonFeatures.find((s) => s.eval_id === sectionId)
+    return {
+      eval_id: sectionId,
+      category: section?.category ?? "Unknown section",
+    }
   })
 
   // Rows hidden one at a time, for the same dropdown
   $: hiddenMetricsInfo = listHiddenMetrics(
     labeledChartComparisonFeatures,
-    hiddenEvalIds,
+    hiddenSectionIds,
     hiddenMetricKeys,
   )
 
-  function hideEval(evalId: string) {
-    if (hiddenEvalIds.includes(evalId)) return
-    hiddenEvalIds = [...hiddenEvalIds, evalId]
+  function hideSection(sectionId: string) {
+    if (hiddenSectionIds.includes(sectionId)) return
+    hiddenSectionIds = [...hiddenSectionIds, sectionId]
   }
 
-  function showEval(evalId: string) {
-    hiddenEvalIds = hiddenEvalIds.filter((id) => id !== evalId)
+  function showSection(sectionId: string) {
+    hiddenSectionIds = hiddenSectionIds.filter((id) => id !== sectionId)
   }
 
   function hideMetric(key: string) {
@@ -456,8 +460,8 @@
     hiddenMetricKeys = hiddenMetricKeys.filter((k) => k !== key)
   }
 
-  function showAllHiddenEvals() {
-    hiddenEvalIds = []
+  function showAllHidden() {
+    hiddenSectionIds = []
     hiddenMetricKeys = []
   }
 
@@ -488,16 +492,16 @@
     node.select()
   }
 
-  $: hiddenCount = hiddenEvalsInfo.length + hiddenMetricsInfo.length
+  $: hiddenCount = hiddenSectionsInfo.length + hiddenMetricsInfo.length
 
-  $: hiddenEvalsMenuItems = [
-    ...(hiddenEvalsInfo.length > 0
+  $: hiddenMenuItems = [
+    ...(hiddenSectionsInfo.length > 0
       ? [
-          { label: "Show Eval", header: true },
-          ...hiddenEvalsInfo.map(
+          { label: "Show Section", header: true },
+          ...hiddenSectionsInfo.map(
             (info): FloatingMenuItem => ({
               label: info.category,
-              onclick: () => showEval(info.eval_id),
+              onclick: () => showSection(info.eval_id),
             }),
           ),
         ]
@@ -514,9 +518,7 @@
           ),
         ]
       : []),
-    ...(hiddenCount > 1
-      ? [{ label: "Show All", onclick: showAllHiddenEvals }]
-      : []),
+    ...(hiddenCount > 1 ? [{ label: "Show All", onclick: showAllHidden }] : []),
   ] as FloatingMenuItem[]
 
   // Reactively fetch eval templates for sections
@@ -930,8 +932,8 @@
         <!-- Table action buttons - positioned above table on the right -->
         <div class="flex justify-end gap-2 mb-4">
           {#if hiddenCount > 0}
-            <div class="hidden-evals-dropdown">
-              <FloatingMenu items={hiddenEvalsMenuItems} width="w-72">
+            <div class="hidden-rows-dropdown">
+              <FloatingMenu items={hiddenMenuItems} width="w-72">
                 <button
                   slot="trigger"
                   type="button"
@@ -1074,7 +1076,7 @@
 
           <!-- Comparison Data - only show if models are selected -->
           {#if validSelectedModels.length > 0}
-            {#each visibleComparisonFeatures as section}
+            {#each labeledComparisonFeatures as section}
               <!-- Section Header -->
               <div
                 class="bg-gray-50 px-6 py-3 border-b border-gray-200 flex items-center gap-2"
@@ -1086,7 +1088,7 @@
                 </h4>
                 <button
                   type="button"
-                  on:click={() => hideEval(section.eval_id)}
+                  on:click={() => hideSection(section.eval_id)}
                   class="w-6 h-6 rounded-full flex items-center justify-center text-gray-500 hover:bg-gray-200 hover:text-gray-900 transition-colors"
                   title={section.eval_id === COST_SECTION_ID
                     ? "Hide this section"
@@ -1459,8 +1461,8 @@
 />
 
 <style>
-  .hidden-evals-dropdown :global(ul.menu li > button),
-  .hidden-evals-dropdown :global(ul.menu li > a) {
+  .hidden-rows-dropdown :global(ul.menu li > button),
+  .hidden-rows-dropdown :global(ul.menu li > a) {
     font-size: 0.875rem;
     font-weight: 500;
     color: rgb(17 24 39);
@@ -1471,13 +1473,13 @@
      A metric row is two lines - name over section - laid out as a flex column, so
      its "+" goes on the name line rather than on the button, where it would land
      on a line of its own. */
-  .hidden-evals-dropdown
+  .hidden-rows-dropdown
     :global(
       ul.menu
         li:not(:first-child):not(:last-child:nth-child(n + 4))
         > button:not(:has(> span))::before
     ),
-  .hidden-evals-dropdown
+  .hidden-rows-dropdown
     :global(
       ul.menu
         li:not(:first-child):not(:last-child:nth-child(n + 4))
@@ -1491,19 +1493,19 @@
   }
 
   /* The section line of a metric row sits under its name, not under the "+" */
-  .hidden-evals-dropdown :global(ul.menu li > button > span + span) {
+  .hidden-rows-dropdown :global(ul.menu li > button > span + span) {
     padding-left: 0.95rem;
   }
 
   /* "Restore All" footer styling — gray-500. */
-  .hidden-evals-dropdown
+  .hidden-rows-dropdown
     :global(ul.menu li:last-child:nth-child(n + 4) > button) {
     color: rgb(107 114 128);
   }
 
   /* Divider before the "Show all hidden" footer. nth-child(n+4) ensures we
      only render it when the list has header + 2+ evals + show-all footer. */
-  .hidden-evals-dropdown :global(ul.menu li:last-child:nth-child(n + 4)) {
+  .hidden-rows-dropdown :global(ul.menu li:last-child:nth-child(n + 4)) {
     border-top: 1px solid rgb(209 213 219);
     margin-top: 0.5rem;
     padding-top: 0.5rem;

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest"
+import {
+  applyMetricLabels,
+  filterVisibleSections,
+  listHiddenMetrics,
+  parseHiddenListParam,
+  parseMetricLabelsParam,
+  withMetricLabel,
+  type ComparisonSection,
+} from "./compare_view"
+
+const injection: ComparisonSection = {
+  category: "Injection Attribution (Code)",
+  eval_id: "eval_1",
+  items: [
+    {
+      label: "Prompt Injection Correct",
+      key: "eval_1::prompt_injection_correct",
+    },
+    { label: "Attack Missed", key: "eval_1::attack_missed" },
+    { label: "Overall Correct", key: "eval_1::overall_correct" },
+  ],
+}
+
+const tone: ComparisonSection = {
+  category: "Tone",
+  eval_id: "eval_2",
+  items: [{ label: "Overall Correct", key: "eval_2::overall_correct" }],
+}
+
+const cost: ComparisonSection = {
+  category: "Average Usage, Cost & Latency",
+  eval_id: "kiln_cost_section",
+  items: [
+    { label: "Total Tokens", key: "cost::mean_total_tokens" },
+    { label: "Cost (USD)", key: "cost::mean_cost" },
+  ],
+}
+
+const sections = [injection, tone, cost]
+
+describe("parseHiddenListParam", () => {
+  it("returns nothing for a missing or empty param", () => {
+    expect(parseHiddenListParam(null)).toEqual([])
+    expect(parseHiddenListParam("")).toEqual([])
+  })
+
+  it("trims, dedupes and drops empty entries", () => {
+    expect(parseHiddenListParam(" a, b ,,a,")).toEqual(["a", "b"])
+  })
+
+  it("drops entries the validator rejects", () => {
+    expect(
+      parseHiddenListParam(
+        "eval_1::attack_missed,garbage,cost::mean_cost",
+        (k) => k.includes("::"),
+      ),
+    ).toEqual(["eval_1::attack_missed", "cost::mean_cost"])
+  })
+})
+
+describe("filterVisibleSections", () => {
+  it("returns the same array when nothing is hidden", () => {
+    expect(filterVisibleSections(sections, [], [])).toBe(sections)
+  })
+
+  it("drops hidden sections, the cost section included", () => {
+    expect(
+      filterVisibleSections(sections, ["eval_2", "kiln_cost_section"], []).map(
+        (s) => s.eval_id,
+      ),
+    ).toEqual(["eval_1"])
+  })
+
+  it("drops hidden rows from any section", () => {
+    const visible = filterVisibleSections(
+      sections,
+      [],
+      ["eval_1::attack_missed", "cost::mean_cost"],
+    )
+    expect(visible.map((s) => s.items.map((i) => i.key))).toEqual([
+      ["eval_1::prompt_injection_correct", "eval_1::overall_correct"],
+      ["eval_2::overall_correct"],
+      ["cost::mean_total_tokens"],
+    ])
+  })
+
+  it("keeps a section whose rows are all hidden, with no items", () => {
+    const visible = filterVisibleSections(
+      sections,
+      [],
+      ["eval_2::overall_correct"],
+    )
+    const emptied = visible.find((s) => s.eval_id === "eval_2")
+    expect(emptied).toBeDefined()
+    expect(emptied?.items).toEqual([])
+    expect(emptied?.category).toBe("Tone")
+  })
+
+  it("does not mutate the input", () => {
+    filterVisibleSections(sections, ["eval_1"], ["eval_2::overall_correct"])
+    expect(sections).toHaveLength(3)
+    expect(tone.items).toHaveLength(1)
+  })
+})
+
+describe("listHiddenMetrics", () => {
+  it("returns nothing when no rows are hidden", () => {
+    expect(listHiddenMetrics(sections, ["eval_1"], [])).toEqual([])
+  })
+
+  it("lists hidden rows in table order, each with its section name", () => {
+    // Hidden in the reverse of table order, to show the order comes from the table
+    const hidden = listHiddenMetrics(
+      sections,
+      [],
+      ["cost::mean_cost", "eval_2::overall_correct", "eval_1::attack_missed"],
+    )
+    expect(hidden).toEqual([
+      {
+        key: "eval_1::attack_missed",
+        label: "Attack Missed",
+        section: "Injection Attribution (Code)",
+      },
+      {
+        key: "eval_2::overall_correct",
+        label: "Overall Correct",
+        section: "Tone",
+      },
+      {
+        key: "cost::mean_cost",
+        label: "Cost (USD)",
+        section: "Average Usage, Cost & Latency",
+      },
+    ])
+  })
+
+  it("leaves out rows of a hidden section", () => {
+    const hidden = listHiddenMetrics(
+      sections,
+      ["eval_1"],
+      ["eval_1::attack_missed", "eval_2::overall_correct"],
+    )
+    expect(hidden.map((h) => h.key)).toEqual(["eval_2::overall_correct"])
+  })
+
+  it("leaves out keys that match no row", () => {
+    const hidden = listHiddenMetrics(
+      sections,
+      [],
+      ["deleted_eval::score", "cost::mean_cost"],
+    )
+    expect(hidden.map((h) => h.key)).toEqual(["cost::mean_cost"])
+  })
+})
+
+describe("parseMetricLabelsParam", () => {
+  it("returns nothing for a missing param or one that is not a JSON object", () => {
+    expect(parseMetricLabelsParam(null)).toEqual({})
+    expect(parseMetricLabelsParam("")).toEqual({})
+    expect(parseMetricLabelsParam("not json")).toEqual({})
+    expect(parseMetricLabelsParam('["a"]')).toEqual({})
+    expect(parseMetricLabelsParam("null")).toEqual({})
+  })
+
+  it("keeps trimmed string names for row keys and drops the rest", () => {
+    const parsed = parseMetricLabelsParam(
+      JSON.stringify({
+        "eval_1::overall_correct": "  Injection OK ",
+        "eval_2::overall_correct": "",
+        "eval_3::overall_correct": 42,
+        not_a_row_key: "Nope",
+      }),
+    )
+    expect(parsed).toEqual({ "eval_1::overall_correct": "Injection OK" })
+  })
+})
+
+describe("applyMetricLabels", () => {
+  it("returns the same array when there are no labels", () => {
+    expect(applyMetricLabels(sections, {})).toBe(sections)
+  })
+
+  it("relabels matching rows in any section and leaves the others alone", () => {
+    const labeled = applyMetricLabels(sections, {
+      "eval_1::overall_correct": "Injection OK",
+      "cost::mean_cost": "Price",
+      "unknown::key": "Ignored",
+    })
+    expect(labeled.map((s) => s.items.map((i) => i.label))).toEqual([
+      ["Prompt Injection Correct", "Attack Missed", "Injection OK"],
+      ["Overall Correct"],
+      ["Total Tokens", "Price"],
+    ])
+  })
+
+  it("does not mutate the input", () => {
+    applyMetricLabels(sections, { "eval_2::overall_correct": "Tone OK" })
+    expect(tone.items[0].label).toBe("Overall Correct")
+  })
+})
+
+describe("withMetricLabel", () => {
+  const key = "eval_1::overall_correct"
+
+  it("stores a trimmed new name", () => {
+    expect(
+      withMetricLabel({}, key, "  Injection OK ", "Overall Correct"),
+    ).toEqual({ [key]: "Injection OK" })
+  })
+
+  it("drops the override for an empty name or the original name", () => {
+    const existing = { [key]: "Injection OK", other: "Kept" }
+    expect(withMetricLabel(existing, key, "   ", "Overall Correct")).toEqual({
+      other: "Kept",
+    })
+    expect(
+      withMetricLabel(existing, key, "Overall Correct", "Overall Correct"),
+    ).toEqual({ other: "Kept" })
+  })
+
+  it("does not mutate the input", () => {
+    const existing = { [key]: "Injection OK" }
+    withMetricLabel(existing, key, "", "Overall Correct")
+    expect(existing).toEqual({ [key]: "Injection OK" })
+  })
+})

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from "vitest"
+import type { Eval } from "$lib/types"
 import {
   applyMetricLabels,
+  buildScoreAxisMaxes,
   filterVisibleSections,
   listHiddenMetrics,
   parseHiddenListParam,
   parseMetricLabelsParam,
+  scoreTypeMax,
   withMetricLabel,
   type ComparisonSection,
 } from "./compare_view"
@@ -223,5 +226,67 @@ describe("withMetricLabel", () => {
     const existing = { [key]: "Injection OK" }
     withMetricLabel(existing, key, "", "Overall Correct")
     expect(existing).toEqual({ [key]: "Injection OK" })
+  })
+})
+
+describe("scoreTypeMax", () => {
+  it("gives each bounded rating type its own full range", () => {
+    expect(scoreTypeMax("five_star")).toBe(5)
+    expect(scoreTypeMax("pass_fail")).toBe(1)
+    expect(scoreTypeMax("pass_fail_critical")).toBe(1)
+  })
+
+  it("gives an unbounded custom score no range", () => {
+    expect(scoreTypeMax("custom")).toBeNull()
+  })
+})
+
+function make_eval(
+  scores: { name: string; type: Eval["output_scores"][number]["type"] }[],
+): Eval {
+  return {
+    output_scores: scores.map((score) => ({ ...score, instruction: null })),
+  } as unknown as Eval
+}
+
+describe("buildScoreAxisMaxes", () => {
+  it("keys each max by the comparison table's eval id and score key", () => {
+    expect(
+      buildScoreAxisMaxes({
+        eval_1: make_eval([{ name: "Overall Correct", type: "pass_fail" }]),
+      }),
+    ).toEqual({ "eval_1::overall_correct": 1 })
+  })
+
+  it("takes the max from the score's own rating type", () => {
+    expect(
+      buildScoreAxisMaxes({
+        eval_1: make_eval([
+          { name: "Overall Rating", type: "five_star" },
+          { name: "Attack Missed", type: "pass_fail_critical" },
+        ]),
+        eval_2: make_eval([{ name: "Tone", type: "pass_fail" }]),
+      }),
+    ).toEqual({
+      "eval_1::overall_rating": 5,
+      "eval_1::attack_missed": 1,
+      "eval_2::tone": 1,
+    })
+  })
+
+  it("leaves out a custom score, so its axis stays data-relative", () => {
+    expect(
+      buildScoreAxisMaxes({
+        eval_1: make_eval([
+          { name: "Depth", type: "custom" },
+          { name: "Overall Correct", type: "pass_fail" },
+        ]),
+      }),
+    ).toEqual({ "eval_1::overall_correct": 1 })
+  })
+
+  it("contributes nothing for an eval with no output scores, or an empty cache", () => {
+    expect(buildScoreAxisMaxes({ eval_1: make_eval([]) })).toEqual({})
+    expect(buildScoreAxisMaxes({})).toEqual({})
   })
 })

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.test.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.test.ts
@@ -9,8 +9,8 @@ import {
   parseMetricLabelsParam,
   scoreTypeMax,
   withMetricLabel,
-  type ComparisonSection,
 } from "./compare_view"
+import type { ComparisonSection } from "$lib/utils/compare_metric_keys"
 
 const injection: ComparisonSection = {
   category: "Injection Attribution (Code)",

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.ts
@@ -1,0 +1,141 @@
+// What the compare table shows once the user has adjusted it: whole sections (an
+// eval, or the usage/cost section) and individual rows hidden with an ✕, and rows
+// renamed for display. Pure functions, so the page's reactive statements stay short
+// and this is testable.
+
+export type ComparisonSection = {
+  category: string
+  eval_id: string
+  items: { label: string; key: string }[]
+}
+
+// Display names the user has given rows, by row key
+export type MetricLabels = Record<string, string>
+
+export type HiddenMetricInfo = {
+  key: string
+  label: string
+  // Name of the section the row belongs to, so "Overall Correct" from one eval can
+  // be told apart from the same score name in another
+  section: string
+}
+
+// A comma-separated list from the URL, trimmed and deduped, with entries that fail
+// `isValid` dropped - a hand-edited URL can be messy.
+export function parseHiddenListParam(
+  value: string | null,
+  isValid: (entry: string) => boolean = () => true,
+): string[] {
+  if (!value) return []
+  return [
+    ...new Set(
+      value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0 && isValid(entry)),
+    ),
+  ]
+}
+
+// Drop hidden sections, and hidden rows from the sections that remain. A section
+// whose rows are all hidden stays, with no items - it still has a header to show
+// (and an ✕ of its own). Returns the input untouched when nothing is hidden.
+export function filterVisibleSections<T extends ComparisonSection>(
+  sections: T[],
+  hiddenSectionIds: string[],
+  hiddenMetricKeys: string[],
+): T[] {
+  if (hiddenSectionIds.length === 0 && hiddenMetricKeys.length === 0) {
+    return sections
+  }
+  return sections
+    .filter((section) => !hiddenSectionIds.includes(section.eval_id))
+    .map((section) =>
+      hiddenMetricKeys.length > 0
+        ? {
+            ...section,
+            items: section.items.filter(
+              (item) => !hiddenMetricKeys.includes(item.key),
+            ),
+          }
+        : section,
+    )
+}
+
+// The hidden rows the user can bring back one at a time, in table order. Rows of a
+// hidden section are left out: showing one of those would change nothing until the
+// section itself is shown again. Keys that match no known row (an eval that no
+// longer exists, say) are left out too rather than listed as a raw key.
+export function listHiddenMetrics(
+  sections: ComparisonSection[],
+  hiddenSectionIds: string[],
+  hiddenMetricKeys: string[],
+): HiddenMetricInfo[] {
+  if (hiddenMetricKeys.length === 0) return []
+  return sections
+    .filter((section) => !hiddenSectionIds.includes(section.eval_id))
+    .flatMap((section) =>
+      section.items
+        .filter((item) => hiddenMetricKeys.includes(item.key))
+        .map((item) => ({
+          key: item.key,
+          label: item.label,
+          section: section.category,
+        })),
+    )
+}
+
+// The user's display names from the URL: a JSON object of row key to name. Anything
+// that isn't that shape is ignored rather than allowed to break the page.
+export function parseMetricLabelsParam(value: string | null): MetricLabels {
+  if (!value) return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return {}
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {}
+  }
+  const labels: MetricLabels = {}
+  for (const [key, name] of Object.entries(parsed)) {
+    if (typeof name !== "string") continue
+    const trimmed = name.trim()
+    if (key.includes("::") && trimmed.length > 0) labels[key] = trimmed
+  }
+  return labels
+}
+
+// Rows relabelled with the user's display names, so the name shows everywhere the
+// row does. Returns the input untouched when there are none.
+export function applyMetricLabels<T extends ComparisonSection>(
+  sections: T[],
+  labels: MetricLabels,
+): T[] {
+  if (Object.keys(labels).length === 0) return sections
+  return sections.map((section) => ({
+    ...section,
+    items: section.items.map((item) =>
+      labels[item.key] ? { ...item, label: labels[item.key] } : item,
+    ),
+  }))
+}
+
+// The user's new name for a row, folded into the current set. An empty name, or the
+// row's own original name, drops the override instead of storing it.
+export function withMetricLabel(
+  labels: MetricLabels,
+  key: string,
+  name: string,
+  originalLabel: string | undefined,
+): MetricLabels {
+  const trimmed = name.trim()
+  const next = { ...labels }
+  if (trimmed.length === 0 || trimmed === originalLabel) {
+    delete next[key]
+  } else {
+    next[key] = trimmed
+  }
+  return next
+}

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.ts
@@ -1,3 +1,7 @@
+import type { Eval, TaskOutputRatingType } from "$lib/types"
+import { assertNever } from "$lib/utils/exhaustive"
+import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
+
 // What the compare table shows once the user has adjusted it: whole sections (an
 // eval, or the usage/cost section) and individual rows hidden with an ✕, and rows
 // renamed for display. Pure functions, so the page's reactive statements stay short
@@ -138,4 +142,39 @@ export function withMetricLabel(
     next[key] = trimmed
   }
   return next
+}
+
+// Full range of a score type. Custom scores are unbounded, so they get no absolute
+// max and stay on data-relative scaling in the radar chart.
+export function scoreTypeMax(scoreType: TaskOutputRatingType): number | null {
+  switch (scoreType) {
+    case "five_star":
+      return 5
+    case "pass_fail":
+      return 1
+    case "pass_fail_critical":
+      return 1
+    case "custom":
+      return null
+    default:
+      return assertNever(scoreType)
+  }
+}
+
+// Absolute (full range) max per radar axis key, for the chart's "Full Scale" mode.
+// Keys take the comparison table's `evalId::scoreKey` form: anything else leaves
+// the axis on data-relative scaling with nothing to say so.
+export function buildScoreAxisMaxes(
+  evalDataCache: Record<string, Eval>,
+): Record<string, number> {
+  const maxes: Record<string, number> = {}
+  for (const [evalId, evalData] of Object.entries(evalDataCache)) {
+    for (const score of evalData?.output_scores || []) {
+      const max = scoreTypeMax(score.type)
+      if (max !== null) {
+        maxes[`${evalId}::${string_to_json_key(score.name)}`] = max
+      }
+    }
+  }
+  return maxes
 }

--- a/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.ts
+++ b/app/web_ui/src/routes/(app)/specs/[project_id]/[task_id]/compare/compare_view.ts
@@ -1,4 +1,5 @@
 import type { Eval, TaskOutputRatingType } from "$lib/types"
+import type { ComparisonSection } from "$lib/utils/compare_metric_keys"
 import { assertNever } from "$lib/utils/exhaustive"
 import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_templates"
 
@@ -7,16 +8,10 @@ import { string_to_json_key } from "$lib/utils/json_schema_editor/json_schema_te
 // renamed for display. Pure functions, so the page's reactive statements stay short
 // and this is testable.
 
-export type ComparisonSection = {
-  category: string
-  eval_id: string
-  items: { label: string; key: string }[]
-}
-
 // Display names the user has given rows, by row key
 export type MetricLabels = Record<string, string>
 
-export type HiddenMetricInfo = {
+type HiddenMetricInfo = {
   key: string
   label: string
   // Name of the section the row belongs to, so "Overall Correct" from one eval can
@@ -169,7 +164,7 @@ export function buildScoreAxisMaxes(
 ): Record<string, number> {
   const maxes: Record<string, number> = {}
   for (const [evalId, evalData] of Object.entries(evalDataCache)) {
-    for (const score of evalData?.output_scores || []) {
+    for (const score of evalData.output_scores || []) {
       const max = scoreTypeMax(score.type)
       if (max !== null) {
         maxes[`${evalId}::${string_to_json_key(score.name)}`] = max


### PR DESCRIPTION
## What does this PR do?

**TLDR:** The compare radar chart said nothing with one or two run configs, because every axis was scaled to the selection and a missing score was drawn as zero. This PR adds a Relative / Full Scale toggle, plots only the scores every plotted config has, turns the cost, latency and token rows into hideable axes, and lets the user hide or rename any row. It replaces #1628 with the same feature on top of the current `main`, moves the chart maths into tested modules, and fixes three defects the new tests exposed. Targets `main`. There are no companion branches.

Before this PR, the radar chart on the compare page scaled each axis to the highest value among the selected run configs. One run config sat on the outer ring of every axis. A score with no result was plotted at the centre, which reads the same as a score of zero. Only eval sections had a hide control. After this PR, the chart has a Relative / Full Scale toggle, plots only the scores every plotted run config has a result for and reports the omitted count under the title, charts cost, latency and tokens as relative axes that the user can hide from the table, and lets the user rename any row for display. The chart logic lives in pure modules with unit tests, and the option object that reaches ECharts is asserted by a test.

**Implementation**

- Feature, unchanged from #1628 (first commit, byte-identical to that branch): the scale toggle, the shared-score filter with the omitted count, the five usage axes with "bigger means less" scoring, the hide and rename controls on every table row, and the URL parameters `hidden_metrics` and `metric_labels` that persist them.
- Chart data layer: `lib/utils/radar_chart_data.ts` holds score normalisation, axis scaling, usage-axis inversion, the shared-key filter, label resolution and the tooltip trim. The component computes chart data once per update instead of twice. Its script drops from 629 lines to 374. The whole file is 430 lines; on `main` today it is 417 lines without the feature.
- Shared constants: `lib/utils/compare_metric_keys.ts` holds the cost section id and the five usage keys. The page and the chart import them instead of repeating string literals.
- Typed score range: the page's score-range lookup takes `TaskOutputRatingType` and ends with `assertNever`, so a new rating type fails the type check instead of returning `null`. The lookup and the axis-max builder move into `compare_view.ts`.
- Tests: 33 component tests mock ECharts and assert on the option object that reaches `setOption`. 32 unit tests cover the data module. `compare_view.test.ts` grows from 20 to 26 cases. This is the first unit test of an ECharts component in the repo.
- Fix: score labels, run config names and model names are HTML-escaped in the tooltip and the legend. Labels come from eval score names and from the `metric_labels` URL parameter, so a shared link could inject markup.
- Fix: two run configs with the same name are separate series. Before, they collapsed into one legend entry that showed the first config's model, cost and scores.
- Fix: the note under the title counts omitted axes with the correct word. It counted usage axes together with eval scores and called all of them "scores".
- Fix: the radar card stays on the page when hidden rows leave fewer than three axes, and its empty state says how to get axes back. Before, the card disappeared with no message.
- Fix: the radar centre and radius change in the wide layout so the left-hand axis labels fit. Before, "Input Token Efficiency" was clipped to "…en Efficiency" at the card edge.
- Fix: the hide and rename controls have accessible names, and the rename input has a 60-character limit.
- Fix: the chart redraws when the prompt list becomes `undefined` after it loaded. Before, the guard in the reactive statement stopped the redraw.
- Rename: the page's hide state is named for what it hides, sections rather than evals, because the cost section is hideable too. The URL parameters keep their names. The section type is defined once, in `compare_metric_keys.ts`, and the chart's `comparisonFeatures` prop uses it: same shape, one field fewer.
- Copy: the chart subtitle and the tooltip header cover the usage axes. `escape_html` also escapes the single quote.
- Page-level, carried over from #1628: `updateURL()` passes `noScroll` and `keepFocus` to `goto()`, so a state change no longer jumps the page to the top. The first table column grows from 200 px to 240 px to fit the rename control.

**Before you merge**

- A user sees these changes: the scale toggle, the hide and rename controls on every row, the usage axes on the radar, and the omitted-score count. The old page hid eval sections only.
- In the wide layout the radar is drawn smaller (radius 85 % to 70 %, centre 32 % to 36 %) so the axis labels fit. The compact layout for one or two run configs is unchanged.
- Hiding rows no longer removes the radar card. The card shows an empty state with the ways to get axes back.
- Not included: skipping `lower_is_better` or `informational` scores from the radar. `EvalOutputScore` has no `direction` field on `main`.

<details>
<summary><b>How the refactor was checked</b></summary>

The first commit reproduces the #1628 branch tip `ba08b006e` on `main`; the five changed files are byte-identical (`git diff` between the two is empty for those paths). A test harness was committed on top of it before any refactor. The refactor commits were then gated three ways:

1. The option object the component hands to ECharts, serialised with its formatter functions invoked, for six fixtures. The dump after each refactor commit is byte-identical to the dump at the baseline (`diff -r` is empty).
2. Full-page screenshots of six page states on the seeded fixture project, rendered from a checkout at the baseline commit and from the final commit, on separate ports. Two consecutive renders of the baseline are pixel-identical, so the comparison has no noise. At `e9020ebab`, after the three refactor commits and the first four fixes, all six states are pixel-identical to the baseline (0 pixels differ). At the final commit the differences are confined to the radar plot area in the three-config states (the resize for the labels) and to one subtitle line in the one- and two-config states, measured by the bounding box of the differing pixels.
3. The harness and the existing `compare_view` tests pass unchanged through the refactor commits. The three fix commits each change exactly the assertions they say they change.

Commits, in order:

- `d199675e9` feat(compare): radar chart scale toggle, hideable usage axes, no false zeros, renamable rows — #1628 squashed, byte-identical in its five files
- `0271edcbf` test(compare): characterise the compare radar chart option at baseline — 25 cases, no component change
- `1559d98a2` refactor(compare): extract the radar chart data layer into a tested module — golden identical
- `611c863af` refactor(compare): share the cost section id and usage keys between page and chart — golden identical
- `7d3351b6b` refactor(compare): type the score range lookup and move it into compare_view — golden identical
- `5c278e1b9` fix(compare): escape score labels in the radar tooltip — golden identical (no fixture carries markup characters); one harness assertion changed
- `f12bc6163` fix(compare): keep run configs that share a name apart on the radar — golden changes only in the duplicate-names fixture; one harness assertion changed
- `e3712603f` fix(compare): count omitted axes, not scores, under the radar title — DOM text only
- `e9020ebab` fix(compare): name axes consistently in the radar empty state — DOM text only
- `45b5bfbbb` fix(compare): keep the radar card when hidden rows leave too few axes — DOM only, golden identical
- `db31ec158` fix(compare): make room for the radar axis labels — golden changes only in `radar.center`, `radar.radius`, `axisName.width`
- `3ece384c1` test(compare): assert the radar option shape instead of a tautology — tests only
- `4bb7c8945` fix(compare): label the hide and rename controls for assistive technology — golden identical
- `a4498758d` refactor(compare): name the hide state for what it hides — golden identical
- `bc245af22` fix(compare): redraw the radar when the prompt list loads — golden identical; one new harness case
- `96ac35cfa` fix(compare): update the radar copy for usage axes — golden changes only in tooltip header text

</details>

<details>
<summary><b>Screenshots</b></summary>

Hosted on the `mike/compare-radar-legibility-v2-assets` branch. Never merge that branch. The team can delete it after this PR closes.

**Three run configs, relative scale. The table has hide and rename controls on every row; the radar plots one eval axis and five usage axes:**

![three run configs, relative scale](https://raw.githubusercontent.com/Kiln-AI/Kiln/a392d9b247581e58f98bb163610e23618a837fd7/screenshots/three_relative.png)

**Full scale. The eval axis uses its own 0 to 1 range, and the axis labels fit:**

![three run configs, full scale](https://raw.githubusercontent.com/Kiln-AI/Kiln/a392d9b247581e58f98bb163610e23618a837fd7/screenshots/three_full.png)

**The same view on the #1628 branch, for comparison. The left labels are clipped:**

![before: labels clipped](https://raw.githubusercontent.com/Kiln-AI/Kiln/a392d9b247581e58f98bb163610e23618a837fd7/screenshots/before_three_full.png)

**A row renamed to "Escalation" through the rename control. The name changes on the table, the axis, and the tooltip:**

![renamed row](https://raw.githubusercontent.com/Kiln-AI/Kiln/a392d9b247581e58f98bb163610e23618a837fd7/screenshots/renamed.png)

**Two usage rows hidden from the table. They leave the radar, and the "Show Section" menu lists them:**

![hidden usage rows](https://raw.githubusercontent.com/Kiln-AI/Kiln/a392d9b247581e58f98bb163610e23618a837fd7/screenshots/hidden_usage.png)

**A single run config defaults to full scale with an area fill:**

![single run config](https://raw.githubusercontent.com/Kiln-AI/Kiln/a392d9b247581e58f98bb163610e23618a837fd7/screenshots/single_config.png)

</details>

## Related Issues

Replaces #1628. No tracked issue.

## Contributor License Agreement

_Left for the PR author to complete._

## Checklists

- [x] Tests have been run locally and passed (`uv run ./checks.sh --agent-mode` exits 0 in a clean worktree; `npm run check` reports 0 errors and the same 38 warnings as `main`; `misspell` is not installed locally, so CI covers that check)
- [ ] New tests have been added to any work in /lib — not applicable, this PR changes the web UI only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
