### PR TITLE
New kiln-ui skill for building and reviewing web UI

### DIFF
--- a/.agents/card_style.md
+++ b/.agents/card_style.md
@@ -1,5 +1,7 @@
 ## Card Styling
 
+A card is for a clickable item or an item in a list. Never use a card to group content on a form or a review screen; use headers and spacing for that (see `frontend_design_guide.md`, Layout and containers).
+
 When styling cards use the following classes:
 
 - Always use `card card-bordered border-base-300 shadow-md`

--- a/.agents/code_review_guidelines.md
+++ b/.agents/code_review_guidelines.md
@@ -33,6 +33,8 @@ If the change contains UI changes read:
  - `./frontend_design_guide.md`
  - `./frontend_controls.md`
 
+Then apply the "house control or justify" lens from `./skills/kiln-ui/SKILL.md` section 6: for each visible element the diff adds or restyles, name the house control that renders it or the plan row that justifies a custom one; flag any change under `app/web_ui/src/lib/ui`, `lib/components`, `lib/utils/form_*`, `app_page.svelte` or the shared `kiln_pro_*` components that is not a stated, separate decision; and check the screen against the sibling screen the change names, not against the diff. Style findings under this lens are valid findings.
+
 ### FastAPI / OpenAPI Standards
 
 If the change impacts API endpoints, read `.agents/api_code_review.md` for instructions on how to code review API endpoints.

--- a/.agents/frontend_controls.md
+++ b/.agents/frontend_controls.md
@@ -4,6 +4,8 @@ On top of DaisyUI’s CSS controls like btn, we have svelte controls you can use
 
 Use existing controls wherever possible to ensure consistent visual design.
 
+Use the control, or say in your plan which control you looked at and why it does not fit. A screen that is built from Tailwind classes copied off a house control is not using the control, and it will drift.
+
 ### App Specific Svelte Controls
 
 The following controls are commonly used in our design language:
@@ -16,9 +18,15 @@ The following controls are commonly used in our design language:
 - `intro.svelte` - used for empty screens before data is added. Teaches user about concept, and has buttons guiding them to an action.
 - `dialog.svelte` a modal dialog with close button, title, area for content, and action buttons.
 - `edit_dialog.svelte` a dialog for editing properties like name/description. Has save/cancel buttons.
-- `collapse.svelte` a collapsible section, often titled "Advanced Options" to hide optional controls
 - `float.svelte` - a low-level wrapper for `@floating-ui/dom` positioning. Prefer higher-level components (`floating_menu.svelte`, `info_tooltip.svelte`) when they fit your use case.
 - `floating_menu.svelte` / `table_action_menu.svelte` - floating dropdown menus using `@floating-ui/dom`. Use instead of DaisyUI's `dropdown-content` class, which breaks inside tables, dialogs, and scroll areas. `table_action_menu.svelte` is a convenience wrapper that includes the "..." ellipsis button with hover-to-open; `floating_menu.svelte` is the generic version with a trigger slot.
+- `settings_header.svelte` - a header-only element (title, optional subtitle, bottom rule). The title for any read-only section or any section of a form.
+- `output.svelte` - renders any read-only text or JSON, with copy and pretty-printing. The body for any read-only content: plans, overviews, summaries, traces, descriptions.
+- `see_all_dialog.svelte` - `Dialog` + `Output` for read-only content behind a button.
+- `kiln_section.svelte` - a `SettingsHeader` over a list of `settings_item.svelte` rows; use for settings-style pages.
+- `run/rating.svelte` - the Rating and Feedback selection buttons (`btn btn-sm btn-outline`, `btn-secondary` when selected). The selection-button style for the whole app; copy its classes when a control cannot use it directly.
+- `run_config_component/` - the model, tools and skills pickers. Never rebuild a picker.
+- `collapse.svelte` - the only expander. Never write `aria-expanded`, a chevron with `rotate-180`, or a `{#if expanded}` block by hand.
 
 Read the control's code to better understand it and its parameters. Optionally search for an existing use of the control to see it in use.
 

--- a/.agents/frontend_controls.md
+++ b/.agents/frontend_controls.md
@@ -24,7 +24,7 @@ The following controls are commonly used in our design language:
 - `output.svelte` - renders any read-only text or JSON, with copy and pretty-printing. The body for any read-only content: plans, overviews, summaries, traces, descriptions.
 - `see_all_dialog.svelte` - `Dialog` + `Output` for read-only content behind a button.
 - `kiln_section.svelte` - a `SettingsHeader` over a list of `settings_item.svelte` rows; use for settings-style pages.
-- `run/rating.svelte` - the Rating and Feedback selection buttons (`btn btn-sm btn-outline`, `btn-secondary` when selected). The selection-button style for the whole app; copy its classes when a control cannot use it directly.
+- `run/rating.svelte` - the Rating and Feedback selection buttons (unchosen `btn btn-sm btn-outline` at full contrast, chosen filled `btn btn-sm btn-secondary`). The selection-button style for the whole app; copy its classes when a control cannot use it directly.
 - `run_config_component/` - the model, tools and skills pickers. Never rebuild a picker.
 - `collapse.svelte` - the only expander. Never write `aria-expanded`, a chevron with `rotate-180`, or a `{#if expanded}` block by hand.
 

--- a/.agents/frontend_design_guide.md
+++ b/.agents/frontend_design_guide.md
@@ -36,6 +36,26 @@ Our colors are named, a Daisy UI convention. For example the color “primary”
   - `bg-base-100` - white. Typically don’t set a background color and inherit this.
   - `bg-base-200` - light grey background for cards/blocks/table-headers
 
+### Layout and containers
+
+- We almost never draw a box. Content sits directly on the page, grouped by headers and spacing, the way the Edit Task form and the Run page do. Do not invent rounded, bordered, tinted or shadowed containers to group content.
+- The only boxes we draw are the documented ones: a table's frame (see `tables_style.md`), a card for a clickable or list item (see `card_style.md`), a `Warning` for a message, and `collapse.svelte` for hidden content. If none of those is the element, it is not a box.
+- Read-only content (a plan, a summary, an overview, a trace, a description) renders with `settings_header.svelte` for its title and `output.svelte` for its body. Not a tinted div.
+- Every screen that asks the user for input is a form. Use `form_container.svelte` and `form_element.svelte` for the whole thing: section headers, labels, fields, help text, the submit row. Do not write `<label>`, `<textarea>` or `<input>` by hand, and do not restate FormElement's label classes on a hand-written label.
+- One title per screen: the page title comes from `app_page.svelte`. Inside the page, use `settings_header.svelte` for section titles. Do not add a second `text-2xl font-bold` heading inside the body.
+- A progress or waiting screen is the house animation control (`analyzing_animation.svelte` or `conversation_animation.svelte`) with its own title and description props, nothing else. If a count must be shown, it goes in the description string, not in an extra line under the animation with its own weight and size.
+
+### Buttons
+
+- The default button is the plain grey `btn`. Use it for Previous, Cancel, Close, secondary actions, and anything that is not the one primary action.
+- `btn-outline` is for special cases only. `btn-outline btn-primary` is the one sanctioned use: picking one of several equal options.
+- `btn-ghost` is not a house button. Buttons that sit on a tinted surface must still read as buttons; if a button is the same colour as what it sits on, it is the wrong button.
+- Selection buttons (agree/disagree, pass/fail, yes/no) use the Rating and Feedback style: `btn btn-sm btn-outline`, and `btn-secondary` when selected. Never `btn-success` or `btn-error` for a choice. Red and green are for errors and status, not for disagreement.
+- Two buttons side by side are the same size. Never a small `btn-sm` next to a `btn-primary min-w-64`.
+- Pairs are named as pairs: "Previous" and "Next", never "Previous" and "Continue". A disabled Previous is hidden, not greyed.
+- Button labels are the action, not the verb "View": "Full Trace", "Eval Description", "Eval". The one accepted exception today is "View Eval" on a success screen, where nothing else reads right.
+- One primary button per screen. (Already in this guide; restated because it was not followed.)
+
 ### Fonts
 
 - You should never set a font-face, it’s an app wide standard non-serif font
