### PR TITLE
Fix Linux tray icon scaling

### DIFF
--- a/app/desktop/desktop.py
+++ b/app/desktop/desktop.py
@@ -119,6 +119,11 @@ class DesktopApp:
 
         tray_image = Image.open(self.resource_path("taskbar.png"))
 
+        # taskbar.png is sized for macOS/Windows; Linux trays typically render icons
+        # at ~22-24px, so the source image looks oversized/blurry there unless scaled down.
+        if sys.platform.startswith("linux"):
+            tray_image = tray_image.resize((24, 24), Image.Resampling.LANCZOS)
+
         # Use default on Windows to get "left click to open" behaviour.
         # It looks ugly on MacOS (just a bold effect Apple never uses), so don't use it there
         make_open_studio_default = sys.platform in ("win32", "Windows")

--- a/app/desktop/test_desktop.py
+++ b/app/desktop/test_desktop.py
@@ -236,6 +236,32 @@ class TestDesktopApp:
             menu_calls = mock_kiln_menu_item.call_args_list
             assert menu_calls[0][1]["default"] is False
 
+    @patch("app.desktop.desktop.sys.platform", "linux")
+    def test_run_tray_linux_icon_scaling(
+        self, mock_tk_root, mock_image, mock_kiln_tray, mock_kiln_menu_item
+    ):
+        """Test run_tray scales the tray icon down on Linux."""
+        app = DesktopApp(port=TEST_PORT)
+
+        with patch.object(app, "resource_path", return_value="taskbar.png"):
+            app.run_tray()
+
+            mock_image.resize.assert_called_once()
+            args, _ = mock_image.resize.call_args
+            assert args[0] == (24, 24)
+
+    @patch("app.desktop.desktop.sys.platform", "win32")
+    def test_run_tray_windows_no_icon_scaling(
+        self, mock_tk_root, mock_image, mock_kiln_tray, mock_kiln_menu_item
+    ):
+        """Test run_tray does not scale the tray icon on Windows."""
+        app = DesktopApp(port=TEST_PORT)
+
+        with patch.object(app, "resource_path", return_value="taskbar.png"):
+            app.run_tray()
+
+            mock_image.resize.assert_not_called()
+
     def test_close_splash_with_pyi_splash(self, mock_tk_root):
         """Test close_splash when pyi_splash is available."""
         app = DesktopApp(port=TEST_PORT)


### PR DESCRIPTION
## What does this PR do?
Scales the tray icon to 24x24 with LANCZOS resampling on Linux before creating the QIcon, while leaving behavior on other platforms unchanged.

This intentionally keeps the fix narrowly scoped to icon rendering and does not change the click-to-open-menu behavior.

## Related Issues
Fixes: https://github.com/Kiln-AI/Kiln/issues/528

## Contributor License Agreement
I, @krisnaparahita, confirm that I have read and agree to the [Contributors License Agreement](https://github.com/Kiln-AI/Kiln/blob/main/.config/CLA.md).

## Checklists
- [x] Tests have been run locally and passed (`app/desktop/test_desktop.py`: 20 tests; Ruff)
- [x] Two unit tests were added covering Linux scaling and unchanged Windows behavior
- [x] No work was done in `/lib`