@@ -45,3 +65,5 @@ Our colors are named, a Daisy UI convention. For example the color “primary”
   - font-light: stylish light text often used for subtitles
   - font-bold: usually not needed, use medium
 - You may set font size using daisyUI sizes: text-xs, text-sm, text-lg, text-xl, text-2xl
+- Use `font-medium` for every header inside the page, `font-normal` for body, `font-light` for subtitles and captions. Do not mix a bold title, a light-grey caption and a normal-weight count on the same screen.
+- Never set a font size or weight on a shared control from the call site. `Warning`, `Intro`, the animations and the headers own their type. If a control's default looks wrong on your screen, the screen is wrong, not the control.

--- a/.agents/frontend_design_guide.md
+++ b/.agents/frontend_design_guide.md
@@ -50,7 +50,7 @@ Our colors are named, a Daisy UI convention. For example the color “primary”
 - The default button is the plain grey `btn`. Use it for Previous, Cancel, Close, secondary actions, and anything that is not the one primary action.
 - `btn-outline` is for special cases only. `btn-outline btn-primary` is the one sanctioned use: picking one of several equal options.
 - `btn-ghost` is not a house button. Buttons that sit on a tinted surface must still read as buttons; if a button is the same colour as what it sits on, it is the wrong button.
-- Selection buttons (agree/disagree, pass/fail, yes/no) use the Rating and Feedback style: `btn btn-sm btn-outline`, and `btn-secondary` when selected. Never `btn-success` or `btn-error` for a choice. Red and green are for errors and status, not for disagreement.
+- Selection buttons (agree/disagree, pass/fail, yes/no) use the Rating and Feedback style: unchosen is `btn btn-sm btn-outline` at full contrast, chosen is filled `btn btn-sm btn-secondary` (drop `btn-outline`; the outline-plus-secondary form renders transparent and cannot be told from unchosen). Never `btn-success` or `btn-error` for a choice. Red and green are for errors and status, not for disagreement.
 - Two buttons side by side are the same size. Never a small `btn-sm` next to a `btn-primary min-w-64`.
 - Pairs are named as pairs: "Previous" and "Next", never "Previous" and "Continue". A disabled Previous is hidden, not greyed.
 - Button labels are the action, not the verb "View": "Full Trace", "Eval Description", "Eval". The one accepted exception today is "View Eval" on a success screen, where nothing else reads right.

--- a/.agents/frontend_design_guide.md
+++ b/.agents/frontend_design_guide.md
@@ -48,9 +48,9 @@ Our colors are named, a Daisy UI convention. For example the color “primary”
 ### Buttons
 
 - The default button is the plain grey `btn`. Use it for Previous, Cancel, Close, secondary actions, and anything that is not the one primary action.
-- `btn-outline` is for special cases only. `btn-outline btn-primary` is the one sanctioned use: picking one of several equal options.
+- `btn-outline` has exactly two sanctioned uses: `btn-outline btn-primary` for picking one of several equal options, and the selection recipe below. Nowhere else.
 - `btn-ghost` is not a house button. Buttons that sit on a tinted surface must still read as buttons; if a button is the same colour as what it sits on, it is the wrong button.
-- Selection buttons (agree/disagree, pass/fail, yes/no) use the Rating and Feedback style: unchosen is `btn btn-sm btn-outline` at full contrast, chosen is filled `btn btn-sm btn-secondary` (drop `btn-outline`; the outline-plus-secondary form renders transparent and cannot be told from unchosen). Never `btn-success` or `btn-error` for a choice. Red and green are for errors and status, not for disagreement.
+- Selection buttons (agree/disagree, pass/fail, yes/no) are the second sanctioned use. They follow the Rating and Feedback style: unchosen is `btn btn-sm btn-outline` at full contrast, chosen is filled `btn btn-sm btn-secondary` (drop `btn-outline`; the outline-plus-secondary form renders transparent and cannot be told from unchosen). Never `btn-success` or `btn-error` for a choice. Red and green are for errors and status, not for disagreement.
 - Two buttons side by side are the same size. Never a small `btn-sm` next to a `btn-primary min-w-64`.
 - Pairs are named as pairs: "Previous" and "Next", never "Previous" and "Continue". A disabled Previous is hidden, not greyed.
 - Button labels are the action, not the verb "View": "Full Trace", "Eval Description", "Eval". The one accepted exception today is "View Eval" on a success screen, where nothing else reads right.

--- a/.agents/skills/kiln-ui/SKILL.md
+++ b/.agents/skills/kiln-ui/SKILL.md
@@ -31,11 +31,11 @@ Kiln screens are built from a small set of shared controls and DaisyUI classes. 
 | `Collapse` | `lib/ui/collapse.svelte` | Anything that expands. The only expander. |
 | `PropertyList` | `lib/ui/property_list.svelte` | Name/value pairs with tooltips and links. |
 | `InfoTooltip` | `lib/ui/info_tooltip.svelte` | An "i" with a tooltip. Never a hover div. |
-| Rating buttons | `routes/(app)/run/rating.svelte` (see "Rating and Feedback" in `lib/ui/run_sidebar.svelte`) | Any pick-one selection: agree/disagree, pass/fail. unchosen `btn btn-sm btn-outline` at full contrast, chosen filled `btn btn-sm btn-secondary`. Never `btn-success`/`btn-error`. |
+| Rating buttons | `routes/(app)/run/rating.svelte` (see "Rating and Feedback" in `lib/ui/run_sidebar.svelte`) | Any pick-one selection: agree/disagree, pass/fail, yes/no. unchosen `btn btn-sm btn-outline` at full contrast, chosen filled `btn btn-sm btn-secondary`. The second sanctioned use of `btn-outline`. Never `btn-success`/`btn-error`. |
 | `RunConfigComponent`, `SavedRunConfigsDropdown`, `AvailableModelsDropdown` | `lib/ui/run_config_component/` | Model, tools, skills and run-config pickers. Never rebuilt. |
 | Animations | `lib/ui/animations/analyzing_animation.svelte`, `conversation_animation.svelte`, `refining_animation.svelte` | Progress and waiting screens. Title and description props only; counts go in the description string. |
 | `FloatingMenu`, `TableActionMenu` | `lib/ui/floating_menu.svelte`, `table_action_menu.svelte` | Dropdown menus. |
-| DaisyUI `btn` | | The grey default button for every secondary action. `btn-primary` once per screen. `btn-outline btn-primary` for pick-one-of-many. Nothing else. |
+| DaisyUI `btn` | | The grey default button for every secondary action. `btn-primary` once per screen. `btn-outline` has exactly two sanctioned uses: `btn-outline btn-primary` for picking one of several equal options, and the Rating buttons recipe above. Nothing else. |
 
 Reference screens (what "looks like Kiln" means): the Edit Task form (`routes/(app)/settings/edit_task/[project_id]/[task_id]/`), the Run page (`routes/(app)/run/+page.svelte`, including Rating and Feedback in `lib/ui/run_sidebar.svelte`), and the synthetic data flow (`routes/(app)/generate/[project_id]/[task_id]/synth_kiln_pro.svelte`). Do not take "house" from the nearest screen on your branch; take it from these.
 
@@ -65,7 +65,7 @@ Rules:
 - Never write `aria-expanded`, a chevron with `rotate-180`, or an `{#if expanded}` block. Collapse owns disclosure.
 - Never draw a box: no `rounded*` + `border`/`bg-*` + padding on a div. The documented card string (`card card-bordered border-base-300 shadow-md`) is for clickable or list items only. A table frame is `rounded-lg border` and nothing else.
 - Never set `text_size`, `filled_icon`, `font-*` or `text-*` on a shared control from the call site.
-- Never use `btn-success`/`btn-error` for a choice; never `btn-ghost`; `btn-outline` only as `btn-outline btn-primary` for pick-one.
+- Never use `btn-success`/`btn-error` for a choice; never `btn-ghost`. `btn-outline` has exactly two sanctioned uses: `btn-outline btn-primary` for picking one of several equal options, and the Rating and Feedback recipe (unchosen `btn btn-sm btn-outline`, chosen `btn btn-sm btn-secondary`) for agree/disagree, pass/fail, yes/no.
 - Button labels: no "View". Pairs are Previous/Next. One `btn-primary` per screen. Side-by-side buttons are the same size.
 - Fonts: `font-medium` headers, `font-normal` body, `font-light` subtitles. Text colours: base or `text-gray-500`. Backgrounds: none or `bg-base-200`.
 - Copy: short declarative sentences, no em-dashes, Title Case for step and dialog titles.

--- a/.agents/skills/kiln-ui/SKILL.md
+++ b/.agents/skills/kiln-ui/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: kiln-ui
+description: Build or change anything under app/web_ui with Kiln's house controls and styles only. Invoke before touching any .svelte file, and before writing a task that names a screen, dialog, card, form, button, header or progress state. Produces a component plan, a sibling-screen comparison, a gate run and a handback a reviewer can verify without looking at pixels.
+allowed-tools: Read Grep Glob Bash
+---
+
+# kiln-ui: house controls or justify
+
+Kiln screens are built from a small set of shared controls and DaisyUI classes. A screen assembled from Tailwind copied off a house control looks right in a screenshot and wrong next to the rest of the app, and the next screen copies it. This skill exists because that happened repeatedly on the eval builder while every unit passed review and visual sign-off. The fix is not "read the guide harder": it is to write down which control each element is, before code, and to prove it at handback in a form that does not need eyes.
+
+## 0. Read, every time (5 minutes)
+
+1. `.agents/frontend_design_guide.md` and `.agents/frontend_controls.md`.
+2. `.agents/card_style.md` and `.agents/tables_style.md`.
+3. The control list below. Open the source of every control you plan to use; the props are the contract.
+
+## 1. The house controls and when each is the answer
+
+| Control | Path | It is the answer when |
+|---|---|---|
+| `AppPage` | `routes/(app)/app_page.svelte` | The page title, subtitle, breadcrumbs and top-right action buttons. Every page. The only `text-2xl font-bold` on a screen. |
+| `SettingsHeader` | `lib/ui/settings_header.svelte` | A section title inside the page, with optional subtitle. Read-only sections, form sections, "Case 3 of 10". |
+| `KilnSection` | `lib/ui/kiln_section.svelte` | A `SettingsHeader` over a list of `SettingsItem` rows (settings-style pages). |
+| `Output` | `lib/ui/output.svelte` | Any read-only text or JSON: overview, plan, description, trace field, summary. Never a tinted div. |
+| `SeeAllDialog` | `lib/ui/see_all_dialog.svelte` | Read-only content behind a button, in a wide dialog with Close. |
+| `Dialog` | `lib/ui/dialog.svelte` | Any modal. Title, width, `action_buttons`. Never a hand-rolled overlay. |
+| `EditDialog` | `lib/ui/edit_dialog.svelte` | Editing name/description-style properties with Save/Cancel. |
+| `FormContainer` + `FormElement` | `lib/utils/form_container.svelte`, `lib/utils/form_element.svelte` | Anything the user types or picks. Labels, help text, `info_description`, validation, the submit row. Never `<label>`, `<textarea>`, `<input>`, `<select>` by hand. |
+| `Warning` | `lib/ui/warning.svelte` | A message with an icon (warning, info, success, error, gray). Default `text_size`; never change its font from the call site. |
+| `Intro` | `lib/ui/intro.svelte` | An empty or entry screen: icon, title, paragraphs, buttons. |
+| `Collapse` | `lib/ui/collapse.svelte` | Anything that expands. The only expander. |
+| `PropertyList` | `lib/ui/property_list.svelte` | Name/value pairs with tooltips and links. |
+| `InfoTooltip` | `lib/ui/info_tooltip.svelte` | An "i" with a tooltip. Never a hover div. |
+| Rating buttons | `routes/(app)/run/rating.svelte` (see "Rating and Feedback" in `lib/ui/run_sidebar.svelte`) | Any pick-one selection: agree/disagree, pass/fail. `btn btn-sm btn-outline`, `btn-secondary` when selected. Never `btn-success`/`btn-error`. |
+| `RunConfigComponent`, `SavedRunConfigsDropdown`, `AvailableModelsDropdown` | `lib/ui/run_config_component/` | Model, tools, skills and run-config pickers. Never rebuilt. |
+| Animations | `lib/ui/animations/analyzing_animation.svelte`, `conversation_animation.svelte`, `refining_animation.svelte` | Progress and waiting screens. Title and description props only; counts go in the description string. |
+| `FloatingMenu`, `TableActionMenu` | `lib/ui/floating_menu.svelte`, `table_action_menu.svelte` | Dropdown menus. |
+| DaisyUI `btn` | | The grey default button for every secondary action. `btn-primary` once per screen. `btn-outline btn-primary` for pick-one-of-many. Nothing else. |
+
+Reference screens (what "looks like Kiln" means): the Edit Task form (`routes/(app)/settings/edit_task/[project_id]/[task_id]/`), the Run page (`routes/(app)/run/+page.svelte`, including Rating and Feedback in `lib/ui/run_sidebar.svelte`), and the synthetic data flow (`routes/(app)/generate/[project_id]/[task_id]/synth_kiln_pro.svelte`). Do not take "house" from the nearest screen on your branch; take it from these.
+
+## 2. Component plan, before code (required)
+
+Write a component plan before the first edit (in the PR description, or a `COMPONENT_PLAN.md` beside your notes; never committed to the app). One row per visible element on every screen state you touch:
+
+```
+| Element | House control used | Sibling screen it matches | Justification if custom |
+|---|---|---|---|
+| Step title "Case 3 of 10" | SettingsHeader | edit_task form section header | |
+| Overview body | Output | run page Output block | |
+| Agree / Disagree | rating.svelte classes | Rating and Feedback | |
+| Hint under the reason box | Warning (default text_size) | eval_configs page advisory | |
+```
+
+Rules:
+- No custom row without a justification that names the control you tried and the prop it lacks. "Looks better" is not a justification. "The control has no prop for X" is; propose the prop as a separate shared-control change (section 4).
+- Every WARN and FAIL the gate reports (section 5) must map to a row.
+- Name ONE sibling screen the new screen must read like. The handback ships a side-by-side with it.
+- If the task did not name the sibling, pick the nearest of the three reference screens and say so in the plan.
+
+## 3. Build rules
+
+- Never write `<label>`, `<textarea>`, `<input>`, `<select>` in a route file. FormElement owns them.
+- Never write `aria-expanded`, a chevron with `rotate-180`, or an `{#if expanded}` block. Collapse owns disclosure.
+- Never draw a box: no `rounded*` + `border`/`bg-*` + padding on a div. The documented card string (`card card-bordered border-base-300 shadow-md`) is for clickable or list items only. A table frame is `rounded-lg border` and nothing else.
+- Never set `text_size`, `filled_icon`, `font-*` or `text-*` on a shared control from the call site.
+- Never use `btn-success`/`btn-error` for a choice; never `btn-ghost`; `btn-outline` only as `btn-outline btn-primary` for pick-one.
+- Button labels: no "View". Pairs are Previous/Next. One `btn-primary` per screen. Side-by-side buttons are the same size.
+- Fonts: `font-medium` headers, `font-normal` body, `font-light` subtitles. Text colours: base or `text-gray-500`. Backgrounds: none or `bg-base-200`.
+- Copy: short declarative sentences, no em-dashes, Title Case for step and dialog titles.
+
+## 4. Shared controls are a separate change
+
+Any diff under `lib/ui/`, `lib/components/`, `lib/utils/form_*`, `app_page.svelte`, or the shared synthetic-data components (`generate/[project_id]/[task_id]/kiln_pro_*.svelte`) is a change to every screen that uses the control. It is never folded into a feature change. It needs its own stated decision ("Warning gains prop X because Y"), its own commit, the list of call sites touched, and a review by the control's owner. The gate's `SHARED_CONTROL_TOUCHED` hit is not a false positive; it is the reminder that the decision must be written down.
+
+## 5. Gate, on the diff (required)
+
+```
+bash .agents/skills/kiln-ui/ui_gate.sh --range <base>..<tip>     # the branch's commits
+bash .agents/skills/kiln-ui/ui_gate.sh --worktree                 # before committing
+bash .agents/skills/kiln-ui/ui_gate.sh --files <file>...           # audit whole files
+```
+
+- Exit 1 = FAIL hits. Fix them, or justify each by file:line in the component plan (a justification is a row, not a comment in the code).
+- WARN hits must appear as rows in the plan. INFO hits are listed in the handback.
+- Do not add allowlist lines for the screen you are building. `ui_gate_allow.txt` is for house idioms already shipped on a reference screen.
+- The three reference screens run at 0 FAIL / 1 WARN; a new change is expected to land at 0 FAIL.
+
+## 6. Review lens: house control or justify
+
+Reviewers of a UI change apply this lens alongside the usual ones. For each visible element the diff adds or restyles: (1) which house control renders it, or which plan row justifies a custom element; (2) whether any shared control under `lib/` changed and whether the change states that decision; (3) whether the screen reads like the named sibling (compare the two screenshots, not the diff); (4) whether the gate output attached to the change is clean or every hit is justified. Report each miss as a finding:
+
+```
+FILE:LINE: <route file>:<line>
+CLAIM: <element> is a custom <box|label|expander|button|font> where <control> is the house answer.
+FAILURE: the screen diverges from <sibling screen> in <what a user sees>; the next screen copies it.
+SEVERITY: minor (major if a shared control changed without a stated decision)
+EVIDENCE: the class string, the control's prop that covers it, the plan row that is missing.
+```
+
+Style findings under this lens are valid findings.
+
+## 7. Handback contract (the reviewer signs off on these, not on pixels)
+
+The PR description or handback carries, in this order:
+1. The component plan, final (every row resolved).
+2. The gate output for `--range <base>..<tip>`, verbatim, with each FAIL/WARN mapped to a plan row.
+3. A side-by-side screenshot: the new screen next to its named sibling, same window width.
+4. The list of shared controls touched (or "none"), each with the stated decision that authorised it.
+5. Test counts and the usual checks.
+
+A reviewer reads 1, 2 and 4 before opening 3. A change whose gate output is missing or whose plan has an unjustified custom row is not ready for review.

--- a/.agents/skills/kiln-ui/SKILL.md
+++ b/.agents/skills/kiln-ui/SKILL.md
@@ -78,11 +78,11 @@ Any diff under `lib/ui/`, `lib/components/`, `lib/utils/form_*`, `app_page.svelt
 
 ```
 bash .agents/skills/kiln-ui/ui_gate.sh --range <base>..<tip>     # the branch's commits
-bash .agents/skills/kiln-ui/ui_gate.sh --worktree                 # before committing
-bash .agents/skills/kiln-ui/ui_gate.sh --files <file>...           # audit whole files
+bash .agents/skills/kiln-ui/ui_gate.sh --worktree                 # before committing, untracked files included
+bash .agents/skills/kiln-ui/ui_gate.sh --files <file>...           # audit whole .svelte files
 ```
 
-- The gate skips comment lines, including the inside of multi-line comments, so prose that mentions a class name is not a hit.
+- The gate skips comment spans, including multi-line ones, so prose that mentions a class name is not a hit. Markup before or after a comment on the same line is still reviewed.
 - Exit 1 = FAIL hits. Fix them, or justify each by file:line in the component plan (a justification is a row, not a comment in the code).
 - WARN hits must appear as rows in the plan. INFO hits are listed in the handback.
 - Do not add allowlist lines for the screen you are building. `ui_gate_allow.txt` is for house idioms already shipped on a reference screen.

--- a/.agents/skills/kiln-ui/SKILL.md
+++ b/.agents/skills/kiln-ui/SKILL.md
@@ -31,7 +31,7 @@ Kiln screens are built from a small set of shared controls and DaisyUI classes. 
 | `Collapse` | `lib/ui/collapse.svelte` | Anything that expands. The only expander. |
 | `PropertyList` | `lib/ui/property_list.svelte` | Name/value pairs with tooltips and links. |
 | `InfoTooltip` | `lib/ui/info_tooltip.svelte` | An "i" with a tooltip. Never a hover div. |
-| Rating buttons | `routes/(app)/run/rating.svelte` (see "Rating and Feedback" in `lib/ui/run_sidebar.svelte`) | Any pick-one selection: agree/disagree, pass/fail. `btn btn-sm btn-outline`, `btn-secondary` when selected. Never `btn-success`/`btn-error`. |
+| Rating buttons | `routes/(app)/run/rating.svelte` (see "Rating and Feedback" in `lib/ui/run_sidebar.svelte`) | Any pick-one selection: agree/disagree, pass/fail. unchosen `btn btn-sm btn-outline` at full contrast, chosen filled `btn btn-sm btn-secondary`. Never `btn-success`/`btn-error`. |
 | `RunConfigComponent`, `SavedRunConfigsDropdown`, `AvailableModelsDropdown` | `lib/ui/run_config_component/` | Model, tools, skills and run-config pickers. Never rebuilt. |
 | Animations | `lib/ui/animations/analyzing_animation.svelte`, `conversation_animation.svelte`, `refining_animation.svelte` | Progress and waiting screens. Title and description props only; counts go in the description string. |
 | `FloatingMenu`, `TableActionMenu` | `lib/ui/floating_menu.svelte`, `table_action_menu.svelte` | Dropdown menus. |
@@ -55,7 +55,8 @@ Write a component plan before the first edit (in the PR description, or a `COMPO
 Rules:
 - No custom row without a justification that names the control you tried and the prop it lacks. "Looks better" is not a justification. "The control has no prop for X" is; propose the prop as a separate shared-control change (section 4).
 - Every WARN and FAIL the gate reports (section 5) must map to a row.
-- Name ONE sibling screen the new screen must read like. The handback ships a side-by-side with it.
+- One row per screen for vertical rhythm: which container owns the gap between sections and the one or two values used (the house form runs on 24 between fields; use one gap inside a block). Children carry no margins. The handback carries the measured distances next to the sibling's.
+- Name ONE sibling screen the new screen must read like. The handback ships a side-by-side with it. Some reference screens predate a control (the Edit Task form's section heads are hand-rolled); match the control, and record the difference as known.
 - If the task did not name the sibling, pick the nearest of the three reference screens and say so in the plan.
 
 ## 3. Build rules
@@ -71,7 +72,7 @@ Rules:
 
 ## 4. Shared controls are a separate change
 
-Any diff under `lib/ui/`, `lib/components/`, `lib/utils/form_*`, `app_page.svelte`, or the shared synthetic-data components (`generate/[project_id]/[task_id]/kiln_pro_*.svelte`) is a change to every screen that uses the control. It is never folded into a feature change. It needs its own stated decision ("Warning gains prop X because Y"), its own commit, the list of call sites touched, and a review by the control's owner. The gate's `SHARED_CONTROL_TOUCHED` hit is not a false positive; it is the reminder that the decision must be written down.
+Any diff under `lib/ui/`, `lib/components/`, `lib/utils/form_*`, `app_page.svelte`, or the shared synthetic-data components (`generate/[project_id]/[task_id]/kiln_pro_*.svelte`) is a change to every screen that uses the control. It is never folded into a feature change. It needs its own stated decision ("Warning gains prop X because Y"), its own commit, the list of call sites touched, and a review by the control's owner. The gate's `SHARED_CONTROL_TOUCHED` hit is not a false positive; it is the reminder that the decision must be written down. Expect the first unit on a screen that was built from custom CSS to need several: every hand-rolled element was a control that lacked something (an actions slot, a slot for rich content, an aria attribute). Each is its own additive commit with a test that the existing render path is unchanged; never widen a control from a call site.
 
 ## 5. Gate, on the diff (required)
 
@@ -81,6 +82,7 @@ bash .agents/skills/kiln-ui/ui_gate.sh --worktree                 # before commi
 bash .agents/skills/kiln-ui/ui_gate.sh --files <file>...           # audit whole files
 ```
 
+- The gate skips comment lines, including the inside of multi-line comments, so prose that mentions a class name is not a hit.
 - Exit 1 = FAIL hits. Fix them, or justify each by file:line in the component plan (a justification is a row, not a comment in the code).
 - WARN hits must appear as rows in the plan. INFO hits are listed in the handback.
 - Do not add allowlist lines for the screen you are building. `ui_gate_allow.txt` is for house idioms already shipped on a reference screen.
@@ -108,5 +110,6 @@ The PR description or handback carries, in this order:
 3. A side-by-side screenshot: the new screen next to its named sibling, same window width.
 4. The list of shared controls touched (or "none"), each with the stated decision that authorised it.
 5. Test counts and the usual checks.
+6. An independent screenshot review: a fresh session that gets only the owner's spec (verbatim), the guides and the screenshots, and returns a per-line verdict plus a ranked critique. It must not see the plan or the walk notes. Its findings are fixed or answered before the handback is sent. Builders who have stared at a screen for an hour miss a dimmed button; a fresh reader does not.
 
 A reviewer reads 1, 2 and 4 before opening 3. A change whose gate output is missing or whose plan has an unjustified custom row is not ready for review.

--- a/.agents/skills/kiln-ui/ui_gate.sh
+++ b/.agents/skills/kiln-ui/ui_gate.sh
@@ -57,9 +57,29 @@ case "$MODE" in
 esac
 [ -f "$TMP/shared.tsv" ] || : > "$TMP/shared.tsv"
 
-# comments and script-only lines are not markup; drop lines that are clearly comments
+# Comment lines are not markup. Single-line markers are dropped by prefix; lines INSIDE a
+# multi-line <!-- --> or /* */ block are found by scanning the whole file at the reviewed
+# revision, so a prose comment that mentions "btn-outline" on its third line is not a hit.
 CODE="$TMP/code.tsv"
-grep -vE $'\t[[:space:]]*(//|<!--|\\*|/\\*|--)' "$LINES" > "$CODE" || true
+comment_lines() {  # <file> -> prints "file:line" for every line inside a block comment
+  local f=$1 src
+  case "$MODE" in
+    range) src=$(git -C "$REPO" show "${RANGE##*..}:$f" 2>/dev/null) ;;
+    *)     src=$(cat "$([ "$MODE" = files ] && echo "$f" || echo "$REPO/$f")" 2>/dev/null) ;;
+  esac
+  printf '%s\n' "$src" | awk -v f="$f" '
+    { line=$0; n=NR; inblk_before=inblk
+      while (1) {
+        if (!inblk) { o1=index(line,"<!--"); o2=index(line,"/*"); o=(o1&&o2)?(o1<o2?o1:o2):(o1?o1:o2)
+                      if (!o) break; inblk=(o==o1)?1:2; line=substr(line,o+ (inblk==1?4:2)) ; started=1 }
+        else { c=index(line,(inblk==1)?"-->":"*/"); if (!c) break; inblk=0; line=substr(line,c+ ((inblk==1)?3:2)) }
+      }
+      if (inblk_before || (inblk && started)) print f ":" n
+      started=0
+    }'
+}
+cut -d: -f1 "$LINES" | sort -u | while read -r f; do comment_lines "$f"; done | sort -u > "$TMP/comment_lines.txt"
+grep -vE $'\t[[:space:]]*(//|<!--|\\*|/\\*|--)' "$LINES" | grep -vF -f <(sed 's/$/\t/' "$TMP/comment_lines.txt" | sed 's/^/^/' | sed 's/\^//' ) > "$CODE" || true
 
 # ---- rules --------------------------------------------------------------------------------
 # R <sev> <rule> <grep -E pattern> [exclude pattern]

--- a/.agents/skills/kiln-ui/ui_gate.sh
+++ b/.agents/skills/kiln-ui/ui_gate.sh
@@ -3,14 +3,15 @@
 #
 # Usage:
 #   ui_gate.sh --range <git-range> [--repo <path>]   # added lines of a diff (the unit's landing check)
-#   ui_gate.sh --files <file>...                       # whole files (calibration, audits)
-#   ui_gate.sh --worktree [--repo <path>]              # added lines of the uncommitted diff
+#   ui_gate.sh --files <file>...                       # whole .svelte files (calibration, audits)
+#   ui_gate.sh --worktree [--repo <path>]              # added lines of the uncommitted diff, plus untracked files
 #
 # Output: one line per hit  SEV<TAB>RULE<TAB>file:line<TAB>snippet, then a summary.
 # SEV: FAIL = the unit does not land unless the component plan justifies the hit by
 #      file:line; WARN = must appear as a row in the component plan; INFO = listed only.
 # Exit 1 when any FAIL hit remains. Allowlist: ui_gate_allow.txt beside this script (one regex per
-# line, matched against "file<TAB>snippet"), for house idioms that are not defects.
+# line, matched against "file<TAB>snippet", optionally prefixed "RULE_NAME:" to scope it to that one
+# rule), for house idioms that are not defects.
 #
 # Rules are tuned on the eval builder route and calibrated on the rest of app/web_ui/src/routes
 # (43k lines): the reference screens (run page, edit task, synthetic data) run at 0 FAIL.
@@ -28,17 +29,22 @@ while [ $# -gt 0 ]; do
     *) echo "unknown arg $1" >&2; exit 2;;
   esac
 done
-[ -z "$MODE" ] && { sed -n 2,16p "$0"; exit 2; }
+[ -z "$MODE" ] && { sed -n 2,17p "$0"; exit 2; }
 
 TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
 LINES="$TMP/lines.tsv"   # file:line<TAB>content
 
 # ---- collect the lines under review -------------------------------------------------------
 svelte_only() { grep -E '^app/web_ui/src/.*\.svelte:' | grep -vE '\.test\.|/__tests__/|_mock|/dev/|/preview/'; }
+# Untracked files are invisible to `git diff`, so a brand-new component would otherwise review as
+# zero lines. Worktree mode scans each of them whole, the way --files does.
+untracked_files() { git -C "$REPO" ls-files --others --exclude-standard -- 'app/web_ui/src'; }
 case "$MODE" in
   files)
     for f in "${FILES[@]}"; do
       case "$f" in *.test.*|*/__tests__/*) continue;; esac
+      # Only markup is reviewable: a guide or a script carries <label> examples that are not screens.
+      case "$f" in *.svelte) ;; *) echo "skipped, not a .svelte file: $f" >&2; continue;; esac
       awk -v f="$f" '{ print f ":" NR "\t" $0 }' "$f"
     done > "$LINES" ;;
   range|worktree)
@@ -50,36 +56,49 @@ case "$MODE" in
       /^\+/ { print file ":" ln "\t" substr($0,2); ln++; next }
       /^-/ { next }
       { ln++ }' | svelte_only > "$LINES"
+    if [ "$MODE" = worktree ]; then
+      untracked_files | grep -E '\.svelte$' | grep -vE '\.test\.|/__tests__/|_mock|/dev/|/preview/' \
+        | while read -r f; do awk -v f="$f" '{ print f ":" NR "\t" $0 }' "$REPO/$f"; done >> "$LINES"
+    fi
     # shared controls touched: any file in the diff under the shared dirs (lib/ui, lib/components, the form
     # controls, app_page, and the SDG kiln_pro_* components the builder shares), added OR removed lines
-    "${D[@]}" --name-only -- 'app/web_ui/src' | grep -E '^app/web_ui/src/(lib/ui/|lib/components/|lib/utils/form_|routes/\(app\)/app_page\.svelte|routes/\(app\)/generate/\[project_id\]/\[task_id\]/kiln_pro_)' \
+    { "${D[@]}" --name-only -- 'app/web_ui/src'; [ "$MODE" = worktree ] && untracked_files; } \
+      | grep -E '^app/web_ui/src/(lib/ui/|lib/components/|lib/utils/form_|routes/\(app\)/app_page\.svelte|routes/\(app\)/generate/\[project_id\]/\[task_id\]/kiln_pro_)' \
       | grep -vE '\.test\.|/__tests__/' | sed 's/^/FAIL\tSHARED_CONTROL_TOUCHED\t/; s/$/:0\tshared control edited: must be a separate named decision in the brief/' > "$TMP/shared.tsv" ;;
 esac
 [ -f "$TMP/shared.tsv" ] || : > "$TMP/shared.tsv"
 
-# Comment lines are not markup. Single-line markers are dropped by prefix; lines INSIDE a
-# multi-line <!-- --> or /* */ block are found by scanning the whole file at the reviewed
-# revision, so a prose comment that mentions "btn-outline" on its third line is not a hit.
+# Comment text is not markup. Comment SPANS (<!-- -->, /* */, on one line or across several) are
+# cut out of each reviewed line by scanning the whole file at the reviewed revision, so prose that
+# mentions "btn-outline" is not a hit while markup before or after the comment on the same line
+# still is. Single-line markers (// and --) are dropped by prefix.
 CODE="$TMP/code.tsv"
-comment_lines() {  # <file> -> prints "file:line" for every line inside a block comment
+code_spans() {  # <file> -> prints "file:line<TAB>the line with every comment span removed"
   local f=$1 src
   case "$MODE" in
     range) src=$(git -C "$REPO" show "${RANGE##*..}:$f" 2>/dev/null) ;;
     *)     src=$(cat "$([ "$MODE" = files ] && echo "$f" || echo "$REPO/$f")" 2>/dev/null) ;;
   esac
+  [ -z "$src" ] && return 0
   printf '%s\n' "$src" | awk -v f="$f" '
-    { line=$0; n=NR; inblk_before=inblk
+    { rest=$0; out=""
       while (1) {
-        if (!inblk) { o1=index(line,"<!--"); o2=index(line,"/*"); o=(o1&&o2)?(o1<o2?o1:o2):(o1?o1:o2)
-                      if (!o) break; inblk=(o==o1)?1:2; line=substr(line,o+ (inblk==1?4:2)) ; started=1 }
-        else { c=index(line,(inblk==1)?"-->":"*/"); if (!c) break; inblk=0; line=substr(line,c+ ((inblk==1)?3:2)) }
+        if (!inblk) { o1=index(rest,"<!--"); o2=index(rest,"/*"); o=(o1&&o2)?(o1<o2?o1:o2):(o1?o1:o2)
+                      if (!o) { out=out rest; break }
+                      inblk=(o==o1)?1:2; out=out substr(rest,1,o-1); rest=substr(rest,o+ (inblk==1?4:2)) }
+        else { c=index(rest,(inblk==1)?"-->":"*/"); if (!c) { rest=""; break }
+               rest=substr(rest,c+ ((inblk==1)?3:2)); inblk=0 }
       }
-      if (inblk_before || (inblk && started)) print f ":" n
-      started=0
+      print f ":" NR "\t" out
     }'
 }
-cut -d: -f1 "$LINES" | sort -u | while read -r f; do comment_lines "$f"; done | sort -u > "$TMP/comment_lines.txt"
-grep -vE $'\t[[:space:]]*(//|<!--|\\*|/\\*|--)' "$LINES" | grep -vF -f <(sed 's/$/\t/' "$TMP/comment_lines.txt" | sed 's/^/^/' | sed 's/\^//' ) > "$CODE" || true
+cut -d: -f1 "$LINES" | sort -u | while read -r f; do code_spans "$f"; done > "$TMP/spans.tsv"
+# Replace each reviewed line with its comment-free text; a line that is all comment drops out.
+awk -F'\t' 'NR==FNR { c=$0; sub(/^[^\t]*\t/,"",c); span[$1]=c; seen[$1]=1; next }
+     { c=$0; sub(/^[^\t]*\t/,"",c); if (seen[$1]) c=span[$1]
+       if (c ~ /^[[:space:]]*$/) next
+       print $1 "\t" c }' "$TMP/spans.tsv" "$LINES" \
+  | grep -vE $'\t[[:space:]]*(//|\\*|--)' > "$CODE" || true
 
 # ---- rules --------------------------------------------------------------------------------
 # R <sev> <rule> <grep -E pattern> [exclude pattern]
@@ -120,7 +139,10 @@ R WARN NON_GUIDE_TEXT_COLOR '\btext-(gray|slate|zinc|neutral)-(300|400|600|700|8
 R WARN NON_GUIDE_BG '\bbg-(gray|slate|zinc|neutral|yellow|amber|red|green|blue)-[0-9]+\b|\bbg-(primary|secondary|success|error|warning|info)/[0-9]+\b' '<mark|MARK_CLASS'
 # 13. Arbitrary values (house idioms allowlisted below).
 R INFO ARBITRARY_VALUE '\[[0-9.]+(px|rem|vh|vw|%)\]|\[min\(|\[calc\(' 'max-w-\[(1400|900|300|340)px\]|min-h-\[50vh\]|max-h-\[(70|80)vh\]|min-h-\[calc\(100vh|w-\[70%\]|max-w-\[70%\]'
-} | { if [ -f "$ALLOW" ]; then grep -vE -f <(grep -vE '^\s*(#|$)' "$ALLOW" | sed 's/^/\t[A-Z_]+\t.*/'); else cat; fi; } \
+# An allow line prefixed "RULE_NAME:" only silences that rule; a bare line silences every rule.
+} | { if [ -f "$ALLOW" ]; then grep -vE -f <(grep -vE '^\s*(#|$)' "$ALLOW" \
+        | awk -v t="\t" '/^[A-Z_]+:/ { r=$0; sub(/:.*/,"",r); p=$0; sub(/^[A-Z_]+:/,"",p); print t r t ".*" p; next }
+                          { print t "[A-Z_]+" t ".*" $0 }'); else cat; fi; } \
   | sort -t$'\t' -k1,1 -k2,2 -k3,3 | uniq > "$TMP/hits.tsv"
 
 cat "$TMP/hits.tsv"

--- a/.agents/skills/kiln-ui/ui_gate.sh
+++ b/.agents/skills/kiln-ui/ui_gate.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# kiln-ui gate: flags custom CSS and non-house controls in web UI changes.
+#
+# Usage:
+#   ui_gate.sh --range <git-range> [--repo <path>]   # added lines of a diff (the unit's landing check)
+#   ui_gate.sh --files <file>...                       # whole files (calibration, audits)
+#   ui_gate.sh --worktree [--repo <path>]              # added lines of the uncommitted diff
+#
+# Output: one line per hit  SEV<TAB>RULE<TAB>file:line<TAB>snippet, then a summary.
+# SEV: FAIL = the unit does not land unless the component plan justifies the hit by
+#      file:line; WARN = must appear as a row in the component plan; INFO = listed only.
+# Exit 1 when any FAIL hit remains. Allowlist: ui_gate_allow.txt beside this script (one regex per
+# line, matched against "file<TAB>snippet"), for house idioms that are not defects.
+#
+# Rules are tuned on the eval builder route and calibrated on the rest of app/web_ui/src/routes
+# (43k lines): the reference screens (run page, edit task, synthetic data) run at 0 FAIL.
+set -u
+HERE=$(cd "$(dirname "$0")" && pwd)
+ALLOW="$HERE/ui_gate_allow.txt"
+REPO=.
+MODE=""; RANGE=""; FILES=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --range) MODE=range; RANGE=$2; shift 2;;
+    --worktree) MODE=worktree; shift;;
+    --files) MODE=files; shift; while [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; do FILES+=("$1"); shift; done;;
+    --repo) REPO=$2; shift 2;;
+    *) echo "unknown arg $1" >&2; exit 2;;
+  esac
+done
+[ -z "$MODE" ] && { sed -n 2,16p "$0"; exit 2; }
+
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+LINES="$TMP/lines.tsv"   # file:line<TAB>content
+
+# ---- collect the lines under review -------------------------------------------------------
+svelte_only() { grep -E '^app/web_ui/src/.*\.svelte:' | grep -vE '\.test\.|/__tests__/|_mock|/dev/|/preview/'; }
+case "$MODE" in
+  files)
+    for f in "${FILES[@]}"; do
+      case "$f" in *.test.*|*/__tests__/*) continue;; esac
+      awk -v f="$f" '{ print f ":" NR "\t" $0 }' "$f"
+    done > "$LINES" ;;
+  range|worktree)
+    if [ "$MODE" = range ]; then D=(git -C "$REPO" diff -U0 "$RANGE"); else D=(git -C "$REPO" diff -U0 HEAD); fi
+    "${D[@]}" -- 'app/web_ui/src' | awk '
+      /^diff --git/ { file=$4; sub(/^b\//,"",file); next }
+      /^@@/ { split($3,a,","); ln=substr(a[1],2)+0; next }
+      /^\+\+\+/ { next }
+      /^\+/ { print file ":" ln "\t" substr($0,2); ln++; next }
+      /^-/ { next }
+      { ln++ }' | svelte_only > "$LINES"
+    # shared controls touched: any file in the diff under the shared dirs (lib/ui, lib/components, the form
+    # controls, app_page, and the SDG kiln_pro_* components the builder shares), added OR removed lines
+    "${D[@]}" --name-only -- 'app/web_ui/src' | grep -E '^app/web_ui/src/(lib/ui/|lib/components/|lib/utils/form_|routes/\(app\)/app_page\.svelte|routes/\(app\)/generate/\[project_id\]/\[task_id\]/kiln_pro_)' \
+      | grep -vE '\.test\.|/__tests__/' | sed 's/^/FAIL\tSHARED_CONTROL_TOUCHED\t/; s/$/:0\tshared control edited: must be a separate named decision in the brief/' > "$TMP/shared.tsv" ;;
+esac
+[ -f "$TMP/shared.tsv" ] || : > "$TMP/shared.tsv"
+
+# comments and script-only lines are not markup; drop lines that are clearly comments
+CODE="$TMP/code.tsv"
+grep -vE $'\t[[:space:]]*(//|<!--|\\*|/\\*|--)' "$LINES" > "$CODE" || true
+
+# ---- rules --------------------------------------------------------------------------------
+# R <sev> <rule> <grep -E pattern> [exclude pattern]
+R() {
+  local sev=$1 rule=$2 pat=$3 excl=${4:-'^$'}
+  grep -E "$pat" "$CODE" | grep -vE "$excl" | { if [ -n "${5:-}" ]; then grep -E "$5"; else cat; fi; } | { if [ -n "${6:-}" ]; then grep -E "$6"; else cat; fi; } | sed "s/^/$sev\t$rule\t/"
+}
+{
+cat "$TMP/shared.tsv"
+# 1. A form field built by hand instead of FormElement (checkbox/radio/file/hidden and the
+#    drawer toggle are not form fields in the guide's sense).
+R FAIL RAW_FORM_FIELD '<(textarea|input|select)\b' 'type="(checkbox|radio|file|hidden|search)"|drawer-toggle|class="(toggle|range|rating|checkbox)|rating-hidden|placeholder="Search'
+# 2. A hand-written <label> (FormElement owns labels). Drawer labels and daisy label wrappers excluded.
+R FAIL RAW_LABEL '<label\b' 'for="main-drawer"|drawer-|class="label\b|class="cursor-pointer label'
+# 3. A hand-rolled expander (Collapse owns disclosure).
+R FAIL HANDROLLED_EXPANDER 'aria-expanded=|rotate-180|expanded[[:space:]]*=[[:space:]]*!' 'lib/ui/collapse\.svelte|dropdown|menu'
+# 4. Selection state painted with a status colour (the house selection style is
+#    btn-outline -> btn-secondary when selected; see routes/(app)/run/rating.svelte).
+R FAIL STATUS_COLOR_TOGGLE "\\?[[:space:]]*['\"]btn-(success|error|warning)['\"]|btn-(success|error|warning)['\"][[:space:]]*:[[:space:]]*['\"]btn-outline"
+# 5. "View ..." as a button label.
+R FAIL VIEW_LABEL '(<button[^>]*>|label:[[:space:]]*"|>)[[:space:]]*View [A-Z]|^[^	]+	[[:space:]]*View [A-Z][A-Za-z]*( [A-Za-z]+)*[[:space:]]*$' '<summary|<a\b|href='
+# 6. A self-styled rounded container (rounded + surface/border + padding on one element)
+#    that is not the documented card string. Badges, marks, avatars, pills excluded.
+R FAIL TINTED_BOX 'class="[^"]*\brounded(-(sm|md|lg|xl|2xl|3xl))?\b[^"]*"' 'card card-bordered border-base-300 shadow-md|badge|<mark|rounded-full|avatar|loading|tooltip|dropdown|menu|modal|toast|progress|kbd|<input|<textarea|<code|<pre|overflow-x-auto|rounded-box' '\b(bg-(base-[0-9]+|primary|warning|success|error|info|gray|red|yellow|green|blue)(/[0-9]+)?|border-(warning|success|error|info|primary)/[0-9]+)\b' '\bp[xy]?-[0-9]'
+R WARN ROUNDED_FRAME 'class="[^"]*\brounded(-(sm|md|lg|xl|2xl|3xl))?\b[^"]*\bborder\b[^"]*"' 'card card-bordered border-base-300 shadow-md|badge|<mark|rounded-full|avatar|loading|tooltip|dropdown|menu|modal|toast|progress|kbd|<input|<textarea|<code|<pre|bg-|border-(warning|success|error|info|primary)/'
+# 7. A prop that overrides a shared control's typography or size.
+R FAIL CONTROL_TYPOGRAPHY_OVERRIDE '\b(text_size|filled_icon)=' 'text_size="(sm|base)"'
+# 8. Shadow or border colour added by hand outside the documented card string.
+R WARN CUSTOM_SURFACE '\bshadow(-(sm|md|lg|xl))?\b|\bborder-(gray|slate|zinc|neutral|primary|secondary|success|error|warning|base-[0-9]+)(/[0-9]+)?\b' 'card card-bordered border-base-300 shadow-md|dropdown|menu|tooltip|<mark'
+# 9. Ghost and outline buttons (house: standard grey btn; outline for special cases;
+#    btn-outline btn-primary for pick-one-of-many).
+R WARN GHOST_OR_OUTLINE_BUTTON '\bbtn-ghost\b|\bbtn-outline\b' 'btn-outline btn-primary|btn-primary btn-outline|btn-circle|btn-square'
+# 10. Font weight outside the guide (bold only on page/section headings; semibold never).
+R WARN FONT_WEIGHT '\bfont-(semibold|extrabold|black)\b|\bfont-bold\b' 'text-(xl|2xl|3xl) font-bold|font-bold text-(xl|2xl|3xl)'
+# 11. Text colour outside the guide (text-gray-500 is the secondary colour).
+R WARN NON_GUIDE_TEXT_COLOR '\btext-(gray|slate|zinc|neutral)-(300|400|600|700|800|900)\b' 'text-gray-400.*icon|<svg|placeholder'
+# 12. Tinted backgrounds outside the palette section.
+R WARN NON_GUIDE_BG '\bbg-(gray|slate|zinc|neutral|yellow|amber|red|green|blue)-[0-9]+\b|\bbg-(primary|secondary|success|error|warning|info)/[0-9]+\b' '<mark|MARK_CLASS'
+# 13. Arbitrary values (house idioms allowlisted below).
+R INFO ARBITRARY_VALUE '\[[0-9.]+(px|rem|vh|vw|%)\]|\[min\(|\[calc\(' 'max-w-\[(1400|900|300|340)px\]|min-h-\[50vh\]|max-h-\[(70|80)vh\]|min-h-\[calc\(100vh|w-\[70%\]|max-w-\[70%\]'
+} | { if [ -f "$ALLOW" ]; then grep -vE -f <(grep -vE '^\s*(#|$)' "$ALLOW" | sed 's/^/\t[A-Z_]+\t.*/'); else cat; fi; } \
+  | sort -t$'\t' -k1,1 -k2,2 -k3,3 | uniq > "$TMP/hits.tsv"
+
+cat "$TMP/hits.tsv"
+echo "=== kiln-ui gate: $(wc -l < "$LINES" | tr -d ' ') lines reviewed, $(wc -l < "$TMP/hits.tsv" | tr -d ' ') hits ==="
+cut -f1,2 "$TMP/hits.tsv" | sort | uniq -c | sort -k2,2 -k1,1rn
+NFAIL=$(grep -c '^FAIL' "$TMP/hits.tsv" || true)
+if [ "${NFAIL:-0}" -gt 0 ]; then echo "RESULT: FAIL ($NFAIL FAIL hits: justify each by file:line in the component plan, or fix)"; exit 1; fi
+echo "RESULT: PASS (WARN/INFO hits must appear as rows in the component plan)"

--- a/.agents/skills/kiln-ui/ui_gate_allow.txt
+++ b/.agents/skills/kiln-ui/ui_gate_allow.txt
@@ -1,0 +1,8 @@
+# kiln-ui gate allowlist. One extended regex per line, matched against the hit's
+# "<file>:<line>\t<snippet>" text. Add a line only for a HOUSE idiom (something the app
+# already does on a shipped screen), never to silence a hit on a new screen.
+# The citation mark (output.svelte's MARK_CLASS) is a house idiom since 08-29.
+bg-warning/40 rounded px-0\.5
+# The drawer and sidebar chrome in +layout.svelte and chat_bar.svelte are app shell, not screens.
+routes/\(app\)/\+layout\.svelte:
+routes/\(app\)/chat_bar\.svelte:

--- a/.agents/skills/kiln-ui/ui_gate_allow.txt
+++ b/.agents/skills/kiln-ui/ui_gate_allow.txt
@@ -1,8 +1,10 @@
 # kiln-ui gate allowlist. One extended regex per line, matched against the hit's
-# "<file>:<line>\t<snippet>" text. Add a line only for a HOUSE idiom (something the app
-# already does on a shipped screen), never to silence a hit on a new screen.
+# "<file>:<line>\t<snippet>" text. Prefix a line with "RULE_NAME:" to silence only that rule
+# (RULE_NAME is the second column of a hit); a bare line silences every rule on a matching hit.
+# Add a line only for a HOUSE idiom (something the app already does on a shipped screen), never
+# to silence a hit on a new screen.
 # The citation mark (output.svelte's MARK_CLASS) is a house idiom since 08-29.
-bg-warning/40 rounded px-0\.5
+TINTED_BOX:bg-warning/40 rounded px-0\.5
 # The drawer and sidebar chrome in +layout.svelte and chat_bar.svelte are app shell, not screens.
 routes/\(app\)/\+layout\.svelte:
 routes/\(app\)/chat_bar\.svelte:

--- a/.agents/tables_style.md
+++ b/.agents/tables_style.md
@@ -1,5 +1,7 @@
 ### Table Example
 
+The `rounded-lg border` frame below is for tables only. It is not a container for other content (see `frontend_design_guide.md`, Layout and containers).
+
 Here's an example of our table styling:
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Our end-to-end UI tests are separate and not part of `checks.sh`.
 
 ### Agent Prompts
 
-Agents have access to a number of helpful prompts, which will give you additional context for how you should write code and docs for this repo. Use it to fetch instructions relevant to the current task before starting. For example, read `python_test_guide.md` before writing tests and `frontend_design_guide.md` before writing front end code.
+Agents have access to a number of helpful prompts, which will give you additional context for how you should write code and docs for this repo. Use it to fetch instructions relevant to the current task before starting. For example, read `python_test_guide.md` before writing tests, and invoke the `kiln-ui` skill (`.agents/skills/kiln-ui/SKILL.md`) before any change under `app/web_ui`; it loads `frontend_design_guide.md` and `frontend_controls.md` and adds a component plan and a gate.
 
 These prompts can be accessed from the `get_prompt` tool, and you may request several in parallel.
 


### PR DESCRIPTION
## What does this PR do?

Adds a `kiln-ui` skill under `.agents/skills/` that agents have to run before they touch anything in `app/web_ui`, and points `AGENTS.md` and the code review guidelines at it. There's a second, separable commit that writes down the container, button and font rules we've been giving in review but never put in the design guide, and lists the controls the controls doc doesn't name.

### Why

This is the thing we talked about this week: getting an agent to build UI that actually looks like Kiln is hard, and I hit it on every eval builder screen. The agent copies Tailwind off the nearest screen instead of using the control. The screen looks fine on its own, passes review, and then the next screen copies it. By the time someone looks at the whole flow it doesn't feel like our app anymore, and it's five screens deep.

Nothing in the loop ever asked the one question that matters: which house control is this element? Our guides say "use standard controls" but have no "never do this" list. Reviews treat style as out of scope. And a screenshot of a well-copied screen can't fail, because the copy is pixel-close.

Telling the agent to read the guide harder doesn't work, I tried. What works is making it write down the answer before it writes code, and then proving it at handback in a way a reviewer can check without staring at pixels.

### What the skill does

- **Before code:** a component plan. One row per visible element, naming the house control it uses or justifying a custom one, plus one existing screen the new one has to read like.
- **On the diff:** `ui_gate.sh`. It fails on hand-written form fields and labels, hand-rolled expanders, status colours used for selection, "View" button labels, self-styled boxes, typography overrides on shared controls, and any edit to a shared control that isn't its own stated decision. It warns on ghost and outline buttons and off-guide colours and weights. Runs on a range, the worktree, or named files.
- **At handback:** the plan, the gate output, a side-by-side with the sibling screen, and the list of shared controls touched.
- **At review:** section 6 of the skill is the same list as a review lens. The review guidelines now point at it.

The gate is calibrated on our three reference screens, which come out clean:

```
$ bash .agents/skills/kiln-ui/ui_gate.sh --files \
    'app/web_ui/src/routes/(app)/run/+page.svelte' \
    'app/web_ui/src/routes/(app)/generate/[project_id]/[task_id]/synth_kiln_pro.svelte' \
    'app/web_ui/src/routes/(app)/settings/edit_task/[project_id]/[task_id]/+page.svelte' \
    'app/web_ui/src/routes/(app)/settings/edit_task/[project_id]/[task_id]/load_task_editor.svelte'

=== kiln-ui gate: 752 lines reviewed, 0 hits ===
RESULT: PASS (WARN/INFO hits must appear as rows in the component plan)
```

### Test

Tested on 2 passes of eval builder v2. 

## Checklists

- [x] Tests have been run locally and passed
- [ ] New tests have been added to any work in /lib (no /lib changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